### PR TITLE
feat: 添加 open-meteo 和高德地图天气数据源

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -10086,13 +10086,52 @@
   "weather_config": {
     "description": "天气上下文与屏幕日记",
     "type": "object",
-    "hint": "推荐先只开启天气上下文：已安装并配置 screen_companion 时会自动复用其天气能力；需要独立查询时，再填写 OpenWeatherMap Key 和一个地点（城市优先，经纬度二选一）。",
+    "hint": "推荐先只开启天气上下文：已安装并配置 screen_companion 时会自动复用其天气能力；独立查询可选择 OpenWeatherMap、Open-Meteo 或高德地图 API。",
     "items": {
       "enable_weather_context": {
         "description": "启用天气上下文",
         "type": "bool",
-        "hint": "开启后优先使用本插件的 OpenWeatherMap 配置；尚未配置自建天气时，会尝试回退复用 screen_companion。天气只作为日程、日记和主动契机的背景，不会每句聊天都提。",
+        "hint": "开启后优先使用本插件配置的天气数据源；尚未配置自建天气时，会尝试回退复用 screen_companion。天气只作为日程、日记和主动契机的背景，不会每句聊天都提。",
         "default": true
+      },
+      "weather_source": {
+        "description": "天气数据源",
+        "type": "string",
+        "options": [
+          "openweathermap",
+          "openmeteo",
+          "amap"
+        ],
+        "labels": [
+          "OpenWeatherMap",
+          "Open-Meteo",
+          "高德地图 API"
+        ],
+        "hint": "OpenWeatherMap 需要 API Key；Open-Meteo 无需 Key，但必须填写经纬度；高德地图 API 需要 API Key 和城市编码。",
+        "default": "openweathermap",
+        "condition": {
+          "enable_weather_context": true
+        }
+      },
+      "weather_amap_api_key": {
+        "description": "高德地图 API Key",
+        "type": "string",
+        "hint": "高德开放平台 Web 服务 API Key；仅高德地图数据源使用。",
+        "default": "",
+        "condition": {
+          "enable_weather_context": true,
+          "weather_source": "amap"
+        }
+      },
+      "weather_amap_city": {
+        "description": "高德城市编码",
+        "type": "string",
+        "hint": "填写高德城市 adcode，例如东城区 110101；可从[高德城市编码表](https://a.amap.com/lbs/static/code_resource/AMap_adcode_citycode.zip)查询。",
+        "default": "",
+        "condition": {
+          "enable_weather_context": true,
+          "weather_source": "amap"
+        }
       },
       "weather_api_key": {
         "description": "天气 API Key",
@@ -10100,22 +10139,24 @@
         "hint": "仅独立查询时需要。访问 https://home.openweathermap.org/api_keys 创建 Key 后粘贴；还必须再填写“天气城市”或一组经纬度。留空时会尝试复用 screen_companion 的天气能力。",
         "default": "",
         "condition": {
-          "enable_weather_context": true
+          "enable_weather_context": true,
+          "weather_source": "openweathermap"
         }
       },
       "weather_city": {
         "description": "天气城市（推荐）",
         "type": "string",
-        "hint": "最省事的定位方式，例如 Beijing,CN、Shanghai,CN。城市已填写时会优先使用它，下面的经纬度会被忽略；不填城市才会使用经纬度。",
+        "hint": "仅 OpenWeatherMap 使用，例如 Beijing,CN、Shanghai,CN；城市已填写时会优先使用它，不填城市才会使用经纬度。Open-Meteo 必须填写经纬度。",
         "default": "",
         "condition": {
-          "enable_weather_context": true
+          "enable_weather_context": true,
+          "weather_source": "openweathermap"
         }
       },
       "weather_lat": {
         "description": "天气纬度",
         "type": "float",
-        "hint": "只在“天气城市”留空时生效。需与经度成对填写，例如北京约 39.9042。",
+        "hint": "使用 Open-Meteo 必须填写，并需与经度成对；OpenWeatherMap 仅在城市留空时使用，例如北京约 39.9042；使用高德地图 API 不需要填写经纬度。",
         "default": 0,
         "condition": {
           "enable_weather_context": true
@@ -10124,7 +10165,7 @@
       "weather_lon": {
         "description": "天气经度",
         "type": "float",
-        "hint": "只在“天气城市”留空时生效。需与纬度成对填写，例如北京约 116.4074。",
+        "hint": "使用 Open-Meteo 必须填写，并需与纬度成对；OpenWeatherMap 仅在城市留空时使用，例如北京约 116.4074；使用高德地图 API 不需要填写经纬度。",
         "default": 0,
         "condition": {
           "enable_weather_context": true

--- a/daily_state.py
+++ b/daily_state.py
@@ -138,6 +138,40 @@ DEFAULT_NEWS_SOURCES = "\n".join(
 
 DEFAULT_PERSONA_PROMPT_FALLBACK = "未读取到 AstrBot 默认人格。请保持简洁、温和、有边界,不额外创造新身份。"
 
+
+def _openmeteo_weather_description(code: Any) -> str:
+    try:
+        code = int(code)
+    except (TypeError, ValueError):
+        return "未知"
+    if code == 0:
+        return "晴天"
+    if code == 1:
+        return "少云"
+    if code == 2:
+        return "多云"
+    if code == 3:
+        return "阴天"
+    if code in {45, 48}:
+        return "雾"
+    if 51 <= code <= 55:
+        return "毛毛雨"
+    if code in {56, 57}:
+        return "冻毛毛雨"
+    if 61 <= code <= 65:
+        return "降雨"
+    if code in {66, 67}:
+        return "冻雨"
+    if 71 <= code <= 77:
+        return "降雪"
+    if 80 <= code <= 82:
+        return "阵雨"
+    if code in {85, 86}:
+        return "阵雪"
+    if 95 <= code <= 99:
+        return "雷暴"
+    return "未知"
+
 LEGACY_DEFAULT_NEWS_SOURCES = "\n".join(
     [
         "BBC中文|https://feeds.bbci.co.uk/zhongwen/simp/rss.xml",
@@ -4006,12 +4040,14 @@ class DailyStateMixin:
         today = _today_key()
         if not self.enable_weather_context:
             return {"date": today, "prompt": "暂无天气信息", "source": "disabled"}
+        weather_source = getattr(self, "weather_source", "openweathermap")
         cached = self.data.get("daily_weather", {})
         if isinstance(cached, dict):
             fetched_at = _safe_float(cached.get("fetched_ts"), 0)
             if (
                 not force
                 and cached.get("date") == today
+                and cached.get("weather_source", "openweathermap") == weather_source
                 and _now_ts() - fetched_at < self.weather_refresh_minutes * 60
             ):
                 return cached
@@ -4037,6 +4073,7 @@ class DailyStateMixin:
             "date": today,
             "prompt": prompt,
             "source": source,
+            "weather_source": weather_source,
             "fetched_ts": _now_ts(),
         }
         async with self._data_lock:
@@ -4332,7 +4369,101 @@ class DailyStateMixin:
             text = text[:max_chars]
         return text or "暂无可用的昨日屏幕观察日记。"
 
+    async def _fetch_openmeteo_weather(self) -> dict[str, str]:
+        try:
+            lat = float(getattr(self, "weather_lat", 0))
+            lon = float(getattr(self, "weather_lon", 0))
+        except (TypeError, ValueError):
+            return {"prompt": "", "source": ""}
+        if (
+            not math.isfinite(lat)
+            or not math.isfinite(lon)
+            or not -90 <= lat <= 90
+            or not -180 <= lon <= 180
+            or lat == 0 and lon == 0
+        ):
+            return {"prompt": "", "source": ""}
+        params = urlencode(
+            {
+                "latitude": lat,
+                "longitude": lon,
+                "current": "temperature_2m,weather_code",
+            }
+        )
+        url = f"https://api.open-meteo.com/v1/forecast?{params}"
+        try:
+            import aiohttp
+
+            timeout = aiohttp.ClientTimeout(total=10)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.get(url) as response:
+                    if response.status != 200:
+                        logger.debug(f"[PrivateCompanion] Open-Meteo 天气请求失败: {response.status}")
+                        return {"prompt": "", "source": ""}
+                    weather_data = await response.json()
+        except Exception as e:
+            logger.debug(f"[PrivateCompanion] Open-Meteo 天气获取失败: {e}")
+            return {"prompt": "", "source": ""}
+        try:
+            if not isinstance(weather_data, dict):
+                return {"prompt": "", "source": ""}
+            current = weather_data.get("current")
+            if not isinstance(current, dict):
+                return {"prompt": "", "source": ""}
+            temperature = float(current["temperature_2m"])
+            weather_code = int(current["weather_code"])
+            if not math.isfinite(temperature):
+                return {"prompt": "", "source": ""}
+            description = _openmeteo_weather_description(weather_code)
+            return {
+                "prompt": f"当前天气 {description},约 {temperature:g}°C。",
+                "source": "openmeteo",
+            }
+        except (AttributeError, KeyError, TypeError, ValueError):
+            return {"prompt": "", "source": ""}
+
+    async def _fetch_amap_weather(self) -> dict[str, str]:
+        key = str(getattr(self, "weather_amap_api_key", "") or "").strip()
+        city = str(getattr(self, "weather_amap_city", "") or "").strip()
+        if not key or not city:
+            return {"prompt": "", "source": ""}
+        url = "https://restapi.amap.com/v3/weather/weatherInfo?" + urlencode(
+            {"key": key, "city": city, "extensions": "base", "output": "JSON"}
+        )
+        try:
+            import aiohttp
+
+            async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
+                async with session.get(url) as response:
+                    if response.status != 200:
+                        logger.debug(f"[PrivateCompanion] 高德天气请求失败: {response.status}")
+                        return {"prompt": "", "source": ""}
+                    weather_data = await response.json()
+        except Exception as e:
+            logger.debug(f"[PrivateCompanion] 高德天气获取失败: {e}")
+            return {"prompt": "", "source": ""}
+        try:
+            if not isinstance(weather_data, dict) or str(weather_data.get("status")) != "1":
+                return {"prompt": "", "source": ""}
+            lives = weather_data.get("lives")
+            live = lives[0] if isinstance(lives, list) and lives else None
+            if not isinstance(live, dict) or not str(live.get("weather") or "").strip():
+                return {"prompt": "", "source": ""}
+            temperature = float(live["temperature"])
+            if not math.isfinite(temperature):
+                return {"prompt": "", "source": ""}
+            return {
+                "prompt": f"当前天气 {live['weather']}，约 {temperature:g}°C。",
+                "source": "amap",
+            }
+        except (KeyError, TypeError, ValueError):
+            return {"prompt": "", "source": ""}
+
     async def _fetch_own_weather_prompt(self) -> dict[str, str]:
+        if getattr(self, "weather_source", "openweathermap") == "amap":
+            return await self._fetch_amap_weather()
+        if getattr(self, "weather_source", "openweathermap") == "openmeteo":
+            return await self._fetch_openmeteo_weather()
         if not self.weather_api_key:
             return {"prompt": "", "source": ""}
         url = self._build_weather_url()

--- a/main.py
+++ b/main.py
@@ -1587,8 +1587,13 @@ class PrivateCompanionPlugin(
             else str(raw_natural_photo_extra).strip()
         )
         self.enable_weather_context = self._cfg_bool(c, "enable_weather_context", True)
+        self.weather_source = self._cfg_str(c, "weather_source", "openweathermap").lower()
+        if self.weather_source not in {"openweathermap", "amap", "openmeteo"}:
+            self.weather_source = "openweathermap"
         self.weather_api_key = self._cfg_str(c, "weather_api_key", "")
         self.weather_city = self._cfg_str(c, "weather_city", "")
+        self.weather_amap_api_key = self._cfg_str(c, "weather_amap_api_key", "")
+        self.weather_amap_city = self._cfg_str(c, "weather_amap_city", "")
         self.weather_lat = self._cfg_float(c, "weather_lat", 0.0, -90.0)
         self.weather_lon = self._cfg_float(c, "weather_lon", 0.0, -180.0)
         self.weather_refresh_minutes = self._cfg_int(c, "weather_refresh_minutes", 90, 10, 720)


### PR DESCRIPTION
## 关联 Issue

#66  

## 改动

新增 `weather_source` 配置选项，支持在 OpenWeatherMap、Open-Meteo、
高德地图三种天气数据源之间切换。

### 新增配置项

| 字段 | 类型 | 默认值 | 说明 |
|------|------|--------|------|
| `weather_source` | select | `openweathermap` | `openweathermap` / `openmeteo` / `amap` |
| `weather_amap_api_key` | string | `""` | 高德地图 Web 服务 API Key |
| `weather_amap_city` | string | `""` | 高德城市 adcode（区县级） |

### 代码变更

- **`_conf_schema.json`**: 新增三个配置字段及 WebUI 展示定义
- **`main.py`**: 读取 `weather_source`、`weather_amap_api_key`、`weather_amap_city`
- **`daily_state.py`**:
    - `_fetch_own_weather_prompt()` — 增加配置分发逻辑，根据 `weather_source` 调用对应方法
    - `_fetch_openmeteo_weather()` — 新增，调用 Open-Meteo 免费 API，无需 Key
    - `_fetch_amap_weather()` — 新增，调用高德 `/v3/weather/weatherInfo` 实况接口
    - `_ensure_weather_context()` — 缓存增加 `weather_source` 键，切换数据源时自动失效

### 兼容性

- `weather_source` 默认值为 `"openweathermap"`，已有用户无影响
- Open-Meteo 复用已有的 `weather_lat` / `weather_lon`
- 高德使用独立 API Key 和城市编码，不依赖经纬度
