### PR TITLE
fix: 修复私聊单图延迟回复丢失 TTS 语音块

### DIFF
--- a/private_image.py
+++ b/private_image.py
@@ -3657,6 +3657,26 @@ class PrivateImageMixin:
             cleaned = re.sub(r"(?<=[\u4e00-\u9fff…！？?！~～])\s+(?=[\u4e00-\u9fff])", "\n", cleaned)
         return cleaned.strip()
 
+    def _restore_private_image_framework_tts_reply(
+        self,
+        reply: str,
+        framework_event: AstrMessageEvent,
+    ) -> str:
+        source = str(reply or "").strip()
+        if "[[PCTTS:" not in source:
+            return source
+        restorer = getattr(self, "_restore_protected_tts_blocks", None)
+        if not callable(restorer):
+            return source
+        try:
+            return str(restorer(source, framework_event) or source).strip()
+        except Exception as exc:
+            logger.warning(
+                "[PrivateCompanion] 私聊单图主链 TTS 占位符恢复失败: %s",
+                _single_line(exc, 120),
+            )
+            return source
+
     def _private_image_reply_ignores_vision_summary(self, text: str) -> bool:
         compact = re.sub(r"\s+", "", str(text or ""))
         if not compact:
@@ -4786,6 +4806,10 @@ class PrivateImageMixin:
                 reply = str(getattr(llm_resp, "completion_text", "") or "").strip()
             if "reply_source" not in locals():
                 reply_source = "main_chain"
+            reply = self._restore_private_image_framework_tts_reply(
+                reply,
+                framework_event,
+            )
             if reply and self._private_image_reply_is_internal_error(reply):
                 logger.warning(
                     "[PrivateCompanion] 私聊单图主链返回内部错误文本,已拦截转入兜底: user=%s preview=%s",


### PR DESCRIPTION
#69 使用macaron v1 venti调查 gpt-5.6-sol 修复


开启 TTS 增强后，用户在私聊中只发送图片、不附带文字，并等待图片防抖窗口结束时，延迟回复中的 `<tts>...</tts>` 语音块可能被静默删除。

这条路径会创建一个独立的 `SyntheticPrivateWakeEvent` 作为 `framework_event` 运行 AstrBot 主链。TTS 响应保护 hook 会把 `<tts>` 块替换为 `[[PCTTS:...]]`，并将 token 映射保存到 `framework_event._private_companion_tts_block_tokens`。

但最终手动发送回复时，插件使用的是原始平台 `event`：

```python
sent_reply = await self._send_private_image_reply_text(event, reply)
```

原始 `event` 和 `framework_event` 虽然具有相同的 `unified_msg_origin`，但并不是同一个对象，也不共享实例属性。因此发送链无法从原始 `event` 找到 token 映射，随后把 `[[PCTTS:...]]` 当作孤儿占位符删除，语音正文随之丢失。

### 本次改动

本次只修改 `private_image.py`，共增加 24 行。

1. 新增 `_restore_private_image_framework_tts_reply()`。

   该方法负责在回复离开合成主链事件作用域前，使用创建 token 的 `framework_event` 恢复 `<tts>` 块。

   - 普通回复不包含 `[[PCTTS:` 时直接返回，不增加额外处理。
   - TTS 恢复器不可用时保持原文，由现有孤儿占位符清理继续兜底。
   - 恢复异常时记录明确日志并保持原文，避免异常打断整个私聊单图回复。

2. 在提取主链 `completion_text` 后立即恢复 TTS token。

   恢复发生在以下逻辑之前：

   - 内部错误回复检查；
   - “模型看不到图片”检查；
   - 旧上下文漂移检查；
   - 日志预览；
   - 图片反馈目标记录；
   - 最终手动发送。

   最终消息仍由原始平台 `event` 发送，没有改变 aiocqhttp 等平台适配器的投递路径。

### 为什么这样修改

`[[PCTTS:...]]` 是主链内部的临时保护格式，它的有效范围与创建 token 的事件对象一致。`reply` 从 `framework_event` 的 LLM 响应中提取出来时，正好处于离开该事件作用域的边界，因此这里是最明确、最小的恢复位置。

在这里恢复可以一次解决三个问题：

- 最终发送链能够重新识别 `<tts>` 块并调用 TTS Provider；
- 回复质量检查能够看到 `<tts>` 内的真实正文，不会被随机 token 绕过；
- `last_private_image_vision_feedback_target.reply` 等后续数据不会保存内部 `PCTTS` token。

同时保留 `_private_image_reply_chain` 中现有的恢复和孤儿占位符清理逻辑，继续作为其他路径的兜底保护。

### 为什么不把 token 映射复制到原始 event

在最终发送前把 `_private_companion_tts_block_tokens` 从 `framework_event` 复制到原始 `event`，确实可以让语音恢复，但只能修复发送阶段：

- 更早执行的回复质量检查仍然只能看到 `[[PCTTS:...]]`；
- 图片反馈目标仍可能持久化内部 token；
- 原始平台事件会被写入本属于合成主链事件的临时状态；
- 后续如果出现更多事件级临时属性，容易继续增加逐字段复制。

因此，本 PR 在事件交接边界恢复回复内容，不迁移事件内部状态。

### 为什么不直接使用 framework_event 发送

`SyntheticPrivateWakeEvent.send()` 使用 `context.send_message(...)`。直接用它发送会改变原始平台事件的投递路径，可能影响回复关联、平台特有行为、发送记录和异常处理。

合成事件仍只负责运行主链，原始平台事件继续负责最终发送。

### 用户影响

- 私聊只发图片的延迟回复可以正常保留并合成 TTS 语音块。
- `<tts>` 外的可见正文行为保持不变。
- TTS 块内的“看不到图片”、内部错误或旧上下文内容可以继续被现有质量检查识别。
- 无效或历史孤儿 token 仍会被清理，不会泄漏到聊天界面。
- 无 TTS 的普通私聊图片回复不受影响。