### PR TITLE
fix: 修复陪伴面板中保存群聊唤醒词、关键词时类型解析错误的问题

### DIFF
--- a/page_api.py
+++ b/page_api.py
@@ -6945,7 +6945,15 @@ class PrivateCompanionPageApi(PrivateCompanionPageApiUsersGroupsMixin):
         if key == "QZONE_COOKIE":
             return str(value or "").replace("\r", ";").replace("\n", ";").strip()[:8000]
         if key in {"group_wakeup_direct_words", "group_wakeup_context_words", "group_wakeup_interest_keywords", "recall_forbidden_words"}:
-            return str(value or "").strip()[:1200]
+            parser = getattr(self.plugin, "_parse_text_list_config", None)
+            if callable(parser):
+                limit = 300 if key == "recall_forbidden_words" else 120
+                return parser(value, limit=limit)
+            if isinstance(value, list):
+                return [v for v in value if v]
+            if isinstance(value, str):
+                return [v for v in re.split(r"[\n,，、;；]+", value) if v.strip()]
+            return []
         if key == "recall_forbidden_scope":
             scope = str(value or "bot_and_group").strip().lower()
             return scope if scope in {"bot_only", "group_only", "bot_and_group"} else "bot_and_group"


### PR DESCRIPTION
### 问题描述
在陪伴面板中保存“强唤醒词”、“弱相关唤醒词”、“手动兴趣关键词”时，会错误的将单词拆分成单个字符，如“机器人”会被拆分为“机”、“器”、“人”。

### 根本原因
`page_api.py` 第 6947 行，`_normalize_setting_value()` 中 —— 当陪伴面板保存设置时，所有四个列表类型的键： 
~~~ python
# 旧代码（第 6947-6948 行）                                                                                                                                                                  
  if key in {"group_wakeup_direct_words", "group_wakeup_context_words", "group_wakeup_interest_keywords", "recall_forbidden_words"}:
      return str(value or "").strip()[:1200]  # ← 返回字符串！
~~~
将值转换为纯字符串。随后，`_apply_config_value()` 通过 `setattr(self.plugin, key, value)` 将该字符串设置到插件的运行时属性上。当 `group_wakeup.py:283` 执行 `list(self.group_wakeup_direct_words)` 时，Python 会逐字符迭代该字符串 → `["机", "器", "人"]`。
AstrBot 插件设置页面之所以没有此问题，是因为它通过 schema 类型系统处理，该系统对 `"type": "list"` 字段进行了正确的列表转换。

### 修复方案
在 `_normalize_setting_value()` 中，不再将值转换为字符串，而是使用 `_parse_text_list_config()`（与启动时加载配置所用的解析器相同）将其转换为列表。
同时提供回退逻辑，能够正确处理列表和字符串两种输入类型。
~~~ python
if key in {"group_wakeup_direct_words", "group_wakeup_context_words", "group_wakeup_interest_keywords", "recall_forbidden_words"}:
    parser = getattr(self.plugin, "_parse_text_list_config", None)
    if callable(parser):
        limit = 300 if key == "recall_forbidden_words" else 120
        return parser(value, limit=limit)
    if isinstance(value, list):
        return [v for v in value if v]
    if isinstance(value, str):
        return [v for v in re.split(r"[\n,，、;；]+", value) if v.strip()]
    return []
~~~

### 附带影响
`recall_forbidden_words` （撤回违禁词表）存在相同的 BUG，在此次修复中也一并解决。