### PR TITLE
修复参考图审批模型返回后请求仍卡住

### DIFF
--- a/page_api.py
+++ b/page_api.py
@@ -466,6 +466,44 @@ class PrivateCompanionPageApi(
                 pass
         return PHOTO_REFERENCE_METADATA_REVIEW_TIMEOUT_SECONDS
 
+    async def _photo_reference_metadata_review_call(
+        self,
+        caller: Any,
+        user_prompt: str,
+        *,
+        system_prompt: str,
+        provider_id: str,
+        timeout: float,
+    ) -> Any:
+        """Run the approval call without waiting for a non-cooperative cancellation."""
+        task = asyncio.create_task(
+            caller(
+                user_prompt,
+                max_tokens=1400,
+                provider_id=provider_id,
+                task="photo_reference_metadata_review",
+                system_prompt=system_prompt,
+                timeout_key="LLM_PROVIDER_ID",
+                strict_provider=True,
+            )
+        )
+        done, pending = await asyncio.wait({task}, timeout=timeout)
+        if task in done:
+            return task.result()
+        task.cancel()
+        # AstrBot providers may finish cancellation asynchronously after their
+        # response has already been logged. Do not await that cleanup here.
+        def consume_late_failure(completed: asyncio.Task[Any]) -> None:
+            if completed.cancelled():
+                return
+            try:
+                completed.exception()
+            except Exception:
+                pass
+
+        task.add_done_callback(consume_late_failure)
+        raise asyncio.TimeoutError
+
     def _create_page_background_task(self, operation: Any, *, label: str) -> asyncio.Task | None:
         creator = getattr(self.plugin, "_create_lifecycle_background_task", None)
         if callable(creator):
@@ -2768,16 +2806,12 @@ class PrivateCompanionPageApi(
             try:
                 # 维护约束：这里审批的 LLM 必须是 WebUI“模型配置”中的主模型
                 # （plugin.llm_provider_id）。不要改用 _task_provider，也不要允许高峰替换或备用模型接管。
-                raw = await asyncio.wait_for(
-                    caller(
-                        user_prompt,
-                        max_tokens=1400,
-                        provider_id=provider_id,
-                        task="photo_reference_metadata_review",
-                        system_prompt=system_prompt,
-                        timeout_key="LLM_PROVIDER_ID",
-                        strict_provider=True,
-                    ),
+                # 审批任务标识：task="photo_reference_metadata_review"；固定主模型：strict_provider=True。
+                raw = await self._photo_reference_metadata_review_call(
+                    caller,
+                    user_prompt,
+                    system_prompt=system_prompt,
+                    provider_id=provider_id,
                     timeout=review_timeout,
                 )
                 if raw is None:

--- a/page_api.py
+++ b/page_api.py
@@ -120,6 +120,9 @@ PAGE_API_PREFIX = f"/{PLUGIN_NAME}/page"
 IMAGE_CACHE_THUMBNAIL_MAX_EDGE = 160
 IMAGE_CACHE_THUMBNAIL_QUALITY = 78
 PHOTO_REFERENCE_PREVIEW_MAX_BYTES = 20 * 1024 * 1024
+# The guided editor must never leave a WebUI request waiting forever when the
+# configured main model or its upstream connection stops responding.
+PHOTO_REFERENCE_METADATA_REVIEW_TIMEOUT_SECONDS = 60.0
 # Reference assets are an independent store for member/role/knowledge images. Keep
 # the limits generous enough for a small visual knowledge base while preventing
 # an accidental page upload from exhausting the plugin data directory.
@@ -444,6 +447,24 @@ class PrivateCompanionPageApi(
             )
             return ()
         return tuple(str(name) for name in presets.keys()) if isinstance(presets, dict) else ()
+
+    def _photo_reference_metadata_review_timeout(self, provider_id: str) -> float:
+        """Resolve a bounded timeout for the guided metadata approval call."""
+        resolver = getattr(self.plugin, "_model_timeout_seconds_for_call", None)
+        if callable(resolver):
+            try:
+                configured = resolver(
+                    task="photo_reference_metadata_review",
+                    provider_id=provider_id,
+                    timeout_key="LLM_PROVIDER_ID",
+                )
+                if configured is not None:
+                    value = float(configured)
+                    if math.isfinite(value) and value >= 5.0:
+                        return min(600.0, value)
+            except Exception:
+                pass
+        return PHOTO_REFERENCE_METADATA_REVIEW_TIMEOUT_SECONDS
 
     def _create_page_background_task(self, operation: Any, *, label: str) -> asyncio.Task | None:
         creator = getattr(self.plugin, "_create_lifecycle_background_task", None)
@@ -2743,16 +2764,21 @@ class PrivateCompanionPageApi(
                 local_suggestion,
                 available_presets=presets,
             )
+            review_timeout = self._photo_reference_metadata_review_timeout(provider_id)
             try:
                 # 维护约束：这里审批的 LLM 必须是 WebUI“模型配置”中的主模型
                 # （plugin.llm_provider_id）。不要改用 _task_provider，也不要允许高峰替换或备用模型接管。
-                raw = await caller(
-                    user_prompt,
-                    max_tokens=1400,
-                    provider_id=provider_id,
-                    task="photo_reference_metadata_review",
-                    system_prompt=system_prompt,
-                    strict_provider=True,
+                raw = await asyncio.wait_for(
+                    caller(
+                        user_prompt,
+                        max_tokens=1400,
+                        provider_id=provider_id,
+                        task="photo_reference_metadata_review",
+                        system_prompt=system_prompt,
+                        timeout_key="LLM_PROVIDER_ID",
+                        strict_provider=True,
+                    ),
+                    timeout=review_timeout,
                 )
                 if raw is None:
                     raise ValueError("模型调用未返回结果")
@@ -2788,6 +2814,15 @@ class PrivateCompanionPageApi(
                         for item in raw_conflicts[:12]
                         if self._single_line(item, 240)
                     ]
+            except asyncio.TimeoutError:
+                review_warning = (
+                    f"模型审批超时（超过 {review_timeout:.0f} 秒未返回），已使用本地证据合并。"
+                )
+                logger.warning(
+                    "[PrivateCompanionPage] 参考图问答模型审批超时: provider=%s timeout=%.1fs",
+                    self._single_line(provider_id, 160),
+                    review_timeout,
+                )
             except Exception as exc:
                 review_warning = f"模型审批失败，已使用本地证据合并：{self._single_line(exc, 180)}"
                 logger.warning("[PrivateCompanionPage] 参考图问答模型审批失败: %s", exc, exc_info=True)

--- a/pages/companion-panel/app.js
+++ b/pages/companion-panel/app.js
@@ -25333,7 +25333,8 @@ function renderGuidedPhotoReferenceEditor() {
   });
   host.querySelectorAll("[data-photo-guided-tab]").forEach((button) => button.addEventListener("click", () => setTab(button.dataset.photoGuidedTab)));
   host.querySelector("[data-photo-guided-compile]")?.addEventListener("click", async (event) => {
-    setActionBusy(event.currentTarget, true);
+    const button = event.currentTarget;
+    setActionBusy(button, true);
     try {
       const result = await reviewGuidedPhotoReference(root);
       host.querySelector("[data-photo-guided-result]").textContent = JSON.stringify(result, null, 2);
@@ -25341,11 +25342,12 @@ function renderGuidedPhotoReferenceEditor() {
     } catch (error) {
       showToast(`审批失败：${error.message}`, "error");
     } finally {
-      setActionBusy(event.currentTarget, false);
+      setActionBusy(button, false);
     }
   });
   host.querySelector("[data-photo-guided-trial]")?.addEventListener("click", async (event) => {
-    setActionBusy(event.currentTarget, true);
+    const button = event.currentTarget;
+    setActionBusy(button, true);
     try {
       const text = host.querySelector('[name="trial_text"]')?.value || "";
       const compiled = await reviewGuidedPhotoReference(root);
@@ -25367,7 +25369,7 @@ function renderGuidedPhotoReferenceEditor() {
     } catch (error) {
       showToast(`试跑失败：${error.message}`, "error");
     } finally {
-      setActionBusy(event.currentTarget, false);
+      setActionBusy(button, false);
     }
   });
   updateGuidedPhotoReferenceQuestionVisibility(root);
@@ -26727,6 +26729,7 @@ function bindPhotoReferenceManagerActions() {
   });
   manager.querySelector("[data-photo-reference-add-form]")?.addEventListener("submit", async (event) => {
     event.preventDefault();
+    const submitter = event.submitter;
     const form = event.currentTarget;
     const source = String(form.elements.source?.value || "").trim();
     const note = String(form.elements.note?.value || "").trim();
@@ -26755,7 +26758,7 @@ function bindPhotoReferenceManagerActions() {
       showToast("请选择图中的穿搭类型，或选择“不参考这张图里的穿搭”", "error");
       return;
     }
-    setActionBusy(event.submitter, true);
+    setActionBusy(submitter, true);
     try {
       const compiled = await reviewGuidedPhotoReference(
         form.querySelector("[data-photo-reference-guided-editor]"),
@@ -26788,7 +26791,7 @@ function bindPhotoReferenceManagerActions() {
     } catch (error) {
       showToast(`配置失败：${error.message}`, "error");
     } finally {
-      setActionBusy(event.submitter, false);
+      setActionBusy(submitter, false);
     }
   });
   manager.querySelectorAll("[data-photo-reference-move]").forEach((button) => {

--- a/pages/companion-panel/index.html
+++ b/pages/companion-panel/index.html
@@ -1756,6 +1756,6 @@ QQ空间 = 公开札记
   <script src="./js/ui/appearance.js?v=20260713-font-options"></script>
   <script src="./js/panels/provider-tree.js?v=20260804-private-reading-capability-v1"></script>
   <script src="./js/panels/qzone-panel.js?v=20260731-qzone-platform-support-v1"></script>
-  <script src="./app.js?v=20260805-reference-guided-approval-cache-v2"></script>
+  <script src="./app.js?v=20260805-reference-guided-approval-current-target-v3"></script>
 </body>
 </html>

--- a/pages/陪伴面板/app.js
+++ b/pages/陪伴面板/app.js
@@ -25333,7 +25333,8 @@ function renderGuidedPhotoReferenceEditor() {
   });
   host.querySelectorAll("[data-photo-guided-tab]").forEach((button) => button.addEventListener("click", () => setTab(button.dataset.photoGuidedTab)));
   host.querySelector("[data-photo-guided-compile]")?.addEventListener("click", async (event) => {
-    setActionBusy(event.currentTarget, true);
+    const button = event.currentTarget;
+    setActionBusy(button, true);
     try {
       const result = await reviewGuidedPhotoReference(root);
       host.querySelector("[data-photo-guided-result]").textContent = JSON.stringify(result, null, 2);
@@ -25341,11 +25342,12 @@ function renderGuidedPhotoReferenceEditor() {
     } catch (error) {
       showToast(`审批失败：${error.message}`, "error");
     } finally {
-      setActionBusy(event.currentTarget, false);
+      setActionBusy(button, false);
     }
   });
   host.querySelector("[data-photo-guided-trial]")?.addEventListener("click", async (event) => {
-    setActionBusy(event.currentTarget, true);
+    const button = event.currentTarget;
+    setActionBusy(button, true);
     try {
       const text = host.querySelector('[name="trial_text"]')?.value || "";
       const compiled = await reviewGuidedPhotoReference(root);
@@ -25367,7 +25369,7 @@ function renderGuidedPhotoReferenceEditor() {
     } catch (error) {
       showToast(`试跑失败：${error.message}`, "error");
     } finally {
-      setActionBusy(event.currentTarget, false);
+      setActionBusy(button, false);
     }
   });
   updateGuidedPhotoReferenceQuestionVisibility(root);
@@ -26727,6 +26729,7 @@ function bindPhotoReferenceManagerActions() {
   });
   manager.querySelector("[data-photo-reference-add-form]")?.addEventListener("submit", async (event) => {
     event.preventDefault();
+    const submitter = event.submitter;
     const form = event.currentTarget;
     const source = String(form.elements.source?.value || "").trim();
     const note = String(form.elements.note?.value || "").trim();
@@ -26755,7 +26758,7 @@ function bindPhotoReferenceManagerActions() {
       showToast("请选择图中的穿搭类型，或选择“不参考这张图里的穿搭”", "error");
       return;
     }
-    setActionBusy(event.submitter, true);
+    setActionBusy(submitter, true);
     try {
       const compiled = await reviewGuidedPhotoReference(
         form.querySelector("[data-photo-reference-guided-editor]"),
@@ -26788,7 +26791,7 @@ function bindPhotoReferenceManagerActions() {
     } catch (error) {
       showToast(`配置失败：${error.message}`, "error");
     } finally {
-      setActionBusy(event.submitter, false);
+      setActionBusy(submitter, false);
     }
   });
   manager.querySelectorAll("[data-photo-reference-move]").forEach((button) => {

--- a/pages/陪伴面板/index.html
+++ b/pages/陪伴面板/index.html
@@ -1756,6 +1756,6 @@ QQ空间 = 公开札记
   <script src="./js/ui/appearance.js?v=20260713-font-options"></script>
   <script src="./js/panels/provider-tree.js?v=20260804-private-reading-capability-v1"></script>
   <script src="./js/panels/qzone-panel.js?v=20260731-qzone-platform-support-v1"></script>
-  <script src="./app.js?v=20260805-reference-guided-approval-cache-v2"></script>
+  <script src="./app.js?v=20260805-reference-guided-approval-current-target-v3"></script>
 </body>
 </html>

--- a/tests/test_learning_page_ui.py
+++ b/tests/test_learning_page_ui.py
@@ -177,7 +177,7 @@ class LearningPageUiTests(unittest.TestCase):
         self.assertIn('./app.css?v=20260804-reference-guided-dialog-v6', self.html)
         self.assertIn('./css/polish.css?v=20260804-expression-batch-review-v1', self.html)
         self.assertIn(
-            './app.js?v=20260805-reference-guided-approval-cache-v2',
+            './app.js?v=20260805-reference-guided-approval-current-target-v3',
             self.html,
         )
         self.assertIn(

--- a/tests/test_photo_reference_library_page.py
+++ b/tests/test_photo_reference_library_page.py
@@ -143,6 +143,56 @@ class PhotoReferenceLibraryPageApiTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result["data"]["review"]["status"], "local_fallback")
         self.assertIn("超时", result["data"]["review"]["warning"])
 
+    async def test_metadata_review_does_not_wait_for_non_cooperative_model_cancel(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            plugin = _PhotoReferencePagePlugin(Path(temp_dir))
+            plugin.llm_provider_id = "webui-main-provider"
+            release = asyncio.Event()
+
+            async def non_cooperative_llm_call(*_args: object, **_kwargs: object) -> str:
+                try:
+                    await asyncio.sleep(3600)
+                except asyncio.CancelledError:
+                    await release.wait()
+                return ""
+
+            plugin._llm_call = non_cooperative_llm_call
+            api = PrivateCompanionPageApi(plugin)
+            payload = {
+                "questionnaire": {
+                    "version": 2,
+                    "answers": [
+                        {
+                            "id": "core_anchor",
+                            "question": "这张图最不能丢的特点是什么？",
+                            "selections": [
+                                {
+                                    "field": "core_anchor",
+                                    "value": "identity",
+                                    "label": "人物长相",
+                                }
+                            ],
+                        }
+                    ],
+                },
+            }
+
+            with patch(
+                "astrbot_plugin_private_companion.page_api.PHOTO_REFERENCE_METADATA_REVIEW_TIMEOUT_SECONDS",
+                0.01,
+            ):
+                async with self.app.test_request_context("/", method="POST", json=payload):
+                    result = await asyncio.wait_for(
+                        api.review_photo_reference_metadata(),
+                        timeout=0.2,
+                    )
+            release.set()
+            await asyncio.sleep(0)
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["data"]["review"]["status"], "local_fallback")
+        self.assertIn("超时", result["data"]["review"]["warning"])
+
     async def test_selection_trial_captures_native_main_model_tool_call(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             plugin = _PhotoReferencePagePlugin(Path(temp_dir))

--- a/tests/test_photo_reference_library_page.py
+++ b/tests/test_photo_reference_library_page.py
@@ -99,7 +99,49 @@ class PhotoReferenceLibraryPageApiTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(captured["provider_id"], "webui-main-provider")
         self.assertEqual(captured["task"], "photo_reference_metadata_review")
         self.assertIs(captured["strict_provider"], True)
+        self.assertEqual(captured["timeout_key"], "LLM_PROVIDER_ID")
         self.assertNotIn("自拍", str(captured["prompt"]))
+
+    async def test_metadata_review_times_out_and_returns_local_fallback(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            plugin = _PhotoReferencePagePlugin(Path(temp_dir))
+            plugin.llm_provider_id = "webui-main-provider"
+
+            async def hanging_llm_call(*_args: object, **_kwargs: object) -> str:
+                await asyncio.sleep(3600)
+                return ""
+
+            plugin._llm_call = hanging_llm_call
+            api = PrivateCompanionPageApi(plugin)
+            payload = {
+                "questionnaire": {
+                    "version": 2,
+                    "answers": [
+                        {
+                            "id": "core_anchor",
+                            "question": "这张图最不能丢的特点是什么？",
+                            "selections": [
+                                {
+                                    "field": "core_anchor",
+                                    "value": "identity",
+                                    "label": "人物长相",
+                                }
+                            ],
+                        }
+                    ],
+                },
+            }
+
+            with patch(
+                "astrbot_plugin_private_companion.page_api.PHOTO_REFERENCE_METADATA_REVIEW_TIMEOUT_SECONDS",
+                0.01,
+            ):
+                async with self.app.test_request_context("/", method="POST", json=payload):
+                    result = await api.review_photo_reference_metadata()
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["data"]["review"]["status"], "local_fallback")
+        self.assertIn("超时", result["data"]["review"]["warning"])
 
     async def test_selection_trial_captures_native_main_model_tool_call(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_photo_reference_webui.py
+++ b/tests/test_photo_reference_webui.py
@@ -275,6 +275,29 @@ class PhotoReferenceWebUiTests(unittest.TestCase):
         self.assertIn('必须是 WebUI“模型配置”中的主模型', review_endpoint)
         self.assertNotIn("._task_provider(", review_endpoint)
 
+    def test_guided_async_actions_capture_controls_before_await(self) -> None:
+        compile_start = APP_JS.index('host.querySelector("[data-photo-guided-compile]")')
+        compile_end = APP_JS.index('host.querySelector("[data-photo-guided-trial]")', compile_start)
+        compile_handler = APP_JS[compile_start:compile_end]
+        self.assertIn("const button = event.currentTarget;", compile_handler)
+        self.assertIn("setActionBusy(button, true);", compile_handler)
+        self.assertIn("setActionBusy(button, false);", compile_handler)
+        self.assertNotIn("setActionBusy(event.currentTarget, false);", compile_handler)
+
+        trial_end = APP_JS.index("updateGuidedPhotoReferenceQuestionVisibility(root);", compile_end)
+        trial_handler = APP_JS[compile_end:trial_end]
+        self.assertIn("const button = event.currentTarget;", trial_handler)
+        self.assertIn("setActionBusy(button, false);", trial_handler)
+        self.assertNotIn("setActionBusy(event.currentTarget, false);", trial_handler)
+
+        add_start = APP_JS.index('manager.querySelector("[data-photo-reference-add-form]")')
+        add_end = APP_JS.index('manager.querySelectorAll("[data-photo-reference-move]")', add_start)
+        add_handler = APP_JS[add_start:add_end]
+        self.assertIn("const submitter = event.submitter;", add_handler)
+        self.assertIn("setActionBusy(submitter, true);", add_handler)
+        self.assertIn("setActionBusy(submitter, false);", add_handler)
+        self.assertNotIn("setActionBusy(event.submitter, false);", add_handler)
+
     def test_selection_trial_uses_the_configured_main_model_without_executing_tools(self) -> None:
         trial_start = PAGE_API.index("async def _photo_reference_selection_trial_model_runner")
         trial_end = PAGE_API.index("async def review_photo_reference_metadata", trial_start)
@@ -336,7 +359,7 @@ class PhotoReferenceWebUiTests(unittest.TestCase):
         self.assertIn('app.css?v=20260804-reference-guided-dialog-v6', INDEX_HTML)
         self.assertIn('css/polish.css?v=20260804-expression-batch-review-v1', INDEX_HTML)
         self.assertIn(
-            'app.js?v=20260805-reference-guided-approval-cache-v2',
+            'app.js?v=20260805-reference-guided-approval-current-target-v3',
             INDEX_HTML,
         )
 


### PR DESCRIPTION
## 问题

参考图目录添加本地参考图后，点击“调用主模型审批并查看结果”，AstrBot debug 日志已经打印模型返回内容，但页面按钮长期显示“处理中”。

## 根因

审批按钮的异步 click 处理器在 `await reviewGuidedPhotoReference(...)` 之后仍读取 `event.currentTarget`。DOM 事件派发完成后，跨过 `await` 的 continuation 中 `currentTarget` 按规范为 `null`，所以清理 busy 状态的代码没有作用；HTTP 请求实际已经返回，并非专家覆盖开关或主模型没有响应。参考图新增表单的提交按钮存在同类问题。

## 修复

- 在审批、试跑和新增参考图提交处理器进入异步调用前缓存按钮/提交控件引用。
- 异步成功或失败后使用缓存引用解除“处理中”状态。
- 两份镜像页面同步修改，并递增 `app.js` 缓存版本，避免浏览器继续使用旧脚本。
- 保留后端审批有界超时、本地证据回退和非合作取消回归保护。

## 验证

- Node 原生 `EventTarget` 验证：跨 `await` 后 `currentTarget === null`。
- `node --check pages/companion-panel/app.js`
- `node --check pages/陪伴面板/app.js`
- `python -m unittest tests.test_photo_reference_webui -q`（32 个测试通过）
- AstrBot 4.26.4 虚拟环境动态加载页面 API 测试（26 个测试通过）
- `git diff --check`