### PR TITLE
fix: 记忆插件和官方会话历史写入审核后实际发送的回复而不是原始回复

### DIFF
--- a/daily_state.py
+++ b/daily_state.py
@@ -17592,7 +17592,10 @@ class DailyStateMixin:
                     delivered_text = self._visible_text_without_tts_reading(text, limit=500)
                     current_after_send["last_proactive_message"] = _single_line(delivered_text, 500)
                     current_after_send["last_proactive_sent_at"] = sent_at
-                    current_after_send["last_proactive_delivery_umo"] = _single_line(send_umo_for_send, 180)
+                    current_after_send["last_proactive_delivery_umo"] = _single_line(
+                        getattr(delivered, "delivery_umo", "") or send_umo_for_send,
+                        180,
+                    )
                     delivery_success_recorder = getattr(self, "_note_private_delivery_success", None)
                     if callable(delivery_success_recorder):
                         delivery_success_recorder(user_id, current_after_send, send_umo_for_send)
@@ -17644,21 +17647,28 @@ class DailyStateMixin:
                     planned_action_for_send or "message",
                     delivery_complete,
                 )
+                delivery_umo = str(
+                    getattr(delivered, "delivery_umo", "") or send_umo_for_send
+                ).strip()
+                assistant_archive_text = self._delivered_assistant_text_from_chain(
+                    list(getattr(delivered, "delivered_chain", ()) or ()),
+                    fallback_text=text,
+                )
                 await self._archive_proactive_message_to_conversation(
                     user=user,
+                    umo=delivery_umo,
                     user_prompt=self._build_proactive_archive_user_prompt(
                         reason=reason,
                         action=effective_action_for_send or planned_action_for_send or "message",
                         motive=planned_motive_for_send,
                         action_summary=action_summary,
                     ),
-                    assistant_response=self._build_proactive_archive_assistant_text(
-                        text=text,
-                        image_path=image_path,
-                        extra_components=extra_components,
-                        action_summary=action_summary,
-                        photo_subject_owner=photo_subject_owner_for_send,
-                    ),
+                    assistant_response=assistant_archive_text,
+                )
+                await self._record_final_assistant_in_livingmemory(
+                    umo=delivery_umo,
+                    assistant_response=assistant_archive_text,
+                    delivery_id=str(audit_id or f"proactive:{user_id}:{_now_ts():.6f}"),
                 )
                 if is_troubleshooting_for_send:
                     async with self._data_lock:
@@ -18044,6 +18054,7 @@ class DailyStateMixin:
                         "user": current_snapshot,
                         "user_id": user_id,
                         "text": visible_text,
+                        "umo": delivery_umo,
                         "reason": reason,
                         "action": current.get("last_proactive_action") or effective_action_for_send or planned_action_for_send or "message",
                         "motive": planned_motive_for_send,

