### PR TITLE
feat: integrate gitee_aiimg/mimo_tts direct plugin calls, fix bilibili detection

### DIFF
--- a/news_exploration.py
+++ b/news_exploration.py
@@ -660,8 +660,10 @@ class NewsExplorationMixin:
 
     def _bilibili_plugin_dir(self) -> Path:
         candidates = [
+            Path(__file__).resolve().parent.parent / "astrbot_plugin_bilibili_ai_bot",
             Path(__file__).resolve().parent.parent / "astrbot_plugin_bilibili_bot",
             Path(__file__).resolve().parent.parent / "astrbot_plugin_bilibili",
+            Path(self.data_dir).parent.parent / "plugins" / "astrbot_plugin_bilibili_ai_bot",
             Path(self.data_dir).parent.parent / "plugins" / "astrbot_plugin_bilibili_bot",
             Path(self.data_dir).parent.parent / "plugins" / "astrbot_plugin_bilibili",
         ]

--- a/page_api.py
+++ b/page_api.py
@@ -6804,40 +6804,42 @@ class PrivateCompanionPageApi(PrivateCompanionPageApiUsersGroupsMixin):
                 if self.plugin._private_user_role(item, str(item.get("user_id") or "")) == "owner":
                     break
         umo = self._single_line((enabled_user or {}).get("umo"), 180) if isinstance(enabled_user, dict) else ""
-        config: dict[str, Any] = {}
-        provider_settings: dict[str, Any] = {}
-        provider = None
-        context = getattr(self.plugin, "context", None)
-        if context is not None:
-            getter = getattr(context, "get_config", None)
-            if callable(getter):
-                try:
-                    config = getter(umo) if umo else getter()
-                    if not isinstance(config, dict):
-                        config = {}
-                except Exception:
-                    config = {}
-            provider_settings = dict((config or {}).get("provider_tts_settings", {}) or {})
-            provider_getter = getattr(context, "get_using_tts_provider", None)
-            if callable(provider_getter):
-                try:
-                    provider = provider_getter(umo) if umo else provider_getter()
-                except Exception:
-                    provider = None
+        # Check mimo_tts plugin availability directly via star_registry
+        mimo_tts_plugin = None
+        mimo_tts_api_key = ""
+        try:
+            from astrbot.core.star.star import star_registry
+            for metadata in star_registry:
+                name = str(getattr(metadata, "name", "") or "").lower()
+                if "mimo_tts" in name:
+                    star_cls = getattr(metadata, "star_cls", None)
+                    if star_cls is not None:
+                        mimo_tts_plugin = star_cls
+                        # api_key may be on plugin_config or directly on instance
+                        mimo_tts_api_key = str(getattr(star_cls, "api_key", "") or "").strip()
+                        if not mimo_tts_api_key:
+                            pc = getattr(star_cls, "plugin_config", None)
+                            if pc is not None:
+                                mimo_tts_api_key = str(getattr(pc, "api_key", "") or "").strip()
+                        break
+        except Exception:
+            pass
+        provider_available = mimo_tts_plugin is not None and bool(mimo_tts_api_key)
         provider_label = ""
-        if provider is not None:
-            provider_id = self._provider_id(provider)
-            provider_label = self._provider_name(provider, provider_id) if provider_id else getattr(provider, "__class__", type(provider)).__name__
+        if mimo_tts_plugin is not None:
+            if mimo_tts_api_key:
+                provider_label = "mimo_tts (API Key 已配置)"
+            else:
+                provider_label = "mimo_tts (API Key 未配置)"
         return {
             "enhancement_enabled": bool(getattr(self.plugin, "enable_tts_enhancement", False)),
             "mode": self._single_line(getattr(self.plugin, "tts_generation_mode", ""), 24) or "fast_tag",
             "language": self.plugin._tts_language_label() if hasattr(self.plugin, "_tts_language_label") else "",
             "umo": umo,
-            "settings_enabled": bool(provider_settings.get("enable", False)),
-            "provider_available": provider is not None,
-            "provider_label": self._single_line(provider_label, 80) or "未知 provider",
+            "settings_enabled": mimo_tts_plugin is not None,
+            "provider_available": provider_available,
+            "provider_label": provider_label or "mimo_tts 插件未加载",
         }
-
     def _message_debounce_summary(self, data: dict[str, Any]) -> dict[str, Any]:
         raw = data.get("smart_message_debounce")
         if not isinstance(raw, dict):

