### PR TITLE
feat(profile): 添加 REQ-036 统一用户档案基础能力

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -217,9 +217,23 @@
       "auto_enable_companion_for_new_users": {
         "description": "自动接管新用户陪伴",
         "type": "bool",
-        "hint": "仅在已开启新用户最小档案时生效。默认关闭，关闭时只建档并继续放行 AstrBot 默认主链。",
+        "hint": "兼容旧配置。REQ-036 下新建档案仍默认关闭私聊陪伴，必须由管理员在用户档案中明确授权。",
         "default": false,
         "condition": "enable_auto_user_profile_creation"
+      },
+      "private_companion_disabled_reply": {
+        "description": "未授权私聊回复",
+        "type": "string",
+        "hint": "私聊陪伴未获管理员授权时直接发送的固定文本。为空或无效时使用内置默认文本；此分支不会调用 LLM、Memory、工具、画像或关系结算。",
+        "default": "老大不让我跟陌生人说话哦。"
+      },
+      "portrait_global_mode": {
+        "description": "全局智能画像模式",
+        "type": "string",
+        "options": ["disabled", "use_existing", "learn_and_use"],
+        "labels": ["关闭智能画像", "仅使用已有画像", "持续学习与使用"],
+        "hint": "默认关闭。管理员可在单个用户档案中选择跟随全局或显式覆盖；画像不能授予私聊或主动联系权限。",
+        "default": "disabled"
       },
       "auto_profile_platforms": {
         "description": "自动建档平台",

--- a/core_store.py
+++ b/core_store.py
@@ -126,6 +126,7 @@ from .relationship_ledger import (
 )
 from .storage.store_manager import StoreManager
 from .person_context_contract import empty_person_store, ensure_person_store
+from .unified_profile_service import ensure_new_profile_capabilities, migrate_legacy_capabilities
 from .planning import (
     build_daily_plan_prompt,
     build_detail_enhancement_prompt,
@@ -531,6 +532,14 @@ class CoreStoreMixin:
         data.setdefault("daily_review_completed_day", "")
         data.setdefault("daily_review_case_audit", [])
         ensure_person_store(data)
+        # Legacy profiles retain their effective durable permissions once.
+        # Creation paths below install a separate default-closed state for new
+        # identities, so a user starting a DM cannot manufacture authority.
+        migrate_legacy_capabilities(
+            data,
+            operation_id="req036-capability-v1",
+            dry_run=False,
+        )
         return data
 
     @staticmethod
@@ -2258,8 +2267,6 @@ class CoreStoreMixin:
         now: float | None = None,
     ) -> tuple[dict[str, Any] | None, bool]:
         """Create a minimal private profile without granting implicit authority."""
-        if not bool(getattr(self, "enable_auto_user_profile_creation", False)):
-            return None, False
         canonical_user_id = self._canonical_private_user_id(str(user_id or "").strip())
         if not canonical_user_id or self._is_bot_self_user_id(canonical_user_id):
             return None, False
@@ -2269,7 +2276,14 @@ class CoreStoreMixin:
         users = self.data.setdefault("users", {})
         existing = users.get(canonical_user_id) if isinstance(users, dict) else None
         if isinstance(existing, dict):
+            # A legacy/migrated profile remains addressable even when automatic
+            # creation is disabled.  Its REQ-036 capability state, not a DM,
+            # decides whether the conversation may proceed.
+            if isinstance(existing.get("unified_profile_capabilities"), dict):
+                ensure_new_profile_capabilities(existing)
             return existing, False
+        if not bool(getattr(self, "enable_auto_user_profile_creation", False)):
+            return None, False
 
         user = self._get_user(canonical_user_id)
         created_at = float(now if now is not None else _now_ts())
@@ -2280,15 +2294,15 @@ class CoreStoreMixin:
         # must not bypass the ledger or overwrite an explicitly configured role.
         user["nickname"] = self._auto_profile_nickname(canonical_user_id, sender_display_name)
         user["style"] = _single_line(getattr(self, "default_style", "温柔"), 24) or "温柔"
-        auto_enabled = bool(getattr(self, "auto_enable_companion_for_new_users", False))
-        user["auto_enabled"] = auto_enabled
+        user["auto_enabled"] = False
         user["manual_enabled"] = False
         user["manual_disabled"] = False
-        user["enabled"] = bool(auto_enabled or canonical_user_id in set(self._configured_target_ids()))
-        proactive_enabled = bool(getattr(self, "default_proactive_enabled", False))
-        proactive_limit = _safe_int(getattr(self, "default_proactive_daily_limit", 0), 0, 0, 30)
-        user["proactive_daily_limit"] = proactive_limit if proactive_enabled and auto_enabled else 0
-        user["proactive_boundary_note"] = "" if auto_enabled else "自动建档默认不主动触达"
+        user["enabled"] = False
+        user["private_memory_enabled"] = False
+        user["cross_group_memory_enabled"] = False
+        user["proactive_daily_limit"] = 0
+        user["proactive_boundary_note"] = "自动建档默认不主动触达"
+        ensure_new_profile_capabilities(user)
         user["last_seen"] = max(_safe_float(user.get("last_seen"), 0), created_at)
         user["last_activity_at"] = max(_safe_float(user.get("last_activity_at"), 0), created_at)
         self._note_private_user_umo(canonical_user_id, user, getattr(event, "unified_msg_origin", ""))

--- a/main.py
+++ b/main.py
@@ -138,6 +138,19 @@ from .person_context_contract import (
     build_identity_key,
     contract_self_check as person_contract_self_check,
 )
+from .unified_profile_contract import (
+    build_person_ref as req036_build_person_ref,
+    build_profile_dto as req036_build_profile_dto,
+    build_portrait_request as req036_build_portrait_request,
+    validate_profile_dto as req036_validate_profile_dto,
+)
+from .unified_profile_service import (
+    DEFAULT_UNAUTHORIZED_PRIVATE_REPLY,
+    capability_summary as req036_capability_summary,
+    private_companion_gate as req036_private_companion_gate,
+    proactive_private_gate as req036_proactive_private_gate,
+    update_capabilities as req036_update_capabilities,
+)
 from .context_orchestration import build_context, project_context
 from .p4_shadow import build_p4_shadow
 from .p4_affinity_confinement import apply_legacy_relationship_delta
@@ -2111,6 +2124,259 @@ class PrivateCompanionPlugin(
 
     def get_unified_person_projection(self, person_id: str) -> dict[str, Any] | None:
         return self.unified_person_registry.read_projection(person_id)
+
+    def _req036_private_gate_for_user(self, user: Any) -> dict[str, Any]:
+        return req036_private_companion_gate(
+            user,
+            getattr(self, "private_companion_disabled_reply", DEFAULT_UNAUTHORIZED_PRIVATE_REPLY),
+        )
+
+    def _req036_migrate_configured_target_capability(self, user_id: Any, user: Any) -> bool:
+        """Materialize the one-time legacy target grant without reopening an explicit decision."""
+        if not isinstance(user, dict) or isinstance(user.get("unified_profile_capabilities"), dict):
+            return False
+        if bool(user.get("manual_disabled")):
+            return False
+        canonicalizer = getattr(self, "_canonical_private_user_id", None)
+        raw_user_id = _single_line(user_id, 120)
+        if callable(canonicalizer):
+            try:
+                raw_user_id = _single_line(canonicalizer(raw_user_id), 120)
+            except Exception:
+                return False
+        if not raw_user_id:
+            return False
+        configured_targets = getattr(self, "_configured_target_ids", None)
+        if not callable(configured_targets):
+            return False
+        try:
+            target_ids = set()
+            for target in configured_targets():
+                target_id = _single_line(target, 120)
+                if callable(canonicalizer):
+                    target_id = _single_line(canonicalizer(target_id), 120)
+                if target_id:
+                    target_ids.add(target_id)
+        except Exception:
+            return False
+        if raw_user_id not in target_ids:
+            return False
+        result = req036_update_capabilities(
+            user,
+            {
+                "private_companion_enabled": True,
+                "proactive_private_enabled": _safe_int(user.get("proactive_daily_limit"), 0, 0) > 0,
+            },
+            actor_authorized=True,
+            grant_source="legacy_configured_target_migration",
+            actor_id="compatibility_migration",
+            target_identity=raw_user_id,
+            reason_code="legacy_configured_target_migration",
+        )
+        return bool(result.get("ok"))
+
+    def _req036_capability_summary_for_user(self, user: Any) -> dict[str, Any]:
+        return req036_capability_summary(
+            user,
+            global_portrait_mode=getattr(self, "portrait_global_mode", "disabled"),
+        )
+
+    def _req036_proactive_private_allowed(self, user: Any) -> bool:
+        return bool(req036_proactive_private_gate(user).get("allowed"))
+
+    def _req036_update_capabilities(
+        self,
+        user: dict[str, Any],
+        changes: dict[str, Any],
+        *,
+        actor_id: str = "page_administrator",
+        target_identity: str = "",
+        reason_code: str = "administrator_update",
+    ) -> dict[str, Any]:
+        return req036_update_capabilities(
+            user,
+            changes,
+            actor_authorized=True,
+            grant_source="administrator",
+            actor_id=actor_id,
+            target_identity=target_identity,
+            reason_code=reason_code,
+        )
+
+    def _req036_attach_unified_profile_context(
+        self,
+        event: Any,
+        *,
+        user: dict[str, Any] | None = None,
+        group_id: str = "",
+        source: str = "observation",
+    ) -> dict[str, Any]:
+        """Attach the smallest exact-person context for Memory's read-only use."""
+        identity = self._unified_person_event_identity(event)
+        if not identity:
+            return {"state": "identity_pending", "code": "identity_pending"}
+        resolution = self.resolve_unified_person_identity(identity)
+        if resolution.get("state") != "resolved":
+            profile = user if isinstance(user, dict) else {}
+            created = self.create_unified_person_for_event(
+                event,
+                operation_id=f"req036.{source}:{str(resolution.get('identity_key') or '')[-24:]}",
+                profile={
+                    "display_name": _single_line(profile.get("nickname"), 80),
+                    "affinity_score": _safe_int(profile.get("relationship_score"), 0, -1200, 1200),
+                    "owner_mode": "owner" if _single_line(profile.get("relationship_role"), 40) == "owner" else "not_owner",
+                    "relation_policy_id": _single_line(profile.get("relationship_mode"), 40) or "default_friend",
+                },
+            )
+            if created.get("state") != "resolved":
+                return {"state": "identity_pending", "code": str(created.get("code") or "identity_pending")}
+            resolution = self.resolve_unified_person_identity(identity)
+        projection = resolution.get("projection") if isinstance(resolution.get("projection"), dict) else None
+        if not isinstance(projection, dict):
+            return {"state": "identity_pending", "code": "projection_missing"}
+        person_id = _single_line(projection.get("person_id"), 80)
+        if isinstance(user, dict) and person_id:
+            user["unified_person_id"] = person_id
+            user["unified_profile_projection_revision"] = int(projection.get("projection_revision") or 1)
+        group_scope = ""
+        if group_id and person_id:
+            platform = _single_line(identity.get("subject_namespace"), 80).split(":", 1)[0]
+            group_scope = f"group:{platform}:{_single_line(group_id, 80)}" if platform else ""
+            if group_scope:
+                self.unified_person_registry.upsert_group_overlay(
+                    person_id,
+                    group_scope,
+                    {
+                        "alias": _single_line((user or {}).get("nickname"), 80),
+                        "source": "group_observation",
+                        "public": True,
+                    },
+                    operation_id=f"req036.overlay:{person_id[-12:]}:{_single_line(group_id, 40)}",
+                    actor_id="companion",
+                )
+        if person_id:
+            event_id = _single_line(self._event_message_id(event), 120)
+            event_origin = _single_line(getattr(event, "unified_msg_origin", ""), 200)
+            source_fingerprint = hashlib.sha256(
+                f"req036:{source}:{group_scope or 'private'}:{event_id or event_origin}".encode("utf-8", errors="ignore")
+            ).hexdigest()
+            self.unified_person_registry.record_identity_source_event(
+                person_id,
+                _single_line(projection.get("resolved_identity_key"), 160),
+                group_scope or "private",
+                source_fingerprint,
+                operation_id=f"req036.source:{source}:{source_fingerprint[:24]}",
+            )
+        dto = req036_build_profile_dto(
+            person_ref=req036_build_person_ref(projection),
+            identity_summary={"display_name": _single_line((user or {}).get("nickname"), 80)},
+            expression_summary={
+                "relationship_score": _safe_int((user or {}).get("relationship_score"), 0, -1200, 1200),
+                "relationship_role": _single_line((user or {}).get("relationship_role"), 40) or "friend",
+            },
+            capability_summary=self._req036_capability_summary_for_user(user),
+            context_overlays={"group_scope": group_scope} if group_scope else {},
+            bridge_status={"state": "ready", "source": "companion"},
+        )
+        errors = req036_validate_profile_dto(dto)
+        if errors:
+            return {"state": "degraded", "code": "bridge_contract_mismatch", "errors": errors}
+        try:
+            setattr(event, "private_companion_unified_profile_context", dto)
+        except Exception:
+            return {"state": "degraded", "code": "bridge_unavailable"}
+        return {"state": "profile_exact", "code": "profile_exact", "dto": dto, "person_id": person_id}
+
+    async def _req036_reject_unauthorized_private_event(self, event: Any, gate: dict[str, Any]) -> None:
+        """Reply before any LLM, bridge, tool, portrait, or relationship path."""
+        try:
+            setattr(event, "private_companion_req036_denied", True)
+            setattr(event, "private_companion_req036_denial_code", str(gate.get("code") or "private_companion_disabled"))
+        except Exception:
+            pass
+        await self._reply(event, str(gate.get("reply") or DEFAULT_UNAUTHORIZED_PRIVATE_REPLY))
+        event.stop_event()
+
+    @staticmethod
+    def _req036_group_portrait_query_kind(text: Any) -> str:
+        value = _single_line(text, 240)
+        probe_patterns = (
+            r"喜欢(?:吃|喝|玩|看|听)?什么",
+            r"爱(?:吃|喝|玩|看|听)什么",
+            r"(?:有|有什么|有啥|有哪些).{0,8}(?:爱好|兴趣|偏好|习惯)",
+            r"(?:爱好|兴趣|偏好|习惯|口味|画像)",
+        )
+        if not any(re.search(pattern, value) for pattern in probe_patterns):
+            return ""
+        if re.search(
+            r"(?:^|[\s，,：:])(?:我|我的|本人|俺|咱)(?:[^，,。！？!?]{0,20})"
+            r"(?:喜欢(?:吃|喝|玩|看|听)?什么|爱(?:吃|喝|玩|看|听)什么|"
+            r"(?:有|有什么|有啥|有哪些).{0,8}(?:爱好|兴趣|偏好|习惯)|(?:爱好|兴趣|偏好|习惯|口味|画像))",
+            value,
+        ):
+            return "self"
+        return "third_party"
+
+    async def _req036_read_group_self_portrait(self, event: Any) -> str:
+        dto = getattr(event, "private_companion_unified_profile_context", None)
+        if not isinstance(dto, dict):
+            return "这部分画像暂时不可用。"
+        person_ref = dto.get("person_ref") if isinstance(dto.get("person_ref"), dict) else {}
+        person_id = _single_line(person_ref.get("person_id"), 80)
+        overlays = dto.get("context_overlays") if isinstance(dto.get("context_overlays"), dict) else {}
+        scope = _single_line(overlays.get("group_scope"), 80)
+        if not scope.startswith("group:"):
+            return "这部分画像暂时不可用。"
+        request = req036_build_portrait_request(
+            person_ref=person_ref,
+            requester_person_id=person_id,
+            target_person_id=person_id,
+            scope=scope,
+            purpose="summarize_to_subject",
+        )
+        bridge = self._memory_companion_bridge()
+        reader = getattr(bridge, "read_unified_profile_portrait", None) if bridge is not None else None
+        if not callable(reader):
+            return "这部分画像暂时不可用。"
+        try:
+            result = reader(request, limit=5)
+            if asyncio.iscoroutine(result) or hasattr(result, "__await__"):
+                result = await result
+        except Exception:
+            return "这部分画像暂时不可用。"
+        if not isinstance(result, dict) or not result.get("ok"):
+            return "这部分画像暂时不可用。"
+        summaries = [
+            _single_line(item.get("summary"), 80)
+            for item in result.get("items", [])
+            if isinstance(item, dict) and _single_line(item.get("summary"), 80)
+        ]
+        return "我目前只记得这些公开的低敏偏好：" + "；".join(summaries[:5]) if summaries else "我还没有整理出可公开的低敏画像。"
+
+    async def _req036_portrait_bridge_status_for_user(self, user: Any) -> dict[str, Any]:
+        """Read synchronization state only; facts stay in Memory's admin UI."""
+        source = user if isinstance(user, dict) else {}
+        person_id = _single_line(source.get("unified_person_id"), 80)
+        if not person_id:
+            return {"available": False, "code": "identity_pending", "last_synced_at": "", "portrait_revision": 0}
+        bridge = self._memory_companion_bridge()
+        reader = getattr(bridge, "unified_profile_portrait_status", None) if bridge is not None else None
+        if not callable(reader):
+            return {"available": False, "code": "bridge_unavailable", "last_synced_at": "", "portrait_revision": 0}
+        try:
+            result = reader(person_id)
+            if asyncio.iscoroutine(result) or hasattr(result, "__await__"):
+                result = await result
+        except Exception:
+            return {"available": False, "code": "bridge_degraded", "last_synced_at": "", "portrait_revision": 0}
+        if not isinstance(result, dict):
+            return {"available": False, "code": "bridge_degraded", "last_synced_at": "", "portrait_revision": 0}
+        return {
+            "available": bool(result.get("ok")),
+            "code": _single_line(result.get("code"), 80) or "bridge_degraded",
+            "last_synced_at": _single_line(result.get("last_synced_at"), 80),
+            "portrait_revision": _safe_int(result.get("portrait_revision"), 0, 0),
+        }
 
     def read_p4_effect_state(self, person_id: str) -> dict[str, Any]:
         return self.unified_person_registry.read_p4_effect_state(person_id)
@@ -10615,6 +10881,52 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         except Exception:
             return False
 
+    @filter.on_llm_request(priority=-40000)
+    @_multi_persona_event_context
+    async def guard_req036_private_capability_before_llm(
+        self,
+        event: AstrMessageEvent,
+        req: ProviderRequest,
+        *args,
+        **kwargs,
+    ):
+        """Fail closed before any Provider, Memory, tool, or relationship hook runs."""
+        if self is None or event is None:
+            return
+        try:
+            if not bool(event.is_private_chat()):
+                return
+        except Exception:
+            return
+        if bool(getattr(event, "private_companion_req036_denied", False)):
+            event.stop_event()
+            return
+        try:
+            user_id = self._canonical_private_user_id(str(event.get_sender_id()))
+        except Exception:
+            user_id = ""
+        users = self.data.get("users", {}) if isinstance(getattr(self, "data", None), dict) else {}
+        user = users.get(user_id) if user_id and isinstance(users, dict) else None
+        gate = self._req036_private_gate_for_user(user)
+        if gate.get("allowed"):
+            return
+        if req is not None:
+            for attribute, value in (
+                ("system_prompt", ""),
+                ("prompt", ""),
+                ("contexts", []),
+                ("extra_user_content_parts", []),
+                ("func_tool", None),
+                ("tools", []),
+                ("images", []),
+                ("image_urls", []),
+            ):
+                try:
+                    setattr(req, attribute, value)
+                except Exception:
+                    pass
+        await self._req036_reject_unauthorized_private_event(event, gate)
+
     @filter.on_llm_request(priority=-30000)
     async def enforce_p4_live_confinement_before_enrichment(
         self,
@@ -11811,6 +12123,37 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         """管理私聊陪伴状态、日程、记忆、风格、重要日期和可选外部动作。"""
         if self is None:
             return
+        try:
+            is_private = bool(event.is_private_chat())
+        except Exception:
+            is_private = False
+        if is_private:
+            user_id = str(event.get_sender_id())
+            sender_name_reader = getattr(self, "_sender_display_name", None)
+            if callable(sender_name_reader):
+                sender_display_name = _single_line(sender_name_reader(event), 40)
+            else:
+                sender_display_name = _single_line(user_id, 40)
+            async with self._data_lock:
+                private_user, _ = self._ensure_auto_private_user_profile(
+                    event,
+                    user_id=user_id,
+                    sender_display_name=sender_display_name,
+                    now=_now_ts(),
+                )
+                migrator = getattr(self, "_req036_migrate_configured_target_capability", None)
+                if callable(migrator):
+                    migrator(user_id, private_user)
+                self._req036_attach_unified_profile_context(
+                    event,
+                    user=private_user if isinstance(private_user, dict) else None,
+                    source="private_command",
+                )
+                self._schedule_data_save()
+                private_gate = self._req036_private_gate_for_user(private_user)
+            if not private_gate.get("allowed"):
+                await self._req036_reject_unauthorized_private_event(event, private_gate)
+                return
         self._qzone_note_event_bot(event)
         raw_text = str(event.message_str or "")
         args = raw_text.replace("\u3000", " ").split(maxsplit=2)
@@ -12583,6 +12926,17 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             sender_name=self._sender_display_name(event),
             text=text,
         )
+        async with self._data_lock:
+            users = self.data.get("users", {}) if isinstance(self.data, dict) else {}
+            canonical_sender_id = self._canonical_private_user_id(sender_id)
+            observed_user = users.get(canonical_sender_id) if isinstance(users, dict) else None
+            self._req036_attach_unified_profile_context(
+                event,
+                user=observed_user if isinstance(observed_user, dict) else None,
+                group_id=group_id,
+                source="group_observation",
+            )
+            self._schedule_data_save()
         self._start_group_image_understanding(
             event,
             group_id=group_id,
@@ -12632,6 +12986,45 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                 sender_id,
             )
             self._stop_group_member_safety_event(event)
+
+    @filter.event_message_type(filter.EventMessageType.GROUP_MESSAGE, priority=180000)
+    @_multi_persona_event_context
+    async def guard_req036_group_portrait_queries(self, event: AstrMessageEvent, *args, **kwargs):
+        """Reject third-party portrait probing before any retrieval or LLM hook."""
+        if self is None or bool(getattr(event, "_private_companion_member_safety_blocked", False)):
+            return
+        group_id = self._extract_group_id_from_event(event)
+        if not group_id:
+            return
+        text = self._group_observation_event_text(event)
+        kind = self._req036_group_portrait_query_kind(text)
+        if not kind:
+            return
+        if kind == "third_party":
+            await self._reply(event, "这个我不方便替别人整理啦。")
+            event.stop_event()
+            return
+        # An observation-disabled group must not become a wording bypass.  It
+        # still does not receive normal group capture; this narrow explicit
+        # self-query only prepares a minimal identity/scene reference for the
+        # low-sensitivity, same-person Memory request below.
+        if not isinstance(getattr(event, "private_companion_unified_profile_context", None), dict):
+            try:
+                sender_id = self._canonical_private_user_id(str(event.get_sender_id()))
+            except Exception:
+                sender_id = ""
+            async with self._data_lock:
+                users = self.data.get("users", {}) if isinstance(self.data, dict) else {}
+                user = users.get(sender_id) if sender_id and isinstance(users, dict) else None
+                self._req036_attach_unified_profile_context(
+                    event,
+                    user=user if isinstance(user, dict) else None,
+                    group_id=group_id,
+                    source="group_portrait_query",
+                )
+                self._schedule_data_save()
+        await self._reply(event, await self._req036_read_group_self_portrait(event))
+        event.stop_event()
 
     @filter.event_message_type(filter.EventMessageType.GROUP_MESSAGE)
     @_multi_persona_event_context

--- a/message_pipeline.py
+++ b/message_pipeline.py
@@ -26,7 +26,6 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
         # 戳一戳会以私聊空文本事件进入 AstrBot；不要让空消息保护误拦截。
         logger.debug("[PrivateCompanion] 私聊戳一戳 notice 已放行给专用插件")
         return
-    self._qzone_note_event_bot(event)
     received_ts = _now_ts()
     user_id = str(event.get_sender_id())
     self_id = self._event_self_id(event)
@@ -35,17 +34,26 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
         return
     sender_display_name = _single_line(self._sender_display_name(event), 40)
     text = _single_line(event.message_str, 120)
-    if text.startswith(("陪伴", "/陪伴", "私聊陪伴", "主动陪伴")):
-        return
-    if self._message_debounce_command_text(event, text):
-        return
     async with self._data_lock:
-        _, auto_profile_created = self._ensure_auto_private_user_profile(
+        private_user, auto_profile_created = self._ensure_auto_private_user_profile(
             event,
             user_id=user_id,
             sender_display_name=sender_display_name,
             now=received_ts,
         )
+        migrator = getattr(self, "_req036_migrate_configured_target_capability", None)
+        if callable(migrator):
+            migrator(user_id, private_user)
+        self._req036_attach_unified_profile_context(
+            event,
+            user=private_user if isinstance(private_user, dict) else None,
+            source="private_auto",
+        )
+        # The identity registry and compatibility projection are durable even
+        # for an unauthorized sender; only the subsequent companion path is
+        # denied.  Coalesced persistence keeps that automatic archival state.
+        self._schedule_data_save()
+        private_gate = self._req036_private_gate_for_user(private_user)
     if auto_profile_created:
         logger.info(
             "[PrivateCompanion] 已建立最小用户档案: user=%s platform=%s auto_enabled=%s",
@@ -53,6 +61,17 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
             _single_line(self._platform_kind_for_event(event), 40),
             bool(getattr(self, "auto_enable_companion_for_new_users", False)),
         )
+    if not private_gate.get("allowed"):
+        await self._req036_reject_unauthorized_private_event(event, private_gate)
+        return
+    # All remaining private handlers are authorized-only.  In particular an
+    # unrecognized sender must not write Qzone notes, debounce state, Memory
+    # context, tools, portrait evidence, or relationship entries first.
+    self._qzone_note_event_bot(event)
+    if text.startswith(("陪伴", "/陪伴", "私聊陪伴", "主动陪伴")):
+        return
+    if self._message_debounce_command_text(event, text):
+        return
     existing_reply_preview = self._event_existing_reply_result_preview(event)
     if existing_reply_preview:
         preview_user_id = self._canonical_private_user_id(user_id)

--- a/page_api.py
+++ b/page_api.py
@@ -558,6 +558,9 @@ class PrivateCompanionPageApi(
             ("/user", self.get_user, ["GET"], "Private Companion Page user detail"),
             ("/user/update", self.update_user, ["POST"], "Private Companion Page update user"),
             ("/user/delete", self.delete_user, ["POST"], "Private Companion Page delete user"),
+            ("/user/identity/link", self.link_unified_identity, ["POST"], "Private Companion Page explicit unified identity link"),
+            ("/user/identity/unlink", self.unlink_unified_identity, ["POST"], "Private Companion Page unified identity unlink preview/apply"),
+            ("/user/identity/merge-preview", self.preview_unified_identity_merge, ["POST"], "Private Companion Page unified person merge preview"),
             ("/groups", self.list_groups, ["GET"], "Private Companion Page groups"),
             ("/group", self.get_group, ["GET"], "Private Companion Page group detail"),
             ("/group/update", self.update_group, ["POST"], "Private Companion Page update group"),
@@ -12708,6 +12711,18 @@ class PrivateCompanionPageApi(
         pending_emotion_judgement = self._emotion_pending_judgement_summary(user.get("pending_emotion_judgement"))
         last_emotion_judgement = self._emotion_last_judgement_summary(user.get("last_emotion_judgement"))
         last_emotion_judgement_error = self._emotion_judgement_error_summary(user.get("last_emotion_judgement_error"))
+        capability_getter = getattr(self.plugin, "_req036_capability_summary_for_user", None)
+        capability_summary = capability_getter(user) if callable(capability_getter) else {
+            "private_companion_enabled": bool(user.get("private_companion_enabled", user.get("enabled", False))),
+            "proactive_private_enabled": False,
+            "effective_proactive_private_enabled": False,
+            "portrait_mode": "disabled",
+            "portrait_learning_enabled": False,
+            "portrait_usage_enabled": False,
+            "grant_source": "legacy",
+            "blocked_reasons": [],
+        }
+        private_companion_enabled = bool(capability_summary.get("private_companion_enabled"))
         return {
             "user_id": user_id_text,
             "display_name": display_name,
@@ -12717,7 +12732,19 @@ class PrivateCompanionPageApi(
             "identity_label": self._single_line((platform_profile or {}).get("identity_label"), 60),
             "stable_platform_identity": bool(platform_kind == "qq_official" or is_qq_user),
             "source": source,
-            "enabled": bool(user.get("enabled", True)),
+            "enabled": private_companion_enabled,
+            "private_companion_enabled": private_companion_enabled,
+            "proactive_private_enabled": bool(capability_summary.get("proactive_private_enabled")),
+            "portrait_mode": self._single_line(capability_summary.get("portrait_mode"), 40) or "disabled",
+            "portrait_learning_enabled": bool(capability_summary.get("portrait_learning_enabled")),
+            "portrait_usage_enabled": bool(capability_summary.get("portrait_usage_enabled")),
+            "portrait_mode_override": self._single_line(
+                (user.get("unified_profile_capabilities") if isinstance(user.get("unified_profile_capabilities"), dict) else {}).get("portrait_mode_override"),
+                40,
+            ) or "follow_global",
+            "capability_summary": capability_summary,
+            "unified_person_id": self._single_line(user.get("unified_person_id"), 80),
+            "proactive_contact_enabled": bool(capability_summary.get("effective_proactive_private_enabled")),
             "relationship_role": role,
             "relationship_role_label": role_label,
             "nickname": user.get("nickname", ""),

--- a/page_api_users_groups.py
+++ b/page_api_users_groups.py
@@ -56,6 +56,31 @@ class PrivateCompanionPageApiUsersGroupsMixin:
                     users = {}
                 user_items = [(user_id, dict(user)) for user_id, user in users.items() if isinstance(user, dict)]
             items = [self._user_summary(user_id, user) for user_id, user in user_items]
+            # Source records remain available for replay and explicit unlink,
+            # but one resolved person has one administrative list card.  The
+            # secondary source IDs are exposed as aliases rather than a
+            # competing private profile.
+            projected: dict[str, dict[str, Any]] = {}
+            deduped: list[dict[str, Any]] = []
+            for item in items:
+                person_id = self._single_line(item.get("unified_person_id"), 80)
+                if not person_id:
+                    deduped.append(item)
+                    continue
+                existing = projected.get(person_id)
+                if existing is None:
+                    item["alias_user_ids"] = []
+                    projected[person_id] = item
+                    deduped.append(item)
+                    continue
+                aliases = existing.setdefault("alias_user_ids", [])
+                if not isinstance(aliases, list):
+                    aliases = []
+                    existing["alias_user_ids"] = aliases
+                source_id = self._single_line(item.get("user_id"), 80)
+                if source_id and source_id != self._single_line(existing.get("user_id"), 80) and source_id not in aliases:
+                    aliases.append(source_id)
+            items = deduped
             items.sort(key=lambda item: item.get("last_seen_ts") or 0, reverse=True)
             elapsed_ms = int((time.perf_counter() - start) * 1000)
             if elapsed_ms > 1200:
@@ -120,10 +145,80 @@ class PrivateCompanionPageApiUsersGroupsMixin:
                     },
                 }
             )
+            portrait_status_reader = getattr(self.plugin, "_req036_portrait_bridge_status_for_user", None)
+            detail["portrait_bridge"] = (
+                await portrait_status_reader(user)
+                if callable(portrait_status_reader)
+                else {"available": False, "code": "bridge_unavailable", "last_synced_at": "", "portrait_revision": 0}
+            )
             return self._ok(detail)
         except Exception as exc:
             logger.error(f"[PrivateCompanionPage] 获取用户详情失败: {exc}", exc_info=True)
             return self._error(str(exc))
+    async def link_unified_identity(self) -> dict[str, Any]:
+        payload = await request.get_json(silent=True) or {}
+        person_id = self._single_line(payload.get("person_id"), 80)
+        identity = payload.get("identity") if isinstance(payload.get("identity"), dict) else {}
+        operation_id = self._single_line(payload.get("operation_id"), 120)
+        if not person_id or not identity or not operation_id:
+            return self._error("person_id、identity 和 operation_id 均为必填项")
+        try:
+            async with self.plugin._data_lock:
+                result = self.plugin.unified_person_registry.link_identity(
+                    person_id,
+                    identity,
+                    operation_id=operation_id,
+                    actor_id="page_administrator",
+                )
+                if result.get("changed"):
+                    self.plugin._schedule_data_save()
+            return self._ok({"result": result})
+        except Exception as exc:
+            logger.warning("[PrivateCompanionPage] 统一身份链接失败: %s", exc)
+            return self._error("统一身份链接失败")
+
+    async def unlink_unified_identity(self) -> dict[str, Any]:
+        payload = await request.get_json(silent=True) or {}
+        person_id = self._single_line(payload.get("person_id"), 80)
+        identity = payload.get("identity") if isinstance(payload.get("identity"), dict) else {}
+        operation_id = self._single_line(payload.get("operation_id"), 120)
+        dry_run = bool(payload.get("dry_run", True))
+        if not person_id or not identity or not operation_id:
+            return self._error("person_id、identity 和 operation_id 均为必填项")
+        try:
+            async with self.plugin._data_lock:
+                result = self.plugin.unified_person_registry.unlink_identity(
+                    person_id,
+                    identity,
+                    operation_id=operation_id,
+                    actor_id="page_administrator",
+                    dry_run=dry_run,
+                )
+                if result.get("changed"):
+                    self.plugin._schedule_data_save()
+            return self._ok({"result": result})
+        except Exception as exc:
+            logger.warning("[PrivateCompanionPage] 统一身份解绑失败: %s", exc)
+            return self._error("统一身份解绑失败")
+
+    async def preview_unified_identity_merge(self) -> dict[str, Any]:
+        payload = await request.get_json(silent=True) or {}
+        source_person_id = self._single_line(payload.get("source_person_id"), 80)
+        target_person_id = self._single_line(payload.get("target_person_id"), 80)
+        operation_id = self._single_line(payload.get("operation_id"), 120)
+        if not source_person_id or not target_person_id or not operation_id:
+            return self._error("source_person_id、target_person_id 和 operation_id 均为必填项")
+        try:
+            result = self.plugin.unified_person_registry.preview_person_merge(
+                source_person_id,
+                target_person_id,
+                operation_id=operation_id,
+            )
+            return self._ok({"result": result})
+        except Exception as exc:
+            logger.warning("[PrivateCompanionPage] 统一人物合并预览失败: %s", exc)
+            return self._error("统一人物合并预览失败")
+
     async def update_user(self) -> dict[str, Any]:
         payload = await request.get_json(silent=True) or {}
         user_id = str(payload.get("user_id", "")).strip()
@@ -198,15 +293,36 @@ class PrivateCompanionPageApiUsersGroupsMixin:
                     )
                     if requested_projection.get("expression_band") != requested_interaction_band:
                         return self._error("current interaction band exceeds the configured user cap")
+                capability_changes = {}
                 if "enabled" in payload:
-                    enabled = bool(payload.get("enabled"))
-                    user["enabled"] = enabled
+                    capability_changes["private_companion_enabled"] = bool(payload.get("enabled"))
+                for capability_key in (
+                    "private_companion_enabled",
+                    "proactive_private_enabled",
+                    "portrait_mode",
+                ):
+                    if capability_key in payload:
+                        capability_changes[capability_key] = payload.get(capability_key)
+                if capability_changes:
+                    updater = getattr(self.plugin, "_req036_update_capabilities", None)
+                    if not callable(updater):
+                        return self._error("统一用户权限服务不可用")
+                    capability_result = updater(
+                        user,
+                        capability_changes,
+                        actor_id="page_administrator",
+                        target_identity=user_id,
+                        reason_code="page_administrator_update",
+                    )
+                    if not bool(capability_result.get("ok")):
+                        return self._error(str(capability_result.get("code") or "权限更新失败"))
+                    enabled = bool(capability_result["capabilities"].get("private_companion_enabled"))
                     user["manual_enabled"] = enabled
                     user["manual_disabled"] = not enabled
                     user["auto_enabled"] = False
                     if enabled:
                         self.plugin._ensure_private_user_umo(user_id, user)
-                    if not enabled:
+                    else:
                         self.plugin._clear_pending_proactive_plan(user)
                 if "nickname" in payload:
                     user["nickname"] = self._single_line(payload.get("nickname"), 24)

--- a/pages/companion-panel/app.js
+++ b/pages/companion-panel/app.js
@@ -14003,9 +14003,10 @@ async function renderUserDetail(forceFetch = false) {
       return;
     }
   }
+  const privateEnabled = Boolean(detail.private_companion_enabled ?? detail.enabled);
   box.innerHTML = `
     <div class="toolbar">
-      <button data-user-action="toggle">${escapeHtml(detail.enabled ? "停用私聊陪伴" : "启用私聊陪伴")}</button>
+      <button data-user-action="toggle">${escapeHtml(privateEnabled ? "停用私聊陪伴" : "启用私聊陪伴")}</button>
       <button data-user-action="reset_daily">重置今日额度</button>
       <button data-user-action="clear_schedule">清空主动计划</button>
       <button data-user-action="clear_emotion_state">重置情绪状态</button>
@@ -14020,7 +14021,7 @@ async function renderUserDetail(forceFetch = false) {
           <option value="friend" ${detail.relationship_role !== "owner" ? "selected" : ""}>次要用户</option>
         </select>
       </label>
-      <label>每日主动 <input name="proactive_daily_limit" type="number" min="-1" max="30" step="1" value="${escapeHtml(detail.proactive_daily_limit ?? -1)}" /></label>
+      <label>每日主动 <input name="proactive_daily_limit" type="number" min="-1" max="30" step="1" value="${escapeHtml(detail.proactive_daily_limit ?? -1)}" ${privateEnabled ? "" : "disabled"} /></label>
       <button type="submit">保存</button>
     </form>
     ${renderRelationshipStatus(detail)}
@@ -14033,6 +14034,8 @@ async function renderUserDetail(forceFetch = false) {
     </div>
     <div class="detail-grid">
       ${renderRelationshipPanel(detail.relationship_panel)}
+      ${renderUnifiedProfileCapabilityPanel(detail)}
+      ${renderPortraitBridgeStatus(detail.portrait_bridge)}
       ${detailBlock("关系和主动", detail.formatted?.relationship || "", [["角色", detail.relationship_role_label || ""], ["有效主动上限", `${detail.effective_daily_limit_text || formatProactiveLimit(detail.effective_daily_limit, detail.effective_daily_limit_unlimited)} / 天`], ["下次主动", detail.formatted?.next_proactive || detail.next_proactive], ["动作偏好", detail.formatted?.action_affinity || ""]])}
       ${renderPrivateDeliveryRoute(detail)}
       ${renderPrivateBehaviorHabits(detail)}
@@ -14048,6 +14051,63 @@ async function renderUserDetail(forceFetch = false) {
     </div>
   `;
   bindUserActions(detail);
+}
+
+function portraitModeLabel(mode) {
+  return {
+    disabled: "关闭智能画像",
+    use_existing: "仅使用已有画像",
+    learn_and_use: "持续学习与使用",
+    follow_global: "跟随全局设置",
+  }[String(mode || "")] || "关闭智能画像";
+}
+
+function renderUnifiedProfileCapabilityPanel(detail) {
+  const capabilities = detail?.capability_summary && typeof detail.capability_summary === "object" ? detail.capability_summary : {};
+  const privateEnabled = Boolean(capabilities.private_companion_enabled ?? detail?.private_companion_enabled ?? detail?.enabled);
+  const proactiveEnabled = Boolean(capabilities.proactive_private_enabled ?? detail?.proactive_private_enabled);
+  const effectiveProactive = Boolean(capabilities.effective_proactive_private_enabled ?? detail?.proactive_contact_enabled);
+  const override = String(detail?.portrait_mode_override || "follow_global") === "explicit"
+    ? String(capabilities.portrait_mode || detail?.portrait_mode || "disabled")
+    : "follow_global";
+  const effectivePortraitMode = String(capabilities.portrait_mode || detail?.portrait_mode || "disabled");
+  const personId = String(detail?.unified_person_id || "");
+  return `
+    <section class="detail-block unified-profile-capabilities">
+      <header class="detail-block-head"><div><h2>统一档案权限</h2><p>仅管理员可修改。用户主动私聊不会改变任何开关。</p></div><span class="badge ${privateEnabled ? "ok" : "off"}">${escapeHtml(privateEnabled ? "私聊已授权" : "私聊未授权")}</span></header>
+      <form id="unifiedProfileCapabilitiesForm" class="inline-form">
+        <label><input name="private_companion_enabled" type="checkbox" ${privateEnabled ? "checked" : ""} /> 私聊陪伴</label>
+        <label><input name="proactive_private_enabled" type="checkbox" ${proactiveEnabled ? "checked" : ""} /> 主动私聊</label>
+        <label>智能画像
+          <select name="portrait_mode">
+            <option value="follow_global" ${override === "follow_global" ? "selected" : ""}>跟随全局设置</option>
+            <option value="disabled" ${override === "disabled" ? "selected" : ""}>关闭智能画像</option>
+            <option value="use_existing" ${override === "use_existing" ? "selected" : ""}>仅使用已有画像</option>
+            <option value="learn_and_use" ${override === "learn_and_use" ? "selected" : ""}>持续学习与使用</option>
+          </select>
+        </label>
+        <button type="submit">保存权限</button>
+      </form>
+      <dl><dt>统一人物</dt><dd>${escapeHtml(personId || "等待精确身份投影")}</dd><dt>画像实际模式</dt><dd>${escapeHtml(portraitModeLabel(effectivePortraitMode))}</dd><dt>主动联系</dt><dd>${escapeHtml(effectiveProactive ? "可在既有日程和安全门内执行" : proactiveEnabled ? "等待私聊陪伴授权" : "关闭")}</dd></dl>
+    </section>
+  `;
+}
+
+function renderPortraitBridgeStatus(value) {
+  const status = value && typeof value === "object" ? value : {};
+  const available = Boolean(status.available);
+  const code = String(status.code || "bridge_unavailable");
+  const syncedAt = String(status.last_synced_at || "");
+  const revision = Number(status.portrait_revision || 0);
+  return detailBlock(
+    "画像同步状态",
+    available ? "画像事实和治理入口由 Memory 独立维护；本页不缓存或显示旧画像正文。" : "Memory 当前不可用或身份尚未精确投影；为避免陈旧披露，本页不会回显任何画像摘要。",
+    [
+      ["Bridge", available ? "可用" : code],
+      ["最近同步", syncedAt || "暂无"],
+      ["画像版本", revision ? `r${revision}` : "暂无"],
+    ],
+  );
 }
 
 function renderEmotionDiagnostics(detail) {
@@ -14120,6 +14180,11 @@ function renderUserP4RuntimeStatus(status) {
 
 function renderPrivateDeliveryRoute(detail) {
   const route = detail?.delivery_route && typeof detail.delivery_route === "object" ? detail.delivery_route : {};
+  if (route.reason === "private_companion_disabled" || !Boolean(detail?.private_companion_enabled ?? detail?.enabled)) {
+    return detailBlock("主动投递会话", "私聊陪伴当前关闭；主动联系不会因群聊观察或画像模式而自动开启。", [
+      ["主动联系", "关闭"],
+    ]);
+  }
   const recentError = String(route.recent_error || "").trim();
   const errorLabel = route.recent_error_recovered ? "最近错误（已恢复）" : "最近错误";
   const routeCount = Number(route.route_count || 0);
@@ -15363,6 +15428,23 @@ function bindUserActions(detail) {
       await renderUserDetail(true);
     }
   };
+  const capabilityForm = $("#unifiedProfileCapabilitiesForm");
+  capabilityForm?.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const form = new FormData(event.currentTarget);
+    const saved = await runAction(
+      () => postJson("/user/update", {
+        user_id: detail.user_id,
+        private_companion_enabled: form.get("private_companion_enabled") === "on",
+        proactive_private_enabled: form.get("proactive_private_enabled") === "on",
+        portrait_mode: String(form.get("portrait_mode") || "follow_global"),
+      }),
+      "已保存统一档案权限",
+      event.submitter,
+      { reload: false },
+    );
+    if (saved) await refreshSelectedUserDetail();
+  });
   $("#relationshipStageForm")?.addEventListener("submit", async (event) => {
     event.preventDefault();
     const selectedKey = String(new FormData(event.currentTarget).get("relationship_stage_key") || "");

--- a/pages/陪伴面板/app.js
+++ b/pages/陪伴面板/app.js
@@ -14003,9 +14003,10 @@ async function renderUserDetail(forceFetch = false) {
       return;
     }
   }
+  const privateEnabled = Boolean(detail.private_companion_enabled ?? detail.enabled);
   box.innerHTML = `
     <div class="toolbar">
-      <button data-user-action="toggle">${escapeHtml(detail.enabled ? "停用私聊陪伴" : "启用私聊陪伴")}</button>
+      <button data-user-action="toggle">${escapeHtml(privateEnabled ? "停用私聊陪伴" : "启用私聊陪伴")}</button>
       <button data-user-action="reset_daily">重置今日额度</button>
       <button data-user-action="clear_schedule">清空主动计划</button>
       <button data-user-action="clear_emotion_state">重置情绪状态</button>
@@ -14020,7 +14021,7 @@ async function renderUserDetail(forceFetch = false) {
           <option value="friend" ${detail.relationship_role !== "owner" ? "selected" : ""}>次要用户</option>
         </select>
       </label>
-      <label>每日主动 <input name="proactive_daily_limit" type="number" min="-1" max="30" step="1" value="${escapeHtml(detail.proactive_daily_limit ?? -1)}" /></label>
+      <label>每日主动 <input name="proactive_daily_limit" type="number" min="-1" max="30" step="1" value="${escapeHtml(detail.proactive_daily_limit ?? -1)}" ${privateEnabled ? "" : "disabled"} /></label>
       <button type="submit">保存</button>
     </form>
     ${renderRelationshipStatus(detail)}
@@ -14033,6 +14034,8 @@ async function renderUserDetail(forceFetch = false) {
     </div>
     <div class="detail-grid">
       ${renderRelationshipPanel(detail.relationship_panel)}
+      ${renderUnifiedProfileCapabilityPanel(detail)}
+      ${renderPortraitBridgeStatus(detail.portrait_bridge)}
       ${detailBlock("关系和主动", detail.formatted?.relationship || "", [["角色", detail.relationship_role_label || ""], ["有效主动上限", `${detail.effective_daily_limit_text || formatProactiveLimit(detail.effective_daily_limit, detail.effective_daily_limit_unlimited)} / 天`], ["下次主动", detail.formatted?.next_proactive || detail.next_proactive], ["动作偏好", detail.formatted?.action_affinity || ""]])}
       ${renderPrivateDeliveryRoute(detail)}
       ${renderPrivateBehaviorHabits(detail)}
@@ -14048,6 +14051,63 @@ async function renderUserDetail(forceFetch = false) {
     </div>
   `;
   bindUserActions(detail);
+}
+
+function portraitModeLabel(mode) {
+  return {
+    disabled: "关闭智能画像",
+    use_existing: "仅使用已有画像",
+    learn_and_use: "持续学习与使用",
+    follow_global: "跟随全局设置",
+  }[String(mode || "")] || "关闭智能画像";
+}
+
+function renderUnifiedProfileCapabilityPanel(detail) {
+  const capabilities = detail?.capability_summary && typeof detail.capability_summary === "object" ? detail.capability_summary : {};
+  const privateEnabled = Boolean(capabilities.private_companion_enabled ?? detail?.private_companion_enabled ?? detail?.enabled);
+  const proactiveEnabled = Boolean(capabilities.proactive_private_enabled ?? detail?.proactive_private_enabled);
+  const effectiveProactive = Boolean(capabilities.effective_proactive_private_enabled ?? detail?.proactive_contact_enabled);
+  const override = String(detail?.portrait_mode_override || "follow_global") === "explicit"
+    ? String(capabilities.portrait_mode || detail?.portrait_mode || "disabled")
+    : "follow_global";
+  const effectivePortraitMode = String(capabilities.portrait_mode || detail?.portrait_mode || "disabled");
+  const personId = String(detail?.unified_person_id || "");
+  return `
+    <section class="detail-block unified-profile-capabilities">
+      <header class="detail-block-head"><div><h2>统一档案权限</h2><p>仅管理员可修改。用户主动私聊不会改变任何开关。</p></div><span class="badge ${privateEnabled ? "ok" : "off"}">${escapeHtml(privateEnabled ? "私聊已授权" : "私聊未授权")}</span></header>
+      <form id="unifiedProfileCapabilitiesForm" class="inline-form">
+        <label><input name="private_companion_enabled" type="checkbox" ${privateEnabled ? "checked" : ""} /> 私聊陪伴</label>
+        <label><input name="proactive_private_enabled" type="checkbox" ${proactiveEnabled ? "checked" : ""} /> 主动私聊</label>
+        <label>智能画像
+          <select name="portrait_mode">
+            <option value="follow_global" ${override === "follow_global" ? "selected" : ""}>跟随全局设置</option>
+            <option value="disabled" ${override === "disabled" ? "selected" : ""}>关闭智能画像</option>
+            <option value="use_existing" ${override === "use_existing" ? "selected" : ""}>仅使用已有画像</option>
+            <option value="learn_and_use" ${override === "learn_and_use" ? "selected" : ""}>持续学习与使用</option>
+          </select>
+        </label>
+        <button type="submit">保存权限</button>
+      </form>
+      <dl><dt>统一人物</dt><dd>${escapeHtml(personId || "等待精确身份投影")}</dd><dt>画像实际模式</dt><dd>${escapeHtml(portraitModeLabel(effectivePortraitMode))}</dd><dt>主动联系</dt><dd>${escapeHtml(effectiveProactive ? "可在既有日程和安全门内执行" : proactiveEnabled ? "等待私聊陪伴授权" : "关闭")}</dd></dl>
+    </section>
+  `;
+}
+
+function renderPortraitBridgeStatus(value) {
+  const status = value && typeof value === "object" ? value : {};
+  const available = Boolean(status.available);
+  const code = String(status.code || "bridge_unavailable");
+  const syncedAt = String(status.last_synced_at || "");
+  const revision = Number(status.portrait_revision || 0);
+  return detailBlock(
+    "画像同步状态",
+    available ? "画像事实和治理入口由 Memory 独立维护；本页不缓存或显示旧画像正文。" : "Memory 当前不可用或身份尚未精确投影；为避免陈旧披露，本页不会回显任何画像摘要。",
+    [
+      ["Bridge", available ? "可用" : code],
+      ["最近同步", syncedAt || "暂无"],
+      ["画像版本", revision ? `r${revision}` : "暂无"],
+    ],
+  );
 }
 
 function renderEmotionDiagnostics(detail) {
@@ -14120,6 +14180,11 @@ function renderUserP4RuntimeStatus(status) {
 
 function renderPrivateDeliveryRoute(detail) {
   const route = detail?.delivery_route && typeof detail.delivery_route === "object" ? detail.delivery_route : {};
+  if (route.reason === "private_companion_disabled" || !Boolean(detail?.private_companion_enabled ?? detail?.enabled)) {
+    return detailBlock("主动投递会话", "私聊陪伴当前关闭；主动联系不会因群聊观察或画像模式而自动开启。", [
+      ["主动联系", "关闭"],
+    ]);
+  }
   const recentError = String(route.recent_error || "").trim();
   const errorLabel = route.recent_error_recovered ? "最近错误（已恢复）" : "最近错误";
   const routeCount = Number(route.route_count || 0);
@@ -15363,6 +15428,23 @@ function bindUserActions(detail) {
       await renderUserDetail(true);
     }
   };
+  const capabilityForm = $("#unifiedProfileCapabilitiesForm");
+  capabilityForm?.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const form = new FormData(event.currentTarget);
+    const saved = await runAction(
+      () => postJson("/user/update", {
+        user_id: detail.user_id,
+        private_companion_enabled: form.get("private_companion_enabled") === "on",
+        proactive_private_enabled: form.get("proactive_private_enabled") === "on",
+        portrait_mode: String(form.get("portrait_mode") || "follow_global"),
+      }),
+      "已保存统一档案权限",
+      event.submitter,
+      { reload: false },
+    );
+    if (saved) await refreshSelectedUserDetail();
+  });
   $("#relationshipStageForm")?.addEventListener("submit", async (event) => {
     event.preventDefault();
     const selectedKey = String(new FormData(event.currentTarget).get("relationship_stage_key") || "");

--- a/plugin_bootstrap.py
+++ b/plugin_bootstrap.py
@@ -38,6 +38,7 @@ from .relationship_policy import normalize_relationship_stage_policy
 from .runtime_compat import probe_runtime_capabilities
 from .segmented_message import normalize_component_strategy
 from .unified_person_registry import UnifiedPersonRegistry
+from .unified_profile_service import DEFAULT_UNAUTHORIZED_PRIVATE_REPLY
 
 DEFAULT_AI_DAILY_MORNING_UID = "3706929260006322"
 DEFAULT_AI_DAILY_JUYA_UID = "285286947"
@@ -321,6 +322,15 @@ def _initialize_core_and_relationship_config(self: Any, c: Any) -> None:
         self.default_nickname_strategy = "platform_display_name"
     self.default_proactive_enabled = self._cfg_bool(c, "default_proactive_enabled", False)
     self.default_proactive_daily_limit = self._cfg_int(c, "default_proactive_daily_limit", 0, 0, 30)
+    self.private_companion_disabled_reply = self._cfg_str(
+        c,
+        "private_companion_disabled_reply",
+        DEFAULT_UNAUTHORIZED_PRIVATE_REPLY,
+        DEFAULT_UNAUTHORIZED_PRIVATE_REPLY,
+    )
+    self.portrait_global_mode = self._cfg_str(c, "portrait_global_mode", "disabled", "disabled")
+    if self.portrait_global_mode not in {"disabled", "use_existing", "learn_and_use"}:
+        self.portrait_global_mode = "disabled"
     self.require_private_opt_in = self._cfg_bool(c, "require_private_opt_in", True)
     self.target_user_ids = self._cfg_raw(c, "target_user_ids", [])
     self.private_user_aliases = self._parse_private_user_aliases(self._cfg_raw(c, "private_user_aliases", ""))

--- a/proactive.py
+++ b/proactive.py
@@ -107,6 +107,8 @@ from .helpers import _date_key, _now_ts, _safe_float, _safe_int, _single_line, _
 from .relationship_policy import relationship_stage_for_score
 from .companion_interaction_expression import current_interaction_projection
 from .user_rest_gate import UserRestGateMixin
+from .unified_profile_service import capability_summary as req036_capability_summary
+from .unified_profile_service import update_capabilities as req036_update_capabilities
 from .planning import (
     build_daily_plan_prompt,
     build_detail_enhancement_prompt,
@@ -597,6 +599,13 @@ class ProactiveMixin(UserRestGateMixin):
     def _user_enabled_for_proactive(self, user_id: str, user: dict[str, Any] | None = None) -> bool:
         if not isinstance(user, dict):
             return False
+        req036_gate = getattr(self, "_req036_proactive_private_allowed", None)
+        if callable(req036_gate):
+            try:
+                if not bool(req036_gate(user)):
+                    return False
+            except Exception:
+                return False
         if user.get("enabled") is False or user.get("manual_disabled"):
             return False
         return self._is_target_private_user(user_id, user)
@@ -1574,10 +1583,32 @@ class ProactiveMixin(UserRestGateMixin):
             if user.get("manual_disabled"):
                 self._clear_pending_proactive_plan(user)
                 continue
-            user["enabled"] = True
+            capabilities = user.get("unified_profile_capabilities")
+            if not isinstance(capabilities, dict):
+                # ``target_user_ids`` is an administrator-managed legacy
+                # permission source, not an inbound-DM signal.  Convert it
+                # once when materializing a target record; future syncs only
+                # read the frozen capability state and cannot reopen a user.
+                req036_update_capabilities(
+                    user,
+                    {
+                        "private_companion_enabled": True,
+                        "proactive_private_enabled": _safe_int(user.get("proactive_daily_limit"), 0, 0) > 0,
+                    },
+                    actor_authorized=True,
+                    grant_source="legacy_configured_target_migration",
+                    actor_id="startup_migration",
+                    target_identity=user_id,
+                    reason_code="legacy_configured_target_migration",
+                )
+            capability = req036_capability_summary(user)
+            user["enabled"] = bool(capability.get("private_companion_enabled"))
             user["target_user"] = True
             user.setdefault("nickname", self.default_nickname)
-            self._ensure_private_user_umo(user_id, user)
+            if user["enabled"]:
+                self._ensure_private_user_umo(user_id, user)
+            else:
+                self._clear_pending_proactive_plan(user)
             if self._user_enabled_for_proactive(user_id, user) and _safe_float(user.get("next_proactive_at"), 0) <= 0:
                 self._schedule_next_proactive(user, now=_now_ts())
 

--- a/tests/test_group_observation_ingress.py
+++ b/tests/test_group_observation_ingress.py
@@ -165,10 +165,16 @@ class GroupObservationIngressTests(unittest.IsolatedAsyncioTestCase):
         plugin._message_debounce_command_text = Mock(return_value=False)
         plugin._sender_display_name = Mock(return_value="用户")
         plugin._capture_group_observation_event = AsyncMock(return_value=True)
+        plugin.data = {"users": {}}
+        plugin._data_lock = asyncio.Lock()
+        plugin._canonical_private_user_id = Mock(return_value="user-1")
+        plugin._req036_attach_unified_profile_context = Mock(return_value={"state": "profile_exact"})
+        plugin._schedule_data_save = Mock()
 
         await plugin.capture_group_observation_early(event)
 
         plugin._capture_group_observation_event.assert_awaited_once()
+        plugin._req036_attach_unified_profile_context.assert_called_once()
         self.assertFalse(event._stopped)
 
     def test_observer_priority_and_group_form_default_are_explicit(self) -> None:

--- a/tests/test_private_delivery_binding_command.py
+++ b/tests/test_private_delivery_binding_command.py
@@ -6,6 +6,10 @@ import unittest
 
 from astrbot_plugin_private_companion.interaction_utils import InteractionUtilsMixin
 from astrbot_plugin_private_companion.main import PrivateCompanionPlugin
+from astrbot_plugin_private_companion.unified_profile_service import (
+    default_capabilities,
+    private_companion_gate,
+)
 
 
 class _Event:
@@ -29,7 +33,9 @@ class _Event:
 class _Harness(InteractionUtilsMixin):
     def __init__(self) -> None:
         self.require_private_opt_in = True
-        self.data = {"users": {}}
+        capabilities = default_capabilities(grant_source="legacy_effective_migration")
+        capabilities["private_companion_enabled"] = True
+        self.data = {"users": {"openid-owner": {"unified_profile_capabilities": capabilities}}}
         self._data_lock = asyncio.Lock()
         self.replies: list[str] = []
         self.save_count = 0
@@ -38,6 +44,29 @@ class _Harness(InteractionUtilsMixin):
     @staticmethod
     def _qzone_note_event_bot(event) -> None:
         return None
+
+    @staticmethod
+    def _sender_display_name(_event) -> str:
+        return "测试用户"
+
+    def _ensure_auto_private_user_profile(self, _event, *, user_id: str, **_kwargs):
+        return self._get_user(user_id), False
+
+    @staticmethod
+    def _req036_attach_unified_profile_context(_event, **_kwargs) -> dict:
+        return {"state": "profile_exact"}
+
+    @staticmethod
+    def _schedule_data_save() -> None:
+        return None
+
+    @staticmethod
+    def _req036_private_gate_for_user(user: dict) -> dict:
+        return private_companion_gate(user, "固定拒绝文本")
+
+    async def _req036_reject_unauthorized_private_event(self, event, gate: dict) -> None:
+        await self._reply(event, str(gate["reply"]))
+        event.stop_event()
 
     def _get_user(self, user_id: str) -> dict:
         return self.data["users"].setdefault(user_id, {})

--- a/tests/test_req023_group_observation_profiles.py
+++ b/tests/test_req023_group_observation_profiles.py
@@ -84,8 +84,8 @@ class GroupObservationProfileTests(unittest.TestCase):
         self.assertFalse(profile["private_memory_enabled"])
         self.assertFalse(profile["cross_group_memory_enabled"])
         self.assertFalse(profile["p4_eligible"])
-        self.assertEqual(0, profile["affinity_score"])
-        self.assertEqual("neutral", profile["relationship_state"])
+        self.assertNotIn("affinity_score", profile)
+        self.assertNotIn("relationship_state", profile)
         self.assertNotIn("users", host.data)
         self.assertIsNone(host._worldbook_profile_by_user_id("10001"))
         self.assertEqual("QQ昵称", host._worldbook_profile_by_user_id("10001", include_observation=True)["name"])
@@ -114,7 +114,7 @@ class GroupObservationProfileTests(unittest.TestCase):
         profile = host._ensure_worldbook_group_observation_profile(
             group_id="group-a", sender_id="10001", qq_nickname="QQ昵称", group_card="群名片"
         )
-        before = {key: profile[key] for key in ("affinity_score", "relationship_state", "group_aliases")}
+        before = {key: profile.get(key) for key in ("affinity_score", "relationship_state", "group_aliases")}
 
         self.assertTrue(
             host._confirm_worldbook_observation_profile_name(
@@ -123,8 +123,8 @@ class GroupObservationProfileTests(unittest.TestCase):
         )
         self.assertEqual("小雪", profile["name"])
         self.assertIn("QQ昵称", profile["aliases"])
-        self.assertEqual(before["affinity_score"], profile["affinity_score"])
-        self.assertEqual(before["relationship_state"], profile["relationship_state"])
+        self.assertEqual(before["affinity_score"], profile.get("affinity_score"))
+        self.assertEqual(before["relationship_state"], profile.get("relationship_state"))
         self.assertEqual(before["group_aliases"], profile["group_aliases"])
         self.assertFalse(profile["proactive_contact_enabled"])
         self.assertFalse(profile["p4_eligible"])

--- a/tests/test_req027_user_profiles_relationship_policy.py
+++ b/tests/test_req027_user_profiles_relationship_policy.py
@@ -46,6 +46,23 @@ def _load_platform_compat():
     return module
 
 
+def _load_unified_profile_service():
+    package_name = "req027_unified_profile_package"
+    package = ModuleType(package_name)
+    package.__path__ = [str(ROOT)]
+    sys.modules[package_name] = package
+    spec = importlib.util.spec_from_file_location(
+        f"{package_name}.unified_profile_service",
+        ROOT / "unified_profile_service.py",
+        submodule_search_locations=[],
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
 def _load_class_methods(filename: str, class_name: str, names: set[str], namespace: dict[str, Any]) -> dict[str, Any]:
     path = ROOT / filename
     tree = ast.parse(path.read_text(encoding="utf-8"))
@@ -78,6 +95,7 @@ CORE_METHODS = _load_class_methods(
         ) if str(value).strip() else default,
         "_safe_float": lambda value, default=0.0: float(value or default),
         "_now_ts": lambda: 123.0,
+        "ensure_new_profile_capabilities": _load_unified_profile_service().ensure_new_profile_capabilities,
     },
 )
 

--- a/tests/test_req036_unified_profile.py
+++ b/tests/test_req036_unified_profile.py
@@ -1,0 +1,521 @@
+from __future__ import annotations
+
+import ast
+import asyncio
+import copy
+import hashlib
+import sys
+import time
+import types
+import unittest
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE = "req036_companion"
+if PACKAGE not in sys.modules:
+    module = types.ModuleType(PACKAGE)
+    module.__path__ = [str(ROOT)]
+    sys.modules[PACKAGE] = module
+
+from req036_companion.unified_person_registry import UnifiedPersonRegistry
+from req036_companion.unified_profile_contract import build_profile_dto, build_person_ref, validate_profile_dto
+from req036_companion.unified_profile_service import (
+    DEFAULT_UNAUTHORIZED_PRIVATE_REPLY,
+    capability_summary,
+    default_capabilities,
+    migrate_legacy_capabilities,
+    private_companion_gate,
+    proactive_private_gate,
+    rollback_legacy_capabilities,
+    update_capabilities,
+)
+
+
+def _identity(subject_id: str) -> dict[str, str]:
+    return {
+        "companion_instance_id": "astrbot_plugin_private_companion",
+        "bot_account_id": "onebot:bot-1",
+        "adapter_instance_id": "onebot:default",
+        "subject_namespace": "onebot:user",
+        "platform_subject_id": subject_id,
+    }
+
+
+def _load_method(name: str) -> Any:
+    source = (ROOT / "main.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    owner = next(node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "PrivateCompanionPlugin")
+    method = next(node for node in owner.body if isinstance(node, ast.AsyncFunctionDef) and node.name == name)
+    method = copy.deepcopy(method)
+    method.decorator_list = []
+    module = ast.Module(body=[method], type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace: dict[str, Any] = {
+        "Any": Any,
+        "AstrMessageEvent": Any,
+        "ProviderRequest": Any,
+        "DEFAULT_UNAUTHORIZED_PRIVATE_REPLY": DEFAULT_UNAUTHORIZED_PRIVATE_REPLY,
+        "_now_ts": lambda: 100.0,
+        "_single_line": lambda value, limit=240: str(value or "").strip()[:limit],
+    }
+    exec(compile(module, str(ROOT / "main.py"), "exec"), namespace)
+    return namespace[name]
+
+
+REQ036_LLM_GATE = _load_method("guard_req036_private_capability_before_llm")
+REQ036_GROUP_GATE = _load_method("guard_req036_group_portrait_queries")
+REQ036_COMMAND_GATE = _load_method("companion_command")
+
+
+def _load_sync_plugin_method(name: str) -> Any:
+    source = (ROOT / "main.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    owner = next(node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "PrivateCompanionPlugin")
+    method = next(node for node in owner.body if isinstance(node, ast.FunctionDef) and node.name == name)
+    method = copy.deepcopy(method)
+    module = ast.Module(body=[method], type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace: dict[str, Any] = {
+        "Any": Any,
+        "_single_line": lambda value, limit=120: str(value or "").strip()[:limit],
+        "_safe_int": lambda value, default=0, minimum=0: max(minimum, int(value or default)),
+        "req036_update_capabilities": update_capabilities,
+    }
+    exec(compile(module, str(ROOT / "main.py"), "exec"), namespace)
+    return namespace[name]
+
+
+REQ036_CONFIGURED_TARGET_MIGRATION = _load_sync_plugin_method("_req036_migrate_configured_target_capability")
+
+
+def _load_proactive_target_sync() -> Any:
+    source = (ROOT / "proactive.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    owner = next(node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "ProactiveMixin")
+    method = next(node for node in owner.body if isinstance(node, ast.FunctionDef) and node.name == "_sync_configured_targets")
+    method = copy.deepcopy(method)
+    module = ast.Module(body=[method], type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace: dict[str, Any] = {
+        "req036_capability_summary": capability_summary,
+        "req036_update_capabilities": update_capabilities,
+        "_safe_int": lambda value, default=0, minimum=0: max(minimum, int(value or default)),
+        "_safe_float": lambda value, default=0.0: float(value or default),
+        "_now_ts": lambda: 100.0,
+    }
+    exec(compile(module, str(ROOT / "proactive.py"), "exec"), namespace)
+    return namespace["_sync_configured_targets"]
+
+
+REQ036_CONFIGURED_TARGET_SYNC = _load_proactive_target_sync()
+
+
+def _load_user_list_method() -> Any:
+    source = (ROOT / "page_api_users_groups.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    owner = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "PrivateCompanionPageApiUsersGroupsMixin"
+    )
+    method = next(node for node in owner.body if isinstance(node, ast.AsyncFunctionDef) and node.name == "list_users")
+    module = ast.Module(body=[copy.deepcopy(method)], type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace: dict[str, Any] = {
+        "Any": Any,
+        "logger": types.SimpleNamespace(
+            warning=lambda *_args, **_kwargs: None,
+            error=lambda *_args, **_kwargs: None,
+        ),
+        "time": time,
+    }
+    exec(compile(module, str(ROOT / "page_api_users_groups.py"), "exec"), namespace)
+    return namespace["list_users"]
+
+
+REQ036_USER_LIST = _load_user_list_method()
+
+
+class _PrivateEvent:
+    def __init__(self) -> None:
+        self.stopped = False
+
+    @staticmethod
+    def is_private_chat() -> bool:
+        return True
+
+    @staticmethod
+    def get_sender_id() -> str:
+        return "u-1"
+
+    def stop_event(self) -> None:
+        self.stopped = True
+
+
+class _GateHost:
+    def __init__(self) -> None:
+        self.data = {"users": {"u-1": {"unified_profile_capabilities": default_capabilities()}}}
+        self.replies: list[str] = []
+        self.memory_calls = 0
+        self.tool_calls = 0
+        self.relationship_calls = 0
+
+    @staticmethod
+    def _canonical_private_user_id(value: str) -> str:
+        return value
+
+    @staticmethod
+    def _req036_private_gate_for_user(user: Any) -> dict[str, Any]:
+        return private_companion_gate(user, "固定拒绝文本")
+
+    async def _req036_reject_unauthorized_private_event(self, event: Any, gate: dict[str, Any]) -> None:
+        self.replies.append(str(gate["reply"]))
+        event.private_companion_req036_denied = True
+        event.stop_event()
+
+
+class _CommandEvent(_PrivateEvent):
+    message_str = "陪伴 状态"
+
+
+class _CommandGateHost:
+    def __init__(self) -> None:
+        self._data_lock = asyncio.Lock()
+        self.user = {"unified_profile_capabilities": default_capabilities()}
+        self.replies: list[str] = []
+        self.qzone_calls = 0
+        self.attached_sources: list[str] = []
+
+    @staticmethod
+    def _sender_display_name(_event: Any) -> str:
+        return "测试用户"
+
+    def _ensure_auto_private_user_profile(self, _event: Any, **_kwargs: Any) -> tuple[dict[str, Any], bool]:
+        return self.user, False
+
+    def _req036_attach_unified_profile_context(self, _event: Any, **kwargs: Any) -> dict[str, Any]:
+        self.attached_sources.append(str(kwargs.get("source") or ""))
+        return {"state": "profile_exact"}
+
+    @staticmethod
+    def _schedule_data_save() -> None:
+        return None
+
+    @staticmethod
+    def _req036_private_gate_for_user(user: Any) -> dict[str, Any]:
+        return private_companion_gate(user, "固定拒绝文本")
+
+    async def _req036_reject_unauthorized_private_event(self, event: Any, gate: dict[str, Any]) -> None:
+        self.replies.append(str(gate["reply"]))
+        event.private_companion_req036_denied = True
+        event.stop_event()
+
+    def _qzone_note_event_bot(self, _event: Any) -> None:
+        self.qzone_calls += 1
+
+
+class _GroupEvent:
+    def __init__(self, text: str) -> None:
+        self.message_str = text
+        self.stopped = False
+
+    @staticmethod
+    def get_sender_id() -> str:
+        return "u-1"
+
+    def stop_event(self) -> None:
+        self.stopped = True
+
+
+class _GroupGateHost:
+    replies: list[str]
+
+    def __init__(self) -> None:
+        self.replies = []
+
+    @staticmethod
+    def _extract_group_id_from_event(event: Any) -> str:
+        return "group-disabled"
+
+    @staticmethod
+    def _group_observation_event_text(event: Any) -> str:
+        return str(event.message_str)
+
+    @staticmethod
+    def _req036_group_portrait_query_kind(text: Any) -> str:
+        return "third_party"
+
+    @staticmethod
+    def _group_enabled_for_event(group_id: str) -> bool:
+        raise AssertionError("REQ-036 privacy guard must not depend on group observation enablement")
+
+    async def _reply(self, event: Any, text: str) -> None:
+        self.replies.append(text)
+
+
+class _ConfiguredTargetHost:
+    def __init__(self) -> None:
+        self.default_nickname = "你"
+        self.user: dict[str, Any] = {"proactive_daily_limit": 0}
+        self.delivery_bound = 0
+
+    @staticmethod
+    def _configured_target_ids() -> list[str]:
+        return ["legacy-target"]
+
+    def _get_user(self, user_id: str) -> dict[str, Any]:
+        return self.user
+
+    @staticmethod
+    def _clear_pending_proactive_plan(user: dict[str, Any]) -> None:
+        user["cleared"] = True
+
+    def _ensure_private_user_umo(self, user_id: str, user: dict[str, Any]) -> None:
+        self.delivery_bound += 1
+
+    @staticmethod
+    def _user_enabled_for_proactive(user_id: str, user: dict[str, Any]) -> bool:
+        return False
+
+
+class _LegacyTargetMigrationHost:
+    @staticmethod
+    def _canonical_private_user_id(value: str) -> str:
+        return str(value or "").strip()
+
+    @staticmethod
+    def _configured_target_ids() -> list[str]:
+        return ["legacy-target"]
+
+    @staticmethod
+    def _schedule_next_proactive(user: dict[str, Any], *, now: float) -> None:
+        raise AssertionError("disabled proactive capability must not schedule")
+
+
+class _UserListHost:
+    def __init__(self) -> None:
+        self.plugin = types.SimpleNamespace(
+            _data_lock=asyncio.Lock(),
+            data={"users": {"source-a": {}, "source-b": {}}},
+        )
+
+    @staticmethod
+    def _query_int(_name: str, default: int, _minimum: int, _maximum: int) -> int:
+        return default
+
+    @staticmethod
+    def _single_line(value: Any, limit: int = 80) -> str:
+        return str(value or "").strip()[:limit]
+
+    @staticmethod
+    def _user_summary(user_id: str, _user: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "user_id": user_id,
+            "unified_person_id": "person_" + "d" * 24,
+            "last_seen_ts": 1,
+        }
+
+    @staticmethod
+    def _ok(payload: dict[str, Any]) -> dict[str, Any]:
+        return payload
+
+
+class Req036CompanionTests(unittest.TestCase):
+    def test_default_capabilities_and_hard_proactive_dependency(self) -> None:
+        state = default_capabilities()
+        self.assertFalse(state["private_companion_enabled"])
+        self.assertFalse(state["proactive_private_enabled"])
+        self.assertEqual("disabled", state["portrait_mode"])
+        state["proactive_private_enabled"] = True
+        self.assertEqual("proactive_requires_private_companion", proactive_private_gate({"unified_profile_capabilities": state})["code"])
+
+    def test_administrator_update_records_only_capability_audit(self) -> None:
+        user: dict[str, Any] = {"unified_profile_capabilities": default_capabilities()}
+        result = update_capabilities(
+            user,
+            {"private_companion_enabled": True, "proactive_private_enabled": True, "portrait_mode": "use_existing"},
+            actor_authorized=True,
+            actor_id="page_administrator",
+            target_identity="u-1",
+            reason_code="test",
+        )
+        self.assertTrue(result["ok"])
+        self.assertTrue(result["capabilities"]["effective_proactive_private_enabled"])
+        self.assertEqual("use_existing", result["capabilities"]["portrait_mode"])
+        self.assertEqual("page_administrator", user["unified_profile_capability_audit"][-1]["actor_id"])
+        self.assertNotIn("content", repr(user["unified_profile_capability_audit"]))
+
+    def test_capability_migration_is_dry_idempotent_and_reversible(self) -> None:
+        data: dict[str, Any] = {
+            "users": {
+                "legacy-on": {"enabled": True, "proactive_daily_limit": 2},
+                "legacy-off": {"enabled": False, "proactive_daily_limit": 8},
+            }
+        }
+        before = copy.deepcopy(data)
+        preview = migrate_legacy_capabilities(data, operation_id="req036-test", dry_run=True)
+        self.assertEqual("migration_dry_run", preview["code"])
+        self.assertEqual(before, data)
+        applied = migrate_legacy_capabilities(data, operation_id="req036-test", dry_run=False)
+        self.assertEqual("migration_applied", applied["code"])
+        self.assertTrue(data["users"]["legacy-on"]["unified_profile_capabilities"]["private_companion_enabled"])
+        self.assertFalse(data["users"]["legacy-off"]["unified_profile_capabilities"]["proactive_private_enabled"])
+        self.assertEqual("migration_idempotent_replay", migrate_legacy_capabilities(data, operation_id="req036-test", dry_run=False)["code"])
+        self.assertEqual("migration_rolled_back", rollback_legacy_capabilities(data, operation_id="req036-test")["code"])
+        self.assertEqual(before, {"users": data["users"]})
+
+    def test_exact_identity_link_unlink_and_merge_require_review(self) -> None:
+        store: dict[str, Any] = {}
+        registry = UnifiedPersonRegistry(store)
+        first = registry.create_or_link(_identity("10001"), operation_id="create-1")
+        self.assertTrue(first["ok"])
+        same = registry.create_or_link(_identity("10001"), operation_id="create-1-repeat")
+        self.assertEqual(first["person_id"], same["person_id"])
+        self.assertFalse(same["changed"])
+        linked = registry.link_identity(first["person_id"], _identity("telegram-10001"), operation_id="link-1")
+        self.assertTrue(linked["changed"])
+        self.assertTrue(
+            registry.record_identity_source_event(
+                first["person_id"],
+                linked["identity_key"],
+                "group:onebot:group-a",
+                hashlib.sha256(b"source-event").hexdigest(),
+                operation_id="event-1",
+            )["ok"]
+        )
+        dry_run = registry.unlink_identity(first["person_id"], _identity("telegram-10001"), operation_id="unlink-1", dry_run=True)
+        self.assertEqual("migration_dry_run", dry_run["code"])
+        self.assertEqual(1, dry_run["replayable_event_count"])
+        applied = registry.unlink_identity(first["person_id"], _identity("telegram-10001"), operation_id="unlink-1", dry_run=False)
+        self.assertEqual("identity_unlinked", applied["code"])
+        self.assertTrue(applied["changed"])
+        self.assertTrue(registry.create_or_link(_identity("10002"), operation_id="create-2")["ok"])
+        second = registry.resolve(_identity("10002"))
+        merge = registry.preview_person_merge(first["person_id"], second["person_id"], operation_id="merge-preview")
+        self.assertEqual("merge_manual_review_required", merge["code"])
+        self.assertEqual(0, merge["write_count"])
+
+    def test_unauthorized_private_llm_gate_clears_request_before_other_paths(self) -> None:
+        host = _GateHost()
+        event = _PrivateEvent()
+        req = types.SimpleNamespace(
+            system_prompt="secret",
+            prompt="message",
+            contexts=["memory"],
+            extra_user_content_parts=["extra"],
+            func_tool=object(),
+            tools=["tool"],
+            images=["image"],
+            image_urls=["url"],
+        )
+        asyncio.run(REQ036_LLM_GATE(host, event, req))
+        self.assertTrue(event.stopped)
+        self.assertEqual(["固定拒绝文本"], host.replies)
+        self.assertEqual("", req.system_prompt)
+        self.assertEqual([], req.contexts)
+        self.assertIsNone(req.func_tool)
+        self.assertEqual(0, host.memory_calls)
+        self.assertEqual(0, host.tool_calls)
+        self.assertEqual(0, host.relationship_calls)
+
+    def test_unauthorized_private_command_stops_before_qzone_or_command_actions(self) -> None:
+        host = _CommandGateHost()
+        event = _CommandEvent()
+        asyncio.run(REQ036_COMMAND_GATE(host, event))
+        self.assertTrue(event.stopped)
+        self.assertEqual(["固定拒绝文本"], host.replies)
+        self.assertEqual(0, host.qzone_calls)
+        self.assertEqual(["private_command"], host.attached_sources)
+
+    def test_contract_rejects_raw_conversation_fields(self) -> None:
+        person = {
+            "person_id": "person_" + "a" * 24,
+            "resolved_identity_key": "chat-origin-v1:" + "b" * 64,
+            "projection_revision": 1,
+            "identity_assurance": "observed",
+            "profile_status": "active",
+        }
+        dto = build_profile_dto(person_ref=build_person_ref(person), identity_summary={"display_name": "雪"})
+        self.assertEqual([], validate_profile_dto(dto))
+        dto["identity_summary"]["chat_text"] = "should not cross the bridge"
+        self.assertIn("identity_summary_contains_forbidden_data", validate_profile_dto(dto))
+
+    def test_private_entry_places_side_effects_after_capability_gate(self) -> None:
+        source = (ROOT / "message_pipeline.py").read_text(encoding="utf-8")
+        start = source.index("async def handle_private_message(")
+        end = source.index("async def handle_group_message(", start)
+        handler = source[start:end]
+        self.assertLess(handler.index("if not private_gate.get(\"allowed\")"), handler.index("self._qzone_note_event_bot(event)"))
+        self.assertLess(handler.index("if not private_gate.get(\"allowed\")"), handler.index("self._message_debounce_command_text(event, text)"))
+
+    def test_group_portrait_query_classifier_distinguishes_self_from_third_party(self) -> None:
+        source = (ROOT / "main.py").read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        owner = next(node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "PrivateCompanionPlugin")
+        method = next(node for node in owner.body if isinstance(node, ast.FunctionDef) and node.name == "_req036_group_portrait_query_kind")
+        method = copy.deepcopy(method)
+        method.decorator_list = []
+        module = ast.Module(body=[method], type_ignores=[])
+        ast.fix_missing_locations(module)
+        namespace = {"Any": Any, "re": __import__("re"), "_single_line": lambda value, _limit=240: str(value or "")[:_limit]}
+        exec(compile(module, str(ROOT / "main.py"), "exec"), namespace)
+        classify = namespace["_req036_group_portrait_query_kind"]
+        self.assertEqual("self", classify("@bot 我喜欢什么"))
+        self.assertEqual("self", classify("@bot 我爱吃什么"))
+        self.assertEqual("third_party", classify("@bot 小王喜欢什么"))
+        self.assertEqual("third_party", classify("@bot 小王有什么爱好"))
+
+    def test_group_third_party_guard_applies_when_observation_is_disabled(self) -> None:
+        host = _GroupGateHost()
+        event = _GroupEvent("@bot 小王有什么爱好")
+        asyncio.run(REQ036_GROUP_GATE(host, event))
+        self.assertTrue(event.stopped)
+        self.assertEqual(["这个我不方便替别人整理啦。"], host.replies)
+
+    def test_configured_target_migrates_once_then_respects_capability_freeze(self) -> None:
+        host = _ConfiguredTargetHost()
+        REQ036_CONFIGURED_TARGET_SYNC(host)
+        self.assertTrue(host.user["unified_profile_capabilities"]["private_companion_enabled"])
+        self.assertFalse(host.user["unified_profile_capabilities"]["proactive_private_enabled"])
+        self.assertEqual("legacy_configured_target_migration", host.user["unified_profile_capabilities"]["grant_source"])
+        self.assertEqual(1, host.delivery_bound)
+        update_capabilities(
+            host.user,
+            {"private_companion_enabled": False},
+            actor_authorized=True,
+            actor_id="page_administrator",
+            target_identity="legacy-target",
+        )
+        REQ036_CONFIGURED_TARGET_SYNC(host)
+        self.assertFalse(host.user["unified_profile_capabilities"]["private_companion_enabled"])
+        self.assertEqual(1, host.delivery_bound)
+
+    def test_configured_target_compatibility_migration_never_reopens_explicit_disable(self) -> None:
+        host = _LegacyTargetMigrationHost()
+        user: dict[str, Any] = {"proactive_daily_limit": 1}
+        self.assertTrue(REQ036_CONFIGURED_TARGET_MIGRATION(host, "legacy-target", user))
+        state = user["unified_profile_capabilities"]
+        self.assertTrue(state["private_companion_enabled"])
+        self.assertTrue(state["proactive_private_enabled"])
+        self.assertEqual("legacy_configured_target_migration", state["grant_source"])
+        update_capabilities(
+            user,
+            {"private_companion_enabled": False},
+            actor_authorized=True,
+            actor_id="page_administrator",
+            target_identity="legacy-target",
+        )
+        self.assertFalse(REQ036_CONFIGURED_TARGET_MIGRATION(host, "legacy-target", user))
+        self.assertFalse(user["unified_profile_capabilities"]["private_companion_enabled"])
+
+    def test_user_list_deduplicates_resolved_person_sources_without_crashing(self) -> None:
+        result = asyncio.run(REQ036_USER_LIST(_UserListHost()))
+        self.assertEqual(1, result["total"])
+        self.assertEqual("source-a", result["items"][0]["user_id"])
+        self.assertEqual(["source-b"], result["items"][0]["alias_user_ids"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tts_language_group_command.py
+++ b/tests/test_tts_language_group_command.py
@@ -7,6 +7,7 @@ import unittest
 from astrbot_plugin_private_companion.interaction_utils import InteractionUtilsMixin
 from astrbot_plugin_private_companion.main import PrivateCompanionPlugin
 from astrbot_plugin_private_companion.tts_enhancement import TtsEnhancementMixin
+from astrbot_plugin_private_companion.unified_profile_service import private_companion_gate
 
 
 class _Event:
@@ -34,7 +35,21 @@ class _Harness(InteractionUtilsMixin, TtsEnhancementMixin):
         self.target_user_ids = ["owner"]
         self.config = {"tts_voice_language": "ja"}
         self.tts_voice_language = "ja"
-        self.data = {"users": {"owner": {}, "member": {}}}
+        self.data = {
+            "users": {
+                "owner": {
+                    "unified_profile_capabilities": {
+                        "schema_version": 1,
+                        "private_companion_enabled": True,
+                        "proactive_private_enabled": False,
+                        "portrait_mode": "disabled",
+                        "portrait_mode_override": "follow_global",
+                        "grant_source": "legacy_configured_target_migration",
+                    }
+                },
+                "member": {},
+            }
+        }
         self._data_lock = asyncio.Lock()
         self.replies: list[str] = []
         self.save_count = 0
@@ -56,6 +71,25 @@ class _Harness(InteractionUtilsMixin, TtsEnhancementMixin):
 
     def _get_user(self, user_id: str) -> dict:
         return self.data.setdefault("users", {}).setdefault(user_id, {})
+
+    @staticmethod
+    def _sender_display_name(event) -> str:
+        return str(event.get_sender_id())
+
+    def _ensure_auto_private_user_profile(self, _event, *, user_id: str, **_kwargs):
+        return self._get_user(user_id), False
+
+    @staticmethod
+    def _req036_attach_unified_profile_context(_event, **_kwargs) -> dict:
+        return {"state": "profile_exact"}
+
+    @staticmethod
+    def _schedule_data_save() -> None:
+        return None
+
+    @staticmethod
+    def _req036_private_gate_for_user(user: dict) -> dict:
+        return private_companion_gate(user)
 
     @staticmethod
     def _note_private_user_umo(user_id: str, user: dict, umo: str) -> None:

--- a/unified_person_registry.py
+++ b/unified_person_registry.py
@@ -129,6 +129,10 @@ def _root(store: dict[str, Any]) -> dict[str, Any]:
         root["audit_events"] = []
     if not isinstance(root.get("operations"), dict):
         root["operations"] = {}
+    if not isinstance(root.get("binding_checkpoints"), dict):
+        root["binding_checkpoints"] = {}
+    if not isinstance(root.get("detached_identity_links"), dict):
+        root["detached_identity_links"] = {}
     return root
 
 
@@ -361,6 +365,15 @@ class UnifiedPersonRegistry:
                 "identity_assurance": "observed", "status": "active",
                 "created_at": now, "updated_at": now, "last_operation_id": op,
             }
+            root["binding_checkpoints"][f"{person_id}:{key}"] = {
+                "person_id": person_id,
+                "identity_key": key,
+                "origin_identity_key": key,
+                "relationship_score": stored["affinity_score"],
+                "created_at": now,
+                "operation_id": op,
+                "source_event_count": 0,
+            }
             root["audit_events"].append({"event_id": op, "action": "create_or_link", "actor_id": actor, "person_id": person_id, "at": now})
             projection = build_person_projection(self._store, person_id)
             if projection is None or validate_projection(projection):
@@ -386,14 +399,190 @@ class UnifiedPersonRegistry:
             prior = root["identity_links"].get(key)
             if isinstance(prior, dict) and prior.get("person_id") != person_id:
                 return {"ok": False, "state": "invalid", "code": "identity_conflict", "person_id": person_id}
-            root["identity_links"][key] = {"identity_key": key, "identity": normalized, "person_id": person_id, "identity_assurance": "explicit_linked", "status": "active", "updated_at": _now(), "last_operation_id": op}
+            if isinstance(prior, dict) and prior.get("person_id") == person_id and prior.get("status") == "active":
+                projection = build_person_projection(self._store, person_id)
+                return {
+                    "ok": bool(projection and not validate_projection(projection)),
+                    "state": "resolved" if projection and not validate_projection(projection) else "invalid",
+                    "code": "already_linked",
+                    "person_id": person_id,
+                    "identity_key": key,
+                    "projection": projection,
+                    "changed": False,
+                }
+            now = _now()
+            root["identity_links"][key] = {"identity_key": key, "identity": normalized, "person_id": person_id, "identity_assurance": "explicit_linked", "status": "active", "updated_at": now, "last_operation_id": op}
             if key not in profile.setdefault("identity_keys", []):
                 profile["identity_keys"].append(key)
             profile["identity_assurance"] = "explicit_linked"
             profile["projection_revision"] = int(profile.get("projection_revision") or 1) + 1
-            profile["updated_at"] = _now()
+            profile["updated_at"] = now
+            root["binding_checkpoints"][f"{person_id}:{key}"] = {
+                "person_id": person_id,
+                "identity_key": key,
+                "origin_identity_key": str(profile.get("resolved_identity_key") or key),
+                "relationship_score": int(profile.get("affinity_score") or 0),
+                "created_at": now,
+                "operation_id": op,
+                "source_event_count": 0,
+            }
+            root["audit_events"].append({"event_id": op, "action": "link_identity", "actor_id": str(actor_id), "person_id": person_id, "at": now})
             projection = build_person_projection(self._store, person_id)
             return {"ok": bool(projection and not validate_projection(projection)), "state": "resolved" if projection and not validate_projection(projection) else "invalid", "code": "identity_linked", "person_id": person_id, "identity_key": key, "projection": projection, "changed": True}
+
+    def unlink_identity(
+        self,
+        person_id: str,
+        identity: dict[str, Any],
+        operation_id: str = "",
+        actor_id: str = "companion",
+        *,
+        dry_run: bool = True,
+        **_: Any,
+    ) -> dict[str, Any]:
+        """Detach one explicit identity without inventing a profile split.
+
+        Relationship totals, portrait facts, and suppression markers are never
+        copied here.  The checkpoint tells an administrator whether a later
+        source-event replay can make the split deterministic.
+        """
+        try:
+            person_id = _text(person_id, "person_id")
+            normalized = _identity(identity)
+            op = _operation_id(operation_id)
+            actor = _text(actor_id, "actor_id", 120)
+        except ValueError:
+            return {"ok": False, "state": "invalid", "code": "invalid_request", "person_id": ""}
+        if not op:
+            return {"ok": False, "state": "pending", "code": "explicit_operation_required", "person_id": person_id}
+        key = build_identity_key(normalized)
+        operation_key = f"req036.unlink:{op}"
+        with _LOCK:
+            root = _root(self._store)
+            prior_operation = root["operations"].get(operation_key)
+            if isinstance(prior_operation, dict):
+                return deepcopy(prior_operation)
+            profile = root["profiles"].get(person_id)
+            link = root["identity_links"].get(key)
+            if not isinstance(profile, dict) or not isinstance(link, dict) or link.get("person_id") != person_id:
+                return {"ok": False, "state": "pending", "code": "identity_not_linked", "person_id": person_id, "identity_key": key}
+            identity_keys = [item for item in profile.get("identity_keys", []) if isinstance(item, str)]
+            checkpoint = root["binding_checkpoints"].get(f"{person_id}:{key}")
+            checkpoint = deepcopy(checkpoint) if isinstance(checkpoint, dict) else {}
+            replay_count = int(checkpoint.get("source_event_count") or 0)
+            ambiguity_count = 0
+            if key == profile.get("resolved_identity_key") or len(identity_keys) <= 1:
+                ambiguity_count = 1
+            result = {
+                "ok": ambiguity_count == 0,
+                "state": "resolved" if ambiguity_count == 0 else "pending",
+                "code": "migration_dry_run" if dry_run and ambiguity_count == 0 else (
+                    "split_manual_review_required" if ambiguity_count else "identity_unlinked"
+                ),
+                "person_id": person_id,
+                "identity_key": key,
+                "source_event_count": replay_count,
+                "replayable_event_count": replay_count,
+                "ambiguity_count": ambiguity_count,
+                "checkpoint": checkpoint,
+                "changed": False,
+            }
+            if dry_run or ambiguity_count:
+                return result
+            now = _now()
+            root["detached_identity_links"][key] = {
+                **deepcopy(link),
+                "status": "detached",
+                "detached_at": now,
+                "detached_by": actor,
+                "detach_operation_id": op,
+            }
+            root["identity_links"].pop(key, None)
+            profile["identity_keys"] = [item for item in identity_keys if item != key]
+            profile["projection_revision"] = int(profile.get("projection_revision") or 1) + 1
+            profile["updated_at"] = now
+            root["audit_events"].append({"event_id": op, "action": "unlink_identity", "actor_id": actor, "person_id": person_id, "at": now})
+            result.update({"ok": True, "state": "resolved", "code": "identity_unlinked", "changed": True})
+            root["operations"][operation_key] = deepcopy(result)
+            return result
+
+    def record_identity_source_event(
+        self,
+        person_id: str,
+        identity_key: str,
+        source_scope: str,
+        event_fingerprint: str,
+        *,
+        operation_id: str = "",
+    ) -> dict[str, Any]:
+        """Record a hash-only source event for a later deterministic split.
+
+        The registry never receives message text.  A bounded fingerprint list
+        gives unlink dry-runs a replay count without turning identity storage
+        into a second chat archive.
+        """
+        try:
+            person_id = _text(person_id, "person_id")
+            identity_key = _text(identity_key, "identity_key", 160)
+            source_scope = _text(source_scope or "private", "source_scope", 120)
+            event_fingerprint = _text(event_fingerprint, "event_fingerprint", 80)
+        except ValueError:
+            return {"ok": False, "code": "invalid_request"}
+        if re.fullmatch(r"[0-9a-f]{64}", event_fingerprint) is None:
+            return {"ok": False, "code": "invalid_request"}
+        with _LOCK:
+            root = _root(self._store)
+            link = root["identity_links"].get(identity_key)
+            checkpoint_key = f"{person_id}:{identity_key}"
+            checkpoint = root["binding_checkpoints"].get(checkpoint_key)
+            if not isinstance(link, dict) or link.get("person_id") != person_id or not isinstance(checkpoint, dict):
+                return {"ok": False, "code": "identity_not_linked"}
+            seen = checkpoint.get("source_event_fingerprints")
+            if not isinstance(seen, list):
+                seen = []
+                checkpoint["source_event_fingerprints"] = seen
+            if event_fingerprint in seen:
+                return {
+                    "ok": True,
+                    "code": "source_event_idempotent_replay",
+                    "source_event_count": int(checkpoint.get("source_event_count") or len(seen)),
+                }
+            seen.append(event_fingerprint)
+            del seen[:-512]
+            checkpoint["source_event_count"] = len(seen)
+            checkpoint["last_source_scope"] = source_scope
+            checkpoint["last_source_event_at"] = _now()
+            if operation_id:
+                checkpoint["last_source_operation_id"] = _text(operation_id, "operation_id", 120)
+            return {"ok": True, "code": "source_event_recorded", "source_event_count": len(seen)}
+
+    def preview_person_merge(self, source_person_id: str, target_person_id: str, operation_id: str = "", **_: Any) -> dict[str, Any]:
+        """Expose conflicts without merging two existing people automatically."""
+        try:
+            source_person_id = _text(source_person_id, "source_person_id")
+            target_person_id = _text(target_person_id, "target_person_id")
+            operation_id = _operation_id(operation_id)
+        except ValueError:
+            return {"ok": False, "code": "invalid_request"}
+        with _LOCK:
+            root = _root(self._store)
+            source = root["profiles"].get(source_person_id)
+            target = root["profiles"].get(target_person_id)
+            if not isinstance(source, dict) or not isinstance(target, dict) or source_person_id == target_person_id:
+                return {"ok": False, "code": "invalid_request"}
+            conflicts = [
+                field for field in ("affinity_score", "owner_mode", "relation_policy_id")
+                if source.get(field) != target.get(field)
+            ]
+            return {
+                "ok": False,
+                "code": "merge_manual_review_required",
+                "operation_id": operation_id,
+                "source_person_id": source_person_id,
+                "target_person_id": target_person_id,
+                "conflicts": conflicts,
+                "write_count": 0,
+            }
 
     def read_projection(self, person_id: str) -> dict[str, Any] | None:
         with _LOCK:

--- a/unified_profile_contract.py
+++ b/unified_profile_contract.py
@@ -1,0 +1,338 @@
+"""REQ-036 minimal cross-plugin unified-profile contract.
+
+The contract deliberately contains references and policy state only.  Raw chat
+text, evidence bodies, and authority-owned portrait records never cross this
+boundary.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any
+
+
+CONTRACT_NAME = "chat.unified_profile.v1"
+CONTRACT_VERSION = "1.0"
+SCHEMA_VERSION = "1.0"
+MAX_DTO_BYTES = 32768
+
+PORTRAIT_MODES = frozenset({"disabled", "use_existing", "learn_and_use"})
+PORTRAIT_PURPOSES = frozenset({"adapt_for_subject", "summarize_to_subject", "disclose_to_third_party"})
+IDENTITY_ASSURANCE = frozenset({"unverified", "observed", "verified", "explicit_linked"})
+PROFILE_STATUS = frozenset({"active", "suspended", "quarantined", "deleted"})
+LOW_SENSITIVITY = "low"
+
+PERSON_REF_FIELDS = (
+    "person_id",
+    "resolved_identity_key",
+    "projection_revision",
+    "identity_assurance",
+    "profile_status",
+)
+CAPABILITY_FIELDS = (
+    "private_companion_enabled",
+    "proactive_private_enabled",
+    "effective_proactive_private_enabled",
+    "portrait_mode",
+    "portrait_learning_enabled",
+    "portrait_usage_enabled",
+    "grant_source",
+    "blocked_reasons",
+)
+DTO_FIELDS = (
+    "contract_name",
+    "contract_version",
+    "contract_fingerprint",
+    "schema_version",
+    "person_ref",
+    "identity_summary",
+    "expression_summary",
+    "capability_summary",
+    "portrait_summary",
+    "context_overlays",
+    "bridge_status",
+)
+FORBIDDEN_KEYS = frozenset(
+    {
+        "content",
+        "chat_text",
+        "evidence",
+        "messages",
+        "transcript",
+        "prompt",
+        "raw_prompt",
+        "raw_text",
+        "private_object",
+        "database",
+    }
+)
+
+
+def _canonical(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _shape() -> dict[str, Any]:
+    return {
+        "name": CONTRACT_NAME,
+        "version": CONTRACT_VERSION,
+        "schema": SCHEMA_VERSION,
+        "person_ref": list(PERSON_REF_FIELDS),
+        "capability_summary": list(CAPABILITY_FIELDS),
+        "dto": list(DTO_FIELDS),
+        "portrait_modes": sorted(PORTRAIT_MODES),
+        "portrait_purposes": sorted(PORTRAIT_PURPOSES),
+        "max_bytes": MAX_DTO_BYTES,
+    }
+
+
+CONTRACT_FINGERPRINT = hashlib.sha256(_canonical(_shape()).encode("utf-8")).hexdigest()[:16]
+
+
+def _text(value: Any, limit: int = 240) -> str:
+    if isinstance(value, bool) or value is None:
+        return ""
+    result = str(value).strip()
+    if not result or "\x00" in result:
+        return ""
+    return result[:limit]
+
+
+def _safe(value: Any, depth: int = 0) -> Any:
+    if depth > 2 or value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value
+    if isinstance(value, str):
+        return _text(value, 240)
+    if isinstance(value, (list, tuple)):
+        return [_safe(item, depth + 1) for item in list(value)[:16]]
+    if isinstance(value, dict):
+        result: dict[str, Any] = {}
+        for key, item in list(value.items())[:24]:
+            name = _text(key, 80).lower()
+            if not name or name in FORBIDDEN_KEYS:
+                continue
+            safe = _safe(item, depth + 1)
+            if safe not in (None, "", [], {}):
+                result[name] = safe
+        return result
+    return None
+
+
+def _contains_forbidden(value: Any, depth: int = 0) -> bool:
+    """Reject caller-supplied DTOs that smuggle conversation material in.
+
+    ``build_profile_dto`` already drops these fields, but validation is also a
+    trust boundary because the Memory bridge receives an event-carried DTO.
+    """
+    if depth > 4:
+        return True
+    if isinstance(value, dict):
+        for key, item in value.items():
+            name = _text(key, 80).lower()
+            if not name or name in FORBIDDEN_KEYS:
+                return True
+            if _contains_forbidden(item, depth + 1):
+                return True
+        return False
+    if isinstance(value, (list, tuple)):
+        return any(_contains_forbidden(item, depth + 1) for item in value)
+    return False
+
+
+def _positive_int(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError, OverflowError):
+        return 0
+
+
+def normalize_portrait_mode(value: Any) -> str:
+    mode = _text(value, 40).lower()
+    aliases = {
+        "off": "disabled",
+        "disabled": "disabled",
+        "use": "use_existing",
+        "use_existing": "use_existing",
+        "learn": "learn_and_use",
+        "learn_and_use": "learn_and_use",
+    }
+    return aliases.get(mode, "disabled")
+
+
+def portrait_mode_flags(mode: Any) -> tuple[bool, bool]:
+    normalized = normalize_portrait_mode(mode)
+    return normalized == "learn_and_use", normalized in {"use_existing", "learn_and_use"}
+
+
+def build_person_ref(value: Any) -> dict[str, Any]:
+    source = value if isinstance(value, dict) else {}
+    result = {
+        "person_id": _text(source.get("person_id"), 80),
+        "resolved_identity_key": _text(source.get("resolved_identity_key"), 96),
+        "projection_revision": _positive_int(source.get("projection_revision")),
+        "identity_assurance": _text(source.get("identity_assurance"), 40),
+        "profile_status": _text(source.get("profile_status"), 40),
+    }
+    return result
+
+
+def validate_person_ref(value: Any) -> list[str]:
+    if not isinstance(value, dict):
+        return ["person_ref_invalid"]
+    errors = [f"missing_{field}" for field in PERSON_REF_FIELDS if field not in value]
+    person_id = _text(value.get("person_id"), 80)
+    identity_key = _text(value.get("resolved_identity_key"), 96)
+    if re.fullmatch(r"person_[0-9a-f]{24}", person_id) is None:
+        errors.append("person_id_invalid")
+    if re.fullmatch(r"chat-origin-v1:[0-9a-f]{64}", identity_key) is None:
+        errors.append("identity_key_invalid")
+    if not isinstance(value.get("projection_revision"), int) or value["projection_revision"] < 1:
+        errors.append("projection_revision_invalid")
+    if value.get("identity_assurance") not in IDENTITY_ASSURANCE:
+        errors.append("identity_assurance_invalid")
+    if value.get("profile_status") not in PROFILE_STATUS:
+        errors.append("profile_status_invalid")
+    return errors
+
+
+def build_capability_summary(value: Any) -> dict[str, Any]:
+    source = value if isinstance(value, dict) else {}
+    mode = normalize_portrait_mode(source.get("portrait_mode"))
+    learning, usage = portrait_mode_flags(mode)
+    private_enabled = source.get("private_companion_enabled") is True
+    proactive_enabled = source.get("proactive_private_enabled") is True
+    reasons = [_text(item, 80) for item in source.get("blocked_reasons", []) if _text(item, 80)] if isinstance(source.get("blocked_reasons"), list) else []
+    if proactive_enabled and not private_enabled and "proactive_requires_private_companion" not in reasons:
+        reasons.append("proactive_requires_private_companion")
+    if not private_enabled and "private_companion_disabled" not in reasons:
+        reasons.append("private_companion_disabled")
+    return {
+        "private_companion_enabled": private_enabled,
+        "proactive_private_enabled": proactive_enabled,
+        "effective_proactive_private_enabled": proactive_enabled and private_enabled,
+        "portrait_mode": mode,
+        "portrait_learning_enabled": learning,
+        "portrait_usage_enabled": usage,
+        "grant_source": _text(source.get("grant_source"), 80) or "default_closed",
+        "blocked_reasons": reasons[:8],
+    }
+
+
+def build_profile_dto(
+    *,
+    person_ref: Any,
+    identity_summary: Any = None,
+    expression_summary: Any = None,
+    capability_summary: Any = None,
+    portrait_summary: Any = None,
+    context_overlays: Any = None,
+    bridge_status: Any = None,
+) -> dict[str, Any]:
+    return {
+        "contract_name": CONTRACT_NAME,
+        "contract_version": CONTRACT_VERSION,
+        "contract_fingerprint": CONTRACT_FINGERPRINT,
+        "schema_version": SCHEMA_VERSION,
+        "person_ref": build_person_ref(person_ref),
+        "identity_summary": _safe(identity_summary or {}) or {},
+        "expression_summary": _safe(expression_summary or {}) or {},
+        "capability_summary": build_capability_summary(capability_summary),
+        "portrait_summary": _safe(portrait_summary or {}) or {},
+        "context_overlays": _safe(context_overlays or {}) or {},
+        "bridge_status": _safe(bridge_status or {}) or {},
+    }
+
+
+def dto_size_bytes(value: Any) -> int:
+    try:
+        return len(_canonical(value).encode("utf-8"))
+    except (TypeError, ValueError):
+        return MAX_DTO_BYTES + 1
+
+
+def validate_profile_dto(value: Any) -> list[str]:
+    if not isinstance(value, dict):
+        return ["dto_invalid"]
+    errors = [f"missing_{field}" for field in DTO_FIELDS if field not in value]
+    if value.get("contract_name") != CONTRACT_NAME:
+        errors.append("contract_name_mismatch")
+    if value.get("contract_version") != CONTRACT_VERSION:
+        errors.append("contract_version_mismatch")
+    if value.get("contract_fingerprint") != CONTRACT_FINGERPRINT:
+        errors.append("contract_fingerprint_mismatch")
+    if value.get("schema_version") != SCHEMA_VERSION:
+        errors.append("schema_version_mismatch")
+    for field in ("identity_summary", "expression_summary", "portrait_summary", "context_overlays", "bridge_status"):
+        if not isinstance(value.get(field), dict):
+            errors.append(f"{field}_invalid")
+        elif _contains_forbidden(value.get(field)):
+            errors.append(f"{field}_contains_forbidden_data")
+    errors.extend(validate_person_ref(value.get("person_ref")))
+    capabilities = value.get("capability_summary")
+    if not isinstance(capabilities, dict):
+        errors.append("capability_summary_invalid")
+    elif capabilities != build_capability_summary(capabilities):
+        errors.append("capability_summary_invalid")
+    if dto_size_bytes(value) > MAX_DTO_BYTES:
+        errors.append("dto_too_large")
+    return errors
+
+
+def build_portrait_request(
+    *,
+    person_ref: Any,
+    requester_person_id: Any,
+    target_person_id: Any,
+    scope: Any,
+    purpose: Any,
+) -> dict[str, Any]:
+    return {
+        "contract_name": CONTRACT_NAME,
+        "contract_version": CONTRACT_VERSION,
+        "contract_fingerprint": CONTRACT_FINGERPRINT,
+        "person_ref": build_person_ref(person_ref),
+        "requester_person_id": _text(requester_person_id, 80),
+        "target_person_id": _text(target_person_id, 80),
+        "scope": _text(scope, 80),
+        "purpose": _text(purpose, 80),
+        "max_sensitivity": LOW_SENSITIVITY,
+    }
+
+
+def validate_portrait_request(value: Any) -> list[str]:
+    if not isinstance(value, dict):
+        return ["portrait_request_invalid"]
+    errors: list[str] = []
+    if value.get("contract_name") != CONTRACT_NAME or value.get("contract_version") != CONTRACT_VERSION:
+        errors.append("contract_mismatch")
+    if value.get("contract_fingerprint") != CONTRACT_FINGERPRINT:
+        errors.append("contract_fingerprint_mismatch")
+    errors.extend(validate_person_ref(value.get("person_ref")))
+    if _text(value.get("target_person_id"), 80) != _text((value.get("person_ref") or {}).get("person_id"), 80):
+        errors.append("target_person_mismatch")
+    if value.get("purpose") not in PORTRAIT_PURPOSES:
+        errors.append("portrait_purpose_invalid")
+    if not _text(value.get("scope"), 80):
+        errors.append("scope_invalid")
+    if value.get("max_sensitivity") != LOW_SENSITIVITY:
+        errors.append("max_sensitivity_invalid")
+    if _contains_forbidden(value):
+        errors.append("portrait_request_contains_forbidden_data")
+    return errors
+
+
+def contract_self_check() -> list[str]:
+    expected = hashlib.sha256(_canonical(_shape()).encode("utf-8")).hexdigest()[:16]
+    return [] if expected == CONTRACT_FINGERPRINT else ["contract_fingerprint_stale"]
+
+
+__all__ = [name for name in globals() if name.isupper() or name in {
+    "build_capability_summary", "build_person_ref", "build_profile_dto", "build_portrait_request",
+    "contract_self_check", "dto_size_bytes", "normalize_portrait_mode", "portrait_mode_flags",
+    "validate_person_ref", "validate_profile_dto", "validate_portrait_request",
+}]

--- a/unified_profile_service.py
+++ b/unified_profile_service.py
@@ -1,0 +1,286 @@
+"""Companion-owned REQ-036 capability state and local migration helpers."""
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+from typing import Any
+
+from .unified_profile_contract import build_capability_summary, normalize_portrait_mode
+
+
+CAPABILITY_SCHEMA_VERSION = 1
+MIGRATION_KEY = "req036_capability_migration"
+DEFAULT_UNAUTHORIZED_PRIVATE_REPLY = "老大不让我跟陌生人说话哦。"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _text(value: Any, limit: int = 120) -> str:
+    if isinstance(value, bool) or value is None:
+        return ""
+    result = str(value).strip()
+    return result[:limit] if result and "\x00" not in result else ""
+
+
+def _bool(value: Any) -> bool:
+    return value is True
+
+
+def _legacy_private_enabled(user: dict[str, Any]) -> bool:
+    if "private_companion_enabled" in user:
+        return _bool(user.get("private_companion_enabled"))
+    return _bool(user.get("enabled"))
+
+
+def _legacy_proactive_enabled(user: dict[str, Any], private_enabled: bool) -> bool:
+    if "proactive_private_enabled" in user:
+        return _bool(user.get("proactive_private_enabled"))
+    # The old schema had no capability field.  A non-zero per-user daily
+    # budget was the durable configuration signal; cooldowns and schedules are
+    # deliberately excluded from this migration.
+    try:
+        return private_enabled and int(user.get("proactive_daily_limit") or 0) > 0
+    except (TypeError, ValueError):
+        return False
+
+
+def default_capabilities(*, grant_source: str = "default_closed") -> dict[str, Any]:
+    return {
+        "schema_version": CAPABILITY_SCHEMA_VERSION,
+        "private_companion_enabled": False,
+        "proactive_private_enabled": False,
+        "portrait_mode": "disabled",
+        "portrait_mode_override": "follow_global",
+        "grant_source": _text(grant_source, 80) or "default_closed",
+        "updated_at": _now(),
+    }
+
+
+def normalize_capabilities(value: Any, *, default_source: str = "default_closed") -> dict[str, Any]:
+    source = value if isinstance(value, dict) else {}
+    result = default_capabilities(grant_source=_text(source.get("grant_source"), 80) or default_source)
+    result.update(
+        {
+            "private_companion_enabled": _bool(source.get("private_companion_enabled")),
+            "proactive_private_enabled": _bool(source.get("proactive_private_enabled")),
+            "portrait_mode": normalize_portrait_mode(source.get("portrait_mode")),
+            "portrait_mode_override": "explicit" if _text(source.get("portrait_mode_override"), 40) == "explicit" else "follow_global",
+            "updated_at": _text(source.get("updated_at"), 80) or result["updated_at"],
+        }
+    )
+    return result
+
+
+def ensure_new_profile_capabilities(user: dict[str, Any]) -> dict[str, Any]:
+    """Install the default-closed state for a newly observed profile only."""
+    if not isinstance(user, dict):
+        return default_capabilities()
+    existing = user.get("unified_profile_capabilities")
+    if isinstance(existing, dict):
+        normalized = normalize_capabilities(existing)
+    else:
+        normalized = default_capabilities()
+    user["unified_profile_capabilities"] = normalized
+    # These legacy aliases remain readable by older code, but cannot reopen a
+    # REQ-036 profile after it has been created.
+    user["private_companion_enabled"] = normalized["private_companion_enabled"]
+    user["proactive_private_enabled"] = normalized["proactive_private_enabled"]
+    return normalized
+
+
+def capability_summary(user: Any, *, global_portrait_mode: str = "disabled") -> dict[str, Any]:
+    source = user if isinstance(user, dict) else {}
+    capabilities = source.get("unified_profile_capabilities")
+    if not isinstance(capabilities, dict):
+        capabilities = default_capabilities()
+    resolved = dict(capabilities)
+    if resolved.get("portrait_mode_override") != "explicit":
+        resolved["portrait_mode"] = normalize_portrait_mode(global_portrait_mode)
+    return build_capability_summary(resolved)
+
+
+def private_companion_gate(user: Any, configured_reply: Any = "") -> dict[str, Any]:
+    summary = capability_summary(user)
+    if summary["private_companion_enabled"]:
+        return {"allowed": True, "code": "profile_exact", "reply": "", "capabilities": summary}
+    reply = _text(configured_reply, 480) or DEFAULT_UNAUTHORIZED_PRIVATE_REPLY
+    return {
+        "allowed": False,
+        "code": "private_companion_disabled",
+        "reply": reply,
+        "capabilities": summary,
+    }
+
+
+def proactive_private_gate(user: Any) -> dict[str, Any]:
+    summary = capability_summary(user)
+    if not summary["private_companion_enabled"]:
+        return {"allowed": False, "code": "proactive_requires_private_companion", "capabilities": summary}
+    if not summary["proactive_private_enabled"]:
+        return {"allowed": False, "code": "proactive_private_disabled", "capabilities": summary}
+    return {"allowed": True, "code": "profile_exact", "capabilities": summary}
+
+
+def update_capabilities(
+    user: dict[str, Any],
+    changes: dict[str, Any],
+    *,
+    actor_authorized: bool,
+    grant_source: str = "admin",
+    actor_id: str = "administrator",
+    target_identity: str = "",
+    reason_code: str = "administrator_update",
+) -> dict[str, Any]:
+    if not isinstance(user, dict) or not isinstance(changes, dict):
+        return {"ok": False, "code": "invalid_request", "capabilities": default_capabilities()}
+    if not actor_authorized:
+        return {"ok": False, "code": "admin_required", "capabilities": capability_summary(user)}
+    current = normalize_capabilities(user.get("unified_profile_capabilities"), default_source="default_closed")
+    previous = {
+        key: current.get(key)
+        for key in ("private_companion_enabled", "proactive_private_enabled", "portrait_mode", "portrait_mode_override")
+    }
+    for key in ("private_companion_enabled", "proactive_private_enabled"):
+        if key in changes:
+            current[key] = _bool(changes[key])
+    if "portrait_mode" in changes:
+        requested_mode = _text(changes.get("portrait_mode"), 40).lower()
+        if requested_mode == "follow_global":
+            current["portrait_mode_override"] = "follow_global"
+        else:
+            current["portrait_mode"] = normalize_portrait_mode(requested_mode)
+            current["portrait_mode_override"] = "explicit"
+    current["grant_source"] = _text(grant_source, 80) or "admin"
+    current["updated_at"] = _now()
+    user["unified_profile_capabilities"] = current
+    user["private_companion_enabled"] = current["private_companion_enabled"]
+    user["proactive_private_enabled"] = current["proactive_private_enabled"]
+    # Keep the historical aggregate field compatible without treating it as a
+    # future authority source.
+    user["enabled"] = current["private_companion_enabled"]
+    changed = {
+        key: {"from": previous.get(key), "to": current.get(key)}
+        for key in previous
+        if previous.get(key) != current.get(key)
+    }
+    if changed:
+        audit = user.setdefault("unified_profile_capability_audit", [])
+        if not isinstance(audit, list):
+            audit = []
+            user["unified_profile_capability_audit"] = audit
+        audit.append(
+            {
+                "operation_id": f"req036.capability:{_now()}:{len(audit) + 1}",
+                "actor_id": _text(actor_id, 120) or "administrator",
+                "target_identity": _text(target_identity, 120),
+                "reason_code": _text(reason_code, 80) or "administrator_update",
+                "changed": changed,
+                "at": _now(),
+            }
+        )
+        del audit[:-64]
+    return {"ok": True, "code": "updated", "capabilities": capability_summary(user)}
+
+
+def migration_preview(data: Any, *, operation_id: str = "") -> dict[str, Any]:
+    root = data if isinstance(data, dict) else {}
+    users = root.get("users") if isinstance(root.get("users"), dict) else {}
+    planned: list[dict[str, Any]] = []
+    for user_id, user in users.items():
+        if not isinstance(user, dict):
+            continue
+        existing = user.get("unified_profile_capabilities")
+        if isinstance(existing, dict) and int(existing.get("schema_version") or 0) == CAPABILITY_SCHEMA_VERSION:
+            continue
+        private_enabled = _legacy_private_enabled(user)
+        proactive_enabled = _legacy_proactive_enabled(user, private_enabled)
+        planned.append(
+            {
+                "user_id": _text(user_id, 120),
+                "private_companion_enabled": private_enabled,
+                "proactive_private_enabled": proactive_enabled,
+                "portrait_mode": "disabled",
+                "grant_source": "legacy_effective_migration",
+            }
+        )
+    return {
+        "ok": True,
+        "code": "migration_dry_run",
+        "operation_id": _text(operation_id, 120),
+        "write_count": 0,
+        "planned": planned,
+        "count": len(planned),
+    }
+
+
+def migrate_legacy_capabilities(data: dict[str, Any], *, operation_id: str, dry_run: bool = True) -> dict[str, Any]:
+    operation_id = _text(operation_id, 120)
+    if not isinstance(data, dict) or not operation_id:
+        return {"ok": False, "code": "invalid_request", "count": 0}
+    preview = migration_preview(data, operation_id=operation_id)
+    if dry_run:
+        return preview
+    migration = data.setdefault(MIGRATION_KEY, {"version": CAPABILITY_SCHEMA_VERSION, "operations": {}})
+    operations = migration.setdefault("operations", {}) if isinstance(migration, dict) else {}
+    prior = operations.get(operation_id) if isinstance(operations, dict) else None
+    if isinstance(prior, dict):
+        return {"ok": True, "code": "migration_idempotent_replay", "operation_id": operation_id, "count": int(prior.get("count") or 0)}
+    users = data.get("users") if isinstance(data.get("users"), dict) else {}
+    snapshots: dict[str, Any] = {}
+    for planned in preview["planned"]:
+        user_id = planned["user_id"]
+        user = users.get(user_id)
+        if not isinstance(user, dict):
+            continue
+        snapshots[user_id] = {
+            "unified_profile_capabilities": deepcopy(user.get("unified_profile_capabilities")),
+            "private_companion_enabled": deepcopy(user.get("private_companion_enabled")),
+            "proactive_private_enabled": deepcopy(user.get("proactive_private_enabled")),
+            "enabled": deepcopy(user.get("enabled")),
+        }
+        state = normalize_capabilities(
+            {
+                "private_companion_enabled": planned["private_companion_enabled"],
+                "proactive_private_enabled": planned["proactive_private_enabled"],
+                "portrait_mode": "disabled",
+                "grant_source": "legacy_effective_migration",
+            },
+            default_source="legacy_effective_migration",
+        )
+        user["unified_profile_capabilities"] = state
+        user["private_companion_enabled"] = state["private_companion_enabled"]
+        user["proactive_private_enabled"] = state["proactive_private_enabled"]
+    operations[operation_id] = {"count": len(snapshots), "snapshots": snapshots, "at": _now()}
+    return {"ok": True, "code": "migration_applied", "operation_id": operation_id, "count": len(snapshots)}
+
+
+def rollback_legacy_capabilities(data: dict[str, Any], *, operation_id: str) -> dict[str, Any]:
+    operation_id = _text(operation_id, 120)
+    migration = data.get(MIGRATION_KEY) if isinstance(data, dict) else None
+    operations = migration.get("operations") if isinstance(migration, dict) else None
+    operation = operations.get(operation_id) if isinstance(operations, dict) else None
+    if not isinstance(operation, dict):
+        return {"ok": False, "code": "migration_not_found", "count": 0}
+    users = data.get("users") if isinstance(data.get("users"), dict) else {}
+    restored = 0
+    for user_id, snapshot in (operation.get("snapshots") or {}).items():
+        user = users.get(user_id)
+        if not isinstance(user, dict) or not isinstance(snapshot, dict):
+            continue
+        for key, value in snapshot.items():
+            if value is None:
+                user.pop(key, None)
+            else:
+                user[key] = deepcopy(value)
+        restored += 1
+    operation["rolled_back_at"] = _now()
+    return {"ok": True, "code": "migration_rolled_back", "operation_id": operation_id, "count": restored}
+
+
+__all__ = [name for name in globals() if name.isupper() or name in {
+    "capability_summary", "default_capabilities", "ensure_new_profile_capabilities", "migrate_legacy_capabilities",
+    "migration_preview", "normalize_capabilities", "private_companion_gate", "proactive_private_gate",
+    "rollback_legacy_capabilities", "update_capabilities",
+}]

--- a/worldbook.py
+++ b/worldbook.py
@@ -513,8 +513,6 @@ class WorldbookMixin:
                 "private_memory_enabled": False,
                 "cross_group_memory_enabled": False,
                 "p4_eligible": False,
-                "affinity_score": 0,
-                "relationship_state": "neutral",
                 "auto_registered_ts": now,
             }
             profiles[sender_id] = profile
@@ -527,8 +525,9 @@ class WorldbookMixin:
         profile["private_memory_enabled"] = False
         profile["cross_group_memory_enabled"] = False
         profile["p4_eligible"] = False
-        profile.setdefault("affinity_score", 0)
-        profile.setdefault("relationship_state", "neutral")
+        # New group observation records retain only group-local aliases and
+        # observations.  They never become a second personal relationship
+        # ledger; old compatibility fields may remain in existing records.
         profile.setdefault("profile_origin", "group_observation")
         profile.setdefault("projection_kind", "group_observation")
         profile.setdefault("identity_type", "qq")


### PR DESCRIPTION
## 概要

- 为私聊与群观察入口增加基于精确身份的统一用户档案投影。
- 新自动档案的私聊陪伴、主动私聊与智能画像使用均保持默认关闭。
- 对未授权私聊，在进入 Provider、Memory、工具、画像或关系结算之前直接返回管理员可配置的固定文本。
- 停止群观察写入重复的个人好感度与关系权威，同时保留群内局部观察能力。
- 在 Companion 管理界面增加统一用户档案状态与能力开关。

## 兼容性与安全性

- 保留插件 ID、数据目录、路由和既有用户数据；身份投影、关系、表达与权限继续完全由 Companion 权威管理。
- 仅当历史已配置 target 缺少 REQ-036 能力状态时执行迁移；管理员显式关闭后绝不会被重新开启。
- 群聊中针对第三方的画像探查会在检索或 LLM 处理之前被拒绝。

## 验证

- REQ-036 专项：13 passed。
- 受影响的 owner 私聊命令回归：4 passed。
- 私聊绑定、群观察与用户档案回归：19 passed。
- 在同一隔离 AstrBot 环境中，全量失败集是官方迁移基线的严格子集。
- AST、JSON、JavaScript、镜像面板脚本、敏感模式扫描及 git diff 检查均通过。

## 非目标

- 不改变 Memory 的事实权威；不传递跨场景原始内容；不执行生产迁移、部署或运行时配置变更。