--- a/final_response_persistence.py
+++ b/final_response_persistence.py
@@ -1,0 +1,949 @@
+from __future__ import annotations
+
+import asyncio
+import contextvars
+import hashlib
+import json
+import uuid
+from dataclasses import dataclass, field, is_dataclass, replace
+from functools import wraps
+from typing import Any, Awaitable, Callable
+
+from astrbot.api import logger
+from astrbot.api.event import AstrMessageEvent
+from astrbot.api.message_components import Image, Plain, Record
+from astrbot.core.agent.message import AssistantMessageSegment, TextPart
+from astrbot.core.provider.entities import LLMResponse
+from astrbot.core.star.star import star_map
+from astrbot.core.star.star_handler import EventType, star_handlers_registry
+
+from .helpers import _now_ts, _single_line
+
+
+_DELIVERY_TASK_LABELS = frozenset({"segmented_llm_remainder"})
+
+
+@dataclass(slots=True)
+class DeliveryLedger:
+    """One logical outbound turn, independent of how many sends it uses."""
+
+    umo: str
+    event: AstrMessageEvent | None = None
+    passive: bool = False
+    confirmed_chains: list[list[Any]] = field(default_factory=list)
+    candidate_chain: list[Any] = field(default_factory=list)
+    background_tasks: set[asyncio.Task] = field(default_factory=set)
+    original_send: Any = None
+    original_send_streaming: Any = None
+    streaming: bool = False
+    context_token: contextvars.Token | None = None
+    fallback_task: asyncio.Task | None = None
+    finalized: bool = False
+    finalize_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+    @property
+    def delivered_chain(self) -> list[Any]:
+        return [component for chain in self.confirmed_chains for component in chain]
+
+
+_CURRENT_DELIVERY: contextvars.ContextVar[DeliveryLedger | None] = (
+    contextvars.ContextVar("private_companion_final_delivery", default=None)
+)
+
+
+class FinalResponsePersistenceCoordinator:
+    """Collect platform-confirmed content and commit it to optional sinks."""
+
+    def __init__(self, owner: Any) -> None:
+        self.owner = owner
+
+    @staticmethod
+    def _event_ledger(event: AstrMessageEvent | None) -> DeliveryLedger | None:
+        if event is None:
+            return None
+        ledger = getattr(event, "_private_companion_delivery_ledger", None)
+        return ledger if isinstance(ledger, DeliveryLedger) else None
+
+    def begin_passive(self, event: AstrMessageEvent) -> DeliveryLedger:
+        ledger = self._event_ledger(event)
+        if ledger is None:
+            ledger = DeliveryLedger(
+                umo=str(getattr(event, "unified_msg_origin", "") or ""),
+                event=event,
+                passive=True,
+            )
+            setattr(event, "_private_companion_delivery_ledger", ledger)
+        if ledger.context_token is None:
+            ledger.context_token = _CURRENT_DELIVERY.set(ledger)
+        setattr(event, "_private_companion_persistence_managed", True)
+        return ledger
+
+    def begin_proactive(self, umo: str) -> DeliveryLedger:
+        ledger = DeliveryLedger(umo=str(umo or "").strip())
+        ledger.context_token = _CURRENT_DELIVERY.set(ledger)
+        return ledger
+
+    @staticmethod
+    def _reset_context(ledger: DeliveryLedger) -> None:
+        token = ledger.context_token
+        ledger.context_token = None
+        if token is None:
+            return
+        try:
+            _CURRENT_DELIVERY.reset(token)
+        except (LookupError, ValueError):
+            pass
+
+    def finish_proactive(self, ledger: DeliveryLedger, outcome: Any) -> Any:
+        self._reset_context(ledger)
+        if not is_dataclass(outcome):
+            return outcome
+        fields = getattr(outcome, "__dataclass_fields__", {})
+        updates: dict[str, Any] = {}
+        if "delivery_umo" in fields:
+            updates["delivery_umo"] = ledger.umo
+        if "delivered_chain" in fields:
+            updates["delivered_chain"] = tuple(ledger.delivered_chain)
+        if "delivered_text" in fields and ledger.confirmed_chains:
+            delivered_text = self._delivered_text(ledger.confirmed_chains)
+            if delivered_text:
+                updates["delivered_text"] = delivered_text
+        return replace(outcome, **updates) if updates else outcome
+
+    def confirm(self, umo: str, chain: list[Any] | tuple[Any, ...]) -> None:
+        components = list(chain or [])
+        if not components:
+            return
+        ledger = _CURRENT_DELIVERY.get()
+        if ledger is None:
+            return
+        if ledger.umo and umo and str(umo) != ledger.umo:
+            return
+        self._append_confirmation(ledger, components)
+
+    def _append_confirmation(
+        self,
+        ledger: DeliveryLedger,
+        components: list[Any],
+    ) -> None:
+        ledger.confirmed_chains.append(components)
+        event = ledger.event
+        if ledger.passive and event is not None and ledger.fallback_task is None:
+            try:
+                ledger.fallback_task = asyncio.create_task(
+                    self._finalize_stopped_event_after_yield(ledger)
+                )
+            except RuntimeError:
+                ledger.fallback_task = None
+
+    async def _finalize_stopped_event_after_yield(self, ledger: DeliveryLedger) -> None:
+        await asyncio.sleep(0.05)
+        event = ledger.event
+        if event is None or ledger.finalized:
+            return
+        try:
+            stopped = bool(event.is_stopped())
+        except Exception:
+            stopped = False
+        if stopped:
+            await self.finalize_passive(event)
+
+    def track_background_task(self, task: asyncio.Task | None, label: str) -> None:
+        if task is None or _single_line(label, 100) not in _DELIVERY_TASK_LABELS:
+            return
+        ledger = _CURRENT_DELIVERY.get()
+        if ledger is None or not ledger.passive:
+            return
+        ledger.background_tasks.add(task)
+        task.add_done_callback(ledger.background_tasks.discard)
+
+    def install_send_tracking(self, event: AstrMessageEvent) -> None:
+        if not bool(getattr(event, "_private_companion_persistence_managed", False)):
+            return
+        ledger = self._event_ledger(event) or self.begin_passive(event)
+        try:
+            result = event.get_result()
+        except Exception:
+            result = None
+        chain = list(getattr(result, "chain", []) or []) if result is not None else []
+        if chain:
+            ledger.candidate_chain = chain
+            setattr(event, "_private_companion_final_outbound_chain", tuple(chain))
+        if not callable(ledger.original_send):
+            original_send = getattr(event, "send", None)
+            if callable(original_send):
+                async def tracked_send(message: Any, *args: Any, **kwargs: Any):
+                    send_result = await original_send(message, *args, **kwargs)
+                    if send_result is not False:
+                        sent_chain = getattr(message, "chain", None)
+                        if isinstance(sent_chain, (list, tuple)) and sent_chain:
+                            self._append_confirmation(ledger, list(sent_chain))
+                    return send_result
+
+                ledger.original_send = original_send
+                setattr(event, "_private_companion_original_send", original_send)
+                event.send = tracked_send
+
+        if not callable(ledger.original_send_streaming):
+            original_streaming = getattr(event, "send_streaming", None)
+            if callable(original_streaming):
+                async def tracked_send_streaming(
+                    generator: Any,
+                    *args: Any,
+                    **kwargs: Any,
+                ) -> Any:
+                    captured: list[list[Any]] = []
+
+                    async def capture_generator():
+                        async for message in generator:
+                            sent_chain = getattr(message, "chain", None)
+                            if isinstance(sent_chain, (list, tuple)) and sent_chain:
+                                captured.append(list(sent_chain))
+                            yield message
+
+                    send_result = await original_streaming(
+                        capture_generator(),
+                        *args,
+                        **kwargs,
+                    )
+                    if send_result is not False and captured:
+                        ledger.streaming = True
+                        for sent_chain in captured:
+                            self._append_confirmation(ledger, sent_chain)
+                    return send_result
+
+                ledger.original_send_streaming = original_streaming
+                event.send_streaming = tracked_send_streaming
+
+        setattr(
+            event,
+            "_private_companion_confirmed_send_chains",
+            ledger.confirmed_chains,
+        )
+        setattr(event, "_private_companion_send_tracking_installed", True)
+
+    async def finalize_passive(self, event: AstrMessageEvent) -> bool:
+        ledger = self._event_ledger(event)
+        if ledger is None:
+            return False
+        async with ledger.finalize_lock:
+            if ledger.finalized:
+                return True
+            current = asyncio.current_task()
+            pending = [
+                task
+                for task in list(ledger.background_tasks)
+                if task is not current and not task.done()
+            ]
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
+
+            if callable(ledger.original_send):
+                event.send = ledger.original_send
+            if callable(ledger.original_send_streaming):
+                event.send_streaming = ledger.original_send_streaming
+            setattr(event, "_private_companion_send_tracking_installed", False)
+            self._reset_context(ledger)
+
+            if (
+                not callable(ledger.original_send)
+                and not callable(ledger.original_send_streaming)
+                and bool(getattr(event, "_has_send_oper", False))
+                and ledger.candidate_chain
+            ):
+                if not any(
+                    sent_chain == ledger.candidate_chain
+                    for sent_chain in ledger.confirmed_chains
+                ):
+                    ledger.confirmed_chains.insert(0, list(ledger.candidate_chain))
+            if not ledger.confirmed_chains:
+                return False
+            delivered_text = self._delivered_text(
+                ledger.confirmed_chains,
+                separator="" if ledger.streaming else "\n",
+            )
+            written = await self.owner._finalize_passive_delivered_response(
+                event,
+                chain=ledger.delivered_chain,
+                fallback_text=delivered_text,
+                force=True,
+            )
+            ledger.finalized = True
+            return bool(written)
+
+    def _delivered_text(
+        self,
+        chains: list[list[Any]],
+        *,
+        separator: str = "\n",
+    ) -> str:
+        extractor = getattr(self.owner, "_actual_text_from_delivered_chain", None)
+        if not callable(extractor):
+            return ""
+        return separator.join(
+            text
+            for chain in chains
+            for text in [extractor(chain)]
+            if text
+        ).strip()
+
+
+def collect_proactive_delivery(
+    function: Callable[..., Awaitable[Any]],
+) -> Callable[..., Awaitable[Any]]:
+    """Attach the chains confirmed by the common proactive send primitive."""
+
+    @wraps(function)
+    async def wrapped(self: Any, umo: str, *args: Any, **kwargs: Any) -> Any:
+        coordinator = self._final_response_persistence_coordinator()
+        ledger = coordinator.begin_proactive(umo)
+        try:
+            outcome = await function(self, umo, *args, **kwargs)
+        except BaseException:
+            coordinator._reset_context(ledger)
+            raise
+        return coordinator.finish_proactive(ledger, outcome)
+
+    return wrapped
+
+
+class FinalResponsePersistenceMixin:
+    """Stable integration surface used by PrivateCompanion's thin hooks."""
+
+    def _final_response_persistence_coordinator(
+        self,
+    ) -> FinalResponsePersistenceCoordinator:
+        coordinator = getattr(self, "_final_response_persistence", None)
+        if not isinstance(coordinator, FinalResponsePersistenceCoordinator):
+            coordinator = FinalResponsePersistenceCoordinator(self)
+            self._final_response_persistence = coordinator
+        return coordinator
+
+    def _begin_final_response_persistence(self, event: AstrMessageEvent) -> None:
+        self._final_response_persistence_coordinator().begin_passive(event)
+        self._capture_final_outbound_delivery(event)
+        self._defer_livingmemory_response_capture(event)
+
+    async def _prepare_final_response_after_agent(
+        self,
+        event: AstrMessageEvent,
+        run_context: Any,
+        response: Any,
+    ) -> None:
+        if not bool(getattr(event, "_private_companion_persistence_managed", False)):
+            return
+        try:
+            self._prepare_final_response_persistence(event, run_context, response)
+        finally:
+            self._restore_livingmemory_response_capture(event)
+
+    def _capture_final_outbound_delivery(self, event: AstrMessageEvent) -> None:
+        self._final_response_persistence_coordinator().install_send_tracking(event)
+
+    async def _persist_final_outbound_delivery(self, event: AstrMessageEvent) -> bool:
+        return await self._final_response_persistence_coordinator().finalize_passive(
+            event
+        )
+
+    def _track_final_response_background_task(
+        self,
+        task: asyncio.Task | None,
+        label: str,
+    ) -> None:
+        self._final_response_persistence_coordinator().track_background_task(
+            task,
+            label,
+        )
+
+    def _confirm_outbound_delivery(
+        self,
+        umo: str,
+        chain: list[Any] | tuple[Any, ...],
+    ) -> None:
+        self._final_response_persistence_coordinator().confirm(umo, chain)
+
+    @staticmethod
+    def _actual_text_from_delivered_chain(
+        chain: list[Any] | tuple[Any, ...],
+    ) -> str:
+        text_parts: list[str] = []
+        voice_parts: list[str] = []
+        for component in list(chain or []):
+            if isinstance(component, Plain):
+                text = str(getattr(component, "text", "") or "")
+                if text.strip():
+                    text_parts.append(text)
+                continue
+            if isinstance(component, Record):
+                source_text = str(
+                    getattr(component, "_private_companion_tts_source_text", "")
+                    or getattr(component, "_private_companion_tts_spoken_text", "")
+                    or ""
+                ).strip()
+                if source_text:
+                    voice_parts.append(source_text)
+        return "".join(text_parts or voice_parts).strip()
+
+    @staticmethod
+    def _is_livingmemory_handler_module(module_path: Any) -> bool:
+        normalized = str(module_path or "").strip().lower().replace("-", "_")
+        return "astrbot_plugin_livingmemory" in normalized
+
+    @staticmethod
+    def _is_memory_companion_handler_module(module_path: Any) -> bool:
+        normalized = str(module_path or "").strip().lower().replace("-", "_")
+        return any(
+            plugin_id in normalized
+            for plugin_id in (
+                "astrbot_plugin_memory_companion",
+                "astrbot_plugin_remember_you",
+            )
+        )
+
+    def _livingmemory_response_handlers(
+        self,
+        *,
+        plugins_name: list[str] | None = None,
+    ) -> list[Any]:
+        if not bool(getattr(self, "enable_livingmemory_integration", False)):
+            return []
+        try:
+            handlers = star_handlers_registry.get_handlers_by_event_type(
+                EventType.OnLLMResponseEvent,
+                plugins_name=plugins_name,
+            )
+        except Exception:
+            return []
+        return [
+            handler
+            for handler in handlers
+            if self._is_livingmemory_handler_module(
+                getattr(handler, "handler_module_path", "")
+            )
+        ]
+
+    def _memory_companion_response_handlers(
+        self,
+        *,
+        plugins_name: list[str] | None = None,
+    ) -> list[Any]:
+        if not bool(getattr(self, "enable_livingmemory_integration", False)):
+            return []
+        bridge_getter = getattr(self, "_memory_companion_bridge", None)
+        try:
+            bridge = bridge_getter() if callable(bridge_getter) else None
+        except Exception:
+            return []
+        if not callable(getattr(bridge, "record_visible_turn", None)):
+            return []
+        try:
+            handlers = star_handlers_registry.get_handlers_by_event_type(
+                EventType.OnLLMResponseEvent,
+                plugins_name=plugins_name,
+            )
+        except Exception:
+            return []
+        return [
+            handler
+            for handler in handlers
+            if self._is_memory_companion_handler_module(
+                getattr(handler, "handler_module_path", "")
+            )
+        ]
+
+    @staticmethod
+    def _handler_plugin_name(handler: Any) -> str:
+        plugin = star_map.get(str(getattr(handler, "handler_module_path", "") or ""))
+        return str(getattr(plugin, "name", "") or "").strip()
+
+    def _defer_livingmemory_response_capture(self, event: AstrMessageEvent) -> bool:
+        """Keep recall enabled while postponing raw assistant writes."""
+        if event is None or bool(
+            getattr(event, "_private_companion_final_memory_dispatch", False)
+        ):
+            return False
+        if bool(getattr(event, "_private_companion_livingmemory_deferred", False)):
+            return True
+
+        original_plugins = getattr(event, "plugins_name", None)
+        livingmemory_handlers = self._livingmemory_response_handlers(
+            plugins_name=original_plugins
+        )
+        memory_companion_handlers = self._memory_companion_response_handlers(
+            plugins_name=original_plugins
+        )
+        livingmemory_names = {
+            name
+            for name in (
+                self._handler_plugin_name(handler)
+                for handler in livingmemory_handlers
+            )
+            if name
+        }
+        memory_companion_names = {
+            name
+            for name in (
+                self._handler_plugin_name(handler)
+                for handler in memory_companion_handlers
+            )
+            if name
+        }
+        managed_names = livingmemory_names | memory_companion_names
+        if not managed_names:
+            return False
+
+        if original_plugins is None or original_plugins == ["*"]:
+            allowed_plugins = sorted(
+                {
+                    str(getattr(plugin, "name", "") or "").strip()
+                    for plugin in star_map.values()
+                    if bool(getattr(plugin, "activated", False))
+                    and str(getattr(plugin, "name", "") or "").strip()
+                    not in managed_names
+                }
+            )
+        else:
+            allowed_plugins = [
+                str(name)
+                for name in list(original_plugins or [])
+                if str(name) not in managed_names
+            ]
+
+        setattr(event, "_private_companion_original_plugins_name", original_plugins)
+        setattr(
+            event,
+            "_private_companion_livingmemory_plugin_names",
+            tuple(sorted(livingmemory_names)),
+        )
+        setattr(
+            event,
+            "_private_companion_memory_companion_plugin_names",
+            tuple(sorted(memory_companion_names)),
+        )
+        setattr(event, "_private_companion_livingmemory_deferred", True)
+        event.plugins_name = allowed_plugins
+        return True
+
+    @staticmethod
+    def _restore_livingmemory_response_capture(event: AstrMessageEvent) -> None:
+        if event is None or not bool(
+            getattr(event, "_private_companion_livingmemory_deferred", False)
+        ):
+            return
+        event.plugins_name = getattr(
+            event,
+            "_private_companion_original_plugins_name",
+            None,
+        )
+        setattr(event, "_private_companion_livingmemory_deferred", False)
+
+    @staticmethod
+    def _message_content_text(message: Any) -> str:
+        content = getattr(message, "content", None)
+        if isinstance(content, str):
+            return content.strip()
+        if not isinstance(content, list):
+            return ""
+        return "".join(
+            str(getattr(part, "text", "") or "")
+            for part in content
+            if isinstance(part, TextPart)
+        ).strip()
+
+    @staticmethod
+    def _event_uses_streaming_result(event: AstrMessageEvent) -> bool:
+        try:
+            result = event.get_result()
+        except Exception:
+            return False
+        content_type = getattr(result, "result_content_type", None)
+        label = str(getattr(content_type, "name", "") or content_type or "").upper()
+        return "STREAMING" in label
+
+    def _last_assistant_text(self, run_context: Any) -> str:
+        messages = getattr(run_context, "messages", None)
+        if not isinstance(messages, list):
+            return ""
+        for message in reversed(messages):
+            if str(getattr(message, "role", "") or "") == "assistant":
+                return self._message_content_text(message)
+        return ""
+
+    def _prepare_final_response_persistence(
+        self,
+        event: AstrMessageEvent,
+        run_context: Any,
+        response: Any,
+    ) -> None:
+        if event is None or not bool(
+            getattr(event, "_private_companion_persistence_managed", False)
+        ):
+            return
+        messages = getattr(run_context, "messages", None)
+        if not isinstance(messages, list):
+            return
+        for message in reversed(messages):
+            if str(getattr(message, "role", "") or "") != "assistant":
+                continue
+            setattr(
+                event,
+                "_private_companion_raw_assistant_text",
+                self._message_content_text(message),
+            )
+            setattr(event, "_private_companion_official_assistant_message", message)
+            try:
+                message._no_save = True
+            except Exception:
+                pass
+            break
+
+        setattr(
+            event,
+            "_private_companion_reviewed_assistant_text",
+            str(getattr(response, "completion_text", "") or "").strip(),
+        )
+        try:
+            request = event.get_extra("provider_request")
+            conversation = getattr(request, "conversation", None)
+            conversation_id = str(getattr(conversation, "cid", "") or "").strip()
+            if conversation_id:
+                setattr(
+                    event,
+                    "_private_companion_response_conversation_id",
+                    conversation_id,
+                )
+        except Exception:
+            pass
+
+    def _delivered_assistant_text_from_chain(
+        self,
+        chain: list[Any] | tuple[Any, ...],
+        *,
+        fallback_text: str = "",
+    ) -> str:
+        components = list(chain or [])
+        text = str(fallback_text or "").strip()
+        if not text:
+            text = self._actual_text_from_delivered_chain(components)
+        image_count = sum(isinstance(component, Image) for component in components)
+        record_count = sum(isinstance(component, Record) for component in components)
+        notes: list[str] = []
+        if image_count:
+            notes.append(
+                "发送了一张图片" if image_count == 1 else f"发送了 {image_count} 张图片"
+            )
+        if record_count and not text:
+            notes.append(
+                "发送了一条语音" if record_count == 1 else f"发送了 {record_count} 条语音"
+            )
+        if notes:
+            suffix = "（" + "，".join(notes) + "）"
+            text = f"{text}{suffix}" if text else suffix
+        return text.strip()
+
+    def _stage_delivered_assistant_for_official_history(
+        self,
+        *,
+        event: AstrMessageEvent,
+        assistant_response: str,
+    ) -> bool:
+        response_text = str(assistant_response or "").strip()
+        message = getattr(event, "_private_companion_official_assistant_message", None)
+        if (
+            not response_text
+            or message is None
+            or str(getattr(message, "role", "") or "") != "assistant"
+        ):
+            return False
+        try:
+            message.content = [TextPart(text=response_text)]
+            if hasattr(message, "tool_calls"):
+                message.tool_calls = None
+            if hasattr(message, "tool_call_id"):
+                message.tool_call_id = None
+            message._no_save = False
+        except Exception as exc:
+            logger.warning(
+                "[PrivateCompanion] 实际回复暂存到 AstrBot 会话上下文失败: session=%s error=%s",
+                _single_line(getattr(event, "unified_msg_origin", ""), 140),
+                _single_line(exc, 160),
+            )
+            return False
+        logger.info(
+            "[PrivateCompanion] 已将实际发送回复交给 AstrBot 核心保存: %s",
+            _single_line(getattr(event, "unified_msg_origin", ""), 140),
+        )
+        return True
+
+    async def _append_delivered_assistant_to_conversation(
+        self,
+        *,
+        event: AstrMessageEvent,
+        assistant_response: str,
+    ) -> bool:
+        umo = str(getattr(event, "unified_msg_origin", "") or "").strip()
+        response_text = str(assistant_response or "").strip()
+        conv_mgr = getattr(getattr(self, "context", None), "conversation_manager", None)
+        if not umo or not response_text or conv_mgr is None:
+            return False
+        requested_cid = str(
+            getattr(event, "_private_companion_response_conversation_id", "") or ""
+        ).strip()
+
+        async def write() -> bool:
+            conv_id = requested_cid or str(
+                await conv_mgr.get_curr_conversation_id(umo) or ""
+            ).strip()
+            if not conv_id:
+                return False
+            conversation = await conv_mgr.get_conversation(umo, conv_id)
+            if conversation is None:
+                return False
+            raw_history = getattr(conversation, "history", "[]")
+            history = (
+                json.loads(raw_history or "[]")
+                if isinstance(raw_history, str)
+                else list(raw_history)
+                if isinstance(raw_history, list)
+                else []
+            )
+            history.append(AssistantMessageSegment(content=response_text).model_dump())
+            await conv_mgr.update_conversation(umo, conv_id, history=history)
+            return True
+
+        try:
+            written = bool(
+                await self._conversation_db_operation(
+                    "append_delivered_assistant",
+                    write,
+                )
+            )
+        except Exception as exc:
+            logger.warning(
+                "[PrivateCompanion] 实际回复写入 AstrBot 会话历史失败: session=%s error=%s",
+                _single_line(umo, 140),
+                _single_line(exc, 160),
+            )
+            return False
+        if written:
+            logger.info(
+                "[PrivateCompanion] 已将实际发送回复写入 AstrBot 会话历史: %s",
+                _single_line(umo, 140),
+            )
+        return written
+
+    async def _record_final_assistant_in_livingmemory(
+        self,
+        *,
+        umo: str,
+        assistant_response: str,
+        delivery_id: str,
+        event: AstrMessageEvent | None = None,
+    ) -> bool:
+        response_text = str(assistant_response or "").strip()
+        umo = str(umo or "").strip()
+        if not umo or not response_text:
+            return False
+
+        handlers = self._livingmemory_response_handlers()
+        if event is not None and bool(
+            getattr(event, "_private_companion_persistence_managed", False)
+        ):
+            selected_names = set(
+                getattr(event, "_private_companion_livingmemory_plugin_names", ()) or ()
+            )
+            if not selected_names:
+                return False
+            handlers = [
+                handler
+                for handler in handlers
+                if self._handler_plugin_name(handler) in selected_names
+            ]
+        if not handlers:
+            return False
+
+        dedup_key = str(delivery_id or "").strip() or hashlib.sha1(
+            f"{umo}\0{response_text}".encode("utf-8", errors="ignore")
+        ).hexdigest()
+        recorded = getattr(self, "_livingmemory_final_delivery_ids", None)
+        if not isinstance(recorded, dict):
+            recorded = {}
+            self._livingmemory_final_delivery_ids = recorded
+        if dedup_key in recorded:
+            return True
+
+        dispatch_event = event or self._proactive_synthetic_event(
+            umo,
+            prompt="",
+            name=str(getattr(self, "bot_name", "") or "PrivateCompanion"),
+        )
+        if dispatch_event is None:
+            return False
+        setattr(dispatch_event, "_private_companion_final_memory_dispatch", True)
+        response = LLMResponse(role="assistant", completion_text=response_text)
+        delivered = False
+        invoked_plugins: set[int] = set()
+        for handler in handlers:
+            plugin_metadata = star_map.get(
+                str(getattr(handler, "handler_module_path", "") or "")
+            )
+            plugin_instance = getattr(plugin_metadata, "star_cls", None)
+            direct_handler = getattr(plugin_instance, "handle_memory_reflection", None)
+            try:
+                if callable(direct_handler) and id(plugin_instance) not in invoked_plugins:
+                    await direct_handler(dispatch_event, response)
+                    invoked_plugins.add(id(plugin_instance))
+                elif not callable(direct_handler):
+                    await handler.handler(dispatch_event, response)
+                else:
+                    continue
+                delivered = True
+            except Exception as exc:
+                logger.warning(
+                    "[PrivateCompanion] LivingMemory 最终回复写入失败: session=%s handler=%s error=%s",
+                    _single_line(umo, 140),
+                    _single_line(getattr(handler, "handler_name", ""), 80),
+                    _single_line(exc, 160),
+                )
+        if delivered:
+            recorded[dedup_key] = _now_ts()
+            if len(recorded) > 512:
+                for old_key, _ in sorted(
+                    recorded.items(), key=lambda item: item[1]
+                )[:-384]:
+                    recorded.pop(old_key, None)
+            logger.info(
+                "[PrivateCompanion] 已将实际发送回复交给 LivingMemory 记录: %s",
+                _single_line(umo, 140),
+            )
+        return delivered
+
+    async def _memory_companion_record_confirmed_assistant_message(
+        self,
+        event: Any,
+        *,
+        content: str,
+        delivery_id: str = "",
+    ) -> bool:
+        response_text = str(content or "").strip()[:2000]
+        session_id = _single_line(getattr(event, "unified_msg_origin", ""), 200)
+        if not response_text or not session_id:
+            return False
+        bridge = self._memory_companion_bridge()
+        recorder = getattr(bridge, "record_visible_turn", None) if bridge else None
+        if not callable(recorder):
+            return False
+        try:
+            private_chat = bool(getattr(event, "is_private_chat", lambda: False)())
+        except Exception:
+            private_chat = False
+        try:
+            user_id = _single_line(event.get_sender_id(), 80)
+        except Exception:
+            user_id = ""
+        try:
+            user_name = _single_line(self._sender_display_name(event), 80)
+        except Exception:
+            user_name = user_id
+        try:
+            await recorder(
+                role="assistant",
+                content=response_text,
+                scope="private" if private_chat else "group",
+                session_id=session_id,
+                platform=session_id.split(":", 1)[0] if ":" in session_id else "",
+                user_id=user_id,
+                user_name=user_name,
+                message_id=(
+                    "private_companion_delivered_"
+                    f"{_single_line(delivery_id, 120) or uuid.uuid4().hex}"
+                ),
+                source="private_companion_confirmed_reply",
+                metadata={
+                    "clean_visible_text": response_text,
+                    "delivery_confirmed": True,
+                    "conversation_turn": "passive_reply",
+                },
+            )
+            return True
+        except Exception as exc:
+            optional_failed = getattr(
+                self, "_memory_companion_optional_dependency_failed", None
+            )
+            if callable(optional_failed) and optional_failed(
+                exc, where="record_confirmed_assistant_message"
+            ):
+                return False
+            logger.debug(
+                "[PrivateCompanion] MemoryCompanion 实际回复写入失败: %s",
+                _single_line(exc, 120),
+            )
+            return False
+
+    async def _finalize_passive_delivered_response(
+        self,
+        event: AstrMessageEvent,
+        *,
+        chain: list[Any] | tuple[Any, ...] | None = None,
+        fallback_text: str = "",
+        force: bool = False,
+    ) -> bool:
+        if event is None or not bool(
+            getattr(event, "_private_companion_persistence_managed", False)
+        ):
+            return False
+        if bool(getattr(event, "private_companion_proactive_framework", False)) and str(
+            getattr(event, "_private_companion_external_proactive_source", "") or ""
+        ) != "proactive_chat":
+            return False
+        if bool(getattr(event, "_private_companion_delivery_persisted", False)):
+            return True
+        if not force and not bool(getattr(event, "_has_send_oper", False)):
+            return False
+
+        delivered_chain = list(
+            chain
+            if chain is not None
+            else getattr(event, "_private_companion_final_outbound_chain", ())
+        )
+        response_text = self._delivered_assistant_text_from_chain(
+            delivered_chain,
+            fallback_text=fallback_text,
+        )
+        if not response_text:
+            return False
+
+        official_written = self._stage_delivered_assistant_for_official_history(
+            event=event,
+            assistant_response=response_text,
+        )
+        if not official_written:
+            official_written = await self._append_delivered_assistant_to_conversation(
+                event=event,
+                assistant_response=response_text,
+            )
+        delivery_id = str(
+            getattr(event, "_private_companion_delivery_id", "")
+            or self._event_message_id(event)
+            or f"passive:{id(event)}"
+        )
+        memory_written = await self._record_final_assistant_in_livingmemory(
+            umo=str(getattr(event, "unified_msg_origin", "") or ""),
+            assistant_response=response_text,
+            delivery_id=delivery_id,
+            event=event,
+        )
+        memory_companion_written = False
+        if bool(
+            getattr(event, "_private_companion_memory_companion_plugin_names", ())
+        ):
+            memory_companion_written = bool(
+                await self._memory_companion_record_confirmed_assistant_message(
+                    event,
+                    content=response_text,
+                    delivery_id=delivery_id,
+                )
+            )
+        if official_written or memory_written or memory_companion_written:
+            setattr(event, "_private_companion_delivery_persisted", True)
+        return official_written or memory_written or memory_companion_written

