### PR TITLE
fix: page_api_users_groups.py 补充缺失的 _safe_int 导入 (NameError)

### DIFF
--- a/page_api_users_groups.py
+++ b/page_api_users_groups.py
@@ -7,6 +7,8 @@ from typing import Any
 from astrbot.api import logger
 from quart import request
 
+from .helpers import _safe_int
+
 
 class PrivateCompanionPageApiUsersGroupsMixin:
     async def list_users(self) -> dict[str, Any]:


### PR DESCRIPTION
## 问题
通过管理页面更新用户、且请求体包含 `proactive_daily_limit` 字段时，后端抛出 `NameError: name '_safe_int' is not defined`，导致「更新用户」失败。

## 根本原因
`page_api_users_groups.py:84` 以模块级函数形式调用了 `_safe_int`，但该文件导入区从未导入它。该缺陷由 v4.0.0 (3ed5565) 重构引入：当时把用户/群组相关的 page API 逻辑从 `page_api.py` 拆分到新建的 `page_api_users_groups.py`，调用被搬入新文件，但对应的 `from .helpers import _safe_int` 未一并迁移。

## 改动
在导入区补充：
```python
from .helpers import _safe_int
```

## 验证
- 修复前 `ruff check --select F821` 报 `Undefined name '_safe_int'`（:84）
- 修复后 `ruff check --select F401,F811,F821` 全部通过
- `ast.parse` 语法解析通过

Fixes #18
