### PR TITLE
fix:重写图片表情包缓存配置页，修复裂图问题，加批量编辑

### DIFF
--- a/page_api.py
+++ b/page_api.py
@@ -40,6 +40,15 @@ from .memo_notes import (
 
 PLUGIN_NAME = "astrbot_plugin_private_companion"
 PAGE_API_PREFIX = f"/{PLUGIN_NAME}/page"
+IMAGE_CACHE_THUMBNAIL_MAX_EDGE = 160
+IMAGE_CACHE_THUMBNAIL_QUALITY = 78
+
+try:
+    from PIL import Image as PILImage
+    from PIL import ImageOps as PILImageOps
+except Exception:  # pragma: no cover - Pillow 缺失时回退压缩预览原图
+    PILImage = None
+    PILImageOps = None
 
 
 class PrivateCompanionPageApi(PrivateCompanionPageApiQzoneMixin, PrivateCompanionPageApiUsersGroupsMixin):
@@ -213,8 +222,11 @@ class PrivateCompanionPageApi(PrivateCompanionPageApiQzoneMixin, PrivateCompanio
             ("/token/reset", self.reset_token_stats, ["POST"], "Private Companion Page reset token stats"),
             ("/image_cache/list", self.list_image_cache, ["GET"], "Private Companion Page image cache list"),
             ("/image_cache/preview", self.get_image_cache_preview, ["GET"], "Private Companion Page image cache preview"),
+            ("/image_cache/preview_data", self.get_image_cache_preview_data, ["GET"], "Private Companion Page image cache preview data"),
+            ("/image_cache/thumbnail_data", self.get_image_cache_thumbnail_data, ["GET"], "Private Companion Page image cache thumbnail data"),
             ("/image_cache/update", self.update_image_cache_item, ["POST"], "Private Companion Page update image cache item"),
             ("/image_cache/delete", self.delete_image_cache_item, ["POST"], "Private Companion Page delete image cache item"),
+            ("/image_cache/bulk_delete", self.bulk_delete_image_cache_items, ["POST"], "Private Companion Page bulk delete image cache items"),
             ("/daily_outfit/image", self.get_daily_outfit_image, ["GET"], "Private Companion Page daily outfit image"),
             ("/daily_outfit/image_data", self.get_daily_outfit_image_data, ["GET"], "Private Companion Page daily outfit image data"),
             ("/bookshelf/unlock", self.unlock_bookshelf, ["POST"], "Private Companion Page unlock bookshelf"),
@@ -925,11 +937,18 @@ class PrivateCompanionPageApi(PrivateCompanionPageApiQzoneMixin, PrivateCompanio
             logger.error(f"[PrivateCompanionPage] 更新图片缓存失败: {exc}", exc_info=True)
             return self._error(str(exc))
 
+    def _image_cache_preview_dir(self) -> Path:
+        return (Path(getattr(self.plugin, "data_dir", "")) / "private_image_cache_previews").resolve()
+
+    @staticmethod
+    def _image_cache_clean_key(key: str) -> str:
+        return re.sub(r"[^0-9A-Za-z_.-]+", "_", str(key or ""))[:80]
+
     def _image_cache_preview_file(self, key: str, raw: dict[str, Any] | None = None) -> Path | None:
-        clean_key = re.sub(r"[^0-9A-Za-z_.-]+", "_", str(key or ""))[:80]
+        clean_key = self._image_cache_clean_key(key)
         if not clean_key:
             return None
-        base = (Path(getattr(self.plugin, "data_dir", "")) / "private_image_cache_previews").resolve()
+        base = self._image_cache_preview_dir()
         candidates: list[Path] = []
         preview_path = self._single_line((raw or {}).get("preview_path"), 260) if isinstance(raw, dict) else ""
         if preview_path:
@@ -945,6 +964,67 @@ class PrivateCompanionPageApi(PrivateCompanionPageApiQzoneMixin, PrivateCompanio
             except Exception:
                 continue
         return None
+
+    def _image_cache_thumbnail_file(self, key: str) -> Path | None:
+        clean_key = self._image_cache_clean_key(key)
+        if not clean_key:
+            return None
+        return self._image_cache_preview_dir() / ".thumbnails" / f"{clean_key}.webp"
+
+    async def _get_or_create_image_cache_thumbnail(self, key: str, source: Path) -> Path | None:
+        return await asyncio.to_thread(self._build_image_cache_thumbnail_sync, key, source)
+
+    def _build_image_cache_thumbnail_sync(self, key: str, source: Path) -> Path | None:
+        if PILImage is None:
+            return None
+        target = self._image_cache_thumbnail_file(key)
+        if target is None:
+            return None
+        try:
+            if target.is_file() and target.stat().st_mtime >= source.stat().st_mtime:
+                return target
+        except OSError:
+            pass
+
+        temporary = target.with_name(f".{target.name}.{uuid.uuid4().hex}.tmp")
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with PILImage.open(source) as image:
+                if PILImageOps is not None:
+                    image = PILImageOps.exif_transpose(image)
+                image.seek(0)
+                if image.mode in {"RGBA", "LA"} or (image.mode == "P" and "transparency" in image.info):
+                    rgba = image.convert("RGBA")
+                    background = PILImage.new("RGBA", rgba.size, (255, 255, 255, 255))
+                    background.alpha_composite(rgba)
+                    image = background.convert("RGB")
+                else:
+                    image = image.convert("RGB")
+                resampling = getattr(PILImage, "Resampling", PILImage)
+                image.thumbnail(
+                    (IMAGE_CACHE_THUMBNAIL_MAX_EDGE, IMAGE_CACHE_THUMBNAIL_MAX_EDGE),
+                    resampling.LANCZOS,
+                )
+                image.save(
+                    temporary,
+                    format="WEBP",
+                    quality=IMAGE_CACHE_THUMBNAIL_QUALITY,
+                    method=6,
+                )
+            temporary.replace(target)
+            return target
+        except Exception as exc:
+            logger.warning(
+                "[PrivateCompanionPage] 生成图片缓存缩略图失败: key=%s error=%s",
+                self._single_line(key, 80),
+                self._single_line(exc, 160),
+            )
+            return None
+        finally:
+            try:
+                temporary.unlink(missing_ok=True)
+            except OSError:
+                pass
 
     def _restore_image_cache_preview_metadata(self, key: str, raw: dict[str, Any]) -> bool:
         preview = self._image_cache_preview_file(key, raw)
@@ -963,26 +1043,67 @@ class PrivateCompanionPageApi(PrivateCompanionPageApiQzoneMixin, PrivateCompanio
             changed = True
         return changed
 
-    async def get_image_cache_preview(self) -> Any:
+    async def _resolve_image_cache_preview_for_request(self) -> tuple[str, Path] | dict[str, Any]:
         key = self._single_line(request.args.get("key"), 120)
         if not key:
             return self._error("缺少缓存 key")
+        async with self.plugin._data_lock:
+            cache = self.plugin.data.get("private_image_vision_cache")
+            item = cache.get(key) if isinstance(cache, dict) else None
+            if not isinstance(item, dict):
+                return self._error("缓存条目不存在")
+            path = self._image_cache_preview_file(key, item)
+            if path is None:
+                return self._error("缓存预览文件不存在")
+            if self._restore_image_cache_preview_metadata(key, item):
+                self.plugin._save_data_sync()
+        return key, path
+
+    @staticmethod
+    async def _encode_image_cache_file_data_url(path: Path, mime: str = "") -> dict[str, str]:
+        raw = await asyncio.to_thread(path.read_bytes)
+        content_type = mime or mimetypes.guess_type(str(path))[0] or "image/jpeg"
+        encoded = base64.b64encode(raw).decode("ascii")
+        return {"data_url": f"data:{content_type};base64,{encoded}", "mime": content_type}
+
+    async def get_image_cache_preview(self) -> Any:
         try:
-            async with self.plugin._data_lock:
-                cache = self.plugin.data.get("private_image_vision_cache")
-                item = cache.get(key) if isinstance(cache, dict) else None
-                if not isinstance(item, dict):
-                    return self._error("缓存条目不存在")
-                path = self._image_cache_preview_file(key, item)
-                if path is None:
-                    return self._error("缓存预览文件不存在")
-                if self._restore_image_cache_preview_metadata(key, item):
-                    self.plugin._save_data_sync()
+            resolved = await self._resolve_image_cache_preview_for_request()
+            if isinstance(resolved, dict):
+                return resolved
+            _key, path = resolved
             response = await send_file(str(path))
             response.headers["Cache-Control"] = "no-store, max-age=0"
             return response
         except Exception as exc:
             logger.error(f"[PrivateCompanionPage] 获取图片缓存预览失败: {exc}", exc_info=True)
+            return self._error(str(exc))
+
+    async def get_image_cache_preview_data(self) -> dict[str, Any]:
+        try:
+            resolved = await self._resolve_image_cache_preview_for_request()
+            if isinstance(resolved, dict):
+                return resolved
+            _key, path = resolved
+            return self._ok(await self._encode_image_cache_file_data_url(path))
+        except Exception as exc:
+            logger.error(f"[PrivateCompanionPage] 获取图片缓存预览数据失败: {exc}", exc_info=True)
+            return self._error(str(exc))
+
+    async def get_image_cache_thumbnail_data(self) -> dict[str, Any]:
+        try:
+            resolved = await self._resolve_image_cache_preview_for_request()
+            if isinstance(resolved, dict):
+                return resolved
+            key, source = resolved
+            thumbnail = await self._get_or_create_image_cache_thumbnail(key, source)
+            if thumbnail is not None:
+                return self._ok(
+                    await self._encode_image_cache_file_data_url(thumbnail, "image/webp")
+                )
+            return self._ok(await self._encode_image_cache_file_data_url(source))
+        except Exception as exc:
+            logger.error(f"[PrivateCompanionPage] 获取图片缓存缩略图失败: {exc}", exc_info=True)
             return self._error(str(exc))
 
     async def delete_image_cache_item(self) -> dict[str, Any]:
@@ -1001,20 +1122,79 @@ class PrivateCompanionPageApi(PrivateCompanionPageApiQzoneMixin, PrivateCompanio
                     preview_path = self._single_line(removed.get("preview_path"), 260)
                 self.plugin._save_data_sync()
                 remaining = len(cache)
-            self._remove_image_cache_preview_file(preview_path)
+            self._remove_image_cache_preview_file(preview_path, key)
             return self._ok({"key": key, "remaining": remaining})
         except Exception as exc:
             logger.error(f"[PrivateCompanionPage] 删除图片缓存失败: {exc}", exc_info=True)
             return self._error(str(exc))
 
-    def _remove_image_cache_preview_file(self, preview_path: str) -> None:
-        if not preview_path:
+    async def bulk_delete_image_cache_items(self) -> dict[str, Any]:
+        payload = await request.get_json(silent=True) or {}
+        raw_keys = payload.get("keys")
+        if not isinstance(raw_keys, list):
+            return self._error("keys 必须是缓存 key 数组")
+        if payload.get("confirm") is not True:
+            return self._error("批量删除需要 confirm=true")
+        keys: list[str] = []
+        for value in raw_keys[:500]:
+            key = self._single_line(value, 120)
+            if key and key not in keys:
+                keys.append(key)
+        if not keys:
+            return self._error("没有选择缓存条目")
+        try:
+            removed_items: list[tuple[str, str]] = []
+            missing_keys: list[str] = []
+            async with self.plugin._data_lock:
+                cache = self.plugin.data.get("private_image_vision_cache")
+                if not isinstance(cache, dict):
+                    return self._error("图片缓存不存在")
+                for key in keys:
+                    if key not in cache:
+                        missing_keys.append(key)
+                        continue
+                    removed = cache.pop(key, None)
+                    removed_items.append(
+                        (
+                            key,
+                            self._single_line(removed.get("preview_path"), 260)
+                            if isinstance(removed, dict)
+                            else "",
+                        )
+                    )
+                if removed_items:
+                    self.plugin._save_data_sync()
+                remaining = len(cache)
+            for key, preview_path in removed_items:
+                self._remove_image_cache_preview_file(preview_path, key)
+            return self._ok(
+                {
+                    "removed": len(removed_items),
+                    "removed_keys": [key for key, _path in removed_items],
+                    "missing_keys": missing_keys,
+                    "remaining": remaining,
+                }
+            )
+        except Exception as exc:
+            logger.error(f"[PrivateCompanionPage] 批量删除图片缓存失败: {exc}", exc_info=True)
+            return self._error(str(exc))
+
+    def _remove_image_cache_preview_file(self, preview_path: str, key: str = "") -> None:
+        path: Path | None = None
+        try:
+            base = self._image_cache_preview_dir()
+            if preview_path:
+                path = Path(preview_path).resolve()
+            if path is not None and path.is_file() and path.is_relative_to(base):
+                path.unlink(missing_ok=True)
+        except Exception:
+            pass
+        thumbnail = self._image_cache_thumbnail_file(key or (path.stem if path is not None else ""))
+        if thumbnail is None:
             return
         try:
-            path = Path(preview_path).resolve()
-            base = (Path(getattr(self.plugin, "data_dir", "")) / "private_image_cache_previews").resolve()
-            if path.is_file() and path.is_relative_to(base):
-                path.unlink(missing_ok=True)
+            if thumbnail.is_relative_to(self._image_cache_preview_dir()):
+                thumbnail.unlink(missing_ok=True)
         except Exception:
             pass
 
@@ -1040,6 +1220,8 @@ class PrivateCompanionPageApi(PrivateCompanionPageApiQzoneMixin, PrivateCompanio
             "image_aliases_text": " ".join(image_aliases[:12]),
             "image_count": _safe_int(raw.get("image_count"), len(image_keys), 0),
             "preview_url": f"{PAGE_API_PREFIX}/image_cache/preview?key={quote(key, safe='')}" if preview_exists else "",
+            "preview_endpoint": f"/image_cache/preview_data?key={quote(key, safe='')}" if preview_exists else "",
+            "thumbnail_endpoint": f"/image_cache/thumbnail_data?key={quote(key, safe='')}" if preview_exists else "",
             "preview_size": _safe_int(raw.get("preview_size"), 0, 0),
             "preview_width": _safe_int(raw.get("preview_width"), 0, 0),
             "preview_height": _safe_int(raw.get("preview_height"), 0, 0),

--- a/pages/陪伴面板/app.css
+++ b/pages/陪伴面板/app.css
@@ -11537,6 +11537,49 @@ html[data-bookshelf-direction="backward"]::view-transition-new(bookshelf-view) {
   align-items: center;
 }
 
+#imageCacheBatchModeBtn.is-active {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+}
+
+.image-cache-batch-bar {
+  position: sticky;
+  top: 8px;
+  z-index: 3;
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  min-height: 54px;
+  border: 1px solid rgba(26, 75, 140, 0.28);
+  border-left: 5px solid var(--accent);
+  border-radius: var(--radius);
+  padding: 9px 12px;
+  background: var(--panel);
+  background: color-mix(in srgb, var(--panel) 92%, var(--accent-soft));
+  box-shadow: 0 12px 30px rgba(15, 42, 74, 0.12), var(--shadow-ring);
+}
+
+.image-cache-batch-bar[hidden] {
+  display: none;
+}
+
+.image-cache-batch-bar > strong {
+  color: var(--accent-strong);
+  white-space: nowrap;
+}
+
+.image-cache-batch-bar > span {
+  flex: 1;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.image-cache-batch-bar .actions {
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
 .image-cache-layout {
   display: grid;
   grid-template-columns: minmax(280px, 0.42fr) minmax(0, 1fr);
@@ -11564,6 +11607,7 @@ html[data-bookshelf-direction="backward"]::view-transition-new(bookshelf-view) {
 }
 
 .image-cache-row {
+  position: relative;
   display: grid;
   grid-template-columns: 44px minmax(0, 1fr) auto;
   gap: 10px;
@@ -11579,10 +11623,45 @@ html[data-bookshelf-direction="backward"]::view-transition-new(bookshelf-view) {
   cursor: pointer;
 }
 
+.image-cache-row.is-batch-mode {
+  grid-template-columns: 24px 44px minmax(0, 1fr) auto;
+}
+
 .image-cache-row:hover,
 .image-cache-row.is-active {
   border-color: rgba(26, 75, 140, 0.32);
   background: var(--accent-soft);
+}
+
+.image-cache-row.is-selected {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px rgba(26, 75, 140, 0.18) inset;
+}
+
+.image-cache-row:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.image-cache-select-control {
+  display: none;
+  place-items: center;
+  width: 24px;
+  height: 44px;
+  margin: 0;
+  cursor: pointer;
+}
+
+.image-cache-row.is-batch-mode .image-cache-select-control {
+  display: grid;
+}
+
+.image-cache-select-control input {
+  width: 18px;
+  height: 18px;
+  margin: 0;
+  accent-color: var(--accent);
+  cursor: pointer;
 }
 
 .image-cache-thumb {
@@ -11607,6 +11686,19 @@ html[data-bookshelf-direction="backward"]::view-transition-new(bookshelf-view) {
   object-fit: cover;
 }
 
+.image-cache-thumb.is-load-error::after {
+  content: "加载失败";
+  padding: 3px;
+  color: var(--muted);
+  font-size: 10px;
+  line-height: 1.2;
+  text-align: center;
+}
+
+.image-cache-thumb.is-load-error img {
+  display: none;
+}
+
 .image-cache-row-main {
   min-width: 0;
 }
@@ -11627,7 +11719,7 @@ html[data-bookshelf-direction="backward"]::view-transition-new(bookshelf-view) {
 }
 
 .image-cache-row-main i,
-.image-cache-row > span:last-child {
+.image-cache-ownership {
   margin-top: 4px;
   color: var(--muted);
   font-size: 12px;
@@ -11692,6 +11784,21 @@ html[data-bookshelf-direction="backward"]::view-transition-new(bookshelf-view) {
 .image-cache-preview figcaption {
   color: var(--muted);
   font-size: 12px;
+}
+
+.image-cache-preview.is-load-error::before {
+  content: "预览加载失败，请刷新后重试";
+  display: grid;
+  place-items: center;
+  min-height: 140px;
+  width: min(360px, 100%);
+  border: 1px dashed var(--line);
+  border-radius: var(--radius-sm);
+  color: var(--muted);
+}
+
+.image-cache-preview.is-load-error img {
+  display: none;
 }
 
 .image-cache-editor label {
@@ -11773,6 +11880,47 @@ html[data-bookshelf-direction="backward"]::view-transition-new(bookshelf-view) {
   align-self: center;
   justify-self: center;
   padding: 28px;
+  text-align: center;
+}
+
+.image-cache-pager {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+  min-height: 42px;
+}
+
+.image-cache-pager[hidden] {
+  display: none;
+}
+
+.image-cache-page-numbers {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+}
+
+.image-cache-page-numbers button {
+  min-width: 34px;
+  padding-inline: 9px;
+}
+
+.image-cache-page-numbers button.is-active {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: #fff;
+}
+
+.image-cache-page-numbers i,
+.image-cache-page-status {
+  color: var(--muted);
+  font-size: 12px;
+  font-style: normal;
+}
+
+.image-cache-page-status {
+  min-width: 74px;
   text-align: center;
 }
 
@@ -21264,6 +21412,20 @@ pre {
   .image-cache-toolbar,
   .image-cache-editor {
     grid-template-columns: 1fr;
+  }
+
+  .image-cache-batch-bar {
+    position: static;
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .image-cache-batch-bar .actions {
+    justify-content: flex-start;
+  }
+
+  .image-cache-pager {
+    flex-wrap: wrap;
   }
 
   .image-cache-list {

--- a/pages/陪伴面板/app.js
+++ b/pages/陪伴面板/app.js
@@ -100,6 +100,12 @@ const state = {
   imageCacheFilter: "",
   imageCacheScope: "all",
   imageCacheLoaded: false,
+  imageCachePage: 1,
+  imageCachePageSize: 36,
+  imageCacheRequestSeq: 0,
+  imageCacheBatchMode: false,
+  selectedImageCacheKeys: new Set(),
+  imageCacheImageData: new Map(),
   selectedImageCacheKey: "",
   troubleshootingFilter: "all",
   troubleshootingCategory: "all",
@@ -4650,16 +4656,26 @@ async function restoreConfigBackup(id) {
   showToast("已从备份恢复");
 }
 
-async function loadImageCache() {
+async function loadImageCache({ clampPage = true } = {}) {
   const params = new URLSearchParams();
-  params.set("limit", "300");
+  const pageSize = Math.max(1, Number(state.imageCachePageSize || 36));
+  const page = Math.max(1, Number(state.imageCachePage || 1));
+  params.set("limit", String(pageSize));
+  params.set("offset", String((page - 1) * pageSize));
   if (state.imageCacheFilter) params.set("q", state.imageCacheFilter);
   if (state.imageCacheScope && state.imageCacheScope !== "all") params.set("scope", state.imageCacheScope);
+  const requestSeq = ++state.imageCacheRequestSeq;
   const data = await fetchJson(`/image_cache/list?${params.toString()}`);
+  if (requestSeq !== state.imageCacheRequestSeq) return data;
   state.imageCacheItems = Array.isArray(data.items) ? data.items : [];
   state.imageCacheTotal = Number(data.total || 0);
   state.imageCacheScopes = Array.isArray(data.scopes) ? data.scopes : [];
   state.imageCacheLoaded = true;
+  const totalPages = Math.max(1, Math.ceil(state.imageCacheTotal / pageSize));
+  if (clampPage && state.imageCachePage > totalPages) {
+    state.imageCachePage = totalPages;
+    return loadImageCache({ clampPage: false });
+  }
   if (state.selectedImageCacheKey && !state.imageCacheItems.some((item) => item.key === state.selectedImageCacheKey)) {
     state.selectedImageCacheKey = "";
   }
@@ -4668,6 +4684,16 @@ async function loadImageCache() {
   }
   renderImageCache();
   return data;
+}
+
+async function goToImageCachePage(targetPage) {
+  const pageSize = Math.max(1, Number(state.imageCachePageSize || 36));
+  const pages = Math.max(1, Math.ceil(Number(state.imageCacheTotal || 0) / pageSize));
+  const nextPage = Math.min(pages, Math.max(1, Number(targetPage) || 1));
+  if (nextPage === state.imageCachePage) return;
+  state.imageCachePage = nextPage;
+  await loadImageCache();
+  $("#imageCacheList")?.scrollTo({ top: 0, behavior: "smooth" });
 }
 
 async function loadTroubleshooting(options = {}) {
@@ -10178,18 +10204,129 @@ function renderImageCache() {
       <span>左侧点击图片/表情包缓存后，可以编辑摘要或删除。</span>
     </div>
   `;
+  renderImageCacheBatchControls();
+  renderImageCachePager();
+  void hydrateImageCacheImages(listEl);
+  void hydrateImageCacheImages(detailEl);
+}
+
+function renderImageCacheBatchControls() {
+  const toggle = $("#imageCacheBatchModeBtn");
+  const bar = $("#imageCacheBatchBar");
+  const count = $("#imageCacheSelectionCount");
+  const selectedCount = state.selectedImageCacheKeys.size;
+  const pageSelectedCount = (state.imageCacheItems || [])
+    .filter((item) => state.selectedImageCacheKeys.has(item.key)).length;
+  if (toggle) {
+    toggle.textContent = state.imageCacheBatchMode
+      ? `退出批量（${selectedCount}）`
+      : selectedCount
+        ? `批量编辑（${selectedCount}）`
+        : "批量编辑";
+    toggle.setAttribute("aria-pressed", state.imageCacheBatchMode ? "true" : "false");
+    toggle.classList.toggle("is-active", state.imageCacheBatchMode);
+  }
+  if (!bar) return;
+  bar.hidden = !state.imageCacheBatchMode;
+  if (count) count.textContent = `已选 ${selectedCount} 条 · 本页 ${pageSelectedCount} 条`;
+  const hasPageItems = Boolean(state.imageCacheItems?.length);
+  const selectPage = $("#imageCacheSelectPageBtn");
+  const invertPage = $("#imageCacheInvertPageBtn");
+  const clear = $("#imageCacheClearSelectionBtn");
+  const remove = $("#imageCacheBulkDeleteBtn");
+  if (selectPage) selectPage.disabled = !hasPageItems;
+  if (invertPage) invertPage.disabled = !hasPageItems;
+  if (clear) clear.disabled = selectedCount === 0;
+  if (remove) remove.disabled = selectedCount === 0;
+}
+
+function imageCachePageSequence(current, total) {
+  if (total <= 7) return Array.from({ length: total }, (_value, index) => index + 1);
+  const keep = new Set([1, current - 1, current, current + 1, total]);
+  const pages = [...keep].filter((page) => page >= 1 && page <= total).sort((a, b) => a - b);
+  const result = [];
+  let previous = 0;
+  pages.forEach((page) => {
+    if (page - previous > 1) result.push("…");
+    result.push(page);
+    previous = page;
+  });
+  return result;
+}
+
+function renderImageCachePager() {
+  const pager = $("#imageCachePager");
+  if (!pager) return;
+  const total = Math.max(0, Number(state.imageCacheTotal || 0));
+  const pageSize = Math.max(1, Number(state.imageCachePageSize || 36));
+  const pages = Math.max(1, Math.ceil(total / pageSize));
+  const page = Math.min(pages, Math.max(1, Number(state.imageCachePage || 1)));
+  const start = total ? (page - 1) * pageSize + 1 : 0;
+  const end = Math.min(total, page * pageSize);
+  pager.hidden = !state.imageCacheLoaded || total <= pageSize;
+  pager.innerHTML = `
+    <button type="button" data-image-cache-page="${page - 1}" ${page <= 1 ? "disabled" : ""}>上一页</button>
+    <span class="image-cache-page-numbers">
+      ${imageCachePageSequence(page, pages).map((value) => value === "…"
+        ? `<i aria-hidden="true">…</i>`
+        : `<button type="button" data-image-cache-page="${value}" class="${value === page ? "is-active" : ""}" aria-current="${value === page ? "page" : "false"}">${value}</button>`).join("")}
+    </span>
+    <span class="image-cache-page-status">${start}-${end} / ${total}</span>
+    <button type="button" data-image-cache-page="${page + 1}" ${page >= pages ? "disabled" : ""}>下一页</button>
+  `;
+}
+
+async function hydrateImageCacheImages(root = document) {
+  const images = [...root.querySelectorAll("img[data-image-cache-src]")]
+    .filter((image) => image.dataset.loaded !== "1" && image.dataset.loading !== "1");
+  let cursor = 0;
+  const worker = async () => {
+    while (cursor < images.length) {
+      const image = images[cursor];
+      cursor += 1;
+      const endpoint = image.dataset.imageCacheSrc || "";
+      if (!endpoint) continue;
+      image.dataset.loading = "1";
+      try {
+        let dataUrl = state.imageCacheImageData.get(endpoint) || "";
+        if (!dataUrl) {
+          const result = await fetchJson(endpoint);
+          dataUrl = result?.data_url || "";
+          if (dataUrl) state.imageCacheImageData.set(endpoint, dataUrl);
+        }
+        if (!dataUrl) throw new Error("图片接口未返回数据");
+        image.src = dataUrl;
+        image.dataset.loaded = "1";
+        image.classList.remove("is-load-error");
+        image.closest(".image-cache-thumb, .image-cache-preview")?.classList.remove("is-load-error");
+      } catch (error) {
+        image.alt = "图片加载失败";
+        image.classList.add("is-load-error");
+        image.closest(".image-cache-thumb, .image-cache-preview")?.classList.add("is-load-error");
+      } finally {
+        delete image.dataset.loading;
+      }
+    }
+  };
+  const concurrency = Math.min(6, images.length);
+  await Promise.all(Array.from({ length: concurrency }, () => worker()));
 }
 
 function imageCacheListItemMarkup(item) {
   const selected = item.key === state.selectedImageCacheKey;
+  const checked = state.selectedImageCacheKeys.has(item.key);
   const title = item.image_type || imageCacheScopeLabel(item.scope);
   const preview = item.visible || item.intent || item.text || "无摘要";
-  const ownership = item.ownership ? `<span>${escapeHtml(item.ownership)}</span>` : "";
-  const thumb = item.preview_url
-    ? `<span class="image-cache-thumb has-image"><img src="${escapeHtml(item.preview_url)}" alt="${escapeHtml(title)}" loading="lazy" /></span>`
+  const ownership = item.ownership ? `<span class="image-cache-ownership">${escapeHtml(item.ownership)}</span>` : "";
+  const thumbnailEndpoint = item.thumbnail_endpoint || item.preview_endpoint || "";
+  const thumb = thumbnailEndpoint
+    ? `<span class="image-cache-thumb has-image"><img src="${TRANSPARENT_IMAGE}" data-image-cache-src="${escapeHtml(thumbnailEndpoint)}" alt="${escapeHtml(title)}" loading="lazy" /></span>`
     : `<span class="image-cache-thumb">${escapeHtml((item.image_type || "图").slice(0, 2))}</span>`;
   return `
-    <button type="button" class="image-cache-row ${selected ? "is-active" : ""}" data-image-cache-key="${escapeHtml(item.key)}">
+    <article class="image-cache-row ${selected ? "is-active" : ""} ${checked ? "is-selected" : ""} ${state.imageCacheBatchMode ? "is-batch-mode" : ""}" data-image-cache-key="${escapeHtml(item.key)}" role="button" tabindex="0" aria-label="${escapeHtml(state.imageCacheBatchMode ? `选择 ${title}` : `打开 ${title}`)}" aria-pressed="${checked ? "true" : "false"}">
+      <label class="image-cache-select-control" data-image-cache-select-control title="选择缓存">
+        <input type="checkbox" data-image-cache-select="${escapeHtml(item.key)}" ${checked ? "checked" : ""} aria-label="选择 ${escapeHtml(title)}" />
+      </label>
       ${thumb}
       <span class="image-cache-row-main">
         <b>${escapeHtml(title)}</b>
@@ -10197,14 +10334,15 @@ function imageCacheListItemMarkup(item) {
         <i>${escapeHtml(imageCacheScopeLabel(item.scope))} · 命中 ${escapeHtml(item.hits || 0)} · ${escapeHtml(item.last_hit || item.created || "未知时间")}</i>
       </span>
       ${ownership}
-    </button>
+    </article>
   `;
 }
 
 function imageCacheDetailMarkup(item) {
   const aliases = Array.isArray(item.image_aliases) ? item.image_aliases : [];
   const keys = Array.isArray(item.image_keys) ? item.image_keys : [];
-  const previewMeta = item.preview_url
+  const previewEndpoint = item.preview_endpoint || item.thumbnail_endpoint || "";
+  const previewMeta = previewEndpoint
     ? [
         item.preview_width && item.preview_height ? `${item.preview_width}x${item.preview_height}` : "",
         item.preview_size ? formatBytes(item.preview_size) : "",
@@ -10220,9 +10358,9 @@ function imageCacheDetailMarkup(item) {
         </div>
         <button type="button" class="danger" data-image-cache-delete="${escapeHtml(item.key)}">删除缓存</button>
       </header>
-      ${item.preview_url ? `
+      ${previewEndpoint ? `
         <figure class="image-cache-preview">
-          <img src="${escapeHtml(item.preview_url)}" alt="${escapeHtml(item.image_type || "图片缓存预览")}" />
+          <img src="${TRANSPARENT_IMAGE}" data-image-cache-src="${escapeHtml(previewEndpoint)}" alt="${escapeHtml(item.image_type || "图片缓存预览")}" />
           ${previewMeta ? `<figcaption>${escapeHtml(previewMeta)} · 压缩预览</figcaption>` : `<figcaption>压缩预览</figcaption>`}
         </figure>
       ` : ""}
@@ -25936,9 +26074,77 @@ document.addEventListener("click", async (event) => {
     void copyTextToClipboard(copyButton.dataset.copyText || "", "已复制摘要");
     return;
   }
+  const imageCacheBatchModeButton = element?.closest("#imageCacheBatchModeBtn");
+  if (imageCacheBatchModeButton) {
+    state.imageCacheBatchMode = !state.imageCacheBatchMode;
+    renderImageCache();
+    return;
+  }
+  const imageCachePageButton = element?.closest("[data-image-cache-page]");
+  if (imageCachePageButton) {
+    await goToImageCachePage(imageCachePageButton.dataset.imageCachePage);
+    return;
+  }
+  const imageCacheSelectPageButton = element?.closest("#imageCacheSelectPageBtn");
+  if (imageCacheSelectPageButton) {
+    (state.imageCacheItems || []).forEach((item) => {
+      if (item.key) state.selectedImageCacheKeys.add(item.key);
+    });
+    renderImageCache();
+    return;
+  }
+  const imageCacheInvertPageButton = element?.closest("#imageCacheInvertPageBtn");
+  if (imageCacheInvertPageButton) {
+    (state.imageCacheItems || []).forEach((item) => {
+      if (state.selectedImageCacheKeys.has(item.key)) state.selectedImageCacheKeys.delete(item.key);
+      else state.selectedImageCacheKeys.add(item.key);
+    });
+    renderImageCache();
+    return;
+  }
+  const imageCacheClearSelectionButton = element?.closest("#imageCacheClearSelectionBtn");
+  if (imageCacheClearSelectionButton) {
+    state.selectedImageCacheKeys.clear();
+    renderImageCache();
+    return;
+  }
+  const imageCacheBulkDeleteButton = element?.closest("#imageCacheBulkDeleteBtn");
+  if (imageCacheBulkDeleteButton) {
+    const keys = [...state.selectedImageCacheKeys];
+    if (!keys.length) return;
+    if (!requireSecondClick(
+      imageCacheBulkDeleteButton,
+      `image-cache-bulk:${keys.slice().sort().join("|")}`,
+      `再次点击会删除已选的 ${keys.length} 条图片缓存`,
+      `再次点击删除 ${keys.length} 条`,
+    )) return;
+    setActionBusy(imageCacheBulkDeleteButton, true);
+    try {
+      const result = await postJson("/image_cache/bulk_delete", { keys, confirm: true });
+      state.selectedImageCacheKeys.clear();
+      if (keys.includes(state.selectedImageCacheKey)) state.selectedImageCacheKey = "";
+      state.imageCacheImageData.clear();
+      await loadImageCache();
+      showToast(`已批量删除 ${Number(result?.removed || 0)} 条图片缓存`);
+    } catch (error) {
+      showToast(`批量删除失败：${error.message}`, "error");
+    } finally {
+      setActionBusy(imageCacheBulkDeleteButton, false);
+    }
+    return;
+  }
+  const imageCacheSelectControl = element?.closest("[data-image-cache-select-control]");
+  if (imageCacheSelectControl) return;
   const row = element?.closest("[data-image-cache-key]");
   if (row) {
-    state.selectedImageCacheKey = row.dataset.imageCacheKey || "";
+    const key = row.dataset.imageCacheKey || "";
+    if (!key) return;
+    if (state.imageCacheBatchMode) {
+      if (state.selectedImageCacheKeys.has(key)) state.selectedImageCacheKeys.delete(key);
+      else state.selectedImageCacheKeys.add(key);
+    } else {
+      state.selectedImageCacheKey = key;
+    }
     renderImageCache();
     return;
   }
@@ -25950,7 +26156,9 @@ document.addEventListener("click", async (event) => {
     setActionBusy(deleteButton, true);
     try {
       await postJson("/image_cache/delete", { key });
+      state.selectedImageCacheKeys.delete(key);
       state.selectedImageCacheKey = "";
+      state.imageCacheImageData.clear();
       await loadImageCache();
       showToast("图片缓存已删除");
     } catch (error) {
@@ -26420,6 +26628,17 @@ document.addEventListener("submit", async (event) => {
 });
 
 document.addEventListener("change", (event) => {
+  const imageCacheCheckbox = event.target instanceof HTMLInputElement && event.target.matches("[data-image-cache-select]")
+    ? event.target
+    : null;
+  if (imageCacheCheckbox) {
+    const key = imageCacheCheckbox.dataset.imageCacheSelect || "";
+    if (!key) return;
+    if (imageCacheCheckbox.checked) state.selectedImageCacheKeys.add(key);
+    else state.selectedImageCacheKeys.delete(key);
+    renderImageCache();
+    return;
+  }
   const target = event.target instanceof HTMLSelectElement ? event.target : null;
   if (!target || !target.matches("[data-diary-date]")) return;
   state.selectedDiaryDate = target.value;
@@ -26468,6 +26687,7 @@ document.getElementById("appearanceThemeGrid")?.addEventListener("keydown", (eve
 });
 
 $("#refreshImageCacheBtn")?.addEventListener("click", () => {
+  state.imageCacheImageData.clear();
   loadImageCache().catch((error) => showToast(`刷新失败：${error.message}`, "error"));
 });
 $("#refreshTroubleshootingBtn")?.addEventListener("click", () => {
@@ -26477,6 +26697,7 @@ $("#refreshTroubleshootingBtn")?.addEventListener("click", () => {
 });
 $("#imageCacheFilter")?.addEventListener("input", (event) => {
   state.imageCacheFilter = event.target.value || "";
+  state.imageCachePage = 1;
   window.clearTimeout(state._imageCacheFilterTimer);
   state._imageCacheFilterTimer = window.setTimeout(() => {
     loadImageCache().catch((error) => showToast(`筛选失败：${error.message}`, "error"));
@@ -26484,7 +26705,15 @@ $("#imageCacheFilter")?.addEventListener("input", (event) => {
 });
 $("#imageCacheScope")?.addEventListener("change", (event) => {
   state.imageCacheScope = event.target.value || "all";
+  state.imageCachePage = 1;
   loadImageCache().catch((error) => showToast(`筛选失败：${error.message}`, "error"));
+});
+document.addEventListener("keydown", (event) => {
+  if (event.key !== "Enter" && event.key !== " ") return;
+  const row = event.target instanceof Element ? event.target.closest("[data-image-cache-key]") : null;
+  if (!row || event.target !== row) return;
+  event.preventDefault();
+  row.click();
 });
 $("#bookshelfUnlockForm").addEventListener("submit", async (event) => {
   event.preventDefault();

--- a/pages/陪伴面板/index.html
+++ b/pages/陪伴面板/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>陪伴面板</title>
-  <link rel="stylesheet" href="./app.css?v=20260722-expression-editor" />
+  <link rel="stylesheet" href="./app.css?v=20260723-image-cache-batch" />
   <link rel="stylesheet" href="./css/header-tools.css?v=20260713-font-options" />
   <link rel="stylesheet" href="./css/qzone-mobile.css?v=20260711-qzone-image-preview" />
   <link rel="stylesheet" href="./css/polish.css?v=20260715-learning-nav-merged-v1" />
@@ -1076,6 +1076,7 @@ QQ空间 = 公开札记
             </div>
             <div class="actions compact">
               <button type="button" data-jump-tab="config">返回配置页</button>
+              <button id="imageCacheBatchModeBtn" type="button" aria-pressed="false">批量编辑</button>
               <button id="refreshImageCacheBtn" type="button">刷新缓存</button>
             </div>
           </div>
@@ -1086,10 +1087,21 @@ QQ空间 = 公开札记
               <option value="all">全部范围</option>
             </select>
           </div>
+          <div id="imageCacheBatchBar" class="image-cache-batch-bar" hidden>
+            <strong id="imageCacheSelectionCount">已选 0 条</strong>
+            <span>选择会跨分页和筛选保留</span>
+            <div class="actions compact">
+              <button id="imageCacheSelectPageBtn" type="button">全选本页</button>
+              <button id="imageCacheInvertPageBtn" type="button">反选本页</button>
+              <button id="imageCacheClearSelectionBtn" type="button">清空选择</button>
+              <button id="imageCacheBulkDeleteBtn" type="button" class="danger">批量删除</button>
+            </div>
+          </div>
           <div class="image-cache-layout">
             <div id="imageCacheList" class="image-cache-list"></div>
             <div id="imageCacheDetail" class="image-cache-detail"></div>
           </div>
+          <nav id="imageCachePager" class="image-cache-pager" aria-label="图片缓存分页"></nav>
         </div>
       </section>
 
@@ -1568,6 +1580,6 @@ QQ空间 = 公开札记
   <script src="./js/ui/appearance.js?v=20260713-font-options"></script>
   <script src="./js/panels/provider-tree.js?v=20260711-provider-debug"></script>
   <script src="./js/panels/qzone-panel.js?v=20260711-qzone-preview-context"></script>
-  <script src="./app.js?v=20260723-feature-save-discard"></script>
+  <script src="./app.js?v=20260723-image-cache-batch"></script>
 </body>
 </html>

--- a/private_image.py
+++ b/private_image.py
@@ -526,8 +526,10 @@ class PrivateImageMixin:
         try:
             path = Path(preview_path).resolve()
             base = self._private_image_cache_preview_dir().resolve()
-            if path.is_file() and path.is_relative_to(base):
-                path.unlink(missing_ok=True)
+            if not path.is_relative_to(base):
+                return
+            path.unlink(missing_ok=True)
+            (base / ".thumbnails" / f"{path.stem}.webp").unlink(missing_ok=True)
         except Exception:
             pass
 
@@ -830,7 +832,11 @@ class PrivateImageMixin:
             cached_keys = {str(value) for value in item.get("image_keys", []) if str(value or "").strip()}
             cached_aliases = {str(value).strip() for value in item.get("image_aliases", []) if str(value or "").strip()}
             if (cached_keys & targets) or (cached_aliases & alias_targets):
-                cache.pop(key, None)
+                removed_item = cache.pop(key, None)
+                if isinstance(removed_item, dict):
+                    self._remove_private_image_cache_preview_file(
+                        _single_line(removed_item.get("preview_path"), 260)
+                    )
                 removed += 1
         if removed:
             logger.info("[PrivateCompanion] 私聊图片视觉缓存已因负反馈失效: removed=%s reason=%s", removed, _single_line(reason, 120))


### PR DESCRIPTION
## 变更内容

<img width="1513" height="1071" alt="image" src="https://github.com/user-attachments/assets/b6c5ad32-df9b-47f5-a878-0a57603c5673" />

这个页面原来图片全是裂的，并且没法批量删除，基本处在不可用状态。
这个pr使用webp thumbnail缩略图的方式加速渲染包含大量图片的前端页面。
并且加了分页，批量编辑方便修改。

修改后
<img width="1629" height="1092" alt="image" src="https://github.com/user-attachments/assets/c9668372-7989-4c61-9f73-341a2bf1bbda" />


这里的修复思路参考了我自己的插件前端[astrbot_plugin_mood_of_the_moment](https://github.com/Kalospacer/astrbot_plugin_mood_of_the_moment)可以试用一下？

改issue#56时怀疑是缓存系统问题就顺手看了这个，然后改了。
另外这个页面的入口真得重新放一下吧，别说我了gpt都找不到入口在哪，有点可怕

使用Codex GPT-5.6-Sol High

- 修复图片/表情包缓存页裂图：图片改由 AstrBot Page bridge 鉴权接口以 base64 数据加载。
- 按需生成并复用 160px WebP 缩略图，源预览更新后自动重建。
- 增加分页、批量编辑模式、单项勾选、全选本页、反选本页和清空选择。
- 选择状态跨分页和筛选条件保留，并支持一次批量删除所选缓存。
- 删除或淘汰缓存时同步清理压缩预览和 WebP 缩略图。

## 根因

原页面把受 Dashboard 鉴权保护的插件 API URL 直接设置为 `<img src>`。插件 Page 运行在 iframe 中，图片请求无法携带 Dashboard Bearer 鉴权，因此列表缩略图和详情预览都会加载失败。

## 影响

缓存页现在可以稳定显示图片，并能在缓存条目较多时分页整理；批量选择不会因换页或修改筛选条件丢失。