--- a/main.py
+++ b/main.py
@@ -2971,6 +2971,9 @@ class PrivateCompanionPlugin(
                 )
 
         task.add_done_callback(discard_finished_task)
+        tracker = getattr(self, "_track_final_response_background_task", None)
+        if callable(tracker):
+            tracker(task, label)
         return task
 
     async def _cancel_lifecycle_background_tasks(self, timeout: float = 3.0) -> None:
@@ -4249,6 +4252,54 @@ class PrivateCompanionPlugin(
                 delattr(event, attr_name)
             except Exception:
                 pass
+
+    @filter.on_agent_begin(priority=100000)
+    async def begin_final_response_persistence(
+        self,
+        event: AstrMessageEvent,
+        run_context: Any,
+        *args,
+        **kwargs,
+    ):
+        """Defer optional memory sinks until the platform confirms delivery."""
+        if self is None or not self.enabled or event is None:
+            return
+        self._begin_final_response_persistence(event)
+
+    @filter.on_agent_done(priority=-100000)
+    async def prepare_final_response_persistence(
+        self,
+        event: AstrMessageEvent,
+        run_context: Any,
+        response: Any,
+        *args,
+        **kwargs,
+    ):
+        if self is None or event is None:
+            return
+        await self._prepare_final_response_after_agent(event, run_context, response)
+
+    @filter.on_decorating_result(priority=-30000)
+    async def capture_final_outbound_chain_for_persistence(
+        self,
+        event: AstrMessageEvent,
+        *args,
+        **kwargs,
+    ):
+        if self is None or event is None:
+            return
+        self._capture_final_outbound_delivery(event)
+
+    @filter.after_message_sent(priority=-100000)
+    async def persist_confirmed_passive_reply(
+        self,
+        event: AstrMessageEvent,
+        *args,
+        **kwargs,
+    ):
+        if self is None or event is None:
+            return
+        await self._persist_final_outbound_delivery(event)
 
     @filter.on_decorating_result()
     async def suppress_group_llm_reply_block_before_send(self, event: AstrMessageEvent, *args, **kwargs):

--- a/memory_companion_adapter.py
+++ b/memory_companion_adapter.py
@@ -979,6 +979,7 @@ class MemoryCompanionAdapterMixin:
         user: dict[str, Any],
         user_id: str,
         text: str,
+        umo: str = "",
         reason: str = "",
         action: str = "message",
         motive: str = "",
@@ -994,7 +995,7 @@ class MemoryCompanionAdapterMixin:
         proactive_recorder = getattr(bridge, "record_proactive_message", None) if bridge is not None else None
         if not callable(visible_turn_recorder) and not callable(proactive_recorder):
             return
-        umo = _single_line(user.get("umo"), 200)
+        umo = _single_line(umo or user.get("umo"), 200)
         if not umo:
             return
         platform = umo.split(":", 1)[0] if ":" in umo else ""

--- a/private_image.py
+++ b/private_image.py
@@ -4735,6 +4735,26 @@ class PrivateImageMixin:
             vision_text=vision_text,
             image_count=image_count,
         )
