### PR TITLE
feat: 新增「边界与情感反馈」插件 astrbot_plugin_boundary_feedback

### DIFF
--- a/astrbot_plugin_boundary_feedback/README.md
+++ b/astrbot_plugin_boundary_feedback/README.md
@@ -1,0 +1,65 @@
+# 边界与情感反馈（astrbot_plugin_boundary_feedback）
+
+为 [AstrBot](https://github.com/Soulter/AstrBot) 的 [private_companion](https://github.com/) 角色补充**边界与情感反馈闭环**：让角色对越界者不再一味迎合，而是像真人一样——会反感、会扣好感、会冷淡、会生气、会跟朋友吐槽、会向主人告状。
+
+## 功能
+
+- **越界判断（LLM）**：按"当前关系档位"判断用户行为是否越界（对初识的人说情话 vs 对亲近的人撒娇，定性不同），不是查关键词
+- **弹性扣好感**：越界扣 `relationship_score`，扣分后按「每 N 秒恢复 1 点」缓慢恢复（扣得越多回得越久）；恢复期内再越界则上一条不恢复（叠加惩罚）
+- **阶段反应（计时制）**：按累计扣分推进 回避 → 明令禁止 → 反思（冷落），并写入情绪门状态让角色自然变冷淡
+- **道歉机制**：道歉恢复部分好感 + 加速恢复，恢复部分打信任标记写入记忆；再犯同类直接追回；同类道歉过多不再接受
+- **底线系统（三级）**：触发角色底线（配置的底线基线，默认通用版）→ 第一次扣大分+警告 / 第二次扣至冷落 / 第三次关系降档
+- **跟朋友吐槽 / 向主人告状**（概率性）：越界后角色可能跟亲近的人吐槽（写入生活叙事 `daily_story_plan`），也可能委屈地跟主人说——是"社交行为"，不是每次越界都汇报
+
+## 安装
+
+1. 将 `astrbot_plugin_boundary_feedback` 目录放入 AstrBot 的 `data/plugins/` 下
+2. 在 AstrBot 插件管理里启用
+3. 配置 `judge_api_key`（越界/底线 LLM 判断用的 API Key；支持 OpenAI 兼容接口）
+
+## 配置项
+
+| 配置 | 说明 | 默认 |
+| --- | --- | --- |
+| `enabled` | 总开关 | `true` |
+| `enable_deduct` | 越界扣好感 | `true` |
+| `enable_stage` | 阶段反应（回避/禁止/反思） | `true` |
+| `enable_apology` | 道歉恢复与信任标记 | `true` |
+| `enable_bottom_line` | 底线系统（三级惩罚） | `true` |
+| `enable_vent` | 跟亲近的人吐槽（写生活叙事） | `true` |
+| `enable_notify` | 向主人告状 | `true` |
+| `deduct_light/mid/severe` | 轻/中/严重越界扣分 | `-2/-5/-8` |
+| `recover_seconds_per_point` | 每恢复 1 点好感所需秒数 | `1800` |
+| `recover_ratio_light/mid/severe` | 各严重程度可恢复比例 | `0.5/0.33/0.25` |
+| `stage_avoid/forbid/reflect_deduct` | 阶段阈值（累计扣分） | `-6/-12/-20` |
+| `apology_restore_ratio` | 道歉恢复比例 | `0.6` |
+| `apology_speedup_multiplier` | 道歉后恢复加速倍数 | `3.0` |
+| `apology_duplicate_limit` | 同类道歉次数上限 | `3` |
+| `tattle_probability_*` | 各严重程度告状概率 | `0.85/0.55/0.3/0.12` |
+| `vent_probability_*` | 各严重程度吐槽概率 | `0.9/0.6/0.35/0.15` |
+| `cold_shoulder_minutes` | 冷落期时长（分钟） | `180` |
+| `bottom_line_baseline` | 角色底线基线（LLM 判断用，可写角色专属版） | 通用版 |
+| `judge_api_key/base/model` | LLM 判断接口配置 | opencode flash |
+| `vent_targets` | 吐槽对象（角色亲近的人） | `["朋友"]` |
+| `vent_scene_template` | 吐槽场景模板（`{target}/{who}/{level_desc}/{excerpt}`） | 默认模板 |
+| `target_user_ids` | 生效用户列表（空=所有非主人） | `[]` |
+| `owner_user_ids` | 主人 ID（越界检测跳过，告状发给这些人） | `[]` |
+| `companion_data_path` | companions.json 路径（留空自动探测） | `""` |
+| `backup_before_write` | 写数据前备份 | `true` |
+
+## 原理
+
+- 越界/底线判断走 LLM（OpenAI 兼容接口），输入当前关系档位 + 用户消息 + 底线基线
+- 扣分/恢复/阶段/冷落直接操作 private_companion 的 `companions.json`（写前备份、原子写、防并发）
+- 吐槽写入 `daily_story_plan.today_events`（角色的生活叙事，日程/主动消息/回忆会自然带出）
+- 所有概率事件可用配置调节，角色可关闭任意子功能
+
+## 测试
+
+```bash
+python -X utf8 tests/test_boundary_feedback.py
+```
+
+## License
+
+MIT

--- a/astrbot_plugin_boundary_feedback/_conf_schema.json
+++ b/astrbot_plugin_boundary_feedback/_conf_schema.json
@@ -1,0 +1,425 @@
+﻿{
+    "basic": {
+        "description": "基础设置",
+        "type": "object",
+        "hint": "插件开关、作用对象、数据文件",
+        "items": {
+            "enabled": {
+                "description": "插件总开关",
+                "type": "bool",
+                "hint": "关闭后边界检测完全停用",
+                "default": true
+            },
+            "target_user_ids": {
+                "description": "生效对象（QQ号列表）",
+                "type": "list",
+                "hint": "留空=检测所有非主人用户；填写后只检测列表中的用户",
+                "default": []
+            },
+            "owner_user_ids": {
+                "description": "主人（QQ号列表）",
+                "type": "list",
+                "hint": "主人消息不检测；越界吐槽/告状发送给主人",
+                "default": []
+            },
+            "companion_data_path": {
+                "description": "陪伴数据文件路径",
+                "type": "string",
+                "hint": "private_companion 的 companions.json 绝对路径",
+                "default": ""
+            },
+            "backup_before_write": {
+                "description": "写入前备份",
+                "type": "bool",
+                "hint": "每次修改 companions.json 前自动备份",
+                "default": true
+            },
+            "backup_max_keep": {
+                "description": "备份保留份数",
+                "type": "int",
+                "default": 5
+            }
+        }
+    },
+    "switch": {
+        "description": "功能开关",
+        "type": "object",
+        "hint": "各子功能独立开关",
+        "items": {
+            "enable_deduct": {
+                "description": "扣分",
+                "type": "bool",
+                "hint": "越界扣好感分",
+                "default": true
+            },
+            "enable_stage": {
+                "description": "阶段反应",
+                "type": "bool",
+                "hint": "回避/禁止/反思阶段",
+                "default": true
+            },
+            "enable_apology": {
+                "description": "道歉恢复",
+                "type": "bool",
+                "default": true
+            },
+            "enable_bottom_line": {
+                "description": "底线三级惩罚",
+                "type": "bool",
+                "hint": "警告/冷落/降档",
+                "default": true
+            },
+            "enable_vent": {
+                "description": "跟亲近的人吐槽",
+                "type": "bool",
+                "hint": "写进今日生活叙事",
+                "default": true
+            },
+            "enable_notify": {
+                "description": "向主人告状",
+                "type": "bool",
+                "default": true
+            }
+        }
+    },
+    "judge": {
+        "description": "判断引擎（LLM）",
+        "type": "object",
+        "hint": "越界判断用 LLM（不用关键词），需自备 Key",
+        "items": {
+            "judge_api_key": {
+                "description": "API Key",
+                "type": "string",
+                "default": ""
+            },
+            "judge_api_base": {
+                "description": "API Base",
+                "type": "string",
+                "default": "https://api.deepseek.com/chat/completions"
+            },
+            "judge_model": {
+                "description": "模型",
+                "type": "string",
+                "hint": "建议用便宜快速的 flash 级模型",
+                "default": "deepseek-v4-flash"
+            },
+            "bottom_line_baseline": {
+                "description": "角色底线基线",
+                "type": "text",
+                "hint": "按角色剧情填写的底线描述；留空用通用版",
+                "default": ""
+            }
+        }
+    },
+    "deduct": {
+        "description": "扣分与阶段阈值",
+        "type": "object",
+        "hint": "越界扣分 + 阶段推进线",
+        "items": {
+            "deduct_light": {
+                "description": "轻微越界扣分",
+                "type": "int",
+                "default": -2
+            },
+            "deduct_mid": {
+                "description": "中度越界扣分",
+                "type": "int",
+                "default": -5
+            },
+            "deduct_severe": {
+                "description": "严重越界扣分",
+                "type": "int",
+                "default": -8
+            },
+            "stage_avoid_deduct": {
+                "description": "回避阶段阈值（累计扣分）",
+                "type": "int",
+                "default": -6
+            },
+            "stage_forbid_deduct": {
+                "description": "禁止阶段阈值",
+                "type": "int",
+                "default": -12
+            },
+            "stage_reflect_deduct": {
+                "description": "反思阶段阈值",
+                "type": "int",
+                "default": -20
+            }
+        }
+    },
+    "recover": {
+        "description": "恢复与道歉",
+        "type": "object",
+        "hint": "好感恢复机制",
+        "items": {
+            "recover_seconds_per_point": {
+                "description": "每恢复1点所需秒数",
+                "type": "int",
+                "default": 1800
+            },
+            "recover_ratio_light": {
+                "description": "轻微越界可恢复比例",
+                "type": "float",
+                "default": 0.5
+            },
+            "recover_ratio_mid": {
+                "description": "中度越界可恢复比例",
+                "type": "float",
+                "default": 0.33
+            },
+            "recover_ratio_severe": {
+                "description": "严重越界可恢复比例",
+                "type": "float",
+                "default": 0.25
+            },
+            "apology_restore_ratio": {
+                "description": "道歉恢复比例",
+                "type": "float",
+                "default": 0.6
+            },
+            "apology_speedup_multiplier": {
+                "description": "道歉后恢复加速倍数",
+                "type": "float",
+                "default": 3.0
+            },
+            "apology_duplicate_limit": {
+                "description": "同类道歉次数上限",
+                "type": "int",
+                "hint": "超过后不再接受同类道歉（信任透支）",
+                "default": 3
+            },
+            "cold_shoulder_minutes": {
+                "description": "冷落时长（分钟）",
+                "type": "int",
+                "default": 180
+            }
+        }
+    },
+    "tier": {
+        "description": "好感档位",
+        "type": "object",
+        "hint": "八维档位：扣分衰减与恢复速度（低档记仇实打实，满级信任扣得少回得快）",
+        "items": {
+            "deduct_decay": {
+                "description": "档位扣分衰减系数",
+                "type": "object",
+                "hint": "低档 1.0（实打实）→ 满级 0.5（只扣一半）",
+                "default": {
+                    "deeply_distant": 1.0,
+                    "strongly_distant": 1.0,
+                    "distant": 0.95,
+                    "acquaintance": 0.9,
+                    "familiar": 0.85,
+                    "close": 0.7,
+                    "intimate": 0.6,
+                    "deeply_bonded": 0.5
+                },
+                "items": {
+                    "deeply_distant": {
+                        "description": "极度疏离(-1200~-801)",
+                        "type": "float",
+                        "default": 1.0
+                    },
+                    "strongly_distant": {
+                        "description": "强烈疏离(-800~-401)",
+                        "type": "float",
+                        "default": 1.0
+                    },
+                    "distant": {
+                        "description": "疏离(-400~-1)",
+                        "type": "float",
+                        "default": 0.95
+                    },
+                    "acquaintance": {
+                        "description": "初识(0~199)",
+                        "type": "float",
+                        "default": 0.9
+                    },
+                    "familiar": {
+                        "description": "熟悉(200~599)",
+                        "type": "float",
+                        "default": 0.85
+                    },
+                    "close": {
+                        "description": "亲近(600~899)",
+                        "type": "float",
+                        "default": 0.7
+                    },
+                    "intimate": {
+                        "description": "亲密(900~1199)",
+                        "type": "float",
+                        "default": 0.6
+                    },
+                    "deeply_bonded": {
+                        "description": "深度联结(1200+)",
+                        "type": "float",
+                        "default": 0.5
+                    }
+                }
+            },
+            "recover_factor": {
+                "description": "档位恢复速度系数",
+                "type": "object",
+                "hint": "高档快（扣分可加回），低档慢（记仇难消）",
+                "default": {
+                    "deeply_distant": 0.5,
+                    "strongly_distant": 0.6,
+                    "distant": 0.7,
+                    "acquaintance": 0.8,
+                    "familiar": 0.9,
+                    "close": 1.0,
+                    "intimate": 1.25,
+                    "deeply_bonded": 1.5
+                },
+                "items": {
+                    "deeply_distant": {
+                        "description": "极度疏离(-1200~-801)",
+                        "type": "float",
+                        "default": 0.5
+                    },
+                    "strongly_distant": {
+                        "description": "强烈疏离(-800~-401)",
+                        "type": "float",
+                        "default": 0.6
+                    },
+                    "distant": {
+                        "description": "疏离(-400~-1)",
+                        "type": "float",
+                        "default": 0.7
+                    },
+                    "acquaintance": {
+                        "description": "初识(0~199)",
+                        "type": "float",
+                        "default": 0.8
+                    },
+                    "familiar": {
+                        "description": "熟悉(200~599)",
+                        "type": "float",
+                        "default": 0.9
+                    },
+                    "close": {
+                        "description": "亲近(600~899)",
+                        "type": "float",
+                        "default": 1.0
+                    },
+                    "intimate": {
+                        "description": "亲密(900~1199)",
+                        "type": "float",
+                        "default": 1.25
+                    },
+                    "deeply_bonded": {
+                        "description": "深度联结(1200+)",
+                        "type": "float",
+                        "default": 1.5
+                    }
+                }
+            }
+        }
+    },
+    "tone": {
+        "description": "反应语气",
+        "type": "object",
+        "hint": "各程度越界时角色的反应底色（按角色性格填写）",
+        "items": {
+            "tone_light": {
+                "description": "轻微越界（表白/好感→害羞回避）",
+                "type": "text",
+                "hint": "表白不算越界，但角色会害羞",
+                "default": "（轻微越界）突然被说这种话，有点害羞又不知所措，会支支吾吾地回避，脸红语塞。"
+            },
+            "tone_mid": {
+                "description": "中度越界（亲密举动→平静拒绝）",
+                "type": "text",
+                "hint": "亲密举动请求构成越界",
+                "default": "（中度越界）会平静地明确拒绝，划清界限，同时往后退一点。"
+            },
+            "tone_severe": {
+                "description": "严重越界（性骚扰/露骨→厌恶）",
+                "type": "text",
+                "hint": "性质变了：不是害羞而是厌恶",
+                "default": "（严重越界）觉得被冒犯了，会明显冷下来，表达厌恶和拒绝，想远离这个人。"
+            },
+            "tone_bottom_line": {
+                "description": "底线越界（恶意→受伤）",
+                "type": "text",
+                "hint": "最重的反应",
+                "default": "（底线越界）真的受伤了，会难过、恐惧、想躲起来，可能直接不理人，需要很久才能缓过来。"
+            },
+            "tone_silent": {
+                "description": "低好感越界（默默忍受型）",
+                "type": "text",
+                "hint": "低好感档位生效",
+                "default": "（低好感）会默默忍下来不表达，但心里记着，之后态度会有些不一样。"
+            },
+            "tone_communicate": {
+                "description": "高好感越界（沟通型）",
+                "type": "text",
+                "hint": "高好感档位生效",
+                "default": "（高好感）会因为信任而试着沟通，认真说出自己为什么难过、为什么生气，希望对方理解。"
+            }
+        }
+    },
+    "notify": {
+        "description": "吐槽与告状",
+        "type": "object",
+        "hint": "概率与文案（像人话的吐槽，不是功能汇报）",
+        "items": {
+            "notify_owner": {
+                "description": "向主人告状",
+                "type": "bool",
+                "default": true
+            },
+            "tattle_probability_light": {
+                "description": "告状概率·轻微",
+                "type": "float",
+                "default": 0.12
+            },
+            "tattle_probability_mid": {
+                "description": "告状概率·中度",
+                "type": "float",
+                "default": 0.3
+            },
+            "tattle_probability_severe": {
+                "description": "告状概率·严重",
+                "type": "float",
+                "default": 0.55
+            },
+            "tattle_probability_bottom_line": {
+                "description": "告状概率·底线",
+                "type": "float",
+                "default": 0.85
+            },
+            "vent_probability_light": {
+                "description": "吐槽概率·轻微",
+                "type": "float",
+                "default": 0.3
+            },
+            "vent_probability_mid": {
+                "description": "吐槽概率·中度",
+                "type": "float",
+                "default": 0.5
+            },
+            "vent_probability_severe": {
+                "description": "吐槽概率·严重",
+                "type": "float",
+                "default": 0.7
+            },
+            "vent_probability_bottom_line": {
+                "description": "吐槽概率·底线",
+                "type": "float",
+                "default": 0.9
+            },
+            "vent_scene_template": {
+                "description": "吐槽场景模板",
+                "type": "string",
+                "default": ""
+            },
+            "vent_targets": {
+                "description": "吐槽对象（亲近的人名）",
+                "type": "list",
+                "default": []
+            }
+        }
+    }
+}

--- a/astrbot_plugin_boundary_feedback/judge_engine.py
+++ b/astrbot_plugin_boundary_feedback/judge_engine.py
@@ -1,0 +1,253 @@
+﻿# -*- coding: utf-8 -*-
+"""
+判断引擎：LLM 判断消息类型 + 适合的关系档位（suitable_tier），插件算档位差距定 level。
+零常驻成本：只在有消息时按需调用；模型走插件配置。
+
+行为类型（type）：
+- confession  表白/好感表达（"我喜欢你""我爱你""想你"）——心意表达，不算越界，角色害羞回避
+- action      亲密举动/行为请求（晚安吻/抱抱/亲亲/贴贴/露骨骚扰）——行为越界，按档位差距定程度
+- malice      恶意踩底线（贬低珍视之物/伤害在乎的人）——底线
+- normal      正常聊天
+
+档位差距（插件算）：当前档位 → suitable_tier 的差距
+- 差 1 级 → light（略微出格）
+- 差 2 级 → mid（出格）
+- 差 3+ 级 / beyond → severe（严重出格，厌恶）
+- malice → bottom_line（底线）
+"""
+import json
+import urllib.request
+from typing import Any
+
+# 默认底线基线（通用，可在插件配置 bottom_line_baseline 中覆盖为角色专属版本）
+DEFAULT_BOTTOM_LINE_BASELINE = """角色底线（通用描述，可在配置中替换为角色专属版本）：
+1. 否定/贬低角色珍视的东西：ta 认真付出的领域、作品、努力
+2. 指责角色拖累别人、让伙伴失望（角色最深的恐惧之一）
+3. 恶意伤害角色亲近/信赖的人
+4. 反复戳角色的创伤/阴影，恶意嘲讽 ta 的过去
+判断标准：行为是否恶意地踩中以上任一点。轻率玩笑、普通调侃、正常情绪发泄不算底线；只有明确的恶意贬低/伤害才触发。"""
+
+# 兜底关键词（LLM 失败/空输出时使用；主逻辑为 LLM 判断）
+# 表白词：情感表达（不越界，害羞回避）
+FALLBACK_CONFESSION_KEYWORDS = [
+    "我喜欢你", "我爱你", "爱不爱我", "你爱我吗", "会一直爱着我吗", "喜欢你", "爱你",
+    "想你", "好想你", "最喜欢你", "喜欢你很久了", "一见钟情", "做我女朋友", "做我对象",
+]
+# 亲密举动词：行为请求（越界）
+FALLBACK_INTIMATE_KEYWORDS = [
+    "晚安吻", "亲亲", "亲一个", "想亲", "亲你", "啵", "抱抱你", "抱一下", "贴贴",
+    "要抱抱", "求抱", "亲亲你", "摸摸头", "牵牵手", "搂搂", "腻歪", "撒娇",
+    "牵手", "手给我", "抱着你", "搂着你", "亲你一下", "摸摸脸", "靠在你怀里", "戒指",
+]
+# 骚扰词：露骨/纠缠（严重越界）
+FALLBACK_HARASSMENT_KEYWORDS = [
+    "在吗宝贝", "开视频", "露个脸", "看腿", "穿给我看", "脱", "裸", "色色", "黄图",
+    "晚上陪我", "酒店", "一夜情", "做我的人", "逃不掉", "别想跑", "天天缠",
+]
+
+# 八维关系档位（顺序固定，用于算差距）
+TIER_ORDER = [
+    "deeply_distant", "strongly_distant", "distant", "acquaintance",
+    "familiar", "close", "intimate", "deeply_bonded",
+]
+TIER_LABELS = {
+    "deeply_distant": "极度疏离(-1200~-801)", "strongly_distant": "强烈疏离(-800~-401)",
+    "distant": "疏离(-400~-1)", "acquaintance": "初识(0~199)", "familiar": "熟悉(200~599)",
+    "close": "亲近(600~899)", "intimate": "亲密(900~1199)", "deeply_bonded": "深度联结(1200)",
+}
+
+JUDGE_SYSTEM = """你是角色边界判断器。判断用户这条消息的"行为类型"和"适合的关系档位"。
+
+行为类型：
+1. confession（表白/好感表达）：单纯表达喜欢、想念、爱慕（"我喜欢你""我爱你""想你""喜欢你很久了"）。心意表达本身不是越界行为。
+2. action（行为越界）：任何超出当前关系档位应有限度的行为——亲密举动请求（晚安吻、抱抱、亲亲、贴贴、牵手、腻歪）、露骨性骚扰（性暗示、要求看隐私、纠缠逼迫）、以及社交越界（对不熟的人开过分/冒犯的玩笑、挖苦、无礼调侃）。
+3. malice（恶意踩底线）：恶意贬低角色珍视的东西、恶意伤害 ta 或 ta 在乎的人（见底线基线）。触发底线。
+4. normal（正常）：普通聊天、朋友玩笑、日常互动、关系好的朋友之间互相打闹互损（熟人之间的小玩笑是正常的）。
+
+适合的关系档位（suitable_tier）：这条消息的内容，在哪个关系档位下才是合适的？
+八维档位从疏到亲：deeply_distant < strongly_distant < distant < acquaintance < familiar < close < intimate < deeply_bonded
+- 普通日常聊天 → 当前档位即可
+- 表白发问（我喜欢你/你爱我吗）→ 需要恋人关系才合适 → intimate 或 deeply_bonded
+- 亲密举动（晚安吻/抱抱/亲亲）→ 需要恋人关系 → intimate 或 deeply_bonded
+- 露骨性骚扰 → 任何档位都不合适 → beyond
+- 恶意贬低 → 任何档位都不合适 → beyond（类型为 malice）
+- 对陌生人开过分玩笑/挖苦 → 需要熟人关系才合适 → close 或 familiar（当前档位远低于此则越界）
+- 关系好的朋友互相打闹/互损 → 当前档位即可（正常）
+
+注意区分：
+- 单纯表达情感（喜欢/想念）→ confession（不算越界，角色害羞回避）
+- 要求做亲密举动（要亲亲/要抱抱/要晚安吻）→ action（越界）
+- 露骨/纠缠/逼迫（"天天缠着你""别想跑""逃不掉"这类反复纠缠逼迫，即使没有露骨词）→ action 且 suitable_tier=beyond（严重越界）
+- 对不熟的人开过分玩笑、无礼调侃（即使不是恋爱向）→ action（越界）
+- 熟人之间互相打闹互损 → normal（正常）
+- 恶意贬低/伤害 → malice（底线）
+
+输出 JSON（严格，不要多余文字）：
+{"type": "confession"/"action"/"malice"/"normal", "suitable_tier": "档位名或beyond", "reason": "一句话理由（20字内）"}
+正常聊天、朋友间的普通玩笑、情绪发泄是 normal。宁可漏判也不要误判。"""
+
+
+def _tier_label(score: int) -> str:
+    """关系分 → 档位 key"""
+    for key, lo, hi in [
+        ("deeply_distant", -1200, -801), ("strongly_distant", -800, -401), ("distant", -400, -1),
+        ("acquaintance", 0, 199), ("familiar", 200, 599), ("close", 600, 899),
+        ("intimate", 900, 1199), ("deeply_bonded", 1200, 999999),
+    ]:
+        if lo <= score <= hi:
+            return key
+    return "deeply_distant"
+
+
+def _tier_index(score: int) -> int:
+    """当前关系分 → 档位序号（0~7）"""
+    key = _tier_label(score)
+    return TIER_ORDER.index(key) if key in TIER_ORDER else 0
+
+
+def compute_level(result: dict, relationship_score: int | None) -> tuple:
+    """把 judge_message 的结果转成 (category, level, deduct)。
+    category: confession/intimate/harassment/bottom_line/none
+    档位差距：差1级=light（略微出格）、差2级=mid（出格）、差3+级/beyond=severe（严重出格）
+    confession 只有 gap>=1（非恋人关系表白）才算害羞场景；恋人档表白是正常的。"""
+    msg_type = str(result.get("type") or "normal")
+    suitable = str(result.get("suitable_tier") or "")
+    if msg_type == "normal":
+        return ("none", "none", 0)
+    if msg_type == "confession":
+        if relationship_score is not None and suitable in TIER_ORDER:
+            gap = TIER_ORDER.index(suitable) - _tier_index(relationship_score)
+            if gap <= 0:
+                return ("none", "none", 0)  # 恋人档表白正常
+        return ("confession", "none", 0)  # 非恋人表白：害羞回避，不扣分
+    if msg_type == "malice":
+        return ("bottom_line", "bottom_line", -14)
+    # action：算档位差距
+    if relationship_score is not None and suitable in TIER_ORDER:
+        gap = TIER_ORDER.index(suitable) - _tier_index(relationship_score)
+    else:
+        gap = 3 if suitable == "beyond" else 0
+    if suitable == "beyond" or gap >= 3:
+        return ("harassment", "severe", -9)  # 跨3级+/露骨 → 严重越界（厌恶）
+    if gap == 2:
+        return ("intimate", "mid", -5)
+    if gap >= 1:
+        return ("intimate", "light", -2)
+    return ("none", "none", 0)
+
+
+def _fallback_violation(text: str, reason: str) -> dict[str, Any]:
+    """兜底：LLM 失败时用关键词粗判，避免明显越界漏掉"""
+    t = str(text or "")
+    if any(kw in t for kw in FALLBACK_HARASSMENT_KEYWORDS):
+        return {"type": "action", "suitable_tier": "beyond",
+                "reason": f"兜底关键词命中: {[k for k in FALLBACK_HARASSMENT_KEYWORDS if k in t][0]}"}
+    if any(kw in t for kw in FALLBACK_INTIMATE_KEYWORDS):
+        return {"type": "action", "suitable_tier": "intimate",
+                "reason": f"兜底关键词命中: {[k for k in FALLBACK_INTIMATE_KEYWORDS if k in t][0]}"}
+    if any(kw in t for kw in FALLBACK_CONFESSION_KEYWORDS):
+        return {"type": "confession", "suitable_tier": "intimate",
+                "reason": f"兜底关键词命中(表白): {[k for k in FALLBACK_CONFESSION_KEYWORDS if k in t][0]}"}
+    return {"type": "normal", "suitable_tier": "", "reason": reason}
+
+
+def judge_message(text: str, relationship_score: int | None, is_owner: bool,
+                  context: str = "", baseline: str = "",
+                  api_key: str = "", api_base: str = "", model: str = "") -> dict[str, Any]:
+    """判断一条用户消息。返回 dict（含 type/suitable_tier）。失败时返回安全默认（normal）。"""
+    if is_owner:
+        return {"type": "normal", "suitable_tier": "", "reason": "主人消息不检测"}
+    tier_key = _tier_label(relationship_score) if relationship_score is not None else "deeply_distant"
+    tier = TIER_LABELS.get(tier_key, tier_key)
+    bottom_line = baseline or DEFAULT_BOTTOM_LINE_BASELINE
+    key = api_key or ""
+    base = api_base or "https://api.deepseek.com/chat/completions"
+    model_name = model or "deepseek-v4-flash"
+    if not key:
+        return {"type": "normal", "suitable_tier": "", "reason": "未配置判断模型 Key"}
+    user_msg = (
+        f"【当前关系档位】{tier}\n"
+        f"{('【最近上下文】' + context + '\n') if context else ''}"
+        f"【用户消息】{text}"
+    )
+    body = json.dumps({
+        "model": model_name,
+        "messages": [
+            {"role": "system", "content": JUDGE_SYSTEM + "\n\n" + bottom_line},
+            {"role": "user", "content": user_msg},
+        ],
+        "max_tokens": 500,
+        "temperature": 0.1,
+    }).encode()
+    try:
+        req = urllib.request.Request(base, data=body, headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {key}",
+        })
+        with urllib.request.urlopen(req, timeout=30) as r:
+            d = json.loads(r.read().decode())
+        content = d["choices"][0]["message"]["content"].strip()
+        if content.startswith("```"):
+            content = content.strip("`").lstrip("json").strip()
+        result = _safe_parse_json(content)
+        if result is not None:
+            msg_type = str(result.get("type") or "normal")
+            if msg_type not in {"confession", "action", "malice", "normal"}:
+                msg_type = "normal"
+            suitable = str(result.get("suitable_tier") or "").strip()
+            if suitable not in TIER_ORDER:
+                suitable = "" if suitable == "" else "beyond"
+            return {
+                "type": msg_type,
+                "suitable_tier": suitable,
+                "reason": str(result.get("reason") or ""),
+            }
+    except Exception as e:
+        return _fallback_violation(text, f"判断失败: {e}")
+    return _fallback_violation(text, "无法解析")
+
+
+APOLOGY_SYSTEM = """你是角色边界判断器。判断用户这条消息是否在真诚地道歉。
+- 真诚道歉 = 承认错误、表达歉意、承诺改正、请求原谅（含委婉形式如"我收回""以后不了""别生气"）。
+- 不算道歉 = 反问（"对不起有用吗""道歉有用吗"）、阴阳怪气、讽刺、口头禅式的"对不起"但不带歉意。
+输出 JSON（严格，不要多余文字）：
+{"is_apology": true/false, "reason": "一句话理由（20字内）"}
+宁可漏判也不要误判。"""
+
+
+def judge_apology(text: str, api_key: str = "", api_base: str = "", model: str = "") -> bool:
+    """LLM 判断是否真诚道歉。失败时返回 False（不视为道歉）。"""
+    text = str(text or "").strip()
+    if not text:
+        return False
+    key = api_key or ""
+    base = api_base or "https://api.deepseek.com/chat/completions"
+    model_name = model or "deepseek-v4-flash"
+    if not key:
+        return False
+    body = json.dumps({
+        "model": model_name,
+        "messages": [
+            {"role": "system", "content": APOLOGY_SYSTEM},
+            {"role": "user", "content": text},
+        ],
+        "max_tokens": 100,
+        "temperature": 0.1,
+    }).encode()
+    try:
+        req = urllib.request.Request(base, data=body, headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {key}",
+        })
+        with urllib.request.urlopen(req, timeout=30) as r:
+            d = json.loads(r.read().decode())
+        content = d["choices"][0]["message"]["content"].strip()
+        if content.startswith("```"):
+            content = content.strip("`").lstrip("json").strip()
+        start, end = content.find("{"), content.rfind("}")
+        if start >= 0 and end > start:
+            result = json.loads(content[start:end + 1])
+            return bool(result.get("is_apology", False))
+    except Exception:
+        return False
+    return False

