### PR TITLE
修复 QQ 图床直链导致引用/合并消息中的图片无法进入视觉理解

### DIFF
--- a/forward_message.py
+++ b/forward_message.py
@@ -1710,7 +1710,14 @@ class ForwardMessageMixin:
             if not text:
                 return False
             if text.startswith(("http://", "https://", "file://", "data:")):
-                return bool(re.search(r"\.(?:png|jpe?g|gif|webp|bmp)(?:[?#].*)?$", text, re.I) or "/bfs/" in text or "image" in text.lower())
+                lowered = text.lower()
+                if re.search(r"\.(?:png|jpe?g|gif|webp|bmp)(?:[?#].*)?$", text, re.I) or "/bfs/" in text or "image" in lowered:
+                    return True
+                # QQ 图床(NTQQ multimedia / qpic)的下载直链不带扩展名, 只能按域名识别;
+                # 同一域名也会下发语音等非图片文件, 按 format 参数排除。
+                if any(host in lowered for host in ("multimedia.nt.qq.com", "qpic.cn")):
+                    return not re.search(r"[?&]format=(?:amr|silk|mp3|m4a|wav|ogg|mp4)\b", lowered)
+                return False
             return bool(
                 re.search(r"(?:^|[A-Za-z]:\\|/).+\.(?:png|jpe?g|gif|webp|bmp)$", text, re.I)
             )

--- a/private_image.py
+++ b/private_image.py
@@ -278,6 +278,7 @@ class PrivateImageMixin:
                         chunks.append(chunk)
                 data = b"".join(chunks)
                 if not data:
+                    logger.info("[PrivateCompanion] 私聊远程图片响应为空,跳过: url=%s", _single_line(text, 120))
                     return ""
                 prefix = data[:16]
                 suffix = ".jpg"
@@ -315,7 +316,14 @@ class PrivateImageMixin:
                 if persisted and persisted not in prepared:
                     prepared.append(persisted)
                 continue
-            if self._private_image_source_to_model_url(source) and source not in prepared:
+            if not self._private_image_source_to_model_url(source):
+                logger.info(
+                    "[PrivateCompanion] 本地图片源不可读,已跳过: namespace=%s source=%s",
+                    namespace,
+                    _single_line(source, 160),
+                )
+                continue
+            if source not in prepared:
                 prepared.append(source)
         return prepared
 


### PR DESCRIPTION
## 问题

用户引用一张图片并 @ Bot 提问时，Bot 始终看不到图片内容。日志稳定输出：

```
[PrivateCompanion] 引用消息图片已解析: message_id=xxx images=2
[PrivateCompanion] 合并/引用图片视觉跳过: 图片源无法转为模型可读源 original=1
[PrivateCompanion] 已注入引用卡片上下文: texts=0 links=1 images=1 vision=False
```

同一时间段直接在群里发图是正常的（`群聊图片视觉转述完成`），只有引用/合并路径失效。

环境：插件 5.10.7、NapCat（OneBot v11 / aiocqhttp）。

## 根因

NapCat 传来的引用消息是一个 OneBot 图片段：

```
{type: "image", data: {summary, file, sub_type, url, file_size}}
```

`_extract_reply_rich_card_info()` 按**键名关键词**把字段分流：

| 字段 | 命中的规则 | 去向 | 实际值 |
| --- | --- | --- | --- |
| `file` | 键名含 `file` → `add_image()` | **images** | 裸文件名，如 `04d0….gif` |
| `url` | 键名含 `url` → `add_link()` | links | 真正可下载的直链 |

`url` 的值在递归到字符串分支时还有一次进 images 的机会，但被 `looks_like_image_source()` 拦下了。NTQQ 的图片直链形如：

```
https://multimedia.nt.qq.com.cn/download?appid=1407&fileid=…&rkey=…
```

它对三个判据全部不命中——结尾没有 `.png/.jpg/.gif` 扩展名、不含 `/bfs/`、URL 里也没有 `image` 字样，于是被判定为“不是图片源”。

结果 `images` 里只剩 `data.file` 的**裸文件名**。它既不匹配 `^https?://`，在 AstrBot 侧也不是有效路径，`_prepare_private_image_sources_for_model()` 走 `_private_image_source_to_model_url()` 得到空串后直接跳过，`prepared` 为空，最终恒定输出「图片源无法转为模型可读源」。

也就是说：**唯一能下载的源被判成非图片，真正进入流程的源必然不可读**，引用图片 100% 看不到。

## 排查证据

1. **直链本身完全正常。** 用插件同款 UA 手动请求日志里那条 URL：`200` / `Content-Type: image/gif` / `717414` 字节。不是 rkey 过期，也不是网络问题。

2. **文件从未落盘。** `plugin_data/<plugin>/private_inbound_images/forward_vision` 目录 mtime 长期不变且为空；而直接发图用的 `group_vision` 有正常写入记录。说明引用路径根本没触发过下载。

3. **失败是静默的。** `_persist_private_remote_image_source()` 里“过大 / 超限 / 非图片 / 异常”四种失败都有日志，而故障时间点一条都没出现——只可能走了没有日志的分支，即上面那次跳过。

4. **打补丁后即恢复。** 同一条引用图片链路的日志变成：

```
本地图片源不可读,已跳过: namespace=forward_vision source=A2AC….jpg   ← 裸文件名，符合预期
合并消息图片视觉完成: images=1 chars=128 preview=第1张：聊天记录；…
已注入引用卡片上下文: images=2 vision=True
```

裸文件名照常跳过，直链下载成功并完成识别。

## 改动

**`forward_message.py` — `looks_like_image_source()`**

对 QQ 图床（`multimedia.nt.qq.com`、`qpic.cn`）按域名识别直链。同一域名也会下发语音等非图片文件（实际日志中出现过 `appid=1403&format=amr` 的链接进入该路径），因此用 `format` 参数排除，避免把语音当图片下载一次。

原有三个判据保持不变，仅在其全部不命中时才走新增分支，其它平台的链接判定不受影响。

**`private_image.py` — 两处补日志**

- `_prepare_private_image_sources_for_model()`：本地图片源不可读时记录 `namespace` 和 `source`
- `_persist_private_remote_image_source()`：远程响应体为空时记录 `url`

这两处原本是仅有的**无日志**失败分支，也是该问题难以从日志定位的直接原因（日志上只看得到最终的“图片源无法转为模型可读源”）。此改动只增加 INFO 日志，不改变控制流。

## 验证

**1. 生产环境实证。** 即上面证据 4：打补丁前恒定失败，打补丁后同一链路恢复识别。

**2. 判定函数用例。** 从改后源文件中抽出 `looks_like_image_source()` 实测 15 例全通过：

| 输入 | 期望 | 结果 |
| --- | --- | --- |
| NTQQ 图片直链（故障链接） | True | ✅ |
| NTQQ 语音直链 `format=amr` | False | ✅ |
| NTQQ 语音 `format=silk` | False | ✅ |
| `gchat.qpic.cn` 群图床 | True | ✅ |
| `c2cpicdw.qpic.cn` 私聊图床 | True | ✅ |
| 普通 `.png` / 带参数 `.jpg?x=1` | True | ✅ |
| B站 `/bfs/` | True | ✅ |
| URL 含 `image` 关键字 | True | ✅ |
| 裸文件名（交本地分支处理） | True | ✅ |
| 本地绝对路径 / `file://` URI | True | ✅ |
| 普通网页、QQ空间链接（不应误收） | False | ✅ |
| 空串 | False | ✅ |

**3.** `py_compile` 通过；改动文件无异常控制字符；未新增配置项，不改变既有默认行为。

