### PR TITLE
 修复：工具调用轮次最终回复丢失（未写入会话历史）

### DIFF
--- a/final_response_persistence.py
+++ b/final_response_persistence.py
@@ -239,6 +239,26 @@ class FinalResponsePersistenceCoordinator:
         async with ledger.finalize_lock:
             if ledger.finalized:
                 return True
+            # A tool-calling turn streams intermediate assistant text before
+            # the agent finishes. That intermediate send must not be treated
+            # as the final reply: on_agent_done has not run yet, so there is
+            # no official assistant message to stage, and finalising here
+            # would lock the ledger before the real reply arrives. The real
+            # reply's _no_save flag would then never be cleared and the core
+            # would drop it from history. Wait for the final reply's own
+            # after_message_sent instead. A stopped event is the exception:
+            # no final reply is coming, so this send IS the reply (the
+            # direct-send-and-stop path).
+            if (
+                getattr(event, "_private_companion_official_assistant_message", None)
+                is None
+            ):
+                try:
+                    stopped = bool(event.is_stopped())
+                except Exception:
+                    stopped = False
+                if not stopped:
+                    return False
             current = asyncio.current_task()
             pending = [
                 task

--- a/tests/test_final_response_persistence.py
+++ b/tests/test_final_response_persistence.py
@@ -389,11 +389,23 @@ class FinalResponsePersistenceTests(unittest.IsolatedAsyncioTestCase):
         plugin = PrivateCompanionPlugin.__new__(PrivateCompanionPlugin)
         plugin._finalize_passive_delivered_response = AsyncMock(return_value=True)
         event = _SendTrackerEvent()
+        run_context = SimpleNamespace(
+            messages=[
+                Message(role="assistant", content=[TextPart(text="Agent 原始回复")])
+            ]
+        )
 
         await plugin.capture_final_outbound_chain_for_persistence(event)
         tracked_send = event.send
         outbound = SimpleNamespace(chain=[Plain("适配器实际接收的回复")])
         await tracked_send(outbound)
+        # The agent finished before the platform confirmed delivery, so the
+        # official assistant message is staged before the after-sent finalizer.
+        await plugin._prepare_final_response_after_agent(
+            event,
+            run_context,
+            LLMResponse(role="assistant", completion_text="审核后的候选回复"),
+        )
         await plugin.persist_confirmed_passive_reply(event)
 
         plugin._finalize_passive_delivered_response.assert_awaited_once()
@@ -406,10 +418,20 @@ class FinalResponsePersistenceTests(unittest.IsolatedAsyncioTestCase):
         plugin = PrivateCompanionPlugin.__new__(PrivateCompanionPlugin)
         plugin._finalize_passive_delivered_response = AsyncMock(return_value=True)
         event = _SendTrackerEvent(send_error=RuntimeError("adapter send failed"))
+        run_context = SimpleNamespace(
+            messages=[
+                Message(role="assistant", content=[TextPart(text="Agent 原始回复")])
+            ]
+        )
 
         await plugin.capture_final_outbound_chain_for_persistence(event)
         with self.assertRaisesRegex(RuntimeError, "adapter send failed"):
             await event.send(SimpleNamespace(chain=[Plain("不会送达")]))
+        await plugin._prepare_final_response_after_agent(
+            event,
+            run_context,
+            LLMResponse(role="assistant", completion_text="审核后的候选回复"),
+        )
         await plugin.persist_confirmed_passive_reply(event)
 
         plugin._finalize_passive_delivered_response.assert_not_awaited()
@@ -419,9 +441,19 @@ class FinalResponsePersistenceTests(unittest.IsolatedAsyncioTestCase):
         plugin = PrivateCompanionPlugin.__new__(PrivateCompanionPlugin)
         plugin._finalize_passive_delivered_response = AsyncMock(return_value=True)
         event = _SendTrackerEvent(send_result=False)
+        run_context = SimpleNamespace(
+            messages=[
+                Message(role="assistant", content=[TextPart(text="Agent 原始回复")])
+            ]
+        )
 
         await plugin.capture_final_outbound_chain_for_persistence(event)
         result = await event.send(SimpleNamespace(chain=[Plain("平台拒绝接收")]))
+        await plugin._prepare_final_response_after_agent(
+            event,
+            run_context,
+            LLMResponse(role="assistant", completion_text="审核后的候选回复"),
+        )
         await plugin.persist_confirmed_passive_reply(event)
 
         self.assertFalse(result)
@@ -433,9 +465,21 @@ class FinalResponsePersistenceTests(unittest.IsolatedAsyncioTestCase):
         plugin._finalize_passive_delivered_response = AsyncMock(return_value=True)
         event = _SendTrackerEvent()
         event._has_send_oper = False
+        run_context = SimpleNamespace(
+            messages=[
+                Message(role="assistant", content=[TextPart(text="Agent 原始回复")])
+            ]
+        )
 
         plugin._begin_final_response_persistence(event)
         plugin._capture_final_outbound_delivery(event)
+        # The agent finished before the segmented reply is sent, so the
+        # official assistant message is staged first.
+        await plugin._prepare_final_response_after_agent(
+            event,
+            run_context,
+            LLMResponse(role="assistant", completion_text="审核后的候选回复"),
+        )
         await event.send(SimpleNamespace(chain=[Plain("第一段")]))
 
         async def send_remainder():
@@ -469,6 +513,51 @@ class FinalResponsePersistenceTests(unittest.IsolatedAsyncioTestCase):
         plugin._finalize_passive_delivered_response.assert_awaited_once()
         call = plugin._finalize_passive_delivered_response.await_args
         self.assertEqual("直接发送后终止传播", call.kwargs["fallback_text"])
+
+    async def test_tool_intermediate_send_waits_for_final_reply(self):
+        # A tool-calling turn sends intermediate assistant text before the
+        # agent finishes. The intermediate send must NOT be finalised: doing
+        # so would lock the ledger before the real reply arrives, leaving the
+        # real reply's _no_save flag stuck True and dropping it from history.
+        plugin = PrivateCompanionPlugin.__new__(PrivateCompanionPlugin)
+        plugin._finalize_passive_delivered_response = AsyncMock(return_value=True)
+        event = _SendTrackerEvent()
+        run_context = SimpleNamespace(
+            messages=[
+                Message(
+                    role="assistant",
+                    content=[TextPart(text="好的，我先把这条记下来")],
+                )
+            ]
+        )
+
+        plugin._begin_final_response_persistence(event)
+
+        # Intermediate assistant text of the tool call is sent while the agent
+        # is still running (no official assistant message staged yet).
+        await event.send(SimpleNamespace(chain=[Plain("好的，我先把这条记下来")]))
+        await plugin.persist_confirmed_passive_reply(event)
+
+        # The intermediate send must not finalize nor lock the ledger.
+        plugin._finalize_passive_delivered_response.assert_not_awaited()
+        self.assertFalse(event._private_companion_delivery_ledger.finalized)
+
+        # Agent finishes: on_agent_done stages the official assistant message.
+        await plugin._prepare_final_response_after_agent(
+            event,
+            run_context,
+            LLMResponse(role="assistant", completion_text="已记录"),
+        )
+
+        # Final reply is sent and only now does the finalizer run.
+        await event.send(SimpleNamespace(chain=[Plain("已记录")]))
+        await plugin.persist_confirmed_passive_reply(event)
+
+        plugin._finalize_passive_delivered_response.assert_awaited_once()
+        call = plugin._finalize_passive_delivered_response.await_args
+        self.assertIn("好的，我先把这条记下来", call.kwargs["fallback_text"])
+        self.assertIn("已记录", call.kwargs["fallback_text"])
+        self.assertTrue(event._private_companion_delivery_ledger.finalized)
 
     async def test_proactive_collector_replaces_candidate_with_confirmed_chain(self):
         outcome = await _ActiveCollector().send(UMO)


### PR DESCRIPTION
  ## 问题

  当用户消息触发带工具调用的 Agent 轮次（如`memory_companion_remember`）时，最终回复没有写入会话历史。下一轮请求中模型只看到用户指令、看不到自己的确认回复，于是把指令当作未完成反复执行——重复记录、重复回复「已记录」，仿佛第一次收到这条指令。

  ## 复现步骤

  1. 发送一条会触发 Agent 调用工具的消息（如「记住这个学习模式」→ `memory_companion_remember`）。
  2. Agent 先流式输出中间文本，再调用工具，最后生成最终回复。
  3. 查看传给下一次 LLM 请求的会话历史：中间文本被写入了，但最终回复完全缺失。

  ## 根因

  `final_response_persistence.py` 的 `finalize_passive` 把工具调用轮次的中间 assistant 文本当成了最终回复：

  - 中间文本发送 → 触发 `after_message_sent` → `finalize_passive` 执行时 `on_agent_done`
  尚未运行，`_private_companion_official_assistant_message` 为 `None`。
  - `_stage_delivered_assistant_for_official_history` 失败，回退到
  `_append_delivered_assistant_to_conversation`（写入中间文本），随后把 `ledger.finalized` 置为 `True`。
  - 真正回复发送时，`finalize_passive` 因 `ledger.finalized` 直接短路；该回复的 `_no_save` 标志永远不会被清除，AstrBot
  核心 `_save_to_history` 会跳过带 `_no_save` 的消息 → 最终回复永久丢失。

  ## 修复方案

  在 `finalize_passive` 中提前返回：当官方 assistant 消息尚未 stage（Agent 未完成）且事件未被 stop 时，不做写回、不锁死
  ledger，等待最终回复自己的 `after_message_sent` 再执行。stop 事件路径（直发后终止）保持不变。

  ## 测试

  - 新增回归测试 `test_tool_intermediate_send_waits_for_final_reply`：复现工具调用时序——中间文本发送不触发
  finalize、不锁死 ledger，Agent 完成后最终回复才正常写回。
  - `test_final_response_persistence.py` 全部 17 个用例通过，无回归。