### PR TITLE
fix(proactive_message): 修复在线生图 API 返回 data URI 时下载失败

### DIFF
--- a/proactive_message.py
+++ b/proactive_message.py
@@ -13762,30 +13762,16 @@ Output:
                 first = items[0]
             if not isinstance(first, dict):
                 return "", "在线图片 API 未返回图片数据"
-            b64 = str(first.get("b64_json") or "").strip()
-            if b64:
-                image_bytes = base64.b64decode(b64)
-                path = await self._save_external_generated_image(
-                    image_bytes,
-                    session_key=session_key,
-                    ext=".png",
-                )
+            image_value = str(first.get("b64_json") or first.get("url") or "").strip()
+            if image_value:
                 logger.info(
-                    "[PrivateCompanion] 在线图片 API 生图返回 base64: bytes=%s path=%s",
-                    len(image_bytes),
-                    _single_line(path, 160),
+                    "[PrivateCompanion] 在线图片 API 生图返回: %s",
+                    self._external_image_diagnostic_text(image_value, 180),
                 )
-                note = "ok；上游短暂错误后重试成功" if retried_after_upstream_error else "ok"
-                return path, note if path else "保存在线图片失败"
-            image_url = str(first.get("url") or "").strip()
-            if image_url:
-                logger.info(
-                    "[PrivateCompanion] 在线图片 API 生图返回 URL: %s",
-                    self._external_image_diagnostic_text(image_url, 180),
-                )
-                saved, note = await self._download_external_image_url(
-                    image_url,
+                saved, note = await self._materialize_external_image_value(
+                    image_value,
                     session_key=session_key,
+                    success_note="ok",
                 )
                 if saved and retried_after_upstream_error:
                     note = f"{note}；上游短暂错误后重试成功"
@@ -13911,39 +13897,19 @@ Output:
                 first = items[0]
             if not isinstance(first, dict):
                 return "", "参考图接口未返回图片数据"
-            b64 = str(first.get("b64_json") or "").strip()
-            if b64:
-                generated_bytes = base64.b64decode(b64)
-                saved = await self._save_external_generated_image(
-                    generated_bytes,
-                    session_key=session_key,
-                    ext=".png",
-                )
+            image_value = str(first.get("b64_json") or first.get("url") or "").strip()
+            if image_value:
                 logger.info(
-                    "[PrivateCompanion] 在线图片 API 参考图返回 base64: bytes=%s path=%s",
-                    len(generated_bytes),
-                    _single_line(saved, 160),
+                    "[PrivateCompanion] 在线图片 API 参考图返回: %s",
+                    self._external_image_diagnostic_text(image_value, 180),
                 )
-                if not saved:
-                    return "", "保存在线参考图生图失败"
-                note = "ok；已使用本地人设参考图"
-                if retried_after_upstream_error:
+                saved, note = await self._materialize_external_image_value(
+                    image_value,
+                    session_key=session_key,
+                    success_note="ok；已使用本地人设参考图",
+                )
+                if saved and retried_after_upstream_error:
                     note += "；上游短暂错误后重试成功"
-                return saved, note
-            image_url = str(first.get("url") or "").strip()
-            if image_url:
-                logger.info(
-                    "[PrivateCompanion] 在线图片 API 参考图返回 URL: %s",
-                    self._external_image_diagnostic_text(image_url, 180),
-                )
-                saved, note = await self._download_external_image_url(
-                    image_url,
-                    session_key=session_key,
-                )
-                if saved:
-                    note = "ok；已使用本地人设参考图"
-                    if retried_after_upstream_error:
-                        note += "；上游短暂错误后重试成功"
                 return saved, note
             return "", "参考图接口未返回 url 或 b64_json"
         except asyncio.TimeoutError:


### PR DESCRIPTION
#60 的pr 使用claude desktop GLM-5.2
这个pr不包括 astrbot_plugin_private_companion
No module named 'data.plugins.astrbot_plugin_private_companion.group_member_safety'修复，因为这个我导入不了也没法测试
main.py:141 from .group_member_safety import GroupMemberSafetyMixin，但插件目录里根本没有 group_member_safety.py 这个文件——上游漏传了。

所以这个pr没经过测试，麻烦自己补一下

`proactive_message.py` 中解析在线图片 API 响应的两条路径——普通 generations 与参考图 edits——原本各自手写「`b64_json` 优先、`url` 走 `_download_external_image_url` 下载」逻辑，漏了 `url` 字段塞 data URI 的情况。部分 NewAPI/OpenAI 兼容中转会把图片以 `data:image/png;base64,...` 形式放进 `url` 字段返回，aiohttp 不支持 `data:` scheme 直接抛异常，导致整条生图链路失败。

改为统一取 `b64_json or url` 后调用已有的 `_materialize_external_image_value`，它已经正确处理 data URI / 裸 base64 / HTTP URL 三种返回。`retried_after_upstream_error` 后缀逻辑保留。

## 改动范围

仅 `proactive_message.py`，两处响应解析路径，+22 / -56。