### PR TITLE
修复 NAI 联动模式生图链路日志缺失

### DIFF
--- a/proactive_message.py
+++ b/proactive_message.py
@@ -10621,6 +10621,7 @@ Output:
         started = time.time()
         trace_id = self._photo_generation_trace_id(session_key, workflow_kind)
         original_prompt_text = str(prompt_text or "").strip()
+        prompt_format = self._photo_generation_prompt_format_mode()
         request_text = str(request_text or original_prompt_text).strip()
         requester_user_id = _single_line(requester_user_id, 80)
         if requester_is_private is None:
@@ -10640,6 +10641,7 @@ Output:
                 "continuity_key": continuity_key,
                 "workflow_kind": workflow_kind,
                 "request_text": request_text,
+                "prompt_format": prompt_format,
             },
         )
         reference_image_path = _path_text(reference_image_path, 1000)
@@ -11181,6 +11183,7 @@ Output:
             trace_id,
             "prompt_composed",
             data={
+                "prompt_format": prompt_format,
                 "prompt": complete_prompt_text,
                 "submitted_prompt": prompt_text,
                 "prompt_hash": prompt_hash,
@@ -11209,12 +11212,13 @@ Output:
             "backend_selected",
             data={
                 "preferred": preferred,
+                "prompt_format": prompt_format,
                 "reference_count": len(reference_image_paths),
                 "image_size": image_size,
             },
         )
         logger.info(
-            "[PrivateCompanion] 生图开始: trace=%s session=%s kind=%s presets=%s prompt_chars=%s prompt_hash=%s prompt_debug=%s "
+            "[PrivateCompanion] 生图开始: trace=%s session=%s kind=%s prompt_format=%s presets=%s prompt_chars=%s prompt_hash=%s prompt_debug=%s "
             "reference=%s reference_exists=%s reference_id=%s reference_kind=%s reference_roles=%s "
             "wardrobe_version=%s wardrobe_rule=%s wardrobe_mode=%s wardrobe_category=%s outfit_locked=%s "
             "preset_hint=%s preset_source=%s suggestion_status=%s selected_presets=%s adjustments=%s daily_outfit_removed=%s continuity_reference=%s "
@@ -11223,6 +11227,7 @@ Output:
             trace_id,
             _single_line(session_key, 80),
             _single_line(workflow_kind, 30),
+            prompt_format,
             ",".join(preset_names) or "-",
             len(str(prompt_text or "")),
             prompt_hash[:16],

--- a/tests/test_photo_prompt_context_generation.py
+++ b/tests/test_photo_prompt_context_generation.py
@@ -53,6 +53,7 @@ def _astrbot_stubs() -> dict[str, types.ModuleType]:
         "astrbot.core.platform.platform",
         "astrbot.core.platform.platform_metadata",
         "astrbot.core.star",
+        "astrbot.core.star.star",
         "astrbot.core.star.star_handler",
         "astrbot.core.provider",
         "astrbot.core.provider.entities",
@@ -79,6 +80,7 @@ def _astrbot_stubs() -> dict[str, types.ModuleType]:
     for name in ("AssistantMessageSegment", "TextPart", "UserMessageSegment"):
         setattr(modules["astrbot.core.agent.message"], name, _Dummy)
     modules["astrbot.core.db.po"].Conversation = _Dummy
+    modules["astrbot.core.star.star"].star_map = {}
     symbol_groups = {
         "astrbot.core.platform.astrbot_message": ("AstrBotMessage", "MessageMember"),
         "astrbot.core.platform.message_session": ("MessageSession",),
@@ -335,6 +337,51 @@ class PhotoPromptContextGenerationTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(events[-1]["status"], "ok")
             self.assertEqual(events[-1]["context"]["backend"], "ComfyUI")
             self.assertEqual(events[-1]["data"]["image_path"], str(output))
+
+    async def test_nai_generation_writes_identifiable_complete_trace_chain(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "generated.png"
+            output.write_bytes(b"generated")
+            harness = _PhotoGenerationHarness(str(output))
+            harness.photo_generation_prompt_format = "nai"
+
+            await harness._generate_photo_image(
+                workflow_kind="selfie",
+                prompt_text="{1girl}, 1.5::red dress::, -1::text::",
+                session_key="nai-trace-chain-session",
+            )
+
+            events = [
+                json.loads(line)
+                for line in (Path(directory) / "photo_generation_trace.txt")
+                .read_text(encoding="utf-8")
+                .splitlines()
+            ]
+
+        expected_stages = [
+            "request_received",
+            "reference_intent_analyzed",
+            "reference_plan_built",
+            "reference_plan_projected",
+            "wardrobe_resolved",
+            "prompt_composed",
+            "backend_selected",
+            "output_validated",
+            "completed",
+        ]
+        stages = [event["stage"] for event in events]
+        self.assertEqual(
+            [stages.index(stage) for stage in expected_stages],
+            sorted(stages.index(stage) for stage in expected_stages),
+        )
+        self.assertTrue(
+            all(event["context"]["prompt_format"] == "nai" for event in events)
+        )
+        prompt_event = next(
+            event for event in events if event["stage"] == "prompt_composed"
+        )
+        self.assertEqual(prompt_event["data"]["prompt_format"], "nai")
+        self.assertIn("1.5::red dress::", prompt_event["data"]["submitted_prompt"])
 
     async def test_matching_outfit_reference_reaches_debug_trace_responsibility(
         self,


### PR DESCRIPTION
问题：切换 photo_generation_prompt_format 为 nai 后，生图 trace 虽然产生了阶段事件，但日志上下文没有记录提示词格式，无法确认或检索 NAI 联动链路。修复：在生图 trace 初始上下文中记录 prompt_format 并贯穿完整链路；在 prompt_composed 和 backend_selected 阶段及常规生图开始日志中输出提示词格式；增加 NAI 完整生图链路回归测试。验证：python -m unittest tests.test_photo_prompt_context_generation（22 个测试通过）；python -m py_compile proactive_message.py tests/test_photo_prompt_context_generation.py。