### PR TITLE
fix: 修复参考图库误报未保存更改

### DIFF
--- a/pages/companion-panel/app.js
+++ b/pages/companion-panel/app.js
@@ -575,9 +575,10 @@ function beginFeatureDetailSession(featureKey) {
   state.featureDetailDirty = false;
 }
 
-function rememberFeatureParamDraft(control) {
+function rememberFeatureParamDraft(control, { allowPhotoReferenceCatalog = false } = {}) {
   const key = String(control?.dataset?.featureParam || "").trim();
   if (!key) return;
+  if (key === "photo_reference_catalog" && !allowPhotoReferenceCatalog) return;
   const value = collectSettingValue(key, control);
   state.featureDetailParamDraft = {
     ...(state.featureDetailParamDraft || {}),
@@ -613,7 +614,10 @@ function featureDetailFormSignature(root = document) {
   page.querySelectorAll("[data-feature-param]").forEach((input) => {
     const paramKey = String(input.dataset.featureParam || "").trim();
     if (!paramKey) return;
-    params[paramKey] = collectSettingValue(paramKey, input);
+    const value = collectSettingValue(paramKey, input);
+    params[paramKey] = paramKey === "photo_reference_catalog"
+      ? photoReferenceCatalogSignature(value)
+      : value;
   });
   return JSON.stringify({
     key,
@@ -22878,20 +22882,29 @@ function currentPhotoReferenceCatalogValue() {
   return state.overview?.settings?.photo_reference_catalog || [];
 }
 
-function parsePhotoReferenceCatalog(value) {
+function parsePhotoReferenceCatalog(value, { generateMissingIds = true } = {}) {
   let rawItems = Array.isArray(value) ? value : [];
   if (typeof value === "string" && value.trim()) {
+    const text = value.trim();
     try {
-      const parsed = JSON.parse(value);
+      const parsed = JSON.parse(text);
       if (Array.isArray(parsed)) rawItems = parsed;
     } catch (_error) {
-      rawItems = [];
+      rawItems = text.split(/\r?\n/)
+        .map((line) => {
+          try {
+            return JSON.parse(line);
+          } catch (_lineError) {
+            return null;
+          }
+        })
+        .filter(Boolean);
     }
   }
   return rawItems
     .filter((item) => item && typeof item === "object" && ["persona", "library"].includes(String(item.kind || "")))
     .map((item) => ({
-      id: String(item.id || (item.kind === "persona" ? "persona" : newPhotoReferenceId())),
+      id: String(item.id || (item.kind === "persona" ? "persona" : generateMissingIds ? newPhotoReferenceId() : "")),
       kind: String(item.kind),
       source: normalizePhotoReferenceSource(item.source),
       note: String(item.note || "").trim(),
@@ -22905,6 +22918,24 @@ function parsePhotoReferenceCatalog(value) {
         metadata_source: String(item.metadata_source || "configured"),
       },
     }));
+}
+
+function photoReferenceCatalogSignature(value) {
+  return JSON.stringify(
+    parsePhotoReferenceCatalog(value, { generateMissingIds: false }).map((item) => ({
+      id: item.kind === "persona" ? "persona" : String(item.id || ""),
+      kind: item.kind,
+      source: item.source,
+      note: item.note,
+      reference_roles: item.metadata.reference_roles,
+      outfit_category: item.metadata.outfit_category,
+      outfit_lock_default: item.metadata.outfit_lock_default,
+      scene_categories: item.metadata.scene_categories,
+      time_categories: item.metadata.time_categories,
+      preferred_preset: item.metadata.preferred_preset,
+      metadata_source: item.metadata.metadata_source,
+    })),
+  );
 }
 
 function photoReferenceCatalogFromStatus(status) {
@@ -22924,6 +22955,14 @@ function hydratePhotoReferenceDraftFromStatus(status) {
     photo_reference_catalog: serialized,
   };
   if (state.overview?.settings) state.overview.settings.photo_reference_catalog = statusCatalog;
+  if (state.featureDetailBaseline) {
+    state.featureDetailBaseline.settings = {
+      ...(state.featureDetailBaseline.settings || {}),
+      photo_reference_catalog: cloneFeatureStateValue(statusCatalog),
+    };
+    state.featureDetailBaseline.formSignature = "";
+    state.featureDetailDirty = false;
+  }
   state.photoReferenceManagerDraft = parsePhotoReferenceCatalog(statusCatalog)
     .filter((item) => item.kind === "library");
   return true;
@@ -23796,14 +23835,21 @@ function syncPhotoReferenceManagerDraft() {
   const items = photoReferenceManagerItems();
   const personaEditor = document.querySelector("[data-photo-reference-persona-source]");
   const catalogInput = document.querySelector('[data-feature-param="photo_reference_catalog"]');
+  const previousSignature = photoReferenceCatalogSignature(currentPhotoReferenceCatalogValue());
+  const serialized = serializePhotoReferenceCatalog(
+    items,
+    personaEditor ? personaEditor.value.trim() : currentPhotoPersonaReferenceValue(),
+  );
   if (catalogInput) {
-    catalogInput.value = serializePhotoReferenceCatalog(
-      items,
-      personaEditor ? personaEditor.value.trim() : currentPhotoPersonaReferenceValue(),
-    );
-    rememberFeatureParamDraft(catalogInput);
+    catalogInput.value = serialized;
   }
+  if (previousSignature === photoReferenceCatalogSignature(serialized)) {
+    refreshFeatureDetailDirty();
+    return false;
+  }
+  if (catalogInput) rememberFeatureParamDraft(catalogInput, { allowPhotoReferenceCatalog: true });
   markFeatureDetailDirty();
+  return true;
 }
 
 function photoReferenceDraftValidationError() {

--- a/pages/陪伴面板/app.js
+++ b/pages/陪伴面板/app.js
@@ -575,9 +575,10 @@ function beginFeatureDetailSession(featureKey) {
   state.featureDetailDirty = false;
 }
 
-function rememberFeatureParamDraft(control) {
+function rememberFeatureParamDraft(control, { allowPhotoReferenceCatalog = false } = {}) {
   const key = String(control?.dataset?.featureParam || "").trim();
   if (!key) return;
+  if (key === "photo_reference_catalog" && !allowPhotoReferenceCatalog) return;
   const value = collectSettingValue(key, control);
   state.featureDetailParamDraft = {
     ...(state.featureDetailParamDraft || {}),
@@ -613,7 +614,10 @@ function featureDetailFormSignature(root = document) {
   page.querySelectorAll("[data-feature-param]").forEach((input) => {
     const paramKey = String(input.dataset.featureParam || "").trim();
     if (!paramKey) return;
-    params[paramKey] = collectSettingValue(paramKey, input);
+    const value = collectSettingValue(paramKey, input);
+    params[paramKey] = paramKey === "photo_reference_catalog"
+      ? photoReferenceCatalogSignature(value)
+      : value;
   });
   return JSON.stringify({
     key,
@@ -22878,20 +22882,29 @@ function currentPhotoReferenceCatalogValue() {
   return state.overview?.settings?.photo_reference_catalog || [];
 }
 
-function parsePhotoReferenceCatalog(value) {
+function parsePhotoReferenceCatalog(value, { generateMissingIds = true } = {}) {
   let rawItems = Array.isArray(value) ? value : [];
   if (typeof value === "string" && value.trim()) {
+    const text = value.trim();
     try {
-      const parsed = JSON.parse(value);
+      const parsed = JSON.parse(text);
       if (Array.isArray(parsed)) rawItems = parsed;
     } catch (_error) {
-      rawItems = [];
+      rawItems = text.split(/\r?\n/)
+        .map((line) => {
+          try {
+            return JSON.parse(line);
+          } catch (_lineError) {
+            return null;
+          }
+        })
+        .filter(Boolean);
     }
   }
   return rawItems
     .filter((item) => item && typeof item === "object" && ["persona", "library"].includes(String(item.kind || "")))
     .map((item) => ({
-      id: String(item.id || (item.kind === "persona" ? "persona" : newPhotoReferenceId())),
+      id: String(item.id || (item.kind === "persona" ? "persona" : generateMissingIds ? newPhotoReferenceId() : "")),
       kind: String(item.kind),
       source: normalizePhotoReferenceSource(item.source),
       note: String(item.note || "").trim(),
@@ -22905,6 +22918,24 @@ function parsePhotoReferenceCatalog(value) {
         metadata_source: String(item.metadata_source || "configured"),
       },
     }));
+}
+
+function photoReferenceCatalogSignature(value) {
+  return JSON.stringify(
+    parsePhotoReferenceCatalog(value, { generateMissingIds: false }).map((item) => ({
+      id: item.kind === "persona" ? "persona" : String(item.id || ""),
+      kind: item.kind,
+      source: item.source,
+      note: item.note,
+      reference_roles: item.metadata.reference_roles,
+      outfit_category: item.metadata.outfit_category,
+      outfit_lock_default: item.metadata.outfit_lock_default,
+      scene_categories: item.metadata.scene_categories,
+      time_categories: item.metadata.time_categories,
+      preferred_preset: item.metadata.preferred_preset,
+      metadata_source: item.metadata.metadata_source,
+    })),
+  );
 }
 
 function photoReferenceCatalogFromStatus(status) {
@@ -22924,6 +22955,14 @@ function hydratePhotoReferenceDraftFromStatus(status) {
     photo_reference_catalog: serialized,
   };
   if (state.overview?.settings) state.overview.settings.photo_reference_catalog = statusCatalog;
+  if (state.featureDetailBaseline) {
+    state.featureDetailBaseline.settings = {
+      ...(state.featureDetailBaseline.settings || {}),
+      photo_reference_catalog: cloneFeatureStateValue(statusCatalog),
+    };
+    state.featureDetailBaseline.formSignature = "";
+    state.featureDetailDirty = false;
+  }
   state.photoReferenceManagerDraft = parsePhotoReferenceCatalog(statusCatalog)
     .filter((item) => item.kind === "library");
   return true;
@@ -23796,14 +23835,21 @@ function syncPhotoReferenceManagerDraft() {
   const items = photoReferenceManagerItems();
   const personaEditor = document.querySelector("[data-photo-reference-persona-source]");
   const catalogInput = document.querySelector('[data-feature-param="photo_reference_catalog"]');
+  const previousSignature = photoReferenceCatalogSignature(currentPhotoReferenceCatalogValue());
+  const serialized = serializePhotoReferenceCatalog(
+    items,
+    personaEditor ? personaEditor.value.trim() : currentPhotoPersonaReferenceValue(),
+  );
   if (catalogInput) {
-    catalogInput.value = serializePhotoReferenceCatalog(
-      items,
-      personaEditor ? personaEditor.value.trim() : currentPhotoPersonaReferenceValue(),
-    );
-    rememberFeatureParamDraft(catalogInput);
+    catalogInput.value = serialized;
   }
+  if (previousSignature === photoReferenceCatalogSignature(serialized)) {
+    refreshFeatureDetailDirty();
+    return false;
+  }
+  if (catalogInput) rememberFeatureParamDraft(catalogInput, { allowPhotoReferenceCatalog: true });
   markFeatureDetailDirty();
+  return true;
 }
 
 function photoReferenceDraftValidationError() {

--- a/tests/test_photo_reference_unsaved_guard.py
+++ b/tests/test_photo_reference_unsaved_guard.py
@@ -1,0 +1,283 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "pages" / "陪伴面板" / "app.js"
+
+
+class PhotoReferenceUnsavedGuardTests(unittest.TestCase):
+    def test_opening_and_round_tripping_an_unchanged_catalog_stays_clean(self) -> None:
+        node = shutil.which("node")
+        if not node:
+            self.skipTest("Node.js 不可用")
+
+        script = f"""
+const fs = require("fs");
+const source = fs.readFileSync({json.dumps(str(APP_JS), ensure_ascii=False)}, "utf8");
+
+function extractFunction(name) {{
+  const marker = `function ${{name}}`;
+  const start = source.indexOf(marker);
+  if (start < 0) return "";
+  const paramsOpen = source.indexOf("(", start + marker.length);
+  let paramsDepth = 0;
+  let paramsClose = -1;
+  for (let index = paramsOpen; index < source.length; index += 1) {{
+    if (source[index] === "(") paramsDepth += 1;
+    if (source[index] === ")" && --paramsDepth === 0) {{
+      paramsClose = index;
+      break;
+    }}
+  }}
+  if (paramsOpen < 0 || paramsClose < 0) {{
+    throw new Error(`无法定位函数参数: ${{name}}`);
+  }}
+  const open = source.indexOf("{{", paramsClose + 1);
+  let depth = 0;
+  let quote = "";
+  let escaped = false;
+  let lineComment = false;
+  let blockComment = false;
+  for (let index = open; index < source.length; index += 1) {{
+    const char = source[index];
+    const next = source[index + 1];
+    if (lineComment) {{
+      if (char === "\\n") lineComment = false;
+      continue;
+    }}
+    if (blockComment) {{
+      if (char === "*" && next === "/") {{
+        blockComment = false;
+        index += 1;
+      }}
+      continue;
+    }}
+    if (quote) {{
+      if (escaped) {{
+        escaped = false;
+      }} else if (char === "\\\\") {{
+        escaped = true;
+      }} else if (char === quote) {{
+        quote = "";
+      }}
+      continue;
+    }}
+    if (char === "/" && next === "/") {{
+      lineComment = true;
+      index += 1;
+      continue;
+    }}
+    if (char === "/" && next === "*") {{
+      blockComment = true;
+      index += 1;
+      continue;
+    }}
+    if (char === "'" || char === '"' || char === "`") {{
+      quote = char;
+      continue;
+    }}
+    if (char === "{{") depth += 1;
+    if (char === "}}" && --depth === 0) return source.slice(start, index + 1);
+  }}
+  throw new Error(`无法提取函数: ${{name}}`);
+}}
+
+const state = {{
+  overview: null,
+  featureDraft: {{}},
+  featureDetailParamDraft: {{}},
+  featureDetailBaseline: null,
+  featureDetailDirty: false,
+  selectedFeatureKey: "",
+  photoReferenceManagerDraft: null,
+  photoReferenceLibraryStatus: {{ options: {{}} }},
+}};
+let markDirtyCalls = 0;
+function isProviderConfigKey() {{ return false; }}
+function syncFeatureFooterAction() {{}}
+function markFeatureDetailDirty() {{
+  markDirtyCalls += 1;
+  state.featureDetailDirty = true;
+}}
+
+const implementation = [
+  "toBool",
+  "collectSettingValue",
+  "cloneFeatureStateValue",
+  "normalizePhotoReferenceSource",
+  "normalizePhotoReferenceMetadataList",
+  "normalizePhotoReferenceMetadataBoolean",
+  "photoReferenceMetadataFromObject",
+  "newPhotoReferenceId",
+  "currentPhotoReferenceCatalogValue",
+  "parsePhotoReferenceCatalog",
+  "photoReferenceCatalogFromStatus",
+  "canonicalPhotoReference",
+  "hydratePhotoReferenceDraftFromStatus",
+  "currentPhotoPersonaReference",
+  "currentPhotoPersonaReferenceValue",
+  "serializePhotoReferenceCatalog",
+  "photoReferenceManagerItems",
+  "rememberFeatureParamDraft",
+  "featureDetailFormSignature",
+  "refreshFeatureDetailDirty",
+  "syncPhotoReferenceManagerDraft",
+  "photoReferenceCatalogSignature",
+].map(extractFunction).filter(Boolean).join("\\n");
+eval(implementation);
+
+if (!source.includes("function photoReferenceCatalogSignature(")) {{
+  globalThis.photoReferenceCatalogSignature = function photoReferenceCatalogSignature(value) {{
+    return JSON.stringify(parsePhotoReferenceCatalog(value));
+  }};
+}}
+
+const catalogInput = {{
+  dataset: {{ featureParam: "photo_reference_catalog" }},
+  type: "textarea",
+  value: "",
+}};
+const featureToggle = {{ checked: true }};
+const featurePage = {{
+  querySelector(selector) {{
+    return selector === "[data-feature-detail-toggle]" ? featureToggle : null;
+  }},
+  querySelectorAll(selector) {{
+    return selector === "[data-feature-param]" ? [catalogInput] : [];
+  }},
+}};
+const document = {{
+  querySelector(selector) {{
+    if (selector === ".feature-detail-page") return featurePage;
+    if (selector === '[data-feature-param="photo_reference_catalog"]') return catalogInput;
+    return null;
+  }},
+  querySelectorAll(selector) {{
+    return selector === "[data-feature-param]" ? [catalogInput] : [];
+  }},
+}};
+
+const persona = {{
+  id: "persona",
+  kind: "persona",
+  source: "C:/references/persona.png",
+  note: "persona",
+  reference_roles: ["identity"],
+  outfit_category: "",
+  outfit_lock_default: false,
+  scene_categories: [],
+  time_categories: [],
+  preferred_preset: "",
+  metadata_source: "configured",
+}};
+const library = {{
+  id: "library_1",
+  kind: "library",
+  source: "C:/references/home.png",
+  note: "home",
+  reference_roles: ["outfit"],
+  outfit_category: "homewear",
+  outfit_lock_default: false,
+  scene_categories: ["home"],
+  time_categories: ["evening"],
+  preferred_preset: "",
+  metadata_source: "configured",
+}};
+const savedCatalog = [persona, library];
+
+state.selectedFeatureKey = "enable_photo_text_action";
+state.featureDraft = {{ enable_photo_text_action: true }};
+state.overview = {{ settings: {{ photo_reference_catalog: savedCatalog }} }};
+state.featureDetailParamDraft = {{}};
+
+catalogInput.value = savedCatalog.map((item) => JSON.stringify(item)).join("\\n");
+rememberFeatureParamDraft(catalogInput);
+if (Object.prototype.hasOwnProperty.call(state.featureDetailParamDraft, "photo_reference_catalog")) {{
+  throw new Error("打开参考图库不应写入 photo_reference_catalog 通用草稿");
+}}
+
+state.featureDetailParamDraft = {{}};
+state.featureDetailDirty = false;
+state.photoReferenceManagerDraft = parsePhotoReferenceCatalog(savedCatalog)
+  .filter((item) => item.kind === "library");
+catalogInput.value = JSON.stringify(savedCatalog);
+state.featureDetailBaseline = {{
+  key: state.selectedFeatureKey,
+  settings: {{ photo_reference_catalog: savedCatalog }},
+  formSignature: featureDetailFormSignature(document),
+}};
+markDirtyCalls = 0;
+syncPhotoReferenceManagerDraft();
+if (markDirtyCalls !== 0 || state.featureDetailDirty) {{
+  throw new Error("未修改返回参考图库不应触发脏状态");
+}}
+
+state.photoReferenceManagerDraft[0].note = "changed";
+syncPhotoReferenceManagerDraft();
+if (
+  markDirtyCalls !== 1
+  || !state.featureDetailDirty
+  || !Object.prototype.hasOwnProperty.call(state.featureDetailParamDraft, "photo_reference_catalog")
+) {{
+  throw new Error("真实修改参考图库后必须写入草稿并触发脏状态");
+}}
+
+const lineValue = savedCatalog.map((item) => JSON.stringify(item)).join("\\n");
+catalogInput.value = lineValue;
+const lineSignature = featureDetailFormSignature(document);
+catalogInput.value = JSON.stringify(savedCatalog);
+const arraySignature = featureDetailFormSignature(document);
+if (lineSignature !== arraySignature) {{
+  throw new Error("目录的 textarea 表示和 JSON 数组表示应得到相同表单签名");
+}}
+
+state.featureDetailParamDraft = {{}};
+state.featureDetailDirty = false;
+state.overview.settings.photo_reference_catalog = [];
+state.featureDetailBaseline = {{
+  key: state.selectedFeatureKey,
+  settings: {{ photo_reference_catalog: [] }},
+  formSignature: "stale-signature",
+}};
+state.photoReferenceManagerDraft = null;
+const status = {{
+  persona,
+  items: [library],
+}};
+const statusCatalog = photoReferenceCatalogFromStatus(status);
+if (!hydratePhotoReferenceDraftFromStatus(status)) {{
+  throw new Error("未修改状态回填应被接受");
+}}
+if (JSON.stringify(state.featureDetailBaseline.settings.photo_reference_catalog) !== JSON.stringify(statusCatalog)) {{
+  throw new Error("状态回填后详情基线应包含当前目录");
+}}
+if (state.featureDetailBaseline.formSignature !== "") {{
+  throw new Error("状态回填后应重新捕获详情页干净基线");
+}}
+
+process.stdout.write("ok");
+"""
+        result = subprocess.run(
+            [node, "-e", script],
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"Node 回归测试失败:\nstdout={result.stdout}\nstderr={result.stderr}",
+        )
+        self.assertEqual(result.stdout, "ok")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 变更
- 参考图目录不再被通用参数草稿收集误判为修改
- 对目录内容生成规范化签名，统一 JSON 数组与逐行 JSON 表示，并避免缺失 ID 导致随机签名漂移
- 仅在目录实际变化时标记详情页为脏；状态回填后同步更新干净基线
- 新增回归测试，覆盖未修改保持干净、真实修改标脏与状态回填

## 验证
- `python -m unittest tests.test_feature_switch_unsaved_guard tests.test_photo_reference_webui tests.test_photo_reference_unsaved_guard -v`（19 项通过）
- `node --check pages/陪伴面板/app.js`
- `node --check pages/companion-panel/app.js`

## 环境说明
全量 `python -m unittest discover -v` 已尝试运行；当前本地环境缺少完整 AstrBot 运行包和 `quart`，相关测试在导入阶段失败，与本次前端修改无关。