### PR TITLE
fix(private_image): 文字请求认领图片上下文后抑制防抖 finalizer 重复派发

### DIFF
--- a/private_image.py
+++ b/private_image.py
@@ -4220,6 +4220,9 @@ class PrivateImageMixin:
         )
         if isinstance(buffer, dict) and now - live_updated_ts <= max_live_age:
             handoffs.pop(key, None)
+            # 标记图片上下文已被本轮文字请求认领,防抖 finalizer 检查到该标记后
+            # 会跳过延迟派发,避免同一张图产生第二条无视觉摘要的回复。
+            buffer["vision_context_claimed_ts"] = now
             images = buffer.pop("images", [])
             image_limit = self._private_image_vision_text_limit(len(images))
             return {
@@ -4989,6 +4992,15 @@ class PrivateImageMixin:
         )
         if has_followup:
             logger.info("[PrivateCompanion] 私聊单图已由补充消息接管: user=%s", user_id)
+            return
+        claimed_ts = _safe_float(buffer.get("vision_context_claimed_ts"), 0.0)
+        if claimed_ts > 0:
+            logger.info(
+                "[PrivateCompanion] 私聊单图上下文已由补充文字请求认领,跳过延迟派发: user=%s claimed_ago=%.1fs",
+                user_id,
+                max(0.0, _now_ts() - claimed_ts),
+            )
+            buffers.pop(key, None)
             return
         original_event = buffer.get("original_event")
         delayed_buffer = dict(buffer)


### PR DESCRIPTION
#63 使用 claude-fable-5

防抖窗口内补发的文字消息走独立 pipeline，其 on_llm_request 注入通过
_take_buffered_private_image_context_for_event 破坏性 pop 认领了图片 上下文（含 vision_task），但 finalizer 的接管检查只看 buffer["messages"]， 看不到这种认领，仍会派发一个 vision 必为空的合成图片事件，命中
image.only.fallback 后回复"没看清图"，造成同一张图两条回复。

live buffer 认领时打 vision_context_claimed_ts 标记，finalizer 检查到 标记即按补充消息接管处理，跳过延迟派发。

## 修复

认领即接管：

- `_take_buffered_private_image_context_for_event` live buffer 分支 pop 前在 buffer 上写 `vision_context_claimed_ts` 标记；
- finalizer 在派发前检查该标记，命中则按"已由补充文字请求认领"记日志并跳过延迟派发（同时清理 buffer）。

图片上下文由认领它的文字请求负责回应，一轮只出一条回复。共 12 行，不影响纯图无补充文字的既有链路（无认领标记时行为完全不变）。