+        livingmemory_recorder = getattr(
+            self,
+            "_record_final_assistant_in_livingmemory",
+            None,
+        )
+        if callable(livingmemory_recorder):
+            message_id_getter = getattr(self, "_event_message_id", None)
+            message_id = (
+                _single_line(message_id_getter(event), 120)
+                if callable(message_id_getter)
+                else ""
+            )
+            await livingmemory_recorder(
+                umo=str(getattr(event, "unified_msg_origin", "") or ""),
+                assistant_response=assistant_message,
+                delivery_id=(
+                    f"private_image:{message_id or user_id}:"
+                    f"{_now_ts():.6f}"
+                ),
+            )
 
     async def _record_private_image_vision_feedback_target(
         self,

--- a/proactive_message.py
+++ b/proactive_message.py
@@ -58,7 +58,7 @@ from astrbot.api.provider import ProviderRequest
 from astrbot.api.star import Context, Star, StarTools, register
 from astrbot.core import file_token_service
 from astrbot.core.astr_main_agent import MainAgentBuildConfig, build_main_agent
-from astrbot.core.agent.message import AssistantMessageSegment, TextPart, UserMessageSegment
+from astrbot.core.agent.message import AssistantMessageSegment, UserMessageSegment
 from astrbot.core.db.po import Conversation
 from astrbot.core.platform.astrbot_message import AstrBotMessage, MessageMember
 from astrbot.core.platform.message_session import MessageSession
@@ -127,6 +127,10 @@ from .helpers import (
     _strip_internal_message_blocks,
     _today_key,
     normalize_bot_relationship_cards,
+)
+from .final_response_persistence import (
+    FinalResponsePersistenceMixin,
+    collect_proactive_delivery,
 )
 from .planning import (
     build_daily_plan_prompt,
@@ -312,6 +316,8 @@ class _ProactiveSendOutcome:
     extra_components_delivered: int = 0
     note: str = ""
     primary_complete: bool = False
+    delivery_umo: str = ""
+    delivered_chain: tuple[Any, ...] = ()
 
     def __bool__(self) -> bool:
         return self.delivered
@@ -410,7 +416,7 @@ class _CapturedFrameworkSendMessage(Exception):
     """Stop the framework agent once its send_message_to_user payload is captured."""
 
 
-class ProactiveMessageMixin:
+class ProactiveMessageMixin(FinalResponsePersistenceMixin):
     """主动消息生成、动作执行和发送链路"""
 
     def _proactive_chat_bridge_user(self, session_id: str) -> tuple[str, dict[str, Any] | None]:
@@ -6638,22 +6644,51 @@ Output:
                 outcome = await self._send_proactive_message_chain(umo, text)
                 if not bool(getattr(outcome, "delivered", False)):
                     continue
+                delivered_text = str(
+                    getattr(outcome, "delivered_text", "") or text
+                ).strip()
+                delivery_umo = str(
+                    getattr(outcome, "delivery_umo", "") or umo
+                ).strip()
+                assistant_archive_text = self._delivered_assistant_text_from_chain(
+                    list(getattr(outcome, "delivered_chain", ()) or ()),
+                    fallback_text=delivered_text,
+                )
                 if getattr(self, "context", None) is not None:
                     await self._archive_proactive_message_to_conversation(
                         user=user,
+                        umo=delivery_umo,
                         user_prompt=self._build_proactive_archive_user_prompt(
                             reason="goodnight_screen_check",
                             action="message",
                             motive=motive,
                             action_summary=safe_context,
                         ),
-                        assistant_response=self._build_proactive_archive_assistant_text(
-                            text=text,
-                            action_summary=safe_context,
-                        ),
+                        assistant_response=assistant_archive_text,
+                    )
+                await self._record_final_assistant_in_livingmemory(
+                    umo=delivery_umo,
+                    assistant_response=assistant_archive_text,
+                    delivery_id=f"goodnight:{user_id}:{_now_ts():.6f}",
+                )
+                memory_companion_recorder = getattr(
+                    self,
+                    "_memory_companion_record_proactive_message",
+                    None,
+                )
+                if callable(memory_companion_recorder):
+                    await memory_companion_recorder(
+                        user=user,
+                        user_id=user_id,
+                        text=delivered_text,
+                        umo=delivery_umo,
+                        reason="goodnight_screen_check",
+                        action="message",
+                        motive=motive,
+                        action_summary=safe_context,
                     )
                 sent_at = _now_ts()
-                visible = self._visible_text_without_tts_reading(text, limit=500)
+                visible = self._visible_text_without_tts_reading(delivered_text, limit=500)
                 async with self._data_lock:
                     current = self._get_user(user_id)
                     self._reset_daily_counter_if_needed(current)
@@ -6665,7 +6700,7 @@ Output:
                     current["last_proactive_reason"] = "goodnight_screen_check"
                     current["last_proactive_action"] = "message"
                     current["last_proactive_motive"] = motive
-                    current["last_proactive_delivery_umo"] = umo
+                    current["last_proactive_delivery_umo"] = delivery_umo
                     current["last_proactive_delivery_inbound_count"] = _safe_int(current.get("inbound_count"), 0)
                     current["goodnight_screen_check_reminded_at"] = sent_at
                     current["goodnight_screen_check_state"] = "reminded"
@@ -17316,6 +17351,10 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
             ]
         for action, params in attempts:
             if await self._call_onebot_forward_action(client, action, **params):
+                self._confirm_outbound_delivery(
+                    "",
+                    [Plain(segment) for segment in cleaned_segments],
+                )
                 logger.info(
                     "[PrivateCompanion] 分段消息已合并转发发送: source=%s target=%s:%s segments=%s",
                     source or "unknown",
@@ -17549,6 +17588,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
                 session_obj = self._session_for_platform(session, platform)
                 precise_result = await platform.send_by_session(session_obj, MessageChain(processed_chain))
                 if precise_result is not False:
+                    self._confirm_outbound_delivery(umo, processed_chain)
                     return True
                 precise_error = RuntimeError("精确平台发送返回 False（平台未接受消息）")
                 logger.warning(
@@ -17570,6 +17610,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
                         self._describe_send_target(umo, session, platform),
                         self._format_send_exception(e),
                     )
+                    self._confirm_outbound_delivery(umo, processed_chain)
                     return True
                 logger.warning(
                     "[PrivateCompanion] 精确平台发送失败,回退核心发送: target=%s error=%s",
@@ -17584,6 +17625,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
         try:
             core_result = await self.context.send_message(core_session, self._build_result_from_chain(processed_chain))
             if core_result is not False:
+                self._confirm_outbound_delivery(umo, processed_chain)
                 return True
             platform_supports = getattr(self, "_platform_supports", None)
             if not callable(platform_supports) or platform_supports("onebot_actions", umo=umo):
@@ -17610,6 +17652,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
                     self._describe_send_target(umo, session, platform),
                     self._format_send_exception(e),
                 )
+                self._confirm_outbound_delivery(umo, processed_chain)
                 return True
             target = self._describe_send_target(umo, session, platform)
             precise_text = self._format_send_exception(precise_error) or "未尝试或未失败"
@@ -17632,6 +17675,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
             ) from core_error
         direct_ok, direct_error = await self._send_chain_components_via_onebot_direct(umo, session, processed_chain)
         if direct_ok:
+            self._confirm_outbound_delivery(umo, processed_chain)
             return True
         if self._is_onebot_event_checker_send_rejection(direct_error):
             raise RuntimeError(self._onebot_event_checker_rejection_summary())
@@ -18039,6 +18083,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
                 type(exc).__name__,
             )
 