--- a/proactive_message.py
+++ b/proactive_message.py
@@ -4682,6 +4682,14 @@ reason={reason or "check_in"}；action={action or "message"}；topic={_single_li
             return finish("SDGen", image_path, note)
         if preferred == "external":
             if not self._external_photo_available():
+                # external unavailable, try gitee_aiimg directly
+                if self._find_gitee_aiimg_plugin() is not None:
+                    image_path, note = await self._run_gitee_aiimg_photo_generation(
+                        prompt_text,
+                        session_key=session_key,
+                        image_size=image_size,
+                    )
+                    return finish("Gitee AI Image", image_path, note)
                 return finish("在线图片 API", "", "在线图片 API 后端不可用或未配置")
             image_path, note = await self._run_external_photo_generation(
                 prompt_text,
@@ -4689,7 +4697,20 @@ reason={reason or "check_in"}；action={action or "message"}；topic={_single_li
                 reference_image_path=reference_image_path,
                 image_size=image_size,
             )
-            return finish("在线图片 API", image_path, note)
+            logger.info("[PrivateCompanion] external 返回: trace=%s image_path=%s note=%s", trace_id, _single_line(str(image_path), 80) or "-", _single_line(note, 120))
+            if image_path:
+                return finish("在线图片 API", image_path, note)
+            # external failed, try gitee_aiimg
+            logger.info("[PrivateCompanion] external 失败,查找 gitee_aiimg: trace=%s", trace_id)
+            if self._find_gitee_aiimg_plugin() is not None:
+                logger.info("[PrivateCompanion] external 失败,回退 Gitee AI Image: trace=%s note=%s", trace_id, _single_line(note, 180))
+                image_path, note = await self._run_gitee_aiimg_photo_generation(
+                    prompt_text,
+                    session_key=session_key,
+                    image_size=image_size,
+                )
+                return finish("Gitee AI Image", image_path, note)
+            return finish("在线图片 API", "", note)
         external_note = ""
         if self._external_photo_available():
             image_path, note = await self._run_external_photo_generation(
@@ -4705,6 +4726,21 @@ reason={reason or "check_in"}；action={action or "message"}；topic={_single_li
         else:
             external_note = "在线图片 API 后端不可用或未配置"
             logger.info("[PrivateCompanion] 生图后端跳过: trace=%s backend=external note=%s", trace_id, external_note)
+        # Gitee AI Image fallback
+        gitee_aiimg_note = ""
+        if self._find_gitee_aiimg_plugin() is not None:
+            image_path, note = await self._run_gitee_aiimg_photo_generation(
+                prompt_text,
+                session_key=session_key,
+                image_size=image_size,
+            )
+            if image_path:
+                return finish("Gitee AI Image", image_path, note)
+            gitee_aiimg_note = note
+            logger.info("[PrivateCompanion] 生图后端回退: trace=%s backend=gitee_aiimg note=%s", trace_id, _single_line(note, 180))
+        else:
+            gitee_aiimg_note = "Gitee AI Image 插件未加载"
+            logger.info("[PrivateCompanion] 生图后端跳过: trace=%s backend=gitee_aiimg note=%s", trace_id, gitee_aiimg_note)
         if self._comfyui_photo_available():
             busy_state = self._local_photo_generation_busy_state(force_refresh=True)
             if busy_state:
@@ -4746,7 +4782,7 @@ reason={reason or "check_in"}；action={action or "message"}；topic={_single_li
         else:
             sdgen_note = "SDGen 插件不可用或未配置"
             logger.info("[PrivateCompanion] 生图后端跳过: trace=%s backend=sdgen note=%s", trace_id, sdgen_note)
-        return finish("在线图片 API", "", f"在线图片 API 失败：{external_note}；ComfyUI 失败：{comfyui_note}；SDGen 失败：{sdgen_note}")
+        return finish("Gitee AI Image", "", f"在线图片 API 失败：{external_note}；Gitee AI Image 失败：{gitee_aiimg_note}；ComfyUI 失败：{comfyui_note}；SDGen 失败：{sdgen_note}")
 
     async def _build_photo_scene_prompt(
         self, user: dict[str, Any], name: str, reason: str
@@ -5835,6 +5871,53 @@ reason={reason or "check_in"}；action={action or "message"}；topic={_single_li
             return "", note
         except Exception as e:
             logger.warning(f"[PrivateCompanion] 在线图片 API 生图失败: {e}", exc_info=True)
+            return "", str(e)
+
+    def _find_gitee_aiimg_plugin(self) -> Any:
+        """Find gitee_aiimg plugin instance via AstrBot star_registry."""
+        try:
+            from astrbot.core.star.star import star_registry
+            for metadata in star_registry:
+                name = str(getattr(metadata, "name", "") or "").lower()
+                module_path = str(getattr(metadata, "module_path", "") or "").lower()
+                star_cls = getattr(metadata, "star_cls", None)
+                has_draw = hasattr(star_cls, "draw") if star_cls else False
+                logger.info("[PrivateCompanion] 扫描插件: name=%s module_path=%s has_draw=%s", name, module_path, has_draw)
+                if "gitee_aiimg" in name or "gitee_aiimg" in module_path:
+                    if star_cls is not None and has_draw:
+                        logger.info("[PrivateCompanion] 找到 gitee_aiimg 插件: %s", name)
+                        return star_cls
+                    logger.info("[PrivateCompanion] 找到 gitee_aiimg 但 star_cls=%s has_draw=%s attrs=%s", star_cls is not None, has_draw, [a for a in dir(star_cls) if not a.startswith("_") and "draw" in a.lower()] if star_cls else [])
+        except Exception as e:
+            logger.warning("[PrivateCompanion] _find_gitee_aiimg_plugin 异常: %s", e, exc_info=True)
+        return None
+
+    async def _run_gitee_aiimg_photo_generation(
+        self,
+        prompt_text: str,
+        *,
+        session_key: str,
+        image_size: str = "",
+    ) -> tuple[str, str]:
+        """Generate image via gitee_aiimg plugin's ImageDrawService."""
+        plugin = self._find_gitee_aiimg_plugin()
+        if plugin is None:
+            return "", "Gitee AI Image 插件未加载"
+        draw_service = getattr(plugin, "draw", None)
+        if draw_service is None:
+            return "", "Gitee AI Image 插件 draw_service 不可用"
+        try:
+            path = await asyncio.wait_for(
+                draw_service.generate(prompt_text),
+                timeout=180,
+            )
+            if path and Path(path).exists():
+                return str(path), "ok"
+            return "", "Gitee AI Image 未返回有效图片"
+        except asyncio.TimeoutError:
+            return "", "Gitee AI Image 生图超时"
+        except Exception as e:
+            logger.warning(f"[PrivateCompanion] Gitee AI Image 生图失败: {e}", exc_info=True)
             return "", str(e)
 
     async def _run_external_photo_edit_generation(

--- a/tts_enhancement.py
+++ b/tts_enhancement.py
@@ -2076,6 +2076,20 @@ Provider 规则：{emotion_rule}
             return self._sanitize_tts_visible_text(re.sub(TTS_TAG_PATTERN, "", normalized).strip())
         return ""
 
+
+    def _find_mimo_tts_plugin(self) -> Any:
+        """Find mimo_tts plugin instance via AstrBot star_registry."""
+        try:
+            from astrbot.core.star.star import star_registry
+            for metadata in star_registry:
+                name = str(getattr(metadata, "name", "") or "").lower()
+                if "mimo_tts" in name:
+                    star_cls = getattr(metadata, "star_cls", None)
+                    if star_cls is not None and hasattr(star_cls, "synthesize_text"):
+                        return star_cls
+        except Exception:
+            pass
+        return None
     async def _process_tts_tags(self, text: str, event_or_provider: Any, provider_settings: dict[str, Any] | None = None, config: dict[str, Any] | None = None, fallback_plain: str = "") -> list[Any]:
         if hasattr(event_or_provider, "get_result"):
             event = event_or_provider
@@ -2088,6 +2102,9 @@ Provider 规则：{emotion_rule}
                 tts_provider = self.context.get_using_tts_provider(str(getattr(event, "unified_msg_origin", "") or ""))
             except Exception:
                 tts_provider = None
+            # Fallback: use mimo_tts plugin directly
+            if tts_provider is None:
+                tts_provider = self._find_mimo_tts_plugin()
         else:
             event = None
             tts_provider = event_or_provider
@@ -2325,7 +2342,13 @@ Provider 规则：{emotion_rule}
                 _single_line(sanitized, 80),
             )
         try:
-            audio_path = await tts_provider.get_audio(sanitized)
+            if hasattr(tts_provider, "synthesize_text"):
+                # mimo_tts plugin: returns list[Path]
+                paths = await tts_provider.synthesize_text(sanitized)
+                audio_path = str(paths[0]) if paths else ""
+            else:
+                # AstrBot framework TTS provider: returns str path
+                audio_path = await tts_provider.get_audio(sanitized)
         except Exception as exc:
             logger.warning(
                 "[PrivateCompanion] TTS强化生成语音失败: provider=%s error_type=%s error=%s text=%s",


### PR DESCRIPTION
## 变更

- **生图**: 陪伴插件直接调用 gitee_aiimg 插件的 `draw.generate()` 生图，external 失败后自动回退
- **TTS**: 直接调用 mimo_tts 插件的 `synthesize_text()` 生成语音，绕过 AstrBot 框架 TTS provider 会话绑定
- **诊断页**: TTS 状态检测改为通过 `star_registry` 查 mimo_tts 插件实例和 api_key
- **B站联动**: 候选路径加上 `astrbot_plugin_bilibili_ai_bot`

## 测试

- ✅ 生图排障测试通过（gitee_aiimg CPA Gemini）
- ✅ TTS 排障测试通过（mimo_tts 插件直连）
- ✅ B站联动诊断显示正常