### PR TITLE
fix: 生图使用范围勾选"主要用户私聊"保存后丢失

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -9786,6 +9786,9 @@
         "description": "生图使用范围",
         "type": "list",
         "hint": "可选：主要用户私聊、其他陪伴用户私聊、群聊、Bot 主动生图。留空按全部范围开放。",
+        "render_type": "checkbox",
+        "options": ["private_owner", "private_friend", "group", "proactive"],
+        "labels": ["主要用户私聊", "其他陪伴用户私聊", "群聊", "Bot 主动生图"],
         "default": ["private_owner", "private_friend", "group", "proactive"],
         "condition": {
           "enable_photo_text_action": true

--- a/pages/companion-panel/app.js
+++ b/pages/companion-panel/app.js
@@ -24819,7 +24819,7 @@ function featureSettingInput(key, value, accessibility = {}) {
   if (spec.type === "photo-scopes") {
     const allowed = new Set(Array.isArray(value) ? value : String(value || "").split(/[\r\n,，、;；]+/));
     const options = [["private_owner", "主要用户私聊"], ["private_friend", "其他陪伴用户私聊"], ["group", "群聊"], ["proactive", "Bot 主动生图"]];
-    return `<div class="multi-persona-choice-list photo-scope-choice-list" data-feature-param-group="${safeKey}">${options.map(([scope, label]) => `<label><input type="checkbox" data-photo-scope-value="${scope}" data-feature-param="${safeKey}" value="${scope}"${allowed.has(scope) ? " checked" : ""}${accessibilityAttrs}${disabledAttr}><span>${label}</span></label>`).join("")}<textarea data-feature-param="${safeKey}" hidden>${escapeHtml(options.map(([scope]) => scope).filter((scope) => allowed.has(scope)).join("\n"))}</textarea></div>`;
+    return `<div class="multi-persona-choice-list photo-scope-choice-list" data-feature-param-group="${safeKey}">${options.map(([scope, label]) => `<label><input type="checkbox" data-photo-scope-value="${scope}" value="${scope}"${allowed.has(scope) ? " checked" : ""}${accessibilityAttrs}${disabledAttr}><span>${label}</span></label>`).join("")}<textarea data-feature-param="${safeKey}" hidden>${escapeHtml(options.map(([scope]) => scope).filter((scope) => allowed.has(scope)).join("\n"))}</textarea></div>`;
   }
   if (key === "multi_persona_primary_id") {
     const current = String(value || "").trim();
@@ -27369,7 +27369,7 @@ function bindFeatureDetailActions() {
   detailPage?.querySelectorAll("[data-photo-scope-value]").forEach((input) => {
     input.addEventListener("change", () => {
       const host = input.closest(".photo-scope-choice-list");
-      const hidden = host?.querySelector('[data-feature-param="photo_generation_allowed_scopes"]');
+      const hidden = host?.querySelector('textarea[data-feature-param="photo_generation_allowed_scopes"]');
       if (hidden) {
         hidden.value = Array.from(host.querySelectorAll("[data-photo-scope-value]:checked")).map((item) => String(item.value || "").trim()).filter(Boolean).join("\n");
         rememberFeatureParamDraft(hidden);

--- a/pages/陪伴面板/app.js
+++ b/pages/陪伴面板/app.js
@@ -24819,7 +24819,7 @@ function featureSettingInput(key, value, accessibility = {}) {
   if (spec.type === "photo-scopes") {
     const allowed = new Set(Array.isArray(value) ? value : String(value || "").split(/[\r\n,，、;；]+/));
     const options = [["private_owner", "主要用户私聊"], ["private_friend", "其他陪伴用户私聊"], ["group", "群聊"], ["proactive", "Bot 主动生图"]];
-    return `<div class="multi-persona-choice-list photo-scope-choice-list" data-feature-param-group="${safeKey}">${options.map(([scope, label]) => `<label><input type="checkbox" data-photo-scope-value="${scope}" data-feature-param="${safeKey}" value="${scope}"${allowed.has(scope) ? " checked" : ""}${accessibilityAttrs}${disabledAttr}><span>${label}</span></label>`).join("")}<textarea data-feature-param="${safeKey}" hidden>${escapeHtml(options.map(([scope]) => scope).filter((scope) => allowed.has(scope)).join("\n"))}</textarea></div>`;
+    return `<div class="multi-persona-choice-list photo-scope-choice-list" data-feature-param-group="${safeKey}">${options.map(([scope, label]) => `<label><input type="checkbox" data-photo-scope-value="${scope}" value="${scope}"${allowed.has(scope) ? " checked" : ""}${accessibilityAttrs}${disabledAttr}><span>${label}</span></label>`).join("")}<textarea data-feature-param="${safeKey}" hidden>${escapeHtml(options.map(([scope]) => scope).filter((scope) => allowed.has(scope)).join("\n"))}</textarea></div>`;
   }
   if (key === "multi_persona_primary_id") {
     const current = String(value || "").trim();
@@ -27369,7 +27369,7 @@ function bindFeatureDetailActions() {
   detailPage?.querySelectorAll("[data-photo-scope-value]").forEach((input) => {
     input.addEventListener("change", () => {
       const host = input.closest(".photo-scope-choice-list");
-      const hidden = host?.querySelector('[data-feature-param="photo_generation_allowed_scopes"]');
+      const hidden = host?.querySelector('textarea[data-feature-param="photo_generation_allowed_scopes"]');
       if (hidden) {
         hidden.value = Array.from(host.querySelectorAll("[data-photo-scope-value]:checked")).map((item) => String(item.value || "").trim()).filter(Boolean).join("\n");
         rememberFeatureParamDraft(hidden);


### PR DESCRIPTION
## 问题

陪伴面板（pages/陪伴面板 与 pages/companion-panel）中，配置项 `photo_generation_allowed_scopes`（生图使用范围）勾选「主要用户私聊」后保存，刷新页面又变回未勾选。配置文件里该值始终缺少 `private_owner`。

## 根因

`featureSettingInput` 渲染 photo-scopes 勾选框组时，4 个 checkbox 也携带了 `data-feature-param="photo_generation_allowed_scopes"` 属性，且 DOM 顺序位于 hidden textarea **之前**。

`bindFeatureDetailActions` 中 checkbox 的 change 处理器用

```js
host.querySelector('[data-feature-param="photo_generation_allowed_scopes"]')
```

查找 hidden textarea，实际命中的却是**第一个 checkbox**（`querySelector` 返回首个匹配），把选中集合（如 `"private_owner\nprivate_friend\ngroup\nproactive"`）写进该 checkbox 的 `.value`，污染其值。

保存时 `collectSettingValue` 收集到被污染的多行字符串，后端 `page_api_settings.py` 的 `_normalize_setting_value` 只接受白名单单值，污染串被丢弃 → `private_owner` 每次保存都丢失，其他三个选项因 value 未被污染而正常保留。

## 修复

1. **`pages/陪伴面板/app.js` / `pages/companion-panel/app.js`**：
   - 渲染模板：checkbox 移除 `data-feature-param` 属性（与 `multi_persona_ids` 的写法保持一致），仅 hidden textarea 保留该属性；
   - change 处理器：改用 `textarea[data-feature-param="photo_generation_allowed_scopes"]` 精确定位 textarea。
2. **`_conf_schema.json`**：为 `photo_action_config.items.photo_generation_allowed_scopes` 补充 `render_type: "checkbox"`、`options` 与中文 `labels`，使 AstrBot Dashboard 插件配置页也能以勾选框形式编辑该配置（此前为无 `options` 的 `list`，只能文本编辑）。

## 验证

- 两个 app.js 通过 `node --check` 语法检查；`_conf_schema.json` JSON 合法；
- 插件测试套件相关用例（生图配额、配置分组权限、未保存守卫、参考图页面渲染）共 85 项全部通过；
- 修复后勾选「主要用户私聊」保存，配置文件中 `private_owner` 正常保留。