+    @collect_proactive_delivery
     async def _send_proactive_message_chain(
         self,
         umo: str,
@@ -18415,10 +18460,11 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
         user: dict[str, Any],
         user_prompt: str,
         assistant_response: str,
-    ) -> None:
-        umo = str(user.get("umo") or "").strip()
+        umo: str = "",
+    ) -> bool:
+        umo = str(umo or user.get("umo") or "").strip()
         if not umo or not assistant_response:
-            return
+            return False
         for attempt in range(4):
             try:
                 user_msg_obj = UserMessageSegment(content=str(user_prompt or ""))
@@ -18437,19 +18483,20 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
                 written = await self._conversation_db_operation("archive_proactive_message", _write)
                 if not written:
                     logger.warning("[PrivateCompanion] 主动消息存档失败: 无法获取或创建 AstrBot 会话 history umo=%s", _single_line(umo, 140))
-                    return
+                    return False
                 if attempt > 0:
                     logger.info("[PrivateCompanion] 主动消息写入 AstrBot 会话历史成功: %s retry=%s", umo, attempt)
                 else:
                     logger.info("[PrivateCompanion] 已将主动消息写入 AstrBot 会话历史: %s", umo)
-                return
+                return True
             except Exception as e:
                 text = str(e or "").lower()
                 if ("database is locked" in text or "sqlite3.operationalerror" in text) and attempt < 3:
                     await asyncio.sleep(0.25 * (attempt + 1))
                     continue
                 logger.warning("[PrivateCompanion] 主动消息写入会话历史失败: %s", e)
