### PR TITLE
修复 QQ 空间发布工具参数识别问题

### DIFF
--- a/main.py
+++ b/main.py
@@ -1455,7 +1455,12 @@ class PrivateCompanionPlugin(CoreStoreMixin, AstrBotKnowledgeMixin, IntegrationS
 
     @filter.llm_tool(name="pc_qzone_publish_feed")
     async def pc_qzone_publish_feed(self, event: AstrMessageEvent, text: str = "", **kwargs) -> str:
-        """发布一条 QQ 空间说说。必须通过 text 参数传入最终正文。"""
+        """发布一条 QQ 空间说说。必须通过 text 参数传入最终正文。
+
+        Args:
+            text(string): 要发布到 QQ 空间的说说正文。
+            use_latest_draft(boolean): 可选，是否使用最近生成的生活草稿。
+        """
         return await self._pc_qzone_publish_feed_impl(event, text, **kwargs)
 
     @filter.llm_tool(name="pc_get_group_id_by_name")


### PR DESCRIPTION
## 修复内容

修复 `pc_qzone_publish_feed` 工具无法识别 `text` 参数的问题。

## 问题原因

工具虽然在函数签名中声明了 `text` 参数，但 docstring 缺少标准的 `Args:` 部分，导致 AstrBot 工具运行器无法正确解析参数 schema，将 LLM 传入的参数标记为非期望参数并忽略。

## 解决方案

在 `pc_qzone_publish_feed` 的 docstring 中添加 `Args:` 部分，明确声明：
- `text(string)`: 要发布到 QQ 空间的说说正文
- `use_latest_draft(boolean)`: 可选参数，是否使用最近生成的生活草稿

## 测试

修复后工具运行器能正确识别参数，不再报忽略非期望参数警告。

Fixes #11