### PR TITLE
fix: 完整写入生图日志最终提示词

### DIFF
--- a/photo_prompt_context.py
+++ b/photo_prompt_context.py
@@ -80,6 +80,7 @@ class PhotoPromptSection:
 @dataclass(frozen=True, slots=True)
 class ResolvedPhotoPromptContext:
     final_prompt: str
+    complete_prompt: str
     prompt_sections: tuple[PhotoPromptSection, ...]
     reference: Any
     detected_conflicts: tuple[dict[str, Any], ...]
@@ -861,10 +862,12 @@ def resolve_photo_prompt_context(
     sanitized, section_detected, section_removed, residual = _sanitize_sections(tuple(prepared), wardrobe)
     detected.extend(section_detected)
     removed.extend(section_removed)
+    complete_prompt = _assemble(sanitized, prompt_format)
     budgeted = _budget_sections(sanitized)
     residual.extend(_scan_residual_conflicts(budgeted, wardrobe))
     return ResolvedPhotoPromptContext(
         final_prompt=_assemble(budgeted, prompt_format),
+        complete_prompt=complete_prompt,
         prompt_sections=tuple(budgeted),
         reference=clean_reference,
         detected_conflicts=tuple(detected),

--- a/proactive_message.py
+++ b/proactive_message.py
@@ -8628,7 +8628,7 @@ Output:
                 "backend": _single_line(backend, 80),
                 "ok": bool(ok),
                 "prompt_format": self._photo_generation_prompt_format_mode(),
-                "prompt": _single_line(prompt_text, 900),
+                "prompt": str(prompt_text or ""),
                 "path": _path_text(image_path, 1000),
                 "note": _single_line(note, 240),
                 "reference": bool(reference_image_path),
@@ -8794,7 +8794,7 @@ Output:
             "continuity_key": self._normalize_photo_continuity_key(linked.get("continuity_key")),
             "session": _single_line(linked.get("session"), 340),
             "backend": _single_line(linked.get("backend"), 80),
-            "final_prompt": _single_line(linked.get("prompt"), 900),
+            "final_prompt": str(linked.get("prompt") or ""),
             "prompt_hash": _single_line(linked.get("prompt_hash"), 80),
             "prompt_path": _path_text(linked.get("prompt_path"), 1000),
             "reference_intent": deepcopy(linked.get("reference_intent") or {}),
@@ -8847,6 +8847,7 @@ Output:
         prompt_sections: dict[str, str],
         prompt_sections_after: dict[str, Any],
         final_prompt: str,
+        submitted_prompt: str = "",
         conflicts: list[str],
         removed_conflicts: list[str],
         residual_conflicts: list[str],
@@ -8861,6 +8862,9 @@ Output:
         suggested_scene_preset: str = "",
     ) -> tuple[str, str]:
         prompt_hash = hashlib.sha256(str(final_prompt or "").encode("utf-8", "ignore")).hexdigest()
+        submitted_prompt_hash = hashlib.sha256(
+            str(submitted_prompt or final_prompt or "").encode("utf-8", "ignore")
+        ).hexdigest()
         if self._photo_generation_trace_max_bytes() <= 0:
             return "", prompt_hash
         try:
@@ -8951,6 +8955,8 @@ Output:
                     "final_prompt": final_prompt,
                     "final_prompt_length": len(str(final_prompt or "")),
                     "final_prompt_sha256": prompt_hash,
+                    "submitted_prompt_length": len(str(submitted_prompt or final_prompt or "")),
+                    "submitted_prompt_sha256": submitted_prompt_hash,
                 }
             )
             path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
@@ -10455,6 +10461,7 @@ Output:
             reference=reference_candidate or None,
         )
         prompt_text = resolved_context.final_prompt
+        complete_prompt_text = resolved_context.complete_prompt
         reference_candidate = dict(resolved_context.reference or {})
         reference_image_path = _path_text(reference_candidate.get("path"), 1000)
         if not reference_candidate:
@@ -10557,7 +10564,8 @@ Output:
             prompt_sections_before=prompt_sections_before,
             prompt_sections=prompt_sections_for_log,
             prompt_sections_after=prompt_sections_after,
-            final_prompt=prompt_text,
+            final_prompt=complete_prompt_text,
+            submitted_prompt=prompt_text,
             conflicts=conflicts,
             removed_conflicts=removed_conflicts,
             residual_conflicts=residual_conflicts,
@@ -10572,8 +10580,11 @@ Output:
             trace_id,
             "prompt_composed",
             data={
-                "prompt": prompt_text,
+                "prompt": complete_prompt_text,
                 "prompt_hash": prompt_hash,
+                "submitted_prompt_hash": hashlib.sha256(
+                    str(prompt_text or "").encode("utf-8", "ignore")
+                ).hexdigest(),
                 "prompt_path": prompt_path,
                 "sections": prompt_sections_for_log,
                 "conflicts": conflicts,
@@ -10696,7 +10707,7 @@ Output:
                 workflow_kind=workflow_kind,
                 backend=backend,
                 ok=ok,
-                prompt_text=prompt_text,
+                prompt_text=complete_prompt_text,
                 image_path=image_path,
                 note=note,
                 reference_image_path=reference_image_path,

--- a/proactive_message.py
+++ b/proactive_message.py
@@ -8476,6 +8476,8 @@ Output:
             redacted = _redact_outbound_secrets(value, self)
             if normalized_key.endswith("path") or normalized_key.endswith("_path"):
                 return _path_text(redacted, 1000)
+            if normalized_key == "prompt":
+                return redacted
             return _single_line(redacted, 1200)
         if value is None or isinstance(value, (bool, int, float)):
             return value

--- a/proactive_message.py
+++ b/proactive_message.py
@@ -8476,7 +8476,7 @@ Output:
             redacted = _redact_outbound_secrets(value, self)
             if normalized_key.endswith("path") or normalized_key.endswith("_path"):
                 return _path_text(redacted, 1000)
-            if normalized_key == "prompt":
+            if normalized_key in {"prompt", "submitted_prompt"}:
                 return redacted
             return _single_line(redacted, 1200)
         if value is None or isinstance(value, (bool, int, float)):
@@ -10427,6 +10427,7 @@ Output:
                 name="global_fixed_prompt",
                 source="fixed_prompt",
                 positive=f"Additional fixed prompt: {fixed_prompt}" if fixed_prompt else "",
+                protected=True,
             ),
             PhotoPromptSection(
                 name="edit_contract",
@@ -10581,6 +10582,7 @@ Output:
             "prompt_composed",
             data={
                 "prompt": complete_prompt_text,
+                "submitted_prompt": prompt_text,
                 "prompt_hash": prompt_hash,
                 "submitted_prompt_hash": hashlib.sha256(
                     str(prompt_text or "").encode("utf-8", "ignore")

--- a/tests/test_photo_generation_trace.py
+++ b/tests/test_photo_generation_trace.py
@@ -214,6 +214,22 @@ class PhotoGenerationTraceTests(unittest.TestCase):
             self.assertEqual(payload["api_key"], "***")
             self.assertNotIn("plain-secret", payload["url"])
 
+    def test_prompt_composed_writes_the_complete_multiline_prompt(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            harness = _Harness(temp_dir)
+            final_prompt = "Positive prompt:\n" + ("完整画面描述, " * 160) + "\nFINAL_PROMPT_END"
+
+            harness._append_photo_generation_trace_event(
+                "trace-full-prompt",
+                "prompt_composed",
+                data={"prompt": final_prompt, "summary": "s" * 1400},
+            )
+
+            payload = self._read_lines(Path(temp_dir) / "photo_generation_trace.txt")[0]["data"]
+            self.assertEqual(payload["prompt"], final_prompt)
+            self.assertTrue(payload["prompt"].endswith("FINAL_PROMPT_END"))
+            self.assertEqual(len(payload["summary"]), 1200)
+
     def test_reference_candidates_include_metadata_scores_and_selection_reason(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             harness = _SelectionHarness(temp_dir)

--- a/tests/test_photo_prompt_context_generation.py
+++ b/tests/test_photo_prompt_context_generation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import sys
 import tempfile
@@ -282,6 +283,58 @@ class PhotoPromptContextGenerationTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(events[-1]["status"], "ok")
             self.assertEqual(events[-1]["context"]["backend"], "ComfyUI")
             self.assertEqual(events[-1]["data"]["image_path"], str(output))
+
+    async def test_prompt_debug_json_writes_complete_prompt_without_changing_backend_budget(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "generated.png"
+            output.write_bytes(b"generated")
+            harness = _PhotoGenerationHarness(str(output))
+            complete_preset = "Scene preset: " + ("cozy bedroom detail, " * 40) + "PRESET_END"
+            harness._apply_photo_generation_scene_presets = lambda *_args, **_kwargs: (
+                complete_preset,
+                ["long preset"],
+            )
+            harness._write_photo_prompt_debug_file = lambda **kwargs: (
+                ProactiveMessageMixin._write_photo_prompt_debug_file(harness, **kwargs)
+            )
+
+            await harness._generate_photo_image(
+                workflow_kind="selfie",
+                prompt_text="Take a natural selfie in the bedroom.",
+                session_key="complete-prompt-log",
+            )
+
+            backend_prompt = harness.backend_calls[0]["prompt"]
+            debug_path = next((Path(directory) / "photo_prompt_debug").glob("*.json"))
+            debug_payload = json.loads(debug_path.read_text(encoding="utf-8"))
+            logged_prompt = debug_payload["final_prompt"]
+            trace_events = [
+                json.loads(line)
+                for line in (Path(directory) / "photo_generation_trace.txt")
+                .read_text(encoding="utf-8")
+                .splitlines()
+            ]
+            trace_prompt = next(
+                event["data"]["prompt"]
+                for event in trace_events
+                if event["stage"] == "prompt_composed"
+            )
+            recent_prompt = harness.data["recent_photo_generations"][0]["prompt"]
+
+            self.assertIn("[section compacted]", backend_prompt)
+            self.assertNotIn("[section compacted]", logged_prompt)
+            self.assertIn(complete_preset, logged_prompt)
+            self.assertEqual(trace_prompt, logged_prompt)
+            self.assertEqual(recent_prompt, logged_prompt)
+            self.assertEqual(
+                debug_payload["final_prompt_sha256"],
+                hashlib.sha256(logged_prompt.encode("utf-8")).hexdigest(),
+            )
+            self.assertEqual(
+                debug_payload["submitted_prompt_sha256"],
+                hashlib.sha256(backend_prompt.encode("utf-8")).hexdigest(),
+            )
+            self.assertEqual(debug_payload["submitted_prompt_length"], len(backend_prompt))
 
     async def test_backend_receives_physically_sanitized_context_and_reference(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_photo_prompt_context_generation.py
+++ b/tests/test_photo_prompt_context_generation.py
@@ -115,7 +115,7 @@ class _PhotoGenerationHarness(ProactiveMessageMixin):
         self.data: dict = {}
         self.photo_generation_backend = "comfyui"
         self.photo_generation_prompt_format = "traditional"
-        self.photo_generation_fixed_prompt = "pajamas; fine film grain"
+        self.photo_generation_fixed_prompt = "fine film grain"
         self.photo_generation_scene_presets = ""
         self.comfyui_selfie_workflow_name = "selfie-workflow"
         self.comfyui_text2img_workflow_name = ""
@@ -314,17 +314,19 @@ class PhotoPromptContextGenerationTests(unittest.IsolatedAsyncioTestCase):
                 .read_text(encoding="utf-8")
                 .splitlines()
             ]
-            trace_prompt = next(
-                event["data"]["prompt"]
+            trace_prompt_event = next(
+                event
                 for event in trace_events
                 if event["stage"] == "prompt_composed"
             )
+            trace_prompt = trace_prompt_event["data"]["prompt"]
             recent_prompt = harness.data["recent_photo_generations"][0]["prompt"]
 
             self.assertIn("[section compacted]", backend_prompt)
             self.assertNotIn("[section compacted]", logged_prompt)
             self.assertIn(complete_preset, logged_prompt)
             self.assertEqual(trace_prompt, logged_prompt)
+            self.assertEqual(trace_prompt_event["data"]["submitted_prompt"], backend_prompt)
             self.assertEqual(recent_prompt, logged_prompt)
             self.assertEqual(
                 debug_payload["final_prompt_sha256"],
@@ -411,14 +413,16 @@ class PhotoPromptContextGenerationTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(recorded["prompt_sections"]["duplicate_context#2"], "second neutral detail")
         self.assertNotIn("recent_continuity", recorded["prompt_sections"])
 
-    async def test_protected_fixed_rules_reach_backend_without_compaction(self) -> None:
+    async def test_protected_fixed_rules_reach_backend_in_full(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             output = Path(directory) / "generated.png"
             output.write_bytes(b"generated")
             harness = _PhotoGenerationHarness(str(output))
             fixed_prompt = (
                 "Overall Physique: preserve complete body proportions and stable facial structure; "
-                "Lip Color: preserve the exact natural lip color without simplification or substitution."
+                "Lip Color: preserve the exact natural lip color without simplification or substitution; "
+                "Her attire and posture remain modest and unassuming, with no overt exposure or "
+                "suggestive cues—keeping the impression innocent and understated."
             )
             harness.photo_generation_fixed_prompt = fixed_prompt
             _composition_positive, composition_negative = (
@@ -430,7 +434,7 @@ class PhotoPromptContextGenerationTests(unittest.IsolatedAsyncioTestCase):
 
             backend, image_path, _note = await harness._generate_photo_image(
                 workflow_kind="selfie",
-                prompt_text="拍一张自然自拍",
+                prompt_text="Take a natural selfie wearing pajamas.",
                 session_key="protected-fixed-rules",
             )
 
@@ -442,11 +446,15 @@ class PhotoPromptContextGenerationTests(unittest.IsolatedAsyncioTestCase):
             submitted_prompt,
         )
         self.assertIn(
-            "Lip Color: preserve the exact natural lip color without simplification or substitution.",
+            "Lip Color: preserve the exact natural lip color without simplification or substitution",
+            submitted_prompt,
+        )
+        self.assertIn(
+            "Her attire and posture remain modest and unassuming, with no overt exposure or "
+            "suggestive cues—keeping the impression innocent and understated.",
             submitted_prompt,
         )
         self.assertIn(composition_negative, submitted_prompt)
-        self.assertNotIn("[section compacted]", submitted_prompt)
 
     def test_prompt_clip_never_returns_a_partial_word(self) -> None:
         self.assertEqual(


### PR DESCRIPTION
## 根因

调试写入器收到的是已经经过分区预算的后端提示词，因此即使日志层不再截断，`final_prompt` 仍会包含 `[section compacted]`。

## 修改内容

- 同时保留冲突清理后的完整日志提示词与预算化后端提示词
- 调试 JSON、事件日志和最近生图记录写入完整提示词，不再折叠或截断
- 后端继续接收原预算化提示词，生图行为不变
- 调试 JSON 额外记录实际提交提示词的长度和 SHA-256，便于核对
- 保留现有敏感信息脱敏逻辑，其他日志字段继续使用原压缩规则

## 验证

- 用户样本回放：后端版 3505 字、2 个压缩标记；日志版 3766 字、0 个压缩标记
- 103 项相关单元与集成测试通过
- `python -m py_compile photo_prompt_context.py proactive_message.py tests\test_photo_prompt_context_generation.py tests\test_photo_generation_trace.py`
- `git diff --check`
（人话就是生图日志最终提交的提示词不在被压缩）