-                return
+                return False
+        return False
 
     def _format_story_plan_for_prompt(self) -> str:
         plan = self.data.get("daily_story_plan", {})

--- a/tests/test_final_response_persistence.py
+++ b/tests/test_final_response_persistence.py
@@ -1,0 +1,508 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+import json
+import unittest
+from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from astrbot.api.message_components import Plain
+from astrbot.core.agent.message import Message, TextPart
+from astrbot.core.provider.entities import LLMResponse
+
+from astrbot_plugin_private_companion.proactive_message import ProactiveMessageMixin
+from astrbot_plugin_private_companion.final_response_persistence import (
+    FinalResponsePersistenceMixin,
+    collect_proactive_delivery,
+)
+from astrbot_plugin_private_companion.main import PrivateCompanionPlugin
+
+
+UMO = "default:FriendMessage:10001"
+LIVING_MODULE = "data.plugins.astrbot_plugin_livingmemory.main"
+MEMORY_COMPANION_MODULE = "data.plugins.astrbot_plugin_memory_companion.main"
+COMPANION_MODULE = "data.plugins.astrbot_plugin_private_companion.main"
+
+
+class _ConversationManager:
+    def __init__(self) -> None:
+        self.history = [{"role": "user", "content": "真实用户消息"}]
+
+    async def get_curr_conversation_id(self, _umo: str) -> str:
+        return "conversation-1"
+
+    async def get_conversation(self, _umo: str, _cid: str):
+        return SimpleNamespace(history=json.dumps(self.history, ensure_ascii=False))
+
+    async def update_conversation(self, _umo: str, _cid: str, *, history=None, **_kwargs):
+        self.history = list(history or [])
+
+    async def add_message_pair(self, *, cid: str, user_message, assistant_message):
+        assert cid == "conversation-1"
+        self.history.extend([user_message.model_dump(), assistant_message.model_dump()])
+
+
+class _Event:
+    def __init__(self) -> None:
+        self.unified_msg_origin = UMO
+        self.plugins_name = None
+        self._has_send_oper = True
+        self._private_companion_persistence_managed = True
+        self._private_companion_livingmemory_plugin_names = ("LivingMemory",)
+        self._private_companion_response_conversation_id = "conversation-1"
+        self._extras = {
+            "provider_request": SimpleNamespace(
+                conversation=SimpleNamespace(cid="conversation-1")
+            )
+        }
+
+    def get_extra(self, key: str, default=None):
+        return self._extras.get(key, default)
+
+
+class _SendTrackerEvent(_Event):
+    def __init__(
+        self,
+        *,
+        send_error: Exception | None = None,
+        send_result=None,
+    ) -> None:
+        super().__init__()
+        self._result = SimpleNamespace(chain=[Plain("审核后的待发送回复")])
+        self.send_error = send_error
+        self.send_result = send_result
+        self.sent = []
+        self.stopped = False
+
+    def get_result(self):
+        return self._result
+
+    async def send(self, message):
+        if self.send_error is not None:
+            raise self.send_error
+        self.sent.append(message)
+        return self.send_result
+
+    def is_stopped(self) -> bool:
+        return self.stopped
+
+
+@dataclass(frozen=True)
+class _ActiveOutcome:
+    delivered: bool
+    delivered_text: str = ""
+    delivery_umo: str = ""
+    delivered_chain: tuple = ()
+
+
+class _ActiveCollector(FinalResponsePersistenceMixin):
+    @collect_proactive_delivery
+    async def send(self, umo: str) -> _ActiveOutcome:
+        self._confirm_outbound_delivery(umo, [Plain("平台实际收到的主动回复")])
+        return _ActiveOutcome(True, delivered_text="审核后的候选回复")
+
+
+class _Registry:
+    def __init__(self, handlers) -> None:
+        self.handlers = list(handlers)
+
+    def get_handlers_by_event_type(self, _event_type, *, plugins_name=None):
+        if plugins_name not in (None, ["*"]) and "LivingMemory" not in plugins_name:
+            return []
+        return list(self.handlers)
+
+
+class _Harness(ProactiveMessageMixin):
+    enable_livingmemory_integration = True
+    bot_name = "陪伴者"
+
+    def __init__(self) -> None:
+        self.conversation_manager = _ConversationManager()
+        self.context = SimpleNamespace(conversation_manager=self.conversation_manager)
+        self.memory_companion_captured: list[str] = []
+
+    @staticmethod
+    def _memory_companion_bridge():
+        async def record_visible_turn(**_kwargs):
+            return None
+
+        return SimpleNamespace(record_visible_turn=record_visible_turn)
+
+    async def _memory_companion_record_confirmed_assistant_message(
+        self,
+        _event,
+        *,
+        content: str,
+        delivery_id: str = "",
+    ) -> bool:
+        self.memory_companion_captured.append(content)
+        return True
+
+    @staticmethod
+    def _event_message_id(_event) -> str:
+        return "message-1"
+
+    @staticmethod
+    def _proactive_synthetic_event(umo: str, *, prompt: str, name: str):
+        event = _Event()
+        event.unified_msg_origin = umo
+        event._private_companion_persistence_managed = False
+        return event
+
+
+class FinalResponsePersistenceTests(unittest.IsolatedAsyncioTestCase):
+    async def test_raw_assistant_is_deferred_and_only_delivered_text_is_persisted(self):
+        captured: list[str] = []
+
+        async def livingmemory_handler(_event, response):
+            captured.append(response.completion_text)
+
+        handler = SimpleNamespace(
+            handler=livingmemory_handler,
+            handler_name="handle_memory_reflection",
+            handler_module_path=LIVING_MODULE,
+        )
+        memory_companion_handler = SimpleNamespace(
+            handler=livingmemory_handler,
+            handler_name="capture_assistant_response",
+            handler_module_path=MEMORY_COMPANION_MODULE,
+        )
+        plugins = {
+            LIVING_MODULE: SimpleNamespace(
+                name="LivingMemory", activated=True, reserved=False
+            ),
+            MEMORY_COMPANION_MODULE: SimpleNamespace(
+                name="MemoryCompanion", activated=True, reserved=False
+            ),
+            COMPANION_MODULE: SimpleNamespace(
+                name="Private Companion", activated=True, reserved=False
+            ),
+        }
+        harness = _Harness()
+        event = _Event()
+        run_context = SimpleNamespace(
+            messages=[
+                Message(role="user", content=[TextPart(text="真实用户消息")]),
+                Message(role="assistant", content=[TextPart(text="Agent 原始回复")]),
+            ]
+        )
+
+        with patch(
+            "astrbot_plugin_private_companion.final_response_persistence.star_handlers_registry",
+            _Registry([handler, memory_companion_handler]),
+        ), patch(
+            "astrbot_plugin_private_companion.final_response_persistence.star_map",
+            plugins,
+        ):
+            self.assertTrue(harness._defer_livingmemory_response_capture(event))
+            self.assertEqual(["Private Companion"], event.plugins_name)
+
+            harness._prepare_final_response_persistence(
+                event,
+                run_context,
+                LLMResponse(role="assistant", completion_text="审核改写回复"),
+            )
+            self.assertTrue(run_context.messages[-1]._no_save)
+            harness._restore_livingmemory_response_capture(event)
+            self.assertIsNone(event.plugins_name)
+
+            await harness._finalize_passive_delivered_response(
+                event,
+                chain=[Plain("实际发送回复")],
+            )
+
+        self.assertEqual("实际发送回复", captured[-1])
+        self.assertEqual(["实际发送回复"], harness.memory_companion_captured)
+        self.assertFalse(run_context.messages[-1]._no_save)
+        self.assertEqual(
+            "实际发送回复",
+            harness._message_content_text(run_context.messages[-1]),
+        )
+        # AstrBot serializes run_context only after RespondStage and its
+        # after-message-sent hooks return.
+        harness.conversation_manager.history = [
+            item.model_dump()
+            for item in run_context.messages
+            if not item._no_save
+        ]
+        self.assertEqual(
+            ["user", "assistant"],
+            [item["role"] for item in harness.conversation_manager.history],
+        )
+        self.assertEqual(
+            "实际发送回复",
+            harness.conversation_manager.history[-1]["content"][0]["text"],
+        )
+
+    async def test_passive_official_history_falls_back_to_direct_append_without_agent_turn(self):
+        harness = _Harness()
+        event = _Event()
+
+        written = await harness._finalize_passive_delivered_response(
+            event,
+            chain=[Plain("特殊发送路径的实际回复")],
+        )
+
+        self.assertTrue(written)
+        self.assertEqual(
+            "特殊发送路径的实际回复",
+            harness.conversation_manager.history[-1]["content"],
+        )
+
+    async def test_missing_memory_plugins_does_not_block_official_history(self):
+        harness = _Harness()
+        event = _Event()
+
+        with patch(
+            "astrbot_plugin_private_companion.final_response_persistence.star_handlers_registry",
+            _Registry([]),
+        ), patch(
+            "astrbot_plugin_private_companion.final_response_persistence.star_map",
+            {},
+        ):
+            self.assertFalse(harness._defer_livingmemory_response_capture(event))
+            written = await harness._finalize_passive_delivered_response(
+                event,
+                chain=[Plain("没有记忆插件也要保存")],
+            )
+
+        self.assertTrue(written)
+        self.assertEqual(
+            "没有记忆插件也要保存",
+            harness.conversation_manager.history[-1]["content"],
+        )
+
+    async def test_proactive_placeholder_stays_out_of_livingmemory(self):
+        captured: list[str] = []
+
+        async def livingmemory_handler(_event, response):
+            captured.append(response.completion_text)
+
+        handler = SimpleNamespace(
+            handler=livingmemory_handler,
+            handler_name="handle_memory_reflection",
+            handler_module_path=LIVING_MODULE,
+        )
+        plugins = {
+            LIVING_MODULE: SimpleNamespace(
+                name="LivingMemory", activated=True, reserved=False
+            )
+        }
+        harness = _Harness()
+
+        with patch(
+            "astrbot_plugin_private_companion.final_response_persistence.star_handlers_registry",
+            _Registry([handler]),
+        ), patch(
+            "astrbot_plugin_private_companion.final_response_persistence.star_map",
+            plugins,
+        ):
+            await harness._archive_proactive_message_to_conversation(
+                user={"umo": UMO},
+                user_prompt="【主动承接占位】",
+                assistant_response="实际发出的主动消息",
+            )
+            await harness._record_final_assistant_in_livingmemory(
+                umo=UMO,
+                assistant_response="实际发出的主动消息",
+                delivery_id="proactive-1",
+            )
+
+        self.assertEqual(
+            ["user", "assistant"],
+            [item["role"] for item in harness.conversation_manager.history[-2:]],
+        )
+        self.assertEqual("【主动承接占位】", harness.conversation_manager.history[-2]["content"])
+        self.assertEqual(["实际发出的主动消息"], captured)
+
+    async def test_livingmemory_prefers_plugin_public_handler_when_available(self):
+        direct_handler = AsyncMock()
+        registry_handler = AsyncMock()
+        handler = SimpleNamespace(
+            handler=registry_handler,
+            handler_name="handle_memory_reflection",
+            handler_module_path=LIVING_MODULE,
+        )
+        plugins = {
+            LIVING_MODULE: SimpleNamespace(
+                name="LivingMemory",
+                activated=True,
+                reserved=False,
+                star_cls=SimpleNamespace(handle_memory_reflection=direct_handler),
+            )
+        }
+        harness = _Harness()
+
+        with patch(
+            "astrbot_plugin_private_companion.final_response_persistence.star_handlers_registry",
+            _Registry([handler]),
+        ), patch(
+            "astrbot_plugin_private_companion.final_response_persistence.star_map",
+            plugins,
+        ):
+            written = await harness._record_final_assistant_in_livingmemory(
+                umo=UMO,
+                assistant_response="平台确认后的回复",
+                delivery_id="direct-livingmemory-1",
+            )
+
+        self.assertTrue(written)
+        direct_handler.assert_awaited_once()
+        registry_handler.assert_not_awaited()
+
+    async def test_send_tracker_persists_only_after_successful_send(self):
+        plugin = PrivateCompanionPlugin.__new__(PrivateCompanionPlugin)
+        plugin._finalize_passive_delivered_response = AsyncMock(return_value=True)
+        event = _SendTrackerEvent()
+
+        await plugin.capture_final_outbound_chain_for_persistence(event)
+        tracked_send = event.send
+        outbound = SimpleNamespace(chain=[Plain("适配器实际接收的回复")])
+        await tracked_send(outbound)
+        await plugin.persist_confirmed_passive_reply(event)
+
+        plugin._finalize_passive_delivered_response.assert_awaited_once()
+        call = plugin._finalize_passive_delivered_response.await_args
+        self.assertEqual("适配器实际接收的回复", call.kwargs["fallback_text"])
+        self.assertTrue(call.kwargs["force"])
+        self.assertFalse(event._private_companion_send_tracking_installed)
+
+    async def test_send_tracker_does_not_persist_failed_send(self):
+        plugin = PrivateCompanionPlugin.__new__(PrivateCompanionPlugin)
+        plugin._finalize_passive_delivered_response = AsyncMock(return_value=True)
+        event = _SendTrackerEvent(send_error=RuntimeError("adapter send failed"))
+
+        await plugin.capture_final_outbound_chain_for_persistence(event)
+        with self.assertRaisesRegex(RuntimeError, "adapter send failed"):
+            await event.send(SimpleNamespace(chain=[Plain("不会送达")]))
+        await plugin.persist_confirmed_passive_reply(event)
+
+        plugin._finalize_passive_delivered_response.assert_not_awaited()
+        self.assertFalse(event._private_companion_send_tracking_installed)
+
+    async def test_send_tracker_treats_explicit_false_as_failed_send(self):
+        plugin = PrivateCompanionPlugin.__new__(PrivateCompanionPlugin)
+        plugin._finalize_passive_delivered_response = AsyncMock(return_value=True)
+        event = _SendTrackerEvent(send_result=False)
+
+        await plugin.capture_final_outbound_chain_for_persistence(event)
+        result = await event.send(SimpleNamespace(chain=[Plain("平台拒绝接收")]))
+        await plugin.persist_confirmed_passive_reply(event)
+
+        self.assertFalse(result)
+        plugin._finalize_passive_delivered_response.assert_not_awaited()
+        self.assertFalse(event._private_companion_send_tracking_installed)
+
+    async def test_passive_finalizer_waits_for_segmented_remainder(self):
+        plugin = PrivateCompanionPlugin.__new__(PrivateCompanionPlugin)
+        plugin._finalize_passive_delivered_response = AsyncMock(return_value=True)
+        event = _SendTrackerEvent()
+        event._has_send_oper = False
+
+        plugin._begin_final_response_persistence(event)
+        plugin._capture_final_outbound_delivery(event)
+        await event.send(SimpleNamespace(chain=[Plain("第一段")]))
+
+        async def send_remainder():
+            await asyncio.sleep(0)
+            await event.send(SimpleNamespace(chain=[Plain("第二段")]))
+
+        task = asyncio.create_task(send_remainder())
+        plugin._track_final_response_background_task(
+            task,
+            "segmented_llm_remainder",
+        )
+        await plugin.persist_confirmed_passive_reply(event)
+
+        plugin._finalize_passive_delivered_response.assert_awaited_once()
+        call = plugin._finalize_passive_delivered_response.await_args
+        self.assertEqual("第一段\n第二段", call.kwargs["fallback_text"])
+
+    async def test_direct_send_that_stops_event_uses_fallback_finalizer(self):
+        plugin = PrivateCompanionPlugin.__new__(PrivateCompanionPlugin)
+        plugin._finalize_passive_delivered_response = AsyncMock(return_value=True)
+        event = _SendTrackerEvent()
+        event._has_send_oper = False
+        event.stopped = True
+
+        plugin._begin_final_response_persistence(event)
+        await event.send(SimpleNamespace(chain=[Plain("直接发送后终止传播")]))
+        await asyncio.sleep(0.06)
+
+        plugin._finalize_passive_delivered_response.assert_awaited_once()
+        call = plugin._finalize_passive_delivered_response.await_args
+        self.assertEqual("直接发送后终止传播", call.kwargs["fallback_text"])
+
+    async def test_proactive_collector_replaces_candidate_with_confirmed_chain(self):
+        outcome = await _ActiveCollector().send(UMO)
+
+        self.assertTrue(outcome.delivered)
+        self.assertEqual(UMO, outcome.delivery_umo)
+        self.assertEqual("平台实际收到的主动回复", outcome.delivered_text)
+        self.assertEqual(
+            "平台实际收到的主动回复",
+            outcome.delivered_chain[0].text,
+        )
+
+    async def test_streaming_response_persists_only_confirmed_stream_chunks(self):
+        plugin = PrivateCompanionPlugin.__new__(PrivateCompanionPlugin)
+        plugin._finalize_passive_delivered_response = AsyncMock(return_value=True)
+        event = _SendTrackerEvent()
+
+        async def send_streaming(generator, *_args, **_kwargs):
+            async for _ in generator:
+                pass
+
+        event.send_streaming = send_streaming
+        event._has_send_oper = False
+        plugin._begin_final_response_persistence(event)
+        run_context = SimpleNamespace(
+            messages=[
+                Message(role="assistant", content=[TextPart(text="Agent 原始回复")])
+            ]
+        )
+
+        await plugin._prepare_final_response_after_agent(
+            event,
+            run_context,
+            LLMResponse(role="assistant", completion_text="审核后的候选回复"),
+        )
+
+        async def chunks():
+            yield SimpleNamespace(chain=[Plain("实际流式")])
+            yield SimpleNamespace(chain=[Plain("发送回复")])
+
+        await event.send_streaming(chunks())
+        await plugin.persist_confirmed_passive_reply(event)
+
+        plugin._finalize_passive_delivered_response.assert_awaited_once()
+        call = plugin._finalize_passive_delivered_response.await_args
+        self.assertEqual("实际流式发送回复", call.kwargs["fallback_text"])
+        self.assertTrue(call.kwargs["force"])
+
+    async def test_intercepted_reply_does_not_dispatch_or_append_assistant(self):
+        harness = _Harness()
+        event = _Event()
+        run_context = SimpleNamespace(
+            messages=[
+                Message(role="assistant", content=[TextPart(text="会被拦截的原始回复")])
+            ]
+        )
+
+        harness._prepare_final_response_persistence(
+            event,
+            run_context,
+            LLMResponse(role="assistant", completion_text=""),
+        )
+
+        self.assertTrue(run_context.messages[-1]._no_save)
+        self.assertEqual(
+            [{"role": "user", "content": "真实用户消息"}],
+            harness.conversation_manager.history,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

PrivateCompanion 会在模型生成回复后继续执行敏感词拦截、内容审核、改写、分段发送和媒体处理。此前 AstrBot 会话历史以及 LivingMemory 等记忆插件可能在这些处理完成前读取 Agent 原始回复，因此记录内容与用户实际收到的内容不一致。

主要表现为：

- 回复被改写后，记忆中仍可能保存改写前的原始回复。
- 回复被拦截或平台发送失败后，未实际发出的候选回复仍可能被保存。
- 被动回复实际发送成功后，AstrBot 官方会话历史可能缺少最终 assistant 消息。
- 主动消息需要在官方会话历史中保留承接占位，但该占位不应进入 LivingMemory。

## 修改内容

### 1. 使用独立协调器收敛持久化逻辑

- 新增 `final_response_persistence.py`，集中管理一次逻辑回复的候选消息链、实际投递链、流式片段、分段后台任务和最终持久化。
- `main.py` 只保留 Agent 开始/结束、结果装饰完成和发送完成四个薄生命周期钩子，避免把记忆插件适配继续铺进主发送流程。
- 主动消息在公共发送原语处确认实际投递链，并通过装饰器汇总最终 delivery UMO、消息链和文本。
- 保留原作者在 v6.0.1b 中新增的表情有序分段和官方 TTS 分段流程，不修改其状态机与发送时序。

### 2. 以实际投递结果作为持久化依据

- 在最终消息链完成装饰后记录待发送内容。
- 跟踪 `event.send()` 和 `event.send_streaming()` 的实际调用结果，只在发送成功后持久化 assistant 消息。
- 显式返回 `False`、抛出异常、发送前拦截或最终消息链为空时，不写入 assistant 消息。
- 持久化内容从实际投递链提取，优先记录最终文本或 TTS 实际对应文本，而不是 Agent 原始 completion。
- 分段回复会等待已登记的后续分段任务完成，再一次性提交实际成功发送的完整内容。
- 对发送后立即终止事件传播的直接发送路径提供延迟收口，避免遗漏最终持久化。

### 3. 延后记忆插件的 assistant 写入

- 保留 LivingMemory 和 MemoryCompanion 的用户消息处理及记忆召回能力。
- 在 PrivateCompanion 管理的回复流程中，暂时延后它们对原始 assistant 回复的自动记录。
- 最终发送成功后，再以审核、改写和拦截流程处理后的实际内容触发记录。
- 增加 delivery id 去重，避免同一次投递被重复写入。

### 4. 修正 AstrBot 官方会话历史

- 被动回复发送成功后，将最终 assistant 内容写回当前会话上下文。
- 无可用 Agent turn 时，使用会话管理接口直接追加 assistant 消息作为兼容兜底。
- 被拦截或发送失败的回复不追加 assistant 消息。

### 5. 修正主动消息归档

- 主动消息发送结果携带实际 delivery UMO 和实际投递消息链。
- 官方历史继续保存“主动承接占位 + 实际发送内容”。
- LivingMemory 只记录实际发送的 assistant 内容，不记录主动承接占位。
- 归档使用最终改写后的文本，不再使用审核前候选文本。

### 6. 覆盖特殊投递路径

同一套持久化规则同时覆盖：

- 普通被动回复
- 流式回复
- 分段回复和转发消息形式的回复
- 主动消息、晚安检查等主动发送路径
- 私聊图片视觉回复
- 文本、TTS 和附加媒体组合消息

## 预期行为

| 场景 | LivingMemory / MemoryCompanion | AstrBot 官方会话历史 |
| --- | --- | --- |
| 普通被动回复 | 用户消息 + 实际回复 | 用户消息 + 实际回复 |
| 被动回复被改写 | 用户消息 + 改写后的实际回复 | 用户消息 + 改写后的实际回复 |
| 被动回复被拦截 | 不写入 assistant | 不写入被拦截的 assistant |
| 平台发送失败 | 不写入 assistant | 不写入未发送的 assistant |
| 主动消息成功发送 | 仅实际 assistant，不含占位 | 主动承接占位 + 实际 assistant |
| 主动消息被改写 | 仅改写后的实际 assistant | 占位 + 改写后的实际 assistant |

## 兼容性

- 已 rebase 到 `d1bf040`（v6.0.1b），当前修复提交为 `b496750`。
- 保留 v6.0.1b 的主动表情、反应表情有序分段、官方 TTS 分段和 `primary_complete` 投递判断逻辑。
- 未修改 LivingMemory 或 MemoryCompanion 的代码和数据库结构。
- LivingMemory 不可用或相关 handler 不存在时会跳过集成，不影响正常消息发送。
- 所有可选记忆插件均不可用时，AstrBot 官方历史仍会独立保存实际发送的 assistant 内容。
- 对 AstrBot 会话管理接口保留多版本调用方式和直接追加兜底。

## 测试

新增 `tests/test_final_response_persistence.py`，覆盖以下情况：

- 延后原始 assistant，并仅保存实际发送文本。
- 官方历史缺少 Agent turn 时直接追加最终 assistant。
- 主动占位不进入 LivingMemory。
- 发送成功后才持久化。
- 发送异常或显式返回 `False` 时不持久化。
- 流式回复只使用适配器实际消费的流式片段。
- 分段回复等待后续分段发送完成后再持久化完整内容。
- 直接发送并终止事件传播时仍能正确收口。
- 主动消息以公共发送原语确认的实际消息链覆盖候选文本。
- 记忆插件缺失时不阻断官方历史写入。
- 被拦截回复不触发 assistant 写入。

验证结果：

- 最终回复持久化专项测试：13/13 通过。
- 最终回复持久化与 v6.0.1b 官方 TTS 分段兼容测试组合运行：23/23 通过，另有 6 个 subtest 通过。
- Docker 内完整测试：1883 通过，304 个 subtest 通过。
- 完整测试剩余 2 项已知失败：反应素材外部删除后的文件系统缓存时序，以及现有双页面镜像文件的 LF/CRLF 字节差异；相关实现不在本 PR 的语义修改范围内。
- Docker 环境使用 AstrBot v4.26.8 和 LivingMemory 2.5.4，模拟 OneBot v11 与 QQ Official 适配器验证通过。

Docker 集成验证覆盖普通被动回复、审核改写、敏感词拦截、适配器发送失败、主动消息和 QQ Official 群聊。数据库结果符合上表，未发现原始敏感内容、被拦截回复、发送失败回复或主动占位被错误写入 LivingMemory。

## 建议审查重点

- 独立协调器与四个薄生命周期钩子的边界是否足够稳定，是否便于后续主流程继续演进。
- `on_decorating_result` 与 `after_message_sent` 的优先级是否符合当前 AstrBot 生命周期约定。
- 对 `event.send()` / `event.send_streaming()` 的包装是否覆盖各适配器对成功、`False` 和异常结果的约定。
- v6.0.1b 表情有序分段在高优先级 `after_message_sent` 中完成后，低优先级持久化收口是否符合预期。
- LivingMemory handler 的延后与最终重放是否符合插件间事件传播预期。
- 官方历史直接追加兜底在不同 AstrBot 版本中的兼容性。