### PR TITLE
fix: preserve TTS placeholders through passive response review

### DIFF
--- a/user_memory.py
+++ b/user_memory.py
@@ -5833,6 +5833,10 @@ Local classifier result:
         creative_context: str = "",
         review_event: Any | None = None,
     ) -> str:
+        # 带 TTS 保护占位符的回复不参与自检改写：本函数所有分支都会整段替换正文，
+        # 占位符一旦丢失，_restore_protected_tts_blocks 就无法还原语音块，只会发出纯文字。
+        if "[[PCTTS:" in str(response_text or ""):
+            return response_text
         relay_claim_checker = getattr(self, "_unexecuted_relay_claim_reason", None)
         if callable(relay_claim_checker):
             relay_claim_note = relay_claim_checker(response_text)
@@ -7174,7 +7178,8 @@ bot_promises 只记录 Bot 明确承诺要提醒、记住、转述、发送或�
         return False, ""
 
     def _response_review_flags(self, text: str, user: dict[str, Any], *, inbound_text: str = "") -> list[str]:
-        cleaned = str(text or "").strip()
+        # TTS 保护占位符不是可见正文，若参与长度/句数/段落统计会把带语音的短回复误判成过度解释。
+        cleaned = re.sub(r"\[\[PCTTS:[^\]]*\]\]", "", str(text or "")).strip()
         flags: list[str] = []
         if not cleaned:
             return flags


### PR DESCRIPTION
## 问题

私聊说「发条语音」时，语音已经正常生成，但最终只发出纯文字；群聊同样一句话可以正常发出语音。

复现日志（插件 5.10.7）：

私聊——

```
07:19:04.173 [user_memory:5987] 被动回复模型自检完成: mode=severe_only flags=casual_overexplained elapsed=5149ms
07:19:04.188 [respond.stage:206] Prepare to send - ……又来了。我没死，测试结束。
```

群聊，同样的输入——

```
06:46:31.840 [tts_enhancement:4213] FishAudio TTS 已应用模型请求头
06:46:33.105 [tts_enhancement:4323] TTS语音组件已生成: 语音：朝だよ。[強調]起きて。
06:46:33.107 [respond.stage:206] Prepare to send - [ComponentType.Record]
```

## 原因

1. `main.py:10337` 先把 `<tts>…</tts>` 保护成 `[[PCTTS:<hex>]]` 占位符
2. `main.py:10458` 处 `if not is_private_chat: return` —— 群聊到此为止，私聊继续往下
3. 私聊走到 `main.py:10589` 的 `_review_and_rewrite_response`
4. `_response_review_flags` 用**含占位符的原文**统计段落数，占位符独占一行使 `paragraph_count>=2`，打上 `casual_overexplained`
5. 该 flag 属于 severe，`severe_only` 模式下照样送模型改写；改写 prompt 里 `{response_text}` 带着占位符进了模型，而要求列表中没有任何一条说明要保留它
6. 改写后占位符消失，`_restore_protected_tts_blocks` 无从还原，最终发出纯文字

按默认配置复算：`response_review_max_chars=260` → casual 阈值 130 字，而正文只有 34 字远未超限，**仅凭占位符换行就足以触发**。

## 改动

1. `_review_and_rewrite_response` 开头短路：该函数所有分支（relay_claim / music_album / local_only / 模型改写 / casual fallback）都会整段替换正文，任何一条走通都会丢掉占位符，因此含占位符的回复直接返回原文。

2. `_response_review_flags` 在统计长度、句数、段落数之前剥离占位符，避免带语音的短回复被误判。该函数 `group_observation.py:3377` 也在调用，这一处同样受益。

共 6 行新增、1 行修改，不涉及其他链路。

## 测试

- 打补丁前后用同一条回复文本复算 flag：`paragraph_count` 由 2 降为 1，`casual_overexplained` 不再误触发
- 实机验证：私聊「发条语音」可以正常发出语音，群聊行为无变化
- 常规私聊回复（不含占位符）走原有自检逻辑，未受影响

## 备注

`private_image.py:4024` 在改动文本前会先调 `_restore_protected_tts_blocks` 还原，自检这条链路缺少对应处理。

第 1 条的代价是带语音的那一轮会跳过自检。若希望两者兼得，需要把占位符摘出、改写可见正文后再拼回，但语音块与可见正文存在对应关系，改写后未必还能对上，因此这里选择了保守方案。如果您倾向别的做法，我可以照着改。

另外，这类「占位符被下游环节破坏导致无语音」的问题，更新日志里 4.1.6（发送前标签清理）、5.6.14（单图分段发送）、5.10.7（单图延迟回复）已经在别的链路修过三轮，是否值得做一层统一防护，由您判断。