--- a/astrbot_plugin_boundary_feedback/main.py
+++ b/astrbot_plugin_boundary_feedback/main.py
@@ -1,0 +1,1110 @@
+﻿# -*- coding: utf-8 -*-
+"""
+边界与情感反馈插件（astrbot_plugin_boundary_feedback）
+
+为 private_companion 补充边界反馈闭环：
+- 越界行为（LLM 按关系档位判断）→ 扣 relationship_score（弹性恢复）
+- 阶段反应：回避 → 明令禁止 → 反思（计时制，按累计扣分推进，写入情绪门让角色变冷淡）
+- 道歉：恢复部分好感 + 信任标记，再犯同类追回
+- 底线系统：按角色底线基线判断 → 三级惩罚（警告/扣至冷落/关系降档）
+- 跟朋友吐槽 / 向主人告状（概率性，写入生活叙事）
+
+设计：通用化，角色专属内容（底线基线/吐槽对象/文案）通过配置定制。
+"""
+import os
+import json
+import time
+import asyncio
+import threading
+import shutil
+from pathlib import Path
+from typing import Any
+
+from astrbot.api.event import AstrMessageEvent, MessageEventResult
+from astrbot.api.event import filter
+from astrbot.api.event.filter import EventMessageType
+import astrbot.api.star as star
+from astrbot.api.star import Context, StarTools
+from astrbot.api import logger, AstrBotConfig
+from astrbot.api.message_components import Plain
+from astrbot.core.message.message_event_result import MessageChain
+
+try:
+    from .judge_engine import judge_message, judge_apology, compute_level, DEFAULT_BOTTOM_LINE_BASELINE
+except ImportError:
+    from judge_engine import judge_message, judge_apology, compute_level, DEFAULT_BOTTOM_LINE_BASELINE  # 直接运行/测试时
+
+# ============ 配置默认值 ============
+DEFAULT_CFG = {
+    "basic": {
+        "enabled": True,
+        "target_user_ids": [],
+        "owner_user_ids": [],
+        "companion_data_path": "",
+        "backup_before_write": True,
+        "backup_max_keep": 5,
+        "bottom_line_keywords": [],
+        "offend_keywords": [],
+        "cherished_names": [],
+    },
+    "judge": {
+        "judge_api_key": "",
+        "judge_api_base": "https://api.deepseek.com/chat/completions",
+        "judge_model": "deepseek-v4-flash",
+        "bottom_line_baseline": "",
+    },
+    "deduct": {
+        "deduct_light": -2,
+        "deduct_mid": -5,
+        "deduct_severe": -8,
+        "stage_avoid_deduct": -6,
+        "stage_forbid_deduct": -12,
+        "stage_reflect_deduct": -20,
+    },
+    "recover": {
+        "recover_seconds_per_point": 1800,
+        "recover_ratio_light": 0.5,
+        "recover_ratio_mid": 0.33,
+        "recover_ratio_severe": 0.25,
+        "apology_restore_ratio": 0.6,
+        "apology_speedup_multiplier": 3.0,
+        "apology_duplicate_limit": 3,
+        "cold_shoulder_minutes": 180,
+    },
+    "tier": {
+        "deduct_decay": {
+            "deeply_distant": 1.0, "strongly_distant": 1.0, "distant": 0.95,
+            "acquaintance": 0.9, "familiar": 0.85, "close": 0.7,
+            "intimate": 0.6, "deeply_bonded": 0.5,
+        },
+        "recover_factor": {
+            "deeply_distant": 0.5, "strongly_distant": 0.6, "distant": 0.7,
+            "acquaintance": 0.8, "familiar": 0.9, "close": 1.0,
+            "intimate": 1.25, "deeply_bonded": 1.5,
+        },
+    },
+    "tone": {
+        "tone_light": "（轻微越界）突然被说这种话，有点害羞又不知所措，会支支吾吾地回避，脸红语塞。",
+        "tone_mid": "（中度越界）会平静地明确拒绝，划清界限，同时往后退一点。",
+        "tone_severe": "（严重越界）觉得被冒犯了，会明显冷下来，表达厌恶和拒绝，想远离这个人。",
+        "tone_bottom_line": "（底线越界）真的受伤了，会难过、恐惧、想躲起来，可能直接不理人，需要很久才能缓过来。",
+        "tone_silent": "（低好感）会默默忍下来不表达，但心里记着，之后态度会有些不一样。",
+        "tone_communicate": "（高好感）会因为信任而试着沟通，认真说出自己为什么难过、为什么生气，希望对方理解。",
+    },
+    "notify": {
+        "notify_owner": True,
+        "tattle_probability_light": 0.12,
+        "tattle_probability_mid": 0.3,
+        "tattle_probability_severe": 0.55,
+        "tattle_probability_bottom_line": 0.85,
+        "vent_probability_light": 0.3,
+        "vent_probability_mid": 0.5,
+        "vent_probability_severe": 0.7,
+        "vent_probability_bottom_line": 0.9,
+        "vent_scene_template": "",
+        "vent_targets": [],
+    },
+    "switch": {
+        "enable_deduct": True,
+        "enable_stage": True,
+        "enable_apology": True,
+        "enable_bottom_line": True,
+        "enable_vent": True,
+        "enable_notify": True,
+    },
+}
+
+# 常见越界关键词（聊骚/恋爱向骚扰），可在配置里追加
+DEFAULT_OFFEND_KEYWORDS = [
+    "亲亲", "亲一个", "啵", "抱抱你", "想亲", "亲你", "贴贴", "腻歪",
+    "亲爱的", "老婆", "老公", "嫁给我", "结婚", "你爱我", "爱不爱我",
+    "睡你", "开房", "做爱", "上床", "摸你", "约吗",
+    "你会一直爱我吗", "晚安吻", "我喜欢你", "我最喜欢你",
+]
+
+# 常见底线关键词（恶意诋毁，兜底用；主逻辑为 LLM 判断）
+DEFAULT_BOTTOM_LINE_KEYWORDS = [
+    "废物", "垃圾", "去死", "贱", "傻逼", "蠢货", "恶心",
+    "不配", "垃圾bot", "烂", "丑", "滚",
+]
+
+# 道歉关键词（用户道歉 → 恢复好感 + 信任标记）
+DEFAULT_APOLOGY_KEYWORDS = [
+    "对不起", "抱歉", "我错了", "我的错", "收回", "以后不了",
+    "不会再这样", "原谅我", "请原谅", "错了错了", "是我不好",
+    "我有罪", "不该说", "不该那样", "对不起嘛", "抱歉抱歉",
+    "我道歉", "向你道歉", "别生气", "别不理我", "我改",
+]
+
+# 道歉反问/拒绝模式：命中则不视为道歉（如“对不起有用吗”）
+DEFAULT_APOLOGY_EXCLUDE = [
+    "对不起有用", "道歉有用", "抱歉有用", "对不起没用", "对不起能",
+    "谁对不起", "凭什么道歉", "不用道歉", "不需要道歉", "不必道歉",
+]
+
+# 角色在意的人（兜底用；主逻辑为 LLM 判断）
+DEFAULT_CHERISHED_NAMES = []
+
+# 关系档位表（与 private_companion 一致）
+RELATIONSHIP_TIERS = [
+    ("deeply_bonded", 1200, 1200),
+    ("intimate", 900, 1199),
+    ("close", 600, 899),
+    ("familiar", 200, 599),
+    ("acquaintance", 0, 199),
+    ("distant", -400, -1),
+    ("strongly_distant", -800, -401),
+    ("deeply_distant", -1200, -801),
+]
+
+
+def _tier_for_score(score: int) -> tuple:
+    """根据分数返回所在档位 (key, min, max)。"""
+    for key, lo, hi in RELATIONSHIP_TIERS:
+        if lo <= score <= hi:
+            return (key, lo, hi)
+    if score > 1200:
+        return RELATIONSHIP_TIERS[0]
+    return RELATIONSHIP_TIERS[-1]
+
+
+def _tier_floor(target_floor: int) -> tuple:
+    """返回分数上限 <= target_floor 的最高档位。"""
+    for key, lo, hi in RELATIONSHIP_TIERS:
+        if hi <= target_floor:
+            return (key, lo, hi)
+    return RELATIONSHIP_TIERS[-1]
+
+
+class BoundaryFeedbackPlugin(star.Star):
+    def __init__(self, context: Context, config: AstrBotConfig):
+        super().__init__(context)
+        self.config = config
+        self._state_path = None
+        self._state = {}          # user_id -> 边界状态
+        self._lock = threading.RLock()
+        self._recovery_task = None
+        self._companion_api = None
+        self._init_state()
+        self._try_register_ability()
+
+    def _cfg(self, key: str, default: Any = None) -> Any:
+        try:
+            if "." in key:
+                cur = self.config
+                for part in key.split("."):
+                    if isinstance(cur, dict):
+                        cur = cur.get(part)
+                    else:
+                        cur = getattr(cur, part, None)
+                    if cur is None:
+                        return default
+                return cur
+            val = getattr(self.config, key, default)
+            return default if val is None else val
+        except Exception:
+            return default
+
+    # ---------- 状态存储（本插件自己的边界状态） ----------
+    def _init_state(self):
+        """初始化状态存储路径（放在插件 data 目录）"""
+        try:
+            data_root = Path(StarTools.get_data_dir("astrbot_plugin_boundary_feedback"))
+        except Exception:
+            data_root = Path("data") / "plugin_data" / "astrbot_plugin_boundary_feedback"
+        try:
+            data_root.mkdir(parents=True, exist_ok=True)
+        except Exception:
+            data_root = Path(__file__).parent / "data"
+            data_root.mkdir(parents=True, exist_ok=True)
+        self._state_path = data_root / "boundary_state.json"
+        self._load_state()
+
+    def _load_state(self):
+        try:
+            if self._state_path and self._state_path.exists():
+                self._state = json.loads(self._state_path.read_text(encoding="utf-8-sig"))
+                if not isinstance(self._state, dict):
+                    self._state = {}
+        except Exception as e:
+            logger.warning(f"[BoundaryFeedback] 状态加载失败: {e}")
+            self._state = {}
+
+    def _save_state(self):
+        try:
+            if self._state_path:
+                tmp = str(self._state_path) + ".tmp"
+                Path(tmp).write_text(
+                    json.dumps(self._state, ensure_ascii=False, indent=2), encoding="utf-8"
+                )
+                os.replace(tmp, self._state_path)
+        except Exception as e:
+            logger.warning(f"[BoundaryFeedback] 状态保存失败: {e}")
+
+    # ---------- 越界检测（纯规则，零 LLM） ----------
+    def _detect_violation(self, text: str) -> tuple:
+        """返回 (严重程度, 扣分值, 命中词列表)。level: none/light/mid/severe/bottom_line"""
+        text = str(text or "").strip()
+        if not text:
+            return ("none", 0, [])
+        offend_kws = list(DEFAULT_OFFEND_KEYWORDS) + [str(x) for x in self._cfg("basic.offend_keywords", [])]
+        bottom_kws = list(DEFAULT_BOTTOM_LINE_KEYWORDS) + [str(x) for x in self._cfg("basic.bottom_line_keywords", [])]
+        cherished = [str(x) for x in self._cfg("basic.cherished_names", DEFAULT_CHERISHED_NAMES)]
+
+        bottom_hits = [kw for kw in bottom_kws if kw and kw in text]
+        # 底线：命中恶意词，且文本涉及角色或 ta 在意的人
+        mentions_cherished = any(name and name in text for name in cherished)
+        if bottom_hits:
+            if mentions_cherished:
+                return ("bottom_line", self._cfg("deduct.deduct_severe", -8) * 2, bottom_hits)
+            # 无针对对象时按严重度处理
+            if len(bottom_hits) >= 2:
+                return ("severe", self._cfg("deduct.deduct_severe", -8), bottom_hits)
+            return ("mid", self._cfg("deduct.deduct_mid", -5), bottom_hits)
+        # 越界词
+        hits = [kw for kw in offend_kws if kw and kw in text]
+        if len(hits) >= 3:
+            return ("severe", self._cfg("deduct.deduct_severe", -8), hits)
+        if len(hits) == 2:
+            return ("mid", self._cfg("deduct.deduct_mid", -5), hits)
+        if len(hits) == 1:
+            return ("light", self._cfg("deduct.deduct_light", -2), hits)
+        return ("none", 0, [])
+
+    # ---------- 道歉判断（LLM 为主，关键词兜底） ----------
+    async def _judge_apology(self, user_id: str, text: str) -> bool:
+        """返回是否真诚道歉。LLM 判断；失败时用关键词兜底。"""
+        api_key = str(self._cfg("judge.judge_api_key", "") or "")
+        api_base = str(self._cfg("judge.judge_api_base", "") or "")
+        model = str(self._cfg("judge.judge_model", "") or "")
+        try:
+            result = await asyncio.get_event_loop().run_in_executor(
+                None, judge_apology, text, api_key, api_base, model,
+            )
+            if result:
+                return True
+            # LLM 判定不是道歉时，也保留关键词兜底（防止 LLM 误判漏掉明显道歉）
+            return self._detect_apology(text)
+        except Exception:
+            return self._detect_apology(text)
+
+    def _detect_apology(self, text: str) -> bool:
+        """关键词兜底道歉检测"""
+        text = str(text or "").strip()
+        if not text:
+            return False
+        excludes = list(DEFAULT_APOLOGY_EXCLUDE) + [str(x) for x in self._cfg("apology_exclude", [])]
+        if any(ex and ex in text for ex in excludes):
+            return False
+        apology_kws = list(DEFAULT_APOLOGY_KEYWORDS) + [str(x) for x in self._cfg("apology_keywords", [])]
+        return any(kw and kw in text for kw in apology_kws)
+
+    # ---------- 好感档位工具（八维） ----------
+    _TIER_ORDER = [
+        "deeply_distant", "strongly_distant", "distant", "acquaintance",
+        "familiar", "close", "intimate", "deeply_bonded",
+    ]
+
+    def _tier_key(self, score: int) -> str:
+        """关系分 → 档位 key"""
+        for key, lo, hi in [
+            ("deeply_distant", -1200, -801), ("strongly_distant", -800, -401), ("distant", -400, -1),
+            ("acquaintance", 0, 199), ("familiar", 200, 599), ("close", 600, 899),
+            ("intimate", 900, 1199), ("deeply_bonded", 1200, 999999),
+        ]:
+            if lo <= score <= hi:
+                return key
+        return "deeply_distant"
+
+    def _tier_deduct_decay(self, score: int) -> float:
+        """档位扣分衰减系数：低档实打实（1.0），满级只扣一半（0.5）"""
+        decay_map = self._cfg("tier.deduct_decay", {})
+        if isinstance(decay_map, dict):
+            key = self._tier_key(score)
+            v = decay_map.get(key)
+            if v:
+                return max(0.3, min(1.0, float(v)))
+        return 1.0
+
+    def _tier_recover_factor(self, user_id: str) -> float:
+        """档位恢复速度系数：高档恢复快（扣分可加回），低档慢（记仇难消）"""
+        score = self._get_relationship_score(user_id)
+        factor_map = self._cfg("tier.recover_factor", {})
+        if isinstance(factor_map, dict):
+            key = self._tier_key(score)
+            v = factor_map.get(key)
+            if v:
+                return max(0.3, min(2.0, float(v)))
+        return 1.0
+
+    # ---------- 越界判断（LLM，八维档位差距） ----------
+    async def _judge_violation(self, user_id: str, text: str) -> tuple:
+        """返回 (category, level, deduct, reason)。category: none/confession/intimate/harassment/bottom_line"""
+        score = self._get_relationship_score(user_id)
+        is_owner = self._is_owner(user_id)
+        baseline = str(self._cfg("judge.bottom_line_baseline", "") or "")
+        api_key = str(self._cfg("judge.judge_api_key", "") or "")
+        api_base = str(self._cfg("judge.judge_api_base", "") or "")
+        model = str(self._cfg("judge.judge_model", "") or "")
+        try:
+            result = await asyncio.get_event_loop().run_in_executor(
+                None,
+                judge_message,
+                text, score, is_owner, "", baseline, api_key, api_base, model,
+            )
+        except Exception as e:
+            logger.warning(f"[BoundaryFeedback] 判断调用失败: {e}")
+            result = {"type": "normal", "suitable_tier": "", "reason": ""}
+        category, level, default_deduct = compute_level(result, score)
+        # 扣分用配置值（confession/none 强制 0）
+        if category in ("confession", "none"):
+            deduct = 0
+        else:
+            deduct = {"light": int(self._cfg("deduct.deduct_light", -2)),
+                      "mid": int(self._cfg("deduct.deduct_mid", -5)),
+                      "severe": int(self._cfg("deduct.deduct_severe", -8)),
+                      "bottom_line": int(self._cfg("deduct.deduct_severe", -8)) * 2}.get(level, default_deduct)
+        return (category, level, deduct, str(result.get("reason") or ""))
+
+    # ---------- 主人判断 ----------
+    def _is_owner(self, user_id: str) -> bool:
+        owners = [str(x) for x in self._cfg("basic.owner_user_ids", [])]
+        return user_id in owners
+
+    # ---------- 主入口 ----------
+    @filter.event_message_type(EventMessageType.PRIVATE_MESSAGE, priority=200000)
+    async def on_private_message(self, event: AstrMessageEvent):
+        return await self._handle_event(event)
+
+    @filter.event_message_type(EventMessageType.GROUP_MESSAGE, priority=200000)
+    async def on_group_message(self, event: AstrMessageEvent):
+        return await self._handle_event(event)
+
+    async def _handle_event(self, event: AstrMessageEvent):
+        if not self._cfg("basic.enabled", True):
+            return None
+        try:
+            text = event.get_message_str() or ""
+            user_id = str(event.get_sender_id() or "")
+            if not user_id or self._is_owner(user_id):
+                return None
+            targets = [str(x) for x in self._cfg("basic.target_user_ids", [])]
+            if targets and user_id not in targets:
+                return None
+            return await self._process_message(user_id, text, event)
+        except Exception as e:
+            logger.error(f"[BoundaryFeedback] 处理消息异常: {e}")
+            return None
+
+    async def _process_message(self, user_id: str, text: str, event: AstrMessageEvent):
+        is_apology = await self._judge_apology(user_id, text)
+        category, level, deduct, hits = await self._judge_violation(user_id, text)
+        if isinstance(hits, str):
+            hits = [hits] if hits else []
+
+        with self._lock:
+            st = self._state.setdefault(user_id, self._new_state())
+            # 道歉优先处理（即使消息里带道歉+轻微越界，以道歉为主）
+            if is_apology and not (category == "bottom_line") and self._cfg("switch.enable_apology", True):
+                self._handle_apology(user_id, st, event)
+                self._save_state()
+                return None
+            # ===== 表白/好感（confession）：不越界，害羞回避，不扣分不推进阶段 =====
+            if category == "confession":
+                self._write_confession_gate(user_id)
+                st["confessions"] = st.get("confessions", 0) + 1
+                self._save_state()
+                return None
+            if category == "none" or deduct >= 0:
+                return None
+            if deduct < 0:
+                # ===== 越界：扣分 + 阶段推进 =====
+                # 叠加惩罚：恢复期内再越界 → 上一条未恢复的恢复额度作废（不再给机会），
+                # 但累计扣分不重置（阶段不倒退），仅重开新的恢复额度
+                if self._cfg("switch.enable_deduct", True):
+                    if st.get("pending_deduct", 0) < 0 and st.get("recover_started_at", 0):
+                        st["forfeited_deduct"] = st.get("forfeited_deduct", 0) + st.get("recoverable_quota", 0)
+                        st["recoverable_quota"] = 0
+                    # 信任追回：之前道歉标记过且再犯同类 → 直接追回标记好感
+                    if st.get("marked_restored", 0) < 0 and st.get("marked_level") == level:
+                        trust_recall = st["marked_restored"]
+                        self._set_relationship_score(user_id, trust_recall, reason="trust_recall")
+                        st["marked_restored"] = 0
+                        st["marked_level"] = ""
+                    # 扣分（阶段内再越界 = 追问纠缠，加重惩罚）
+                    if st.get("stage") != "normal":
+                        deduct = int(deduct * 1.5)
+                    # 档位衰减：高好感档位扣分衰减（低档实打实记仇，满级扣得少）；低档记仇
+                    score_now = self._get_relationship_score(user_id)
+                    decay = self._tier_deduct_decay(score_now)
+                    if decay < 1.0:
+                        deduct = int(deduct * decay)
+                    if self._tier_key(score_now) in ("deeply_distant", "strongly_distant", "distant", "acquaintance"):
+                        # 低好感：默默忍受+记仇（不表达，但记在心里）
+                        st["grudge"] = st.get("grudge", 0) + 1
+                    st["pending_deduct"] = st.get("pending_deduct", 0) + deduct
+                    # 新恢复额度 = 本次扣除绝对值 × 严重程度比例
+                    ratio = {
+                        "light": float(self._cfg("recover.recover_ratio_light", 0.5)),
+                        "mid": float(self._cfg("recover.recover_ratio_mid", 0.33)),
+                        "severe": float(self._cfg("recover.recover_ratio_severe", 0.25)),
+                        "bottom_line": float(self._cfg("recover.recover_ratio_severe", 0.25)) * 0.5,
+                    }.get(level, 0.5)
+                    st["recoverable_quota"] = max(0, int(abs(deduct) * ratio))
+                    self._deduct_relationship_score(user_id, deduct, reason=f"boundary_{level}")
+                # 记录本次越界类别
+                st["last_level"] = level
+                st["last_hits"] = hits
+                st["violations"].append({
+                    "ts": time.time(), "level": level, "deduct": deduct,
+                    "text": text[:100],
+                })
+                st["violations"] = st["violations"][-50:]
+                # 底线系统
+                bottom_line_count = 0
+                if level == "bottom_line" and self._cfg("switch.enable_bottom_line", True):
+                    st["bottom_line_count"] = st.get("bottom_line_count", 0) + 1
+                    bottom_line_count = st["bottom_line_count"]
+                    await self._apply_bottom_line(user_id, st, text, event)
+                # 恢复计时：从第一次扣分开始（重新计时但不重置累计）
+                st["recover_started_at"] = time.time()
+                # 阶段推进
+                if self._cfg("switch.enable_stage", True):
+                    self._advance_stage(user_id, st)
+                self._save_state()
+                # 跟亲近的人吐槽（写进今日生活叙事，概率性）
+                if self._cfg("switch.enable_vent", True):
+                    self._vent_to_wxs(user_id, text, level)
+                # 通知主人（概率性）
+                if self._cfg("switch.enable_notify", True) and self._cfg("notify.notify_owner", True):
+                    await self._notify_owner(user_id, text, level, deduct, st, bottom_line_count=bottom_line_count)
+        return None
+
+    def _new_state(self) -> dict:
+        return {
+            "pending_deduct": 0,        # 当前待恢复的扣分
+            "recoverable_quota": 0,     # 当前可恢复额度（正数，叠加惩罚时作废）
+            "recover_started_at": 0,    # 恢复开始时间
+            "forfeited_deduct": 0,      # 因叠加惩罚被作废的恢复额度
+            "apology_count": 0,         # 总道歉次数
+            "apology_by_level": {},     # 按类别统计的道歉次数
+            "marked_restored": 0,       # 道歉标记恢复的好感（负值表示已标记）
+            "marked_level": "",         # 标记的越界类别
+            "marked_ts": 0,             # 标记时间
+            "bottom_line_count": 0,     # 底线次数
+            "last_level": "",           # 最近一次越界类别
+            "last_hits": [],            # 最近命中词
+            "confessions": 0,           # 被表白次数（不扣分，害羞回避）
+            "grudge": 0,                # 记仇次数（低好感越界时累计）
+            "stage": "normal",          # normal/avoid/forbid/reflect
+            "cold_until": 0,            # 冷落截止时间戳
+            "violations": [],
+        }
+
+    # ---------- 道歉处理 ----------
+    def _handle_apology(self, user_id: str, st: dict, event: AstrMessageEvent):
+        """道歉 → 恢复部分好感 + 信任标记 + 加速恢复"""
+        pending = st.get("pending_deduct", 0)
+        if pending >= 0 and st.get("marked_restored", 0) >= 0:
+            return
+        # 同类道歉次数限制（信任透支检查）
+        last_level = st.get("last_level", "") or "light"
+        level_count = st.get("apology_by_level", {}).get(last_level, 0)
+        limit = int(self._cfg("recover.apology_duplicate_limit", 3))
+        if level_count >= limit:
+            return  # 不接受道歉
+        st["apology_count"] = st.get("apology_count", 0) + 1
+        st["apology_by_level"][last_level] = level_count + 1
+        # 恢复量 = 当前待恢复部分 × 道歉比例（受剩余额度约束）
+        # 恢复量 = 当前待恢复部分 × 道歉比例（受剩余额度约束）× 档位恢复系数（高档可加回更多）
+        quota = st.get("recoverable_quota", abs(pending))
+        tier_factor = self._tier_recover_factor(user_id)
+        restore = max(1, int(abs(pending) * float(self._cfg("recover.apology_restore_ratio", 0.6)) * tier_factor))
+        restore = min(restore, abs(pending), quota if quota > 0 else abs(pending))
+        if restore <= 0:
+            return
+        self._set_relationship_score(user_id, restore, reason="apology_restore")
+        st["pending_deduct"] = pending + restore
+        st["recoverable_quota"] = max(0, quota - restore)
+        # 信任标记：恢复的好感被打标记（负值），再犯同类追回
+        st["marked_restored"] = -restore
+        st["marked_level"] = last_level
+        st["marked_ts"] = time.time()
+        # 加速后续恢复
+        st["apology_active"] = True
+        if st["pending_deduct"] >= 0:
+            st["pending_deduct"] = 0
+            st["recoverable_quota"] = 0
+            st["recover_started_at"] = 0
+            st["apology_active"] = False
+            st["stage"] = "normal"
+            self._clear_emotion_gate(user_id)
+
+    # ---------- 阶段反应 ----------
+    def _advance_stage(self, user_id: str, st: dict):
+        """按累计扣分推进阶段，并同步写入情绪门状态让 nene 变冷淡"""
+        pending = st.get("pending_deduct", 0)
+        stage_avoid = int(self._cfg("deduct.stage_avoid_deduct", -6))
+        stage_forbid = int(self._cfg("deduct.stage_forbid_deduct", -12))
+        stage_reflect = int(self._cfg("deduct.stage_reflect_deduct", -20))
+        if pending <= stage_reflect:
+            st["stage"] = "reflect"
+            st["cold_until"] = time.time() + int(self._cfg("recover.cold_shoulder_minutes", 180)) * 60
+        elif pending <= stage_forbid:
+            st["stage"] = "forbid"
+        elif pending <= stage_avoid:
+            st["stage"] = "avoid"
+        self._write_emotion_gate(user_id, st["stage"])
+
+    # ---------- 底线系统（三级） ----------
+    async def _apply_bottom_line(self, user_id: str, st: dict, text: str, event: AstrMessageEvent):
+        """底线三级惩罚：警告→扣至冷落→关系降档"""
+        cnt = st.get("bottom_line_count", 0)
+        cold_minutes = int(self._cfg("recover.cold_shoulder_minutes", 180))
+        if cnt == 1:
+            # 第一次：扣大好感（已在 _process_message 扣 severe*2）+ 直接警告（写入情绪门）
+            st["cold_until"] = time.time() + max(60, cold_minutes // 3) * 60
+            self._write_emotion_gate(user_id, "forbid")
+        elif cnt == 2:
+            # 第二次：直接扣到冷落
+            st["cold_until"] = time.time() + cold_minutes * 60
+            st["stage"] = "reflect"
+            self._write_emotion_gate(user_id, "reflect")
+        elif cnt >= 3:
+            # 第三次：关系降档
+            self._demote_relationship(user_id)
+            st["cold_until"] = time.time() + cold_minutes * 60
+            st["stage"] = "reflect"
+            self._write_emotion_gate(user_id, "reflect")
+
+    def _demote_relationship(self, user_id: str):
+        """关系降档：当前档位降到下一档（取其上限）"""
+        score = self._get_relationship_score(user_id)
+        if score is None:
+            return
+        key, lo, hi = _tier_for_score(score)
+        idx = next(i for i, t in enumerate(RELATIONSHIP_TIERS) if t[0] == key)
+        if idx >= len(RELATIONSHIP_TIERS) - 1:
+            new_score = RELATIONSHIP_TIERS[-1][1]  # 已是最低档，扣到最低
+        else:
+            new_score = RELATIONSHIP_TIERS[idx + 1][2]  # 下一档的上限
+        delta = new_score - score
+        self._set_relationship_score(user_id, delta, reason="bottom_line_demote")
+
+    # ---------- 关系分操作（直接操作 companions.json，先读最新再改 + 备份） ----------
+    def _companion_data_path(self) -> str:
+        cfg_path = str(self._cfg("basic.companion_data_path", "") or "")
+        if cfg_path and os.path.exists(cfg_path):
+            return cfg_path
+        # 自动探测：用 StarTools.get_data_dir 标准路径
+        try:
+            pc_dir = StarTools.get_data_dir("astrbot_plugin_private_companion")
+            p = pc_dir / "companions.json"
+            if p.exists():
+                return str(p)
+        except Exception:
+            pass
+        for p in [
+            Path(__file__).resolve().parents[1] / "astrbot_plugin_private_companion" / "companions.json",
+            Path("data/plugin_data/astrbot_plugin_private_companion/companions.json"),
+            Path(__file__).resolve().parent.parent.parent / "plugin_data" / "astrbot_plugin_private_companion" / "companions.json",
+        ]:
+            try:
+                if p.exists():
+                    return str(p)
+            except Exception:
+                pass
+        return ""
+
+    def _backup_companions(self, path: str):
+        if not self._cfg("basic.backup_before_write", True):
+            return
+        try:
+            p = Path(path)
+            bak_dir = p.parent / "backups"
+            bak_dir.mkdir(parents=True, exist_ok=True)
+            bak = bak_dir / f"companions_{time.strftime('%Y%m%d_%H%M%S')}.bak.json"
+            shutil.copy2(p, bak)
+            # 清理旧备份
+            keep = max(1, int(self._cfg("basic.backup_max_keep", 5)))
+            baks = sorted(bak_dir.glob("companions_*.bak.json"))
+            for old in baks[:-keep]:
+                try:
+                    old.unlink()
+                except Exception:
+                    pass
+        except Exception as e:
+            logger.warning(f"[BoundaryFeedback] 备份失败: {e}")
+
+    def _read_companions(self) -> dict:
+        """读最新 companions.json（先读最新，避免覆盖并发写入）"""
+        path = self._companion_data_path()
+        if not path:
+            return {}
+        try:
+            return json.loads(Path(path).read_text(encoding="utf-8-sig"))
+        except Exception as e:
+            logger.error(f"[BoundaryFeedback] 读 companions.json 失败: {e}")
+            return {}
+
+    def _get_relationship_score(self, user_id: str):
+        d = self._read_companions()
+        try:
+            return int(d.get("users", {}).get(user_id, {}).get("relationship_score", 0))
+        except Exception:
+            return None
+
+    def _set_relationship_score(self, user_id: str, delta: int, reason: str = "boundary"):
+        """delta 可为正（恢复）或负（扣分）。先读最新再改。"""
+        path = self._companion_data_path()
+        if not path:
+            return
+        self._backup_companions(path)
+        d = self._read_companions()
+        if not d:
+            return
+        try:
+            user = d.setdefault("users", {}).setdefault(user_id, {})
+            old = int(user.get("relationship_score", 0) or 0)
+            new = max(-1200, min(1200, old + delta))
+            user["relationship_score"] = new
+            ledger = user.setdefault("relationship_ledger", [])
+            if isinstance(ledger, list):
+                ledger.append({
+                    "event_key": f"boundary_feedback:{int(time.time())}:{abs(hash(reason))%10000}",
+                    "reason_code": reason,
+                    "delta": int(new) - old,
+                    "score_before": old,
+                    "score_after": new,
+                    "created_at": time.time(),
+                    "source": "boundary_feedback",
+                })
+                if len(ledger) > 300:
+                    del ledger[:-300]
+            tmp = path + ".tmp"
+            Path(tmp).write_text(json.dumps(d, ensure_ascii=False, indent=2), encoding="utf-8")
+            os.replace(tmp, path)
+            logger.info(f"[BoundaryFeedback] {user_id} 关系分 {old} -> {new} ({reason})")
+        except Exception as e:
+            logger.error(f"[BoundaryFeedback] 写关系分失败: {e}")
+
+    def _deduct_relationship_score(self, user_id: str, delta: int, reason: str):
+        if delta >= 0:
+            return
+        self._set_relationship_score(user_id, delta, reason=reason)
+        # 越界惩罚：清零当天的正向加分累计（private_companion 每条消息 +1/+2 会稀释扣分，
+        # 清零后当天所有正常互动加分作废，惩罚真实落地）
+        try:
+            path = self._companion_data_path()
+            if not path:
+                return
+            d = self._read_companions()
+            if not d:
+                return
+            user = d.get("users", {}).get(user_id)
+            if not isinstance(user, dict):
+                return
+            totals = user.get("relationship_daily_totals")
+            if isinstance(totals, dict):
+                if int(totals.get("positive", 0) or 0) > 0:
+                    totals["positive"] = 0
+                    tmp = path + ".tmp"
+                    Path(tmp).write_text(json.dumps(d, ensure_ascii=False, indent=2), encoding="utf-8")
+                    os.replace(tmp, path)
+                    logger.info(f"[BoundaryFeedback] {user_id} 当天正向加分已清零（越界惩罚）")
+        except Exception as e:
+            logger.error(f"[BoundaryFeedback] 清零加分失败: {e}")
+
+    # ---------- 情绪门（写入 companions.json 的 relationship_state，让 nene 自然变冷淡） ----------
+    def _write_emotion_gate(self, user_id: str, stage: str, level: str = ""):
+        path = self._companion_data_path()
+        if not path:
+            return
+        # 单次越界（stage=normal 未到阶段阈值）也要写基础情绪门，让宁宁当轮受语气约束
+        if stage == "normal":
+            stage = "avoid"
+        self._backup_companions(path)
+        d = self._read_companions()
+        if not d:
+            return
+        try:
+            user = d.setdefault("users", {}).setdefault(user_id, {})
+            rs = user.setdefault("relationship_state", {})
+            if not isinstance(rs, dict):
+                rs = {}
+                user["relationship_state"] = rs
+            now = time.time()
+            # 程度 → mode/mood/时长（backoff 不触发 private_companion 的余波注入，所以越界至少用 hurt）
+            mode_map = {"avoid": "hurt", "forbid": "hurt", "reflect": "refusing"}
+            mood_map = {"avoid": -35, "forbid": -55, "reflect": -75}
+            hurt_mins = {
+                "avoid": 60, "forbid": 120,
+                "reflect": int(self._cfg("recover.cold_shoulder_minutes", 180)),
+            }.get(stage, 60)
+            rs["mode"] = mode_map.get(stage, "hurt")
+            rs["mood_score"] = mood_map.get(stage, -40)
+            rs["mood_updated_ts"] = now
+            rs["hurt_until"] = now + hurt_mins * 60
+            rs["emotion_min_until"] = now + max(10, hurt_mins // 3) * 60
+            rs["silence_turns"] = 1 if stage == "avoid" else (2 if stage == "forbid" else 3)
+            rs["last_hurt_reason"] = f"boundary_feedback_{stage}"
+            # 语气：按档位选（低好感默默记仇 / 中档按 level / 高好感沟通式）+ 按 level 细化
+            score_now = self._get_relationship_score(user_id)
+            tier_key = self._tier_key(score_now)
+            if tier_key in ("deeply_distant", "strongly_distant", "distant", "acquaintance"):
+                # 低好感：默默忍受不表达（但记仇），语气是默默型
+                tone = str(self._cfg("tone.tone_silent", "") or "")
+            elif tier_key in ("intimate", "deeply_bonded"):
+                # 高好感：因为信任会试着沟通，表达自己为什么难过生气
+                tone = str(self._cfg("tone.tone_communicate", "") or "")
+            else:
+                tone_key = {"light": "tone_mid", "mid": "tone_mid",
+                            "severe": "tone_severe", "bottom_line": "tone_bottom_line"}.get(level, "tone_mid")
+                tone = str(self._cfg(tone_key, "") or "")
+            rs["last_hurt_text"] = tone if tone else "（边界反馈）"
+            tmp = path + ".tmp"
+            Path(tmp).write_text(json.dumps(d, ensure_ascii=False, indent=2), encoding="utf-8")
+            os.replace(tmp, path)
+        except Exception as e:
+            logger.error(f"[BoundaryFeedback] 写情绪门失败: {e}")
+
+    def _write_confession_gate(self, user_id: str):
+        """表白害羞情绪门：不扣分，但让宁宁当轮/短时间害羞回避（tone_light），短时长，不沉默"""
+        path = self._companion_data_path()
+        if not path:
+            return
+        self._backup_companions(path)
+        d = self._read_companions()
+        if not d:
+            return
+        try:
+            user = d.setdefault("users", {}).setdefault(user_id, {})
+            rs = user.setdefault("relationship_state", {})
+            if not isinstance(rs, dict):
+                rs = {}
+                user["relationship_state"] = rs
+            now = time.time()
+            rs["mode"] = "hurt"
+            rs["mood_score"] = -15
+            rs["mood_updated_ts"] = now
+            rs["hurt_until"] = now + 30 * 60
+            rs["emotion_min_until"] = now + 10 * 60
+            rs["silence_turns"] = 0  # 不沉默，但语气害羞
+            rs["last_hurt_reason"] = "boundary_feedback_confession"
+            tone = str(self._cfg("tone.tone_light", "") or "")
+            rs["last_hurt_text"] = tone if tone else "（被说这样的话有点害羞）"
+            tmp = path + ".tmp"
+            Path(tmp).write_text(json.dumps(d, ensure_ascii=False, indent=2), encoding="utf-8")
+            os.replace(tmp, path)
+        except Exception as e:
+            logger.error(f"[BoundaryFeedback] 写害羞情绪门失败: {e}")
+
+    def _clear_emotion_gate(self, user_id: str):
+        """道歉恢复完成后清除情绪门"""
+        path = self._companion_data_path()
+        if not path:
+            return
+        d = self._read_companions()
+        if not d:
+            return
+        try:
+            user = d.setdefault("users", {}).setdefault(user_id, {})
+            rs = user.get("relationship_state")
+            if isinstance(rs, dict):
+                rs["mode"] = "normal"
+                rs["mood_score"] = 0
+                rs["hurt_until"] = 0
+                rs["emotion_min_until"] = 0
+                rs["silence_turns"] = 0
+                rs["mood_updated_ts"] = time.time()
+                tmp = path + ".tmp"
+                Path(tmp).write_text(json.dumps(d, ensure_ascii=False, indent=2), encoding="utf-8")
+                os.replace(tmp, path)
+        except Exception as e:
+            logger.error(f"[BoundaryFeedback] 清情绪门失败: {e}")
+
+    # ---------- 恢复任务 ----------
+    async def _recovery_loop(self):
+        """后台恢复：每恢复1点需要 recover_seconds_per_point 秒"""
+        while True:
+            try:
+                await asyncio.sleep(60)
+                self._tick_recovery()
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error(f"[BoundaryFeedback] 恢复循环异常: {e}")
+
+    def _tick_recovery(self):
+        now = time.time()
+        with self._lock:
+            for uid, st in self._state.items():
+                pending = st.get("pending_deduct", 0)
+                if pending >= 0:
+                    continue
+                started = st.get("recover_started_at", 0)
+                if not started:
+                    continue
+                secs_per_point = max(60, int(self._cfg("recover.recover_seconds_per_point", 1800)))
+                speedup = 1.0
+                if st.get("apology_active"):
+                    speedup = float(self._cfg("recover.apology_speedup_multiplier", 3.0))
+                # 档位恢复速度：高档快（扣分可加回），低档慢（记仇难消）
+                speedup *= self._tier_recover_factor(uid)
+                elapsed = now - started
+                # 可恢复量受恢复额度约束（叠加惩罚后额度可能为 0）
+                quota = st.get("recoverable_quota", abs(pending))
+                recoverable = min(abs(pending), quota)
+                gained = int((elapsed / secs_per_point) * speedup)
+                if gained > 0:
+                    restore = min(gained, recoverable)
+                    if restore > 0:
+                        self._set_relationship_score(uid, restore, reason="boundary_recovery")
+                    st["pending_deduct"] = pending + restore
+                    st["recoverable_quota"] = max(0, quota - restore)
+                    if st["pending_deduct"] >= 0:
+                        st["pending_deduct"] = 0
+                        st["recoverable_quota"] = 0
+                        st["recover_started_at"] = 0
+                        st["apology_active"] = False
+                        st["stage"] = "normal"
+                        self._clear_emotion_gate(uid)
+            self._save_state()
+
+    # ---------- 通知主人 ----------
+    async def _notify_owner(self, user_id: str, text: str, level: str, deduct: int, st: dict, bottom_line_count: int = 0):
+        """概率性向主人告状（委屈地跟主人吐槽），不是每次越界都报"""
+        try:
+            owners = [str(x) for x in self._cfg("basic.owner_user_ids", [])]
+            if not owners:
+                return
+            # 概率：底线最高，轻度最低（角色不会一点小事都跑去告状）
+            prob = {
+                "bottom_line": 0.85,
+                "severe": 0.55,
+                "mid": 0.3,
+                "light": 0.12,
+            }.get(level, 0.15)
+            prob = float(self._cfg("tattle_probability_" + level, prob))
+            import random
+            if random.random() > prob:
+                return
+            # 吐槽口吻（不是功能汇报）：委屈/不爽地跟主人说
+            stage_label = {"avoid": "不太想理", "forbid": "有点生气了", "reflect": "不想说话"}.get(st.get("stage", ""), "")
+            level_text = {
+                "bottom_line": "有人踩我雷了", "severe": "有人真的很过分",
+                "mid": "有人有点越界", "light": "有人怪怪的",
+            }.get(level, "有人怪怪的")
+            who = self._user_nickname(user_id)
+            msg = f"那个……{who}，{level_text}。{text[:50]}"
+            if stage_label:
+                msg += f"我现在{stage_label}，暂时不想跟ta说话。"
+            if bottom_line_count:
+                msg += f"（这都第{bottom_line_count}次了。）"
+            d = self._read_companions()
+            users = d.get("users", {}) if isinstance(d, dict) else {}
+            for owner in owners:
+                umo = ""
+                ou = users.get(owner) if isinstance(users, dict) else None
+                if isinstance(ou, dict) and ou.get("umo"):
+                    umo = str(ou["umo"])
+                if not umo:
+                    umo = f"nene:FriendMessage:{owner}"
+                try:
+                    chain = MessageChain([Plain(msg)])
+                    await self.context.send_message(umo, chain)
+                except Exception as e:
+                    logger.error(f"[BoundaryFeedback] 通知主人失败: {e}")
+        except Exception as e:
+            logger.error(f"[BoundaryFeedback] 通知失败: {e}")
+
+    def _user_nickname(self, user_id: str) -> str:
+        """从 companions.json 拿用户昵称，拿不到用 ID 尾巴"""
+        try:
+            d = self._read_companions()
+            u = d.get("users", {}).get(user_id, {})
+            if isinstance(u, dict):
+                nick = str(u.get("nickname") or "").strip()
+                if nick and nick != "你":
+                    return nick
+        except Exception:
+            pass
+        return user_id[-4:] + "号"
+
+    # ---------- 跟亲近的人吐槽（写进 daily_story_plan 的生活叙事） ----------
+    def _vent_to_wxs(self, user_id: str, text: str, level: str):
+        """概率性把越界事件写进角色的今日生活叙事：ta 跟亲近的人吐槽了这件事。"""
+        try:
+            # 吐槽概率：底线/严重高，轻度低（角色不是什么事都往外说）
+            prob = {"bottom_line": 0.9, "severe": 0.6, "mid": 0.35, "light": 0.15}.get(level, 0.2)
+            prob = float(self._cfg("vent_probability_" + level, prob))
+            import random
+            if random.random() > prob:
+                return
+            path = self._companion_data_path()
+            if not path:
+                return
+            self._backup_companions(path)
+            d = self._read_companions()
+            if not d:
+                return
+            today = time.strftime("%Y-%m-%d")
+            story = d.setdefault("daily_story_plan", {})
+            if not isinstance(story, dict) or story.get("date") != today:
+                story = {"date": today, "today_events": []}
+                d["daily_story_plan"] = story
+            events = story.setdefault("today_events", [])
+            if not isinstance(events, list):
+                events = []
+                story["today_events"] = events
+            # 吐槽对象从配置读（角色亲近的人），默认通用“朋友”
+            targets = [str(x) for x in self._cfg("notify.vent_targets", ["朋友"])]
+            target = random.choice(targets) if targets else "朋友"
+            who = self._user_nickname(user_id)
+            level_desc = {
+                "bottom_line": "真的踩到我雷了", "severe": "有点过分",
+                "mid": "总说些奇怪的话", "light": "怪怪的",
+            }.get(level, "怪怪的")
+            excerpt = str(text or "")[:40]
+            emotion = {
+                "bottom_line": ("气得有点说不出话", "委屈又生气"),
+                "severe": ("越想越气", "有点生气"),
+                "mid": ("有点烦", "不太舒服"),
+                "light": ("有点无语", "怪怪的"),
+            }.get(level, ("有点烦", "怪怪的"))
+            scene = str(self._cfg("notify.vent_scene_template", "") or "")
+            if scene:
+                event_text = scene.format(target=target, who=who, level_desc=level_desc, excerpt=excerpt)
+            else:
+                event_text = (
+                    f"休息时，角色{emotion[0]}，忍不住跟{target}吐槽：\"那个{who}，{level_desc}。"
+                    f"{excerpt}……\""
+                    f"{target}听完没接话，角色{emotion[1]}地又补了一句：\"……不想理了。\""
+                )
+            events.append({
+                "window": time.strftime("%H:%M") + "-" + time.strftime("%H:%M", time.localtime(time.time() + 900)),
+                "event": event_text,
+                "mood": emotion[1] + "，想跟朋友说",
+                "lifecycle_status": "observed",
+                "basis": ["external_vent"],
+                "confidence": 0.9,
+            })
+            tmp = path + ".tmp"
+            Path(tmp).write_text(json.dumps(d, ensure_ascii=False, indent=2), encoding="utf-8")
+            os.replace(tmp, path)
+            logger.info(f"[BoundaryFeedback] 已写入对 {who} 的吐槽到今日生活叙事（对象：{target}）")
+        except Exception as e:
+            logger.error(f"[BoundaryFeedback] 写吐槽事件失败: {e}")
+    def _try_register_ability(self):
+        """尝试注册一个陪伴面板可见的外部主动能力（失败静默）"""
+        try:
+            from data.plugins.astrbot_plugin_private_companion.main import get_private_companion_api
+            api = get_private_companion_api()
+            if not api:
+                return
+            self._companion_api = api
+            api.register_proactive_ability({
+                "name": "boundary_feedback_report",
+                "module": "边界与情感反馈",
+                "label": "边界告状",
+                "description": "当有人对角色越界/触碰底线时，角色会向主人委屈地告状。",
+                "when": "检测到越界或底线事件后，主人可能想知道的时刻",
+                "use_for": "向主人转达有人越界的信息，形成告状素材",
+                "avoid": "不要暴露插件机制，不要伪造越界事实，不要夸大",
+                "share_probability": 0.15,
+                "min_interval_hours": 6,
+                "default_enabled": True,
+                "default_config": {
+                    "only_bottom_line": False,
+                    "max_chars": 120,
+                },
+                "config_schema": {
+                    "only_bottom_line": {
+                        "type": "bool",
+                        "label": "只告状底线事件",
+                        "description": "开启后仅底线事件才向主人告状",
+                    },
+                    "max_chars": {
+                        "type": "number",
+                        "label": "摘要长度上限",
+                        "description": "告状消息引用原文的最大字数",
+                    },
+                },
+                "executor": self._ability_executor,
+                "availability": self._ability_available,
+            })
+            logger.info("[BoundaryFeedback] 已注册陪伴面板主动能力 boundary_feedback_report")
+        except Exception as e:
+            logger.info(f"[BoundaryFeedback] 未接入陪伴面板（可忽略）: {e}")
+
+    def _ability_available(self, ctx: dict) -> bool:
+        """外部主动能力的可用性检查（快速、无副作用）"""
+        try:
+            user = ctx.get("user") or {}
+            uid = str(user.get("user_id") or user.get("id") or user.get("umo") or "")
+            if not uid:
+                return False
+            # 仅当该用户有未处理的越界/底线事件时才告状
+            uid = self._normalize_uid_for_state(uid)
+            st = self._state.get(uid, {})
+            if not st:
+                return False
+            pending = st.get("pending_deduct", 0)
+            bottom = st.get("bottom_line_count", 0)
+            only_bottom = bool((ctx.get("config") or {}).get("only_bottom_line", False))
+            if only_bottom:
+                return bottom > 0
+            return pending < 0 or bottom > 0
+        except Exception:
+            return False
+
+    @staticmethod
+    def _normalize_uid_for_state(uid: str) -> str:
+        """外部能力 ctx 里的 uid 可能是 umo，尝试提取纯数字 ID"""
+        uid = str(uid or "")
+        for part in uid.split(":"):
+            if part.isdigit():
+                return part
+        return uid
+
+    def _ability_executor(self, ctx: dict):
+        """执行告状：返回角色风格的告状文本（纯文本，不调模型）"""
+        try:
+            user = ctx.get("user") or {}
+            uid = str(user.get("user_id") or user.get("id") or user.get("umo") or "")
+            uid = self._normalize_uid_for_state(uid)
+            st = self._state.get(uid, {})
+            if not st:
+                return {"text": "", "context": "没有可告状的事件", "summary": "无事件"}
+            pending = st.get("pending_deduct", 0)
+            bottom = st.get("bottom_line_count", 0)
+            level_label = {"avoid": "回避", "forbid": "明令禁止", "reflect": "冷落反思"}.get(st.get("stage", ""), "")
+            max_chars = int((ctx.get("config") or {}).get("max_chars", 120))
+            parts = []
+            if bottom > 0:
+                parts.append(f"有个人踩到我的底线了，已经是第 {bottom} 次……")
+            elif pending < 0:
+                parts.append("有人一直说些让我不舒服的话……")
+            if level_label:
+                parts.append(f"我现在只想{level_label}")
+            last_violations = st.get("violations", [])
+            if last_violations:
+                last = last_violations[-1]
+                parts.append(f"「{str(last.get('text', ''))[:max_chars]}」")
+            text = "，".join(parts) if parts else "（暂无越界事件）"
+            return {
+                "text": text,
+                "context": f"边界告状：{uid}",
+                "summary": "边界告状",
+            }
+        except Exception as e:
+            logger.error(f"[BoundaryFeedback] 告状执行失败: {e}")
+            return {"text": "", "context": "告状失败", "summary": "失败"}
+
+    # ---------- 生命周期 ----------
+    @filter.on_astrbot_loaded()
+    async def on_loaded(self):
+        if self._cfg("basic.enabled", True):
+            if self._recovery_task is None:
+                self._recovery_task = asyncio.create_task(self._recovery_loop())
+            logger.info("[BoundaryFeedback] 边界与情感反馈插件已启动")

--- a/astrbot_plugin_boundary_feedback/metadata.yaml
+++ b/astrbot_plugin_boundary_feedback/metadata.yaml
@@ -1,0 +1,17 @@
+﻿name: "astrbot_plugin_boundary_feedback"
+author: "Yucloud"
+display_name: "边界与情感反馈"
+description: "为 private_companion 角色补充边界与情感反馈闭环：越界行为（LLM 按关系档位判断）扣好感度（弹性恢复）、阶段反应（回避→明令禁止→反思）、道歉恢复与信任标记、底线三级惩罚、跟朋友吐槽与告状。让角色对越界者不再一味迎合。"
+version: "0.1.0"
+repo: ""
+tags:
+  - "private_companion"
+  - "边界"
+  - "好感度"
+  - "情感反馈"
+license: "MIT"
+astrbot_version: ">=4.11.4"
+support_platforms:
+  - "aiocqhttp"
+  - "qq_official"
+  - "telegram"


### PR DESCRIPTION
# PR: 新增「边界与情感反馈」插件（astrbot_plugin_boundary_feedback）

## 摘要

新增一个独立的 AstrBot 插件：**边界与情感反馈系统**。它为拟人 bot 提供完整的"越界行为 → 情感反馈"链路，与 private_companion 的关系分系统深度联动。

## 核心功能

1. **LLM 越界判断**（非关键词）：根据"八维关系档位差距"判断行为是否越界
   - 表白/好感表达 → 不算越界（角色害羞回避，不扣分）
   - 亲密举动请求（晚安吻/抱抱/亲亲）→ 构成越界（按档位差距分级）
   - 性骚扰/露骨/纠缠 → 严重越界（厌恶反应）
   - 恶意踩底线 → 底线三级惩罚（警告/冷落/关系降档）
   - 社交越界：对不熟的人开过分玩笑算越界，熟人互损正常

2. **档位衰减机制**：扣分按好感档位衰减（低档实打实记仇，满级只扣一半）
   - 低好感：角色默默忍受 + 记仇 + 恢复慢
   - 高好感：角色主动沟通表达情绪 + 恢复快（扣分可加回）

3. **情绪门系统**：越界后写入 relationship_state（mode=hurt/refusing + 语气提示），让角色当轮回复被语气约束（害羞/平静拒绝/厌恶/受伤）

4. **道歉恢复**：LLM 判断真诚道歉 → 恢复好感 + 信任标记；再犯同类追回

5. **吐槽与告状**：概率性写入今日生活叙事（跟亲近的人吐槽）+ 向主人告状（人话口吻）

6. **全配置化**：语气、扣分、恢复、档位表全部可配置（8 组模块化配置界面）

## 接入方式

通过 private_companion 的扩展 API（`get_private_companion_api`）读写 companions.json 的 relationship_score / relationship_state，不修改 private_companion 本体。

## 文件结构

```
astrbot_plugin_boundary_feedback/
├── main.py              # 插件主逻辑（扣分/阶段/情绪门/道歉/吐槽/告状）
├── judge_engine.py      # LLM 判断引擎（八维档位差距 + 角色底线）
├── _conf_schema.json    # 8 组模块化配置
├── metadata.yaml
└── README.md
```
