### PR TITLE
feat: 六阶段生理周期状态与经期不适模拟

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -9550,7 +9550,7 @@
       "enable_advanced_cycle_strategy": {
         "description": "启用六阶段周期策略",
         "type": "bool",
-        "hint": "把原有三阶段扩展为月经期、卵泡期早、排卵前期、排卵期、黄体期早和 PMS 期，并按顺序自然推进。默认关闭，避免改变现有行为。",
+        "hint": "把原有三阶段扩展为月经期、卵泡期、排卵前期、排卵期、黄体期和 PMS 期，并按顺序自然推进。默认关闭，避免改变现有行为。",
         "default": false,
         "condition": {
           "enable_cycle_state": true
@@ -9604,26 +9604,26 @@
         "condition": { "enable_advanced_cycle_strategy": true }
       },
       "advanced_cycle_follicular_days": {
-        "description": "卵泡期早持续天数",
+        "description": "卵泡期持续天数",
         "type": "int",
         "default": 5,
         "slider": { "min": 1, "max": 30, "step": 1 },
         "condition": { "enable_advanced_cycle_strategy": true }
       },
       "advanced_cycle_follicular_prompt": {
-        "description": "卵泡期早状态描述",
+        "description": "卵泡期状态描述",
         "type": "string",
-        "default": "处于卵泡期早，精力平稳回升，心情逐渐轻快",
+        "default": "处于卵泡期，精力平稳回升，心情逐渐轻快",
         "condition": { "enable_advanced_cycle_strategy": true }
       },
       "advanced_cycle_follicular_mood": {
-        "description": "卵泡期早情绪底色",
+        "description": "卵泡期情绪底色",
         "type": "string",
         "default": "轻快",
         "condition": { "enable_advanced_cycle_strategy": true }
       },
       "advanced_cycle_follicular_energy": {
-        "description": "卵泡期早精力变化",
+        "description": "卵泡期精力变化",
         "type": "int",
         "hint": "仅在关闭强度联动时使用；设为 0 仍会保留该阶段并继续推进。",
         "default": 0,
@@ -9685,26 +9685,26 @@
         "condition": { "enable_advanced_cycle_strategy": true }
       },
       "advanced_cycle_luteal_days": {
-        "description": "黄体期早持续天数",
+        "description": "黄体期持续天数",
         "type": "int",
         "default": 8,
         "slider": { "min": 1, "max": 30, "step": 1 },
         "condition": { "enable_advanced_cycle_strategy": true }
       },
       "advanced_cycle_luteal_prompt": {
-        "description": "黄体期早状态描述",
+        "description": "黄体期状态描述",
         "type": "string",
-        "default": "处于黄体期早，精力尚可，情绪整体平稳",
+        "default": "处于黄体期，精力尚可，情绪整体平稳",
         "condition": { "enable_advanced_cycle_strategy": true }
       },
       "advanced_cycle_luteal_mood": {
-        "description": "黄体期早情绪底色",
+        "description": "黄体期情绪底色",
         "type": "string",
         "default": "平稳",
         "condition": { "enable_advanced_cycle_strategy": true }
       },
       "advanced_cycle_luteal_energy": {
-        "description": "黄体期早精力变化",
+        "description": "黄体期精力变化",
         "type": "int",
         "hint": "仅在关闭强度联动时使用。",
         "default": 5,
@@ -9736,6 +9736,28 @@
         "hint": "仅在关闭强度联动时使用。",
         "default": -8,
         "slider": { "min": -50, "max": 30, "step": 1 },
+        "condition": { "enable_advanced_cycle_strategy": true }
+      },
+      "advanced_cycle_discomfort_simulation": {
+        "description": "生理期不适模拟",
+        "type": "bool",
+        "hint": "开启后，在月经期、PMS 期等阶段按概率生成短暂的痛经、头痛等不适状态，轻度压低精力并在总览中显示。默认关闭。",
+        "default": false,
+        "condition": { "enable_advanced_cycle_strategy": true }
+      },
+      "advanced_cycle_discomfort_chance": {
+        "description": "不适出现概率",
+        "type": "int",
+        "hint": "每天生成一次不适状态的概率（0-100），0 表示从不生成；同一时间只保留一条不适状态。",
+        "default": 55,
+        "slider": { "min": 0, "max": 100, "step": 1 },
+        "condition": { "enable_advanced_cycle_strategy": true }
+      },
+      "advanced_cycle_discomfort_types": {
+        "description": "可模拟的不适类型",
+        "type": "string",
+        "hint": "逗号分隔。可选：痛经、头痛、腰酸、乏力、情绪低落、恶心；只会出现在与之相关的阶段（如痛经仅在月经期）。",
+        "default": "痛经,头痛,腰酸,乏力",
         "condition": { "enable_advanced_cycle_strategy": true }
       },
       "humanized_state_intensity": {

--- a/command_handlers.py
+++ b/command_handlers.py
@@ -443,9 +443,39 @@ class CommandHandlersMixin:
             f"主动消息终审：{self._feature_on_text(getattr(self, 'enable_proactive_message_review', True))}，模式 {getattr(self, 'proactive_review_mode', 'full')}，强度 {getattr(self, 'proactive_review_strength', 'lenient')}",
             f"用户请求生图每日上限：{command_photo_limit_text}；非指令生图：{_single_line(getattr(self, 'natural_language_photo_generation_mode', 'tool_first'), 24) or 'tool_first'}，规则快判{self._feature_on_text(getattr(self, 'enable_natural_language_photo_generation', False))}，每日上限 {getattr(self, 'natural_language_photo_generation_max_daily', 0)}",
             f"拟人状态：健康 {self._feature_on_text(getattr(self, 'enable_health_state', True))}，饥饿 {self._feature_on_text(getattr(self, 'enable_hunger_state', True))}，生理期 {self._feature_on_text(getattr(self, 'enable_cycle_state', True))}，强度 {getattr(self, 'humanized_state_intensity', 0)}",
+            self._cycle_status_text(),
             f"回复风格：{'已配置' if reply_style else '未配置'}，长度 {len(reply_style)} 字",
         ]
 
+    def _cycle_status_text(self) -> str:
+        """Build the six-phase cycle position line for the status overview."""
+        if not self._advanced_cycle_enabled():
+            return "六阶段周期：未开启"
+        try:
+            runtime = self._advanced_cycle_runtime()
+        except Exception:
+            runtime = {}
+        if not runtime or not runtime.get("phase_name"):
+            return "六阶段周期：已开启（尚未进入首个周期）"
+        parts = [
+            f"{runtime.get('phase_name')} 第{runtime.get('day_in_phase', 1)}/{runtime.get('phase_days', 1)}天",
+            f"周期第{runtime.get('cycle_day', 0)}/{runtime.get('cycle_days', 0)}天",
+        ]
+        if runtime.get("next_phase_name"):
+            parts.append(f"下一阶段{runtime.get('next_phase_name')}")
+        try:
+            discomfort = self._active_cycle_discomfort_conditions()
+        except Exception:
+            discomfort = []
+        if isinstance(discomfort, list) and discomfort:
+            labels = "、".join(
+                _single_line(item.get("label") or item.get("type"), 40)
+                for item in discomfort[:3]
+                if isinstance(item, dict)
+            )
+            if labels:
+                parts.append(f"当前不适：{labels}")
+        return "六阶段周期：" + "，".join(parts)
     def _companion_manual_runtime_snapshot(self, event: AstrMessageEvent | None = None) -> str:
         lines: list[str] = []
         group_id = ""

--- a/daily_state.py
+++ b/daily_state.py
@@ -3315,6 +3315,12 @@ class DailyStateMixin(DailyStateTickMixin):
                 dream_pick = deferred_updates.get("dream_pick")
                 if isinstance(dream_pick, tuple):
                     self._remember_daily_dream_pick(dream_pick)
+                discomfort_roll_date = deferred_updates.get("cycle_discomfort_roll_date")
+                if discomfort_roll_date:
+                    cycle_meta = self.data.get("body_cycle_state")
+                    cycle_meta = dict(cycle_meta) if isinstance(cycle_meta, dict) else {}
+                    cycle_meta["last_discomfort_roll_date"] = discomfort_roll_date
+                    self.data["body_cycle_state"] = cycle_meta
                 body_cycle_conditions = deferred_updates.get("body_cycle_conditions", [])
                 if isinstance(body_cycle_conditions, list):
                     for condition in body_cycle_conditions:
@@ -3391,12 +3397,27 @@ class DailyStateMixin(DailyStateTickMixin):
         if persona_profile.get("allow_hunger", True):
             specs.append(("hunger", "饥饿", *hunger_pick))
         if persona_profile.get("allow_cycle", False):
-            cycle_spec = (
-                self._pick_advanced_cycle_spec(intensity)
-                if self._advanced_cycle_enabled()
-                else self._pick_body_cycle_spec(cycle_pool, intensity)
-            )
-            specs.append(("body_cycle", "周期", *cycle_spec))
+            skip_cycle_spec = False
+            if self._advanced_cycle_enabled():
+                meta = self.data.get("body_cycle_state", {})
+                anchor_ts = _safe_float(meta.get("cycle_anchor_ts"), 0) if isinstance(meta, dict) else 0
+                active_advanced_cycle = any(
+                    isinstance(cond, dict)
+                    and str(cond.get("kind") or "") == "body_cycle"
+                    and str(cond.get("phase") or "") in self._ADVANCED_CYCLE_PHASES
+                    and _safe_float(cond.get("start_ts"), 0) <= _now_ts() < _safe_float(cond.get("end_ts"), 0)
+                    for cond in (self.data.get("state_conditions", []) or [])
+                )
+                # The anchored continuous timeline owns phase progression once
+                # started, so no daily random cycle pick is needed anymore.
+                skip_cycle_spec = anchor_ts > 0 or active_advanced_cycle
+            if not skip_cycle_spec:
+                cycle_spec = (
+                    self._pick_advanced_cycle_spec(intensity)
+                    if self._advanced_cycle_enabled()
+                    else self._pick_body_cycle_spec(cycle_pool, intensity)
+                )
+                specs.append(("body_cycle", "周期", *cycle_spec))
         else:
             specs.append(("body_cycle", "周期", *cycle_pool[0]))
 
@@ -3480,6 +3501,9 @@ class DailyStateMixin(DailyStateTickMixin):
         dream_aftertaste = self._build_dream_aftertaste_condition(dream_pick)
         if dream_aftertaste is not None:
             conditions.append(dream_aftertaste)
+        discomfort_condition = self._maybe_pick_cycle_discomfort(deferred_state_updates)
+        if discomfort_condition is not None:
+            conditions.append(discomfort_condition)
         if 0 <= current_minute < 5 * 60:
             late_night_pool = [
                 ("夜里还没完全安静下来,眼睛和脑子都慢半拍", "困倦", -14, 4),
@@ -3601,6 +3625,64 @@ class DailyStateMixin(DailyStateTickMixin):
         "luteal": 4.5,
         "pms": -7.5,
     }
+    _ADVANCED_CYCLE_PHASE_NAMES = {
+        "menstrual": "月经期",
+        "follicular": "卵泡期",
+        "pre_ovulation": "排卵前期",
+        "ovulation": "排卵期",
+        "luteal": "黄体期",
+        "pms": "PMS 期",
+    }
+    _ADVANCED_CYCLE_DISCOMFORT_SPECS = {
+        "痛经": {
+            "phases": {"menstrual"},
+            "label": "今天有点痛经，小腹闷闷地不舒服",
+            "mood": "疲惫",
+            "energy_delta": -14,
+            "duration_hours": 6,
+            "weight": 4,
+        },
+        "头痛": {
+            "phases": {"menstrual", "pms"},
+            "label": "头有点闷痛，注意力不太集中",
+            "mood": "迟钝",
+            "energy_delta": -10,
+            "duration_hours": 5,
+            "weight": 3,
+        },
+        "腰酸": {
+            "phases": {"menstrual", "luteal"},
+            "label": "腰有点酸，不太想久坐",
+            "mood": "疲惫",
+            "energy_delta": -8,
+            "duration_hours": 6,
+            "weight": 3,
+        },
+        "乏力": {
+            "phases": {"menstrual", "luteal", "pms"},
+            "label": "身上没什么力气，动作慢半拍",
+            "mood": "困倦",
+            "energy_delta": -12,
+            "duration_hours": 8,
+            "weight": 4,
+        },
+        "情绪低落": {
+            "phases": {"pms"},
+            "label": "情绪有点低，不太想说话",
+            "mood": "低落",
+            "energy_delta": -6,
+            "duration_hours": 5,
+            "weight": 2,
+        },
+        "恶心": {
+            "phases": {"menstrual", "pms"},
+            "label": "胃里有点泛恶心，不太想吃东西",
+            "mood": "虚弱",
+            "energy_delta": -9,
+            "duration_hours": 4,
+            "weight": 1,
+        },
+    }
 
     def _advanced_cycle_enabled(self) -> bool:
         return bool(getattr(self, "enable_advanced_cycle_strategy", False))
@@ -3688,6 +3770,170 @@ class DailyStateMixin(DailyStateTickMixin):
             cursor += phase_days
         return "pms", self._advanced_cycle_phase_days("pms")
 
+    def _advanced_cycle_day_of_phase(self, phase: str, day_in_phase: int) -> int:
+        """Map a phase plus its day index to the absolute cycle day."""
+        cursor = 0
+        for candidate in self._ADVANCED_CYCLE_PHASES:
+            if candidate == phase:
+                return cursor + max(1, int(day_in_phase))
+            cursor += self._advanced_cycle_phase_days(candidate)
+        return 1
+
+    def _advanced_cycle_runtime(self) -> dict[str, Any]:
+        """Derive the current six-phase position for display and continuity.
+
+        The stored cycle anchor timestamp is the authoritative continuous
+        timeline: it always yields the current phase and day, even when the
+        bot was offline or no body_cycle condition is currently active. Active
+        conditions are only used as a fallback for old data without an anchor.
+
+        Returns:
+            Phase position details, or an empty dict when the strategy is off
+            or the cycle has not started yet.
+        """
+        if not self._advanced_cycle_enabled():
+            return {}
+        now = _now_ts()
+        meta = self.data.get("body_cycle_state")
+        anchor_ts = _safe_float(meta.get("cycle_anchor_ts"), 0) if isinstance(meta, dict) else 0
+        phase = ""
+        day_in_phase = 0
+        if anchor_ts > 0:
+            cycle_day = int((now - anchor_ts) // 86400) + 1
+            phase, day_in_phase = self._advanced_cycle_position_from_offset(cycle_day)
+        else:
+            # Legacy fallback for historical data created before the anchor
+            # existed. The anchor is always seeded on first enable now, so this
+            # branch only matters while migrating old conditions.
+            conditions = self.data.get("state_conditions", [])
+            if isinstance(conditions, list):
+                for cond in conditions:
+                    if not isinstance(cond, dict) or str(cond.get("kind") or "") != "body_cycle":
+                        continue
+                    cond_phase = str(cond.get("phase") or "")
+                    if cond_phase not in self._ADVANCED_CYCLE_PHASES:
+                        continue
+                    start_ts = _safe_float(cond.get("start_ts"), 0)
+                    end_ts = _safe_float(cond.get("end_ts"), 0)
+                    if start_ts <= now < end_ts:
+                        phase = cond_phase
+                        day_in_phase = int((now - start_ts) // 86400) + 1
+                        break
+            if not phase:
+                return {}
+        phase_days = self._advanced_cycle_phase_days(phase)
+        day_in_phase = max(1, min(phase_days, int(day_in_phase)))
+        label, mood, energy_delta, _ = self._advanced_cycle_phase_spec(phase)
+        next_phase = self._ADVANCED_CYCLE_TRANSITIONS.get(phase, "")
+        next_phase = self._ADVANCED_CYCLE_TRANSITIONS.get(phase, "").removeprefix("body_")
+        return {
+            "phase": phase,
+            "phase_name": self._ADVANCED_CYCLE_PHASE_NAMES.get(phase, phase),
+            "day_in_phase": day_in_phase,
+            "phase_days": phase_days,
+            "cycle_day": self._advanced_cycle_day_of_phase(phase, day_in_phase),
+            "cycle_days": self._advanced_cycle_total_days(),
+            "mood": _single_line(mood, 20),
+            "energy_delta": int(energy_delta),
+            "label": _single_line(label, 160),
+            "next_phase": next_phase,
+            "next_phase_name": self._ADVANCED_CYCLE_PHASE_NAMES.get(next_phase, ""),
+        }
+
+    def _active_cycle_discomfort_conditions(self) -> list[dict[str, Any]]:
+        now = _now_ts()
+        items: list[dict[str, Any]] = []
+        conditions = self.data.get("state_conditions", [])
+        if not isinstance(conditions, list):
+            return items
+        for cond in conditions:
+            if not isinstance(cond, dict) or str(cond.get("kind") or "") != "cycle_discomfort":
+                continue
+            if _safe_float(cond.get("start_ts"), 0) <= now < _safe_float(cond.get("end_ts"), 0):
+                items.append(
+                    {
+                        "type": _single_line(cond.get("phase"), 12) or "经期不适",
+                        "label": _single_line(cond.get("label"), 80),
+                        "mood": _single_line(cond.get("mood"), 12),
+                    }
+                )
+        return items
+
+    def _maybe_pick_cycle_discomfort(self, deferred_state_updates: dict[str, Any] | None = None) -> dict[str, Any] | None:
+        """Roll once per day for a menstrual discomfort episode on the current phase.
+
+        Only runs when the discomfort simulation, the advanced six-phase
+        strategy and the persona cycle allowance are all enabled, and only
+        during phases allowed per discomfort type. Rolls at most once per
+        calendar day and skips the roll while another discomfort condition is
+        still active.
+
+        Returns:
+            A cycle_discomfort condition dict, or None when skipped.
+        """
+        if not bool(getattr(self, "advanced_cycle_discomfort_simulation", False)):
+            return None
+        if not self._persona_state_profile().get("allow_cycle", False):
+            return None
+        intensity = _safe_int(getattr(self, "humanized_state_intensity", 50), 50, 0, 100)
+        if intensity <= 0:
+            return None
+        meta = self.data.get("body_cycle_state")
+        meta = dict(meta) if isinstance(meta, dict) else {}
+        if meta.get("last_discomfort_roll_date") == _today_key():
+            return None
+        runtime = self._advanced_cycle_runtime()
+        phase = runtime.get("phase") if runtime else ""
+        if phase not in self._ADVANCED_CYCLE_PHASES:
+            return None
+        now = _now_ts()
+        conditions = self.data.get("state_conditions", [])
+        if isinstance(conditions, list):
+            for cond in conditions:
+                if (
+                    isinstance(cond, dict)
+                    and str(cond.get("kind") or "") == "cycle_discomfort"
+                    and _safe_float(cond.get("end_ts"), 0) > now
+                ):
+                    return None
+        # One roll attempt per day regardless of the outcome, so a failed roll
+        # does not give the phase extra chances later the same day.
+        if deferred_state_updates is None:
+            meta["last_discomfort_roll_date"] = _today_key()
+            self.data["body_cycle_state"] = meta
+        else:
+            deferred_state_updates["cycle_discomfort_roll_date"] = _today_key()
+        chance = _safe_int(getattr(self, "advanced_cycle_discomfort_chance", 55), 55, 0, 100)
+        if chance <= 0 or random.random() > chance / 100.0:
+            return None
+        raw_types = str(getattr(self, "advanced_cycle_discomfort_types", "") or "痛经,头痛,腰酸,乏力")
+        requested = {token.strip() for token in raw_types.replace("，", ",").split(",") if token.strip()}
+        candidates = [
+            (name, spec)
+            for name, spec in self._ADVANCED_CYCLE_DISCOMFORT_SPECS.items()
+            if name in requested and phase in spec.get("phases", set())
+        ]
+        if not candidates:
+            return None
+        name, spec = random.choices(
+            candidates,
+            weights=[int(spec.get("weight") or 1) for _, spec in candidates],
+            k=1,
+        )[0]
+        energy_delta = int((spec.get("energy_delta") or 0) * max(0.5, intensity / 50.0))
+        return self._make_condition(
+            kind="cycle_discomfort",
+            title="经期不适",
+            label=_single_line(spec.get("label"), 80),
+            mood=_single_line(spec.get("mood"), 12) or "疲惫",
+            energy_delta=energy_delta,
+            duration_hours=_safe_int(spec.get("duration_hours"), 6, 1, 24),
+            intensity=random.randint(45, max(46, min(92, 40 + intensity))),
+            cause="生理周期阶段伴随不适",
+            phase=name,
+            episode_key=f"cycle-discomfort-{_today_key()}",
+        )
+
     def _advanced_cycle_linked_energy(self, phase: str) -> int:
         median = self._ADVANCED_CYCLE_INTENSITY_MEDIANS.get(phase, 0.0)
         intensity = _safe_int(getattr(self, "humanized_state_intensity", 50), 50, 0, 100)
@@ -3696,10 +3942,10 @@ class DailyStateMixin(DailyStateTickMixin):
     def _advanced_cycle_phase_spec(self, phase: str) -> tuple[str, str, int, int]:
         defaults = {
             "menstrual": ("处于月经期，身体更容易疲倦，情绪感受稍敏锐", "疲惫", -12),
-            "follicular": ("处于卵泡期早，精力平稳回升，心情逐渐轻快", "轻快", 0),
+            "follicular": ("处于卵泡期，精力平稳回升，心情逐渐轻快", "轻快", 0),
             "pre_ovulation": ("处于排卵前期，身体逐渐轻盈，精力有所上升", "期待", 8),
             "ovulation": ("处于排卵期，精力较充足，社交意愿稍有增强", "明朗", 9),
-            "luteal": ("处于黄体期早，精力尚可，情绪整体平稳", "平稳", 5),
+            "luteal": ("处于黄体期，精力尚可，情绪整体平稳", "平稳", 5),
             "pms": ("处于 PMS 期，精力有所下降，情绪波动稍明显", "敏感", -8),
         }
         attributes = {
@@ -3753,8 +3999,13 @@ class DailyStateMixin(DailyStateTickMixin):
         neutral = ("不处于生理期", "平稳", 0, 24)
         if self._body_cycle_generation_blocked():
             return neutral
-        now = _now_ts()
         meta = self.data.get("body_cycle_state", {})
+        anchor_ts = _safe_float(meta.get("cycle_anchor_ts"), 0) if isinstance(meta, dict) else 0
+        if anchor_ts > 0:
+            # Once the continuous timeline is anchored, phase progression is
+            # deterministic; a random new-cycle pick would shift it backwards.
+            return neutral
+        now = _now_ts()
         expected_ts = _safe_float(meta.get("next_expected_start_ts"), 0) if isinstance(meta, dict) else 0
         if expected_ts > 0:
             days_late = max(0.0, (now - expected_ts) / 86400)
@@ -3822,6 +4073,11 @@ class DailyStateMixin(DailyStateTickMixin):
         }
         if phase in self._ADVANCED_CYCLE_PHASES:
             payload["strategy"] = "advanced"
+            previous_anchor = _safe_float(meta.get("cycle_anchor_ts"), 0)
+            if phase == "menstrual" and previous_anchor <= 0:
+                payload["cycle_anchor_ts"] = start_ts
+            elif previous_anchor > 0:
+                payload["cycle_anchor_ts"] = previous_anchor
             if phase != "menstrual" and _safe_float(meta.get("last_start_ts"), 0) > 0:
                 payload["last_start_ts"] = _safe_float(meta.get("last_start_ts"), start_ts)
                 payload["next_expected_start_ts"] = _safe_float(
@@ -8584,6 +8840,19 @@ class DailyStateMixin(DailyStateTickMixin):
                 for key in ("manual_offset", "manual_offset_signature", "manual_offset_phase", "manual_offset_day_in_phase"):
                     meta.pop(key, None)
                 self.data["body_cycle_state"] = meta
+            has_cycle_condition = any(
+                isinstance(cond, dict) and str(cond.get("kind") or "") == "body_cycle"
+                for cond in kept
+            )
+            anchor_ts = _safe_float(meta.get("cycle_anchor_ts"), 0)
+            if not has_cycle_condition and anchor_ts <= 0:
+                condition = self._advanced_cycle_condition(
+                    "menstrual",
+                    cause="六阶段周期策略首次启用，自然进入第一周期",
+                )
+                kept.append(condition)
+                self._record_body_cycle_episode(condition)
+                logger.info("[PrivateCompanion] 六阶段周期策略首次启用，已从月经期第 1 天开始推进")
             return kept
 
         signature = self._advanced_cycle_offset_signature(offset)
@@ -8612,6 +8881,7 @@ class DailyStateMixin(DailyStateTickMixin):
                 "manual_offset_signature": signature,
                 "manual_offset_phase": phase,
                 "manual_offset_day_in_phase": day_in_phase,
+                "cycle_anchor_ts": max(0.0, now - (offset - 1) * 86400),
                 "strategy": "advanced",
             }
         )
@@ -8636,7 +8906,7 @@ class DailyStateMixin(DailyStateTickMixin):
             before_count = len(conditions)
             conditions = [
                 cond for cond in conditions
-                if not isinstance(cond, dict) or str(cond.get("kind") or "") != "body_cycle"
+                if not isinstance(cond, dict) or str(cond.get("kind") or "") not in {"body_cycle", "cycle_discomfort"}
             ]
             removed_count = before_count - len(conditions)
             if removed_count:
@@ -8645,6 +8915,20 @@ class DailyStateMixin(DailyStateTickMixin):
         else:
             conditions = self._synchronize_body_cycle_strategy(conditions, now)
             conditions = self._repair_body_cycle_conditions(conditions, now)
+            if not self._advanced_cycle_enabled() or not bool(
+                getattr(self, "advanced_cycle_discomfort_simulation", False)
+            ):
+                before_count = len(conditions)
+                conditions = [
+                    cond
+                    for cond in conditions
+                    if not isinstance(cond, dict) or str(cond.get("kind") or "") != "cycle_discomfort"
+                ]
+                if len(conditions) < before_count:
+                    logger.info(
+                        "[PrivateCompanion] 不适模拟已关闭，清理残留经期不适状态: removed=%s",
+                        before_count - len(conditions),
+                    )
         active = []
         expired = []
         for cond in conditions:
@@ -8656,6 +8940,7 @@ class DailyStateMixin(DailyStateTickMixin):
                 expired.append(cond)
         for cond in expired:
             active.extend(self._spawn_followup_conditions(cond))
+        active = self._reconcile_advanced_cycle_condition(active, now)
         active = self._prune_active_hunger_conditions(active, now)
         self.data["state_conditions"] = active
 
@@ -8744,6 +9029,66 @@ class DailyStateMixin(DailyStateTickMixin):
             )
             self.data["body_cycle_state"] = meta
         return repaired
+
+    def _reconcile_advanced_cycle_condition(self, conditions: list[dict[str, Any]], now: float) -> list[dict[str, Any]]:
+        """Align the active cycle condition with the anchored continuous timeline.
+
+        The anchor always knows the true current phase and day. When the bot
+        was offline or a transition condition was spawned late, this replaces
+        the stale condition with one positioned exactly on the timeline so its
+        energy and mood effects never lag behind the displayed phase.
+
+        Args:
+            conditions: Currently active condition list after follow-up spawns.
+            now: Current unix timestamp.
+
+        Returns:
+            The adjusted condition list.
+        """
+        if not self._advanced_cycle_enabled():
+            return conditions
+        meta = self.data.get("body_cycle_state")
+        anchor_ts = _safe_float(meta.get("cycle_anchor_ts"), 0) if isinstance(meta, dict) else 0
+        if anchor_ts <= 0:
+            return conditions
+        expected_phase, day_in_phase = self._advanced_cycle_position_from_offset(
+            int((now - anchor_ts) // 86400) + 1
+        )
+        phase_days = self._advanced_cycle_phase_days(expected_phase)
+        phase_start = anchor_ts + (self._advanced_cycle_day_of_phase(expected_phase, 1) - 1) * 86400
+        active_cycles = [
+            cond
+            for cond in conditions
+            if isinstance(cond, dict)
+            and str(cond.get("kind") or "") == "body_cycle"
+            and _safe_float(cond.get("start_ts"), 0) <= now < _safe_float(cond.get("end_ts"), 0)
+        ]
+        if len(active_cycles) == 1:
+            cond = active_cycles[0]
+            cond_start = _safe_float(cond.get("start_ts"), 0)
+            if str(cond.get("phase") or "") == expected_phase and abs(cond_start - phase_start) < 6 * 3600:
+                return conditions
+        kept = [
+            cond
+            for cond in conditions
+            if not (isinstance(cond, dict) and str(cond.get("kind") or "") == "body_cycle")
+        ]
+        condition = self._advanced_cycle_condition(
+            expected_phase,
+            cause="周期阶段自然推进",
+        )
+        condition["start_ts"] = phase_start
+        condition["duration_hours"] = phase_days * 24
+        condition["end_ts"] = phase_start + phase_days * 24 * 3600
+        kept.append(condition)
+        self._record_body_cycle_episode(condition)
+        logger.info(
+            "[PrivateCompanion] 已对齐六阶段周期状态: phase=%s phase_start=%s day_in_phase=%s",
+            expected_phase,
+            self._environment_fromtimestamp(phase_start).strftime("%Y-%m-%d %H:%M"),
+            day_in_phase,
+        )
+        return kept
 
     def _spawn_followup_conditions(self, cond: dict[str, Any]) -> list[dict[str, Any]]:
         choice = self._pick_condition_transition(cond)
@@ -8972,6 +9317,16 @@ class DailyStateMixin(DailyStateTickMixin):
             sorted(mood_candidates, key=lambda item: item[1], reverse=True)[0][0]
             if mood_candidates else "平稳"
         )
+        cycle_runtime: dict[str, Any] = {}
+        if self._advanced_cycle_enabled() and profile.get("allow_cycle", False):
+            cycle_runtime = self._advanced_cycle_runtime()
+            if cycle_runtime:
+                values["body_cycle"] = (
+                    f"{cycle_runtime.get('phase_name', '周期')} 第{cycle_runtime.get('day_in_phase', 1)}天"
+                )
+                discomfort = self._active_cycle_discomfort_conditions()
+                if discomfort:
+                    cycle_runtime["discomfort"] = discomfort
         note = self._build_state_note(
             values["sleep"],
             values["dream"],
@@ -8990,6 +9345,7 @@ class DailyStateMixin(DailyStateTickMixin):
             "mood_bias": mood_bias,
             "energy": energy,
             "note": note,
+            "cycle_runtime": cycle_runtime,
             "conditions": active,
             "affect_modulation": compose_affect_modulation(active, now=composed_at),
         }
@@ -9912,7 +10268,7 @@ class DailyStateMixin(DailyStateTickMixin):
             return bool(profile.get("allow_health", True))
         if kind == "hunger":
             return bool(profile.get("allow_hunger", True))
-        if kind == "body_cycle":
+        if kind in {"body_cycle", "cycle_discomfort"}:
             return bool(profile.get("allow_cycle", False))
         return True
 
@@ -11255,9 +11611,9 @@ class DailyStateMixin(DailyStateTickMixin):
                 "passive": "Bot 处于月经期模拟阶段：周期会相对牵制可用精力和身体耐受，回复可适当简短放慢，措辞更温和；不要把状态当成固定台词反复说明。",
             },
             "follicular": {
-                "stage": "处于卵泡期早阶段",
+                "stage": "处于卵泡期阶段",
                 "influence": "精力逐渐回升，语气可以自然轻快一些；仍以当前话题为主，不必主动解释周期",
-                "passive": "Bot 处于卵泡期早模拟阶段：精力逐渐回升，语气可自然轻快一些，不需要主动解释周期。",
+                "passive": "Bot 处于卵泡期模拟阶段：精力逐渐回升，语气可自然轻快一些，不需要主动解释周期。",
             },
             "pre_ovulation": {
                 "stage": "处于排卵前期阶段",
@@ -11270,9 +11626,9 @@ class DailyStateMixin(DailyStateTickMixin):
                 "passive": "Bot 处于排卵期模拟阶段：精力相对充足，语气可略显明朗，但不据此强行提高亲密程度。",
             },
             "luteal": {
-                "stage": "处于黄体期早阶段",
+                "stage": "处于黄体期阶段",
                 "influence": "整体保持平稳，只允许轻微影响语气和节奏，不额外放大情绪",
-                "passive": "Bot 处于黄体期早模拟阶段：整体保持平稳，只轻微影响语气和节奏。",
+                "passive": "Bot 处于黄体期模拟阶段：整体保持平稳，只轻微影响语气和节奏。",
             },
             "pms": {
                 "stage": "处于 PMS 模拟阶段",
@@ -11504,10 +11860,10 @@ class DailyStateMixin(DailyStateTickMixin):
                 "body_period": "可能自然进入生理期阶段",
                 "body_recovery": "可能自然进入恢复期",
                 "body_menstrual": "会自然进入月经期",
-                "body_follicular": "会自然进入卵泡期早",
+                "body_follicular": "会自然进入卵泡期",
                 "body_pre_ovulation": "会自然进入排卵前期",
                 "body_ovulation": "会自然进入排卵期",
-                "body_luteal": "会自然进入黄体期早",
+                "body_luteal": "会自然进入黄体期",
                 "body_pms": "会自然进入 PMS 期",
                 "stable": "也可能直接回稳",
             }.get(target, target)
@@ -11542,10 +11898,10 @@ class DailyStateMixin(DailyStateTickMixin):
             "body_period": "身体感会自然往更敏感的阶段走",
             "body_recovery": "身体感会自然往恢复期走",
             "body_menstrual": "自然进入下一轮月经期",
-            "body_follicular": "自然进入卵泡期早",
+            "body_follicular": "自然进入卵泡期",
             "body_pre_ovulation": "自然进入排卵前期",
             "body_ovulation": "自然进入排卵期",
-            "body_luteal": "自然进入黄体期早",
+            "body_luteal": "自然进入黄体期",
             "body_pms": "自然进入 PMS 期",
             "stable": "慢慢回到平稳",
         }

--- a/page_api.py
+++ b/page_api.py
@@ -26990,6 +26990,31 @@ class PrivateCompanionPageApi(
             return {}
         keys = ["date", "sleep", "dream", "health", "hunger", "body_cycle", "location", "weather", "mood_bias", "energy", "note"]
         summary = {key: state.get(key, "") for key in keys}
+        cycle_runtime = state.get("cycle_runtime") if isinstance(state.get("cycle_runtime"), dict) else {}
+        if cycle_runtime:
+            discomfort = cycle_runtime.get("discomfort")
+            summary["cycle_runtime"] = {
+                "phase": self._single_line(cycle_runtime.get("phase"), 24),
+                "phase_name": self._single_line(cycle_runtime.get("phase_name"), 24),
+                "day_in_phase": self._int(cycle_runtime.get("day_in_phase")),
+                "phase_days": self._int(cycle_runtime.get("phase_days")),
+                "cycle_day": self._int(cycle_runtime.get("cycle_day")),
+                "cycle_days": self._int(cycle_runtime.get("cycle_days")),
+                "mood": self._single_line(cycle_runtime.get("mood"), 20),
+                "energy_delta": self._int(cycle_runtime.get("energy_delta")),
+                "next_phase_name": self._single_line(cycle_runtime.get("next_phase_name"), 24),
+                "discomfort": [
+                    {
+                        "type": self._single_line(item.get("type"), 12),
+                        "label": self._single_line(item.get("label"), 80),
+                        "mood": self._single_line(item.get("mood"), 12),
+                    }
+                    for item in discomfort[:4]
+                    if isinstance(item, dict)
+                ]
+                if isinstance(discomfort, list)
+                else [],
+            }
         location_getter = getattr(self.plugin, "_current_location_state_text", None)
         if callable(location_getter):
             try:

--- a/pages/companion-panel/app.js
+++ b/pages/companion-panel/app.js
@@ -2133,10 +2133,10 @@ const configLabels = {
   advanced_cycle_menstrual_prompt: "月经期状态描述",
   advanced_cycle_menstrual_mood: "月经期情绪底色",
   advanced_cycle_menstrual_energy: "月经期精力变化",
-  advanced_cycle_follicular_days: "卵泡期早天数",
-  advanced_cycle_follicular_prompt: "卵泡期早状态描述",
-  advanced_cycle_follicular_mood: "卵泡期早情绪底色",
-  advanced_cycle_follicular_energy: "卵泡期早精力变化",
+  advanced_cycle_follicular_days: "卵泡期天数",
+  advanced_cycle_follicular_prompt: "卵泡期状态描述",
+  advanced_cycle_follicular_mood: "卵泡期情绪底色",
+  advanced_cycle_follicular_energy: "卵泡期精力变化",
   advanced_cycle_pre_ovulation_days: "排卵前期天数",
   advanced_cycle_pre_ovulation_prompt: "排卵前期状态描述",
   advanced_cycle_pre_ovulation_mood: "排卵前期情绪底色",
@@ -2145,14 +2145,17 @@ const configLabels = {
   advanced_cycle_ovulation_prompt: "排卵期状态描述",
   advanced_cycle_ovulation_mood: "排卵期情绪底色",
   advanced_cycle_ovulation_energy: "排卵期精力变化",
-  advanced_cycle_luteal_days: "黄体期早天数",
-  advanced_cycle_luteal_prompt: "黄体期早状态描述",
-  advanced_cycle_luteal_mood: "黄体期早情绪底色",
-  advanced_cycle_luteal_energy: "黄体期早精力变化",
+  advanced_cycle_luteal_days: "黄体期天数",
+  advanced_cycle_luteal_prompt: "黄体期状态描述",
+  advanced_cycle_luteal_mood: "黄体期情绪底色",
+  advanced_cycle_luteal_energy: "黄体期精力变化",
   advanced_cycle_pms_days: "PMS 期天数",
   advanced_cycle_pms_prompt: "PMS 期状态描述",
   advanced_cycle_pms_mood: "PMS 期情绪底色",
   advanced_cycle_pms_energy: "PMS 期精力变化",
+  advanced_cycle_discomfort_simulation: "生理期不适模拟",
+  advanced_cycle_discomfort_chance: "不适出现概率",
+  advanced_cycle_discomfort_types: "可模拟的不适类型",
   worldview_adaptation_mode: "世界观适配模式",
   worldview_adaptation_prompt: "自定义世界观适配",
   enable_worldview_perception: "世界观适配感知",
@@ -2637,33 +2640,36 @@ const configDescriptions = {
   busy_reply_max_delay_seconds: "繁忙日程中普通私聊的最长等待时间，默认 5 分钟、最多 15 分钟。若小于最短值，运行时会自动交换两者。",
   busy_reply_proactive_resume_buffer_minutes: "普通主动消息顺延到当前忙碌片段结束后，再额外等待这段时间，避免刚忙完就立即开口。",
   enable_cycle_state: "开启后即视为适用，周期只作为 Bot 的模拟身体底色，轻度影响精力、语气和回复节奏；它不是用户事实、医学记录或真实日期追踪。",
-  enable_advanced_cycle_strategy: "关闭时保留原有的生理期前、经期与恢复期随机模拟；开启后按月经期、卵泡期早、排卵前期、排卵期、黄体期早、PMS 连续推进。",
+  enable_advanced_cycle_strategy: "关闭时保留原有的生理期前、经期与恢复期随机模拟；开启后按月经期、卵泡期、排卵前期、排卵期、黄体期、PMS 连续推进。",
   advanced_cycle_link_intensity: "开启后，各阶段精力变化按拟人状态强度线性缩放：0 为无精力增减，50 为阶段基准，100 约为基准两倍；下方手动精力值暂不使用。",
   advanced_cycle_start_offset: "用于首次对齐当前周期。0 表示沿现有状态自然推进；填写 1 及以上表示当前处于配置周期的第几天，超过总天数会循环折算。仅在数值或阶段天数变化时重新应用。",
-  advanced_cycle_menstrual_days: "月经期持续天数，结束后自然进入卵泡期早。",
+  advanced_cycle_menstrual_days: "月经期持续天数，结束后自然进入卵泡期。",
   advanced_cycle_menstrual_prompt: "作为 Bot 当前月经期模拟状态的柔性描述，只影响自然语气和节奏，不要求主动汇报。",
   advanced_cycle_menstrual_mood: "月经期可轻度参考的情绪底色，不会覆盖当前话题和明确情绪。",
   advanced_cycle_menstrual_energy: "未开启强度联动时使用的精力增减值，负数表示更容易疲倦。",
-  advanced_cycle_follicular_days: "卵泡期早持续天数，结束后自然进入排卵前期。",
-  advanced_cycle_follicular_prompt: "作为 Bot 当前卵泡期早模拟状态的柔性描述，不会据此强行增加主动消息。",
-  advanced_cycle_follicular_mood: "卵泡期早可轻度参考的情绪底色。",
+  advanced_cycle_follicular_days: "卵泡期持续天数，结束后自然进入排卵前期。",
+  advanced_cycle_follicular_prompt: "作为 Bot 当前卵泡期模拟状态的柔性描述，不会据此强行增加主动消息。",
+  advanced_cycle_follicular_mood: "卵泡期可轻度参考的情绪底色。",
   advanced_cycle_follicular_energy: "未开启强度联动时使用的精力增减值；可设为 0 保持中性。",
   advanced_cycle_pre_ovulation_days: "排卵前期持续天数，结束后自然进入排卵期。",
   advanced_cycle_pre_ovulation_prompt: "作为 Bot 当前排卵前期模拟状态的柔性描述，不写成医学判断。",
   advanced_cycle_pre_ovulation_mood: "排卵前期可轻度参考的情绪底色。",
   advanced_cycle_pre_ovulation_energy: "未开启强度联动时使用的精力增减值。",
-  advanced_cycle_ovulation_days: "排卵期持续天数，结束后自然进入黄体期早。",
+  advanced_cycle_ovulation_days: "排卵期持续天数，结束后自然进入黄体期。",
   advanced_cycle_ovulation_prompt: "作为 Bot 当前排卵期模拟状态的柔性描述，不会硬性提高亲密程度或主动频率。",
   advanced_cycle_ovulation_mood: "排卵期可轻度参考的情绪底色。",
   advanced_cycle_ovulation_energy: "未开启强度联动时使用的精力增减值。",
-  advanced_cycle_luteal_days: "黄体期早持续天数，结束后自然进入 PMS 期。",
-  advanced_cycle_luteal_prompt: "作为 Bot 当前黄体期早模拟状态的柔性描述，整体仍以当前对话为主。",
-  advanced_cycle_luteal_mood: "黄体期早可轻度参考的情绪底色。",
+  advanced_cycle_luteal_days: "黄体期持续天数，结束后自然进入 PMS 期。",
+  advanced_cycle_luteal_prompt: "作为 Bot 当前黄体期模拟状态的柔性描述，整体仍以当前对话为主。",
+  advanced_cycle_luteal_mood: "黄体期可轻度参考的情绪底色。",
   advanced_cycle_luteal_energy: "未开启强度联动时使用的精力增减值。",
   advanced_cycle_pms_days: "PMS 期持续天数，结束后自然进入下一轮月经期。",
   advanced_cycle_pms_prompt: "作为 Bot 当前 PMS 模拟状态的柔性描述，可稍微收住语气，但不要变得刻薄或反复提及。",
   advanced_cycle_pms_mood: "PMS 期可轻度参考的情绪底色，不覆盖用户当下需求。",
   advanced_cycle_pms_energy: "未开启强度联动时使用的精力增减值，负数表示精力稍低。",
+  advanced_cycle_discomfort_simulation: "开启后，在月经期、PMS 期等阶段按概率生成短暂的痛经、头痛等不适状态，轻度压低精力并在总览中显示；只作为 Bot 自己的模拟底色，不写成医学结论。",
+  advanced_cycle_discomfort_chance: "每天生成一次不适状态的概率，0 表示从不生成；同一时间只保留一条不适状态。",
+  advanced_cycle_discomfort_types: "逗号分隔的可模拟不适类型，可选：痛经、头痛、腰酸、乏力、情绪低落、恶心；只会出现在与之相关的阶段（如痛经仅在月经期）。",
   environment_perception_timezone: "用于判断当前时段、日期语境、节假日和日程跨日。填写 global 跟随 AstrBot 全局时区，也可填写自定义 IANA 时区。",
   holiday_country: "节假日识别地区。目前主要用于 CN，未安装依赖时会自动退化为周末/工作日。",
   enable_weather_context: "开启后默认使用和风天气；未完成独立配置时，会尝试复用 screen_companion。天气只作为日程、日记和主动契机的背景。",
@@ -3169,6 +3175,9 @@ const advancedCycleSettingKeys = [
   "advanced_cycle_pms_prompt",
   "advanced_cycle_pms_mood",
   "advanced_cycle_pms_energy",
+  "advanced_cycle_discomfort_simulation",
+  "advanced_cycle_discomfort_chance",
+  "advanced_cycle_discomfort_types",
 ];
 
 const featureSettingGroups = {
@@ -3520,7 +3529,7 @@ const featureSettingSections = {
       keys: ["advanced_cycle_menstrual_days", "advanced_cycle_menstrual_prompt", "advanced_cycle_menstrual_mood", "advanced_cycle_menstrual_energy"],
     },
     {
-      title: "卵泡期早",
+      title: "卵泡期",
       note: "精力可以平稳回升，但不会据此硬性增加主动消息。",
       keys: ["advanced_cycle_follicular_days", "advanced_cycle_follicular_prompt", "advanced_cycle_follicular_mood", "advanced_cycle_follicular_energy"],
     },
@@ -3535,7 +3544,7 @@ const featureSettingSections = {
       keys: ["advanced_cycle_ovulation_days", "advanced_cycle_ovulation_prompt", "advanced_cycle_ovulation_mood", "advanced_cycle_ovulation_energy"],
     },
     {
-      title: "黄体期早",
+      title: "黄体期",
       note: "整体保持自然平稳，不额外放大情绪。",
       keys: ["advanced_cycle_luteal_days", "advanced_cycle_luteal_prompt", "advanced_cycle_luteal_mood", "advanced_cycle_luteal_energy"],
     },
@@ -3543,6 +3552,11 @@ const featureSettingSections = {
       title: "PMS 期",
       note: "可以稍微收住语气，但不会变得刻薄或反复提及周期。",
       keys: ["advanced_cycle_pms_days", "advanced_cycle_pms_prompt", "advanced_cycle_pms_mood", "advanced_cycle_pms_energy"],
+    },
+    {
+      title: "经期不适模拟",
+      note: "可选。在月经期、PMS 期等阶段按概率生成短暂的痛经、头痛等不适状态，只作为状态底色，不写成医学结论。",
+      keys: ["advanced_cycle_discomfort_simulation", "advanced_cycle_discomfort_chance", "advanced_cycle_discomfort_types"],
     },
     {
       title: "QQ 状态同步",
@@ -4211,6 +4225,9 @@ const featureSettingTypes = {
   advanced_cycle_pms_days: { type: "number", min: 1, max: 30, step: 1 },
   advanced_cycle_pms_prompt: { type: "textarea" },
   advanced_cycle_pms_energy: { type: "number", min: -50, max: 30, step: 1 },
+  advanced_cycle_discomfort_simulation: { type: "checkbox" },
+  advanced_cycle_discomfort_chance: { type: "number", min: 0, max: 100, step: 1 },
+  advanced_cycle_discomfort_types: { type: "textarea" },
   proactive_reply_context_hours: { type: "number", min: 1, max: 72, step: 1 },
   max_proactive_plan_lag_minutes: { type: "number", min: 5, max: 1440, step: 5 },
   greeting_idle_minutes: { type: "number", min: 0, max: 240, step: 5 },
@@ -10336,6 +10353,16 @@ function dashboardLifeText(value, fallback = "暂无数据") {
   return text || fallback;
 }
 
+function cycleBodyText(daily) {
+  const runtime = daily && daily.cycle_runtime;
+  if (!runtime || !runtime.phase_name || !runtime.day_in_phase) return daily.body_cycle || "";
+  let text = `${runtime.phase_name} 第${runtime.day_in_phase}/${runtime.phase_days}天`;
+  if (runtime.discomfort && runtime.discomfort.length) {
+    text += ` · ${runtime.discomfort.map((item) => item.type || "不适").join("、")}`;
+  }
+  return text;
+}
+
 function renderDashboardLifeDesk(overview = {}) {
   const daily = overview.daily_state || {};
   const life = overview.life_observation || {};
@@ -10358,7 +10385,7 @@ function renderDashboardLifeDesk(overview = {}) {
       ["健康", daily.health],
       ["穿搭", outfit.available ? "今日穿搭已生成" : (outfit.error || "暂无穿搭图")],
       ["睡眠", daily.sleep_phase || daily.sleep],
-      ["身体", daily.body_cycle || daily.hunger],
+      ["身体", cycleBodyText(daily) || daily.hunger],
     ];
     factRoot.innerHTML = facts.map(([label, value]) => `
       <div class="life-fact-item">
@@ -19378,17 +19405,34 @@ function renderDreamCard(dream) {
 }
 
 function renderStatePillBoard(daily) {
+  const runtime = daily && daily.cycle_runtime;
   const items = [
     ["睡眠", daily.sleep],
     ["睡眠阶段", daily.sleep_phase || daily.sleep_runtime?.label],
     ["梦境", daily.dream],
     ["健康", daily.health],
     ["饥饿", daily.hunger],
-    ["生理期状态", daily.body_cycle],
-  ].map(([label, value]) => [label, normalizeRoleplayStateText(value)])
+    ["周期状态", daily.body_cycle],
+  ];
+  if (runtime && runtime.phase_name && runtime.day_in_phase) {
+    items.push([
+      "周期阶段",
+      `${runtime.phase_name} 第${runtime.day_in_phase}/${runtime.phase_days}天 · 周期第${runtime.cycle_day}/${runtime.cycle_days}天` +
+        (runtime.mood ? ` · ${runtime.mood}` : "") +
+        (runtime.next_phase_name ? ` · 下一阶段${runtime.next_phase_name}` : ""),
+    ]);
+  }
+  if (runtime && Array.isArray(runtime.discomfort) && runtime.discomfort.length) {
+    items.push([
+      "经期不适",
+      runtime.discomfort.map((item) => (item.type ? `${item.type}（${item.label || ""}）` : item.label || "")).join("；"),
+    ]);
+  }
+  const normalized = items
+    .map(([label, value]) => [label, normalizeRoleplayStateText(value)])
     .filter(([, value]) => value !== undefined && value !== "");
-  $("#statePillBoard").innerHTML = items.length
-    ? items.map(([label, value]) => `
+  $("#statePillBoard").innerHTML = normalized.length
+    ? normalized.map(([label, value]) => `
       <span>
         <b>${escapeHtml(label)}</b>
         ${escapeHtml(value || "-")}
@@ -25489,7 +25533,7 @@ function featureRelatedSettings(key) {
       advanced_cycle_menstrual_mood: "疲惫",
       advanced_cycle_menstrual_energy: -12,
       advanced_cycle_follicular_days: 5,
-      advanced_cycle_follicular_prompt: "处于卵泡期早，精力平稳回升，心情逐渐轻快",
+      advanced_cycle_follicular_prompt: "处于卵泡期，精力平稳回升，心情逐渐轻快",
       advanced_cycle_follicular_mood: "轻快",
       advanced_cycle_follicular_energy: 0,
       advanced_cycle_pre_ovulation_days: 3,
@@ -25501,13 +25545,16 @@ function featureRelatedSettings(key) {
       advanced_cycle_ovulation_mood: "明朗",
       advanced_cycle_ovulation_energy: 9,
       advanced_cycle_luteal_days: 8,
-      advanced_cycle_luteal_prompt: "处于黄体期早，精力尚可，情绪整体平稳",
+      advanced_cycle_luteal_prompt: "处于黄体期，精力尚可，情绪整体平稳",
       advanced_cycle_luteal_mood: "平稳",
       advanced_cycle_luteal_energy: 5,
       advanced_cycle_pms_days: 6,
       advanced_cycle_pms_prompt: "处于 PMS 期，精力有所下降，情绪波动稍明显",
       advanced_cycle_pms_mood: "敏感",
       advanced_cycle_pms_energy: -8,
+      advanced_cycle_discomfort_simulation: false,
+      advanced_cycle_discomfort_chance: 55,
+      advanced_cycle_discomfort_types: "痛经,头痛,腰酸,乏力",
       auto_voice_enabled: true,
       tts_conversion_scope: "full",
       auto_voice_max_chars: 80,

--- a/pages/陪伴面板/app.js
+++ b/pages/陪伴面板/app.js
@@ -2133,10 +2133,10 @@ const configLabels = {
   advanced_cycle_menstrual_prompt: "月经期状态描述",
   advanced_cycle_menstrual_mood: "月经期情绪底色",
   advanced_cycle_menstrual_energy: "月经期精力变化",
-  advanced_cycle_follicular_days: "卵泡期早天数",
-  advanced_cycle_follicular_prompt: "卵泡期早状态描述",
-  advanced_cycle_follicular_mood: "卵泡期早情绪底色",
-  advanced_cycle_follicular_energy: "卵泡期早精力变化",
+  advanced_cycle_follicular_days: "卵泡期天数",
+  advanced_cycle_follicular_prompt: "卵泡期状态描述",
+  advanced_cycle_follicular_mood: "卵泡期情绪底色",
+  advanced_cycle_follicular_energy: "卵泡期精力变化",
   advanced_cycle_pre_ovulation_days: "排卵前期天数",
   advanced_cycle_pre_ovulation_prompt: "排卵前期状态描述",
   advanced_cycle_pre_ovulation_mood: "排卵前期情绪底色",
@@ -2145,14 +2145,17 @@ const configLabels = {
   advanced_cycle_ovulation_prompt: "排卵期状态描述",
   advanced_cycle_ovulation_mood: "排卵期情绪底色",
   advanced_cycle_ovulation_energy: "排卵期精力变化",
-  advanced_cycle_luteal_days: "黄体期早天数",
-  advanced_cycle_luteal_prompt: "黄体期早状态描述",
-  advanced_cycle_luteal_mood: "黄体期早情绪底色",
-  advanced_cycle_luteal_energy: "黄体期早精力变化",
+  advanced_cycle_luteal_days: "黄体期天数",
+  advanced_cycle_luteal_prompt: "黄体期状态描述",
+  advanced_cycle_luteal_mood: "黄体期情绪底色",
+  advanced_cycle_luteal_energy: "黄体期精力变化",
   advanced_cycle_pms_days: "PMS 期天数",
   advanced_cycle_pms_prompt: "PMS 期状态描述",
   advanced_cycle_pms_mood: "PMS 期情绪底色",
   advanced_cycle_pms_energy: "PMS 期精力变化",
+  advanced_cycle_discomfort_simulation: "生理期不适模拟",
+  advanced_cycle_discomfort_chance: "不适出现概率",
+  advanced_cycle_discomfort_types: "可模拟的不适类型",
   worldview_adaptation_mode: "世界观适配模式",
   worldview_adaptation_prompt: "自定义世界观适配",
   enable_worldview_perception: "世界观适配感知",
@@ -2637,33 +2640,36 @@ const configDescriptions = {
   busy_reply_max_delay_seconds: "繁忙日程中普通私聊的最长等待时间，默认 5 分钟、最多 15 分钟。若小于最短值，运行时会自动交换两者。",
   busy_reply_proactive_resume_buffer_minutes: "普通主动消息顺延到当前忙碌片段结束后，再额外等待这段时间，避免刚忙完就立即开口。",
   enable_cycle_state: "开启后即视为适用，周期只作为 Bot 的模拟身体底色，轻度影响精力、语气和回复节奏；它不是用户事实、医学记录或真实日期追踪。",
-  enable_advanced_cycle_strategy: "关闭时保留原有的生理期前、经期与恢复期随机模拟；开启后按月经期、卵泡期早、排卵前期、排卵期、黄体期早、PMS 连续推进。",
+  enable_advanced_cycle_strategy: "关闭时保留原有的生理期前、经期与恢复期随机模拟；开启后按月经期、卵泡期、排卵前期、排卵期、黄体期、PMS 连续推进。",
   advanced_cycle_link_intensity: "开启后，各阶段精力变化按拟人状态强度线性缩放：0 为无精力增减，50 为阶段基准，100 约为基准两倍；下方手动精力值暂不使用。",
   advanced_cycle_start_offset: "用于首次对齐当前周期。0 表示沿现有状态自然推进；填写 1 及以上表示当前处于配置周期的第几天，超过总天数会循环折算。仅在数值或阶段天数变化时重新应用。",
-  advanced_cycle_menstrual_days: "月经期持续天数，结束后自然进入卵泡期早。",
+  advanced_cycle_menstrual_days: "月经期持续天数，结束后自然进入卵泡期。",
   advanced_cycle_menstrual_prompt: "作为 Bot 当前月经期模拟状态的柔性描述，只影响自然语气和节奏，不要求主动汇报。",
   advanced_cycle_menstrual_mood: "月经期可轻度参考的情绪底色，不会覆盖当前话题和明确情绪。",
   advanced_cycle_menstrual_energy: "未开启强度联动时使用的精力增减值，负数表示更容易疲倦。",
-  advanced_cycle_follicular_days: "卵泡期早持续天数，结束后自然进入排卵前期。",
-  advanced_cycle_follicular_prompt: "作为 Bot 当前卵泡期早模拟状态的柔性描述，不会据此强行增加主动消息。",
-  advanced_cycle_follicular_mood: "卵泡期早可轻度参考的情绪底色。",
+  advanced_cycle_follicular_days: "卵泡期持续天数，结束后自然进入排卵前期。",
+  advanced_cycle_follicular_prompt: "作为 Bot 当前卵泡期模拟状态的柔性描述，不会据此强行增加主动消息。",
+  advanced_cycle_follicular_mood: "卵泡期可轻度参考的情绪底色。",
   advanced_cycle_follicular_energy: "未开启强度联动时使用的精力增减值；可设为 0 保持中性。",
   advanced_cycle_pre_ovulation_days: "排卵前期持续天数，结束后自然进入排卵期。",
   advanced_cycle_pre_ovulation_prompt: "作为 Bot 当前排卵前期模拟状态的柔性描述，不写成医学判断。",
   advanced_cycle_pre_ovulation_mood: "排卵前期可轻度参考的情绪底色。",
   advanced_cycle_pre_ovulation_energy: "未开启强度联动时使用的精力增减值。",
-  advanced_cycle_ovulation_days: "排卵期持续天数，结束后自然进入黄体期早。",
+  advanced_cycle_ovulation_days: "排卵期持续天数，结束后自然进入黄体期。",
   advanced_cycle_ovulation_prompt: "作为 Bot 当前排卵期模拟状态的柔性描述，不会硬性提高亲密程度或主动频率。",
   advanced_cycle_ovulation_mood: "排卵期可轻度参考的情绪底色。",
   advanced_cycle_ovulation_energy: "未开启强度联动时使用的精力增减值。",
-  advanced_cycle_luteal_days: "黄体期早持续天数，结束后自然进入 PMS 期。",
-  advanced_cycle_luteal_prompt: "作为 Bot 当前黄体期早模拟状态的柔性描述，整体仍以当前对话为主。",
-  advanced_cycle_luteal_mood: "黄体期早可轻度参考的情绪底色。",
+  advanced_cycle_luteal_days: "黄体期持续天数，结束后自然进入 PMS 期。",
+  advanced_cycle_luteal_prompt: "作为 Bot 当前黄体期模拟状态的柔性描述，整体仍以当前对话为主。",
+  advanced_cycle_luteal_mood: "黄体期可轻度参考的情绪底色。",
   advanced_cycle_luteal_energy: "未开启强度联动时使用的精力增减值。",
   advanced_cycle_pms_days: "PMS 期持续天数，结束后自然进入下一轮月经期。",
   advanced_cycle_pms_prompt: "作为 Bot 当前 PMS 模拟状态的柔性描述，可稍微收住语气，但不要变得刻薄或反复提及。",
   advanced_cycle_pms_mood: "PMS 期可轻度参考的情绪底色，不覆盖用户当下需求。",
   advanced_cycle_pms_energy: "未开启强度联动时使用的精力增减值，负数表示精力稍低。",
+  advanced_cycle_discomfort_simulation: "开启后，在月经期、PMS 期等阶段按概率生成短暂的痛经、头痛等不适状态，轻度压低精力并在总览中显示；只作为 Bot 自己的模拟底色，不写成医学结论。",
+  advanced_cycle_discomfort_chance: "每天生成一次不适状态的概率，0 表示从不生成；同一时间只保留一条不适状态。",
+  advanced_cycle_discomfort_types: "逗号分隔的可模拟不适类型，可选：痛经、头痛、腰酸、乏力、情绪低落、恶心；只会出现在与之相关的阶段（如痛经仅在月经期）。",
   environment_perception_timezone: "用于判断当前时段、日期语境、节假日和日程跨日。填写 global 跟随 AstrBot 全局时区，也可填写自定义 IANA 时区。",
   holiday_country: "节假日识别地区。目前主要用于 CN，未安装依赖时会自动退化为周末/工作日。",
   enable_weather_context: "开启后默认使用和风天气；未完成独立配置时，会尝试复用 screen_companion。天气只作为日程、日记和主动契机的背景。",
@@ -3169,6 +3175,9 @@ const advancedCycleSettingKeys = [
   "advanced_cycle_pms_prompt",
   "advanced_cycle_pms_mood",
   "advanced_cycle_pms_energy",
+  "advanced_cycle_discomfort_simulation",
+  "advanced_cycle_discomfort_chance",
+  "advanced_cycle_discomfort_types",
 ];
 
 const featureSettingGroups = {
@@ -3520,7 +3529,7 @@ const featureSettingSections = {
       keys: ["advanced_cycle_menstrual_days", "advanced_cycle_menstrual_prompt", "advanced_cycle_menstrual_mood", "advanced_cycle_menstrual_energy"],
     },
     {
-      title: "卵泡期早",
+      title: "卵泡期",
       note: "精力可以平稳回升，但不会据此硬性增加主动消息。",
       keys: ["advanced_cycle_follicular_days", "advanced_cycle_follicular_prompt", "advanced_cycle_follicular_mood", "advanced_cycle_follicular_energy"],
     },
@@ -3535,7 +3544,7 @@ const featureSettingSections = {
       keys: ["advanced_cycle_ovulation_days", "advanced_cycle_ovulation_prompt", "advanced_cycle_ovulation_mood", "advanced_cycle_ovulation_energy"],
     },
     {
-      title: "黄体期早",
+      title: "黄体期",
       note: "整体保持自然平稳，不额外放大情绪。",
       keys: ["advanced_cycle_luteal_days", "advanced_cycle_luteal_prompt", "advanced_cycle_luteal_mood", "advanced_cycle_luteal_energy"],
     },
@@ -3543,6 +3552,11 @@ const featureSettingSections = {
       title: "PMS 期",
       note: "可以稍微收住语气，但不会变得刻薄或反复提及周期。",
       keys: ["advanced_cycle_pms_days", "advanced_cycle_pms_prompt", "advanced_cycle_pms_mood", "advanced_cycle_pms_energy"],
+    },
+    {
+      title: "经期不适模拟",
+      note: "可选。在月经期、PMS 期等阶段按概率生成短暂的痛经、头痛等不适状态，只作为状态底色，不写成医学结论。",
+      keys: ["advanced_cycle_discomfort_simulation", "advanced_cycle_discomfort_chance", "advanced_cycle_discomfort_types"],
     },
     {
       title: "QQ 状态同步",
@@ -4211,6 +4225,9 @@ const featureSettingTypes = {
   advanced_cycle_pms_days: { type: "number", min: 1, max: 30, step: 1 },
   advanced_cycle_pms_prompt: { type: "textarea" },
   advanced_cycle_pms_energy: { type: "number", min: -50, max: 30, step: 1 },
+  advanced_cycle_discomfort_simulation: { type: "checkbox" },
+  advanced_cycle_discomfort_chance: { type: "number", min: 0, max: 100, step: 1 },
+  advanced_cycle_discomfort_types: { type: "textarea" },
   proactive_reply_context_hours: { type: "number", min: 1, max: 72, step: 1 },
   max_proactive_plan_lag_minutes: { type: "number", min: 5, max: 1440, step: 5 },
   greeting_idle_minutes: { type: "number", min: 0, max: 240, step: 5 },
@@ -10336,6 +10353,16 @@ function dashboardLifeText(value, fallback = "暂无数据") {
   return text || fallback;
 }
 
+function cycleBodyText(daily) {
+  const runtime = daily && daily.cycle_runtime;
+  if (!runtime || !runtime.phase_name || !runtime.day_in_phase) return daily.body_cycle || "";
+  let text = `${runtime.phase_name} 第${runtime.day_in_phase}/${runtime.phase_days}天`;
+  if (runtime.discomfort && runtime.discomfort.length) {
+    text += ` · ${runtime.discomfort.map((item) => item.type || "不适").join("、")}`;
+  }
+  return text;
+}
+
 function renderDashboardLifeDesk(overview = {}) {
   const daily = overview.daily_state || {};
   const life = overview.life_observation || {};
@@ -10358,7 +10385,7 @@ function renderDashboardLifeDesk(overview = {}) {
       ["健康", daily.health],
       ["穿搭", outfit.available ? "今日穿搭已生成" : (outfit.error || "暂无穿搭图")],
       ["睡眠", daily.sleep_phase || daily.sleep],
-      ["身体", daily.body_cycle || daily.hunger],
+      ["身体", cycleBodyText(daily) || daily.hunger],
     ];
     factRoot.innerHTML = facts.map(([label, value]) => `
       <div class="life-fact-item">
@@ -19378,17 +19405,34 @@ function renderDreamCard(dream) {
 }
 
 function renderStatePillBoard(daily) {
+  const runtime = daily && daily.cycle_runtime;
   const items = [
     ["睡眠", daily.sleep],
     ["睡眠阶段", daily.sleep_phase || daily.sleep_runtime?.label],
     ["梦境", daily.dream],
     ["健康", daily.health],
     ["饥饿", daily.hunger],
-    ["生理期状态", daily.body_cycle],
-  ].map(([label, value]) => [label, normalizeRoleplayStateText(value)])
+    ["周期状态", daily.body_cycle],
+  ];
+  if (runtime && runtime.phase_name && runtime.day_in_phase) {
+    items.push([
+      "周期阶段",
+      `${runtime.phase_name} 第${runtime.day_in_phase}/${runtime.phase_days}天 · 周期第${runtime.cycle_day}/${runtime.cycle_days}天` +
+        (runtime.mood ? ` · ${runtime.mood}` : "") +
+        (runtime.next_phase_name ? ` · 下一阶段${runtime.next_phase_name}` : ""),
+    ]);
+  }
+  if (runtime && Array.isArray(runtime.discomfort) && runtime.discomfort.length) {
+    items.push([
+      "经期不适",
+      runtime.discomfort.map((item) => (item.type ? `${item.type}（${item.label || ""}）` : item.label || "")).join("；"),
+    ]);
+  }
+  const normalized = items
+    .map(([label, value]) => [label, normalizeRoleplayStateText(value)])
     .filter(([, value]) => value !== undefined && value !== "");
-  $("#statePillBoard").innerHTML = items.length
-    ? items.map(([label, value]) => `
+  $("#statePillBoard").innerHTML = normalized.length
+    ? normalized.map(([label, value]) => `
       <span>
         <b>${escapeHtml(label)}</b>
         ${escapeHtml(value || "-")}
@@ -25489,7 +25533,7 @@ function featureRelatedSettings(key) {
       advanced_cycle_menstrual_mood: "疲惫",
       advanced_cycle_menstrual_energy: -12,
       advanced_cycle_follicular_days: 5,
-      advanced_cycle_follicular_prompt: "处于卵泡期早，精力平稳回升，心情逐渐轻快",
+      advanced_cycle_follicular_prompt: "处于卵泡期，精力平稳回升，心情逐渐轻快",
       advanced_cycle_follicular_mood: "轻快",
       advanced_cycle_follicular_energy: 0,
       advanced_cycle_pre_ovulation_days: 3,
@@ -25501,13 +25545,16 @@ function featureRelatedSettings(key) {
       advanced_cycle_ovulation_mood: "明朗",
       advanced_cycle_ovulation_energy: 9,
       advanced_cycle_luteal_days: 8,
-      advanced_cycle_luteal_prompt: "处于黄体期早，精力尚可，情绪整体平稳",
+      advanced_cycle_luteal_prompt: "处于黄体期，精力尚可，情绪整体平稳",
       advanced_cycle_luteal_mood: "平稳",
       advanced_cycle_luteal_energy: 5,
       advanced_cycle_pms_days: 6,
       advanced_cycle_pms_prompt: "处于 PMS 期，精力有所下降，情绪波动稍明显",
       advanced_cycle_pms_mood: "敏感",
       advanced_cycle_pms_energy: -8,
+      advanced_cycle_discomfort_simulation: false,
+      advanced_cycle_discomfort_chance: 55,
+      advanced_cycle_discomfort_types: "痛经,头痛,腰酸,乏力",
       auto_voice_enabled: true,
       tts_conversion_scope: "full",
       auto_voice_max_chars: 80,

--- a/plugin_bootstrap.py
+++ b/plugin_bootstrap.py
@@ -546,7 +546,7 @@ def _initialize_world_and_model_config(self: Any, c: Any) -> None:
     self.advanced_cycle_menstrual_energy = self._cfg_int(c, "advanced_cycle_menstrual_energy", -12, -50, 30)
     self.advanced_cycle_follicular_days = self._cfg_int(c, "advanced_cycle_follicular_days", 5, 1, 30)
     self.advanced_cycle_follicular_prompt = self._cfg_str(
-        c, "advanced_cycle_follicular_prompt", "处于卵泡期早，精力平稳回升，心情逐渐轻快"
+        c, "advanced_cycle_follicular_prompt", "处于卵泡期，精力平稳回升，心情逐渐轻快"
     )
     self.advanced_cycle_follicular_mood = self._cfg_str(c, "advanced_cycle_follicular_mood", "轻快")
     self.advanced_cycle_follicular_energy = self._cfg_int(c, "advanced_cycle_follicular_energy", 0, -50, 30)
@@ -564,7 +564,7 @@ def _initialize_world_and_model_config(self: Any, c: Any) -> None:
     self.advanced_cycle_ovulation_energy = self._cfg_int(c, "advanced_cycle_ovulation_energy", 9, -50, 30)
     self.advanced_cycle_luteal_days = self._cfg_int(c, "advanced_cycle_luteal_days", 8, 1, 30)
     self.advanced_cycle_luteal_prompt = self._cfg_str(
-        c, "advanced_cycle_luteal_prompt", "处于黄体期早，精力尚可，情绪整体平稳"
+        c, "advanced_cycle_luteal_prompt", "处于黄体期，精力尚可，情绪整体平稳"
     )
     self.advanced_cycle_luteal_mood = self._cfg_str(c, "advanced_cycle_luteal_mood", "平稳")
     self.advanced_cycle_luteal_energy = self._cfg_int(c, "advanced_cycle_luteal_energy", 5, -50, 30)

--- a/tests/test_advanced_cycle_strategy.py
+++ b/tests/test_advanced_cycle_strategy.py
@@ -12,7 +12,7 @@ from types import SimpleNamespace
 
 from astrbot.core.config.astrbot_config import AstrBotConfig
 from astrbot_plugin_private_companion.daily_state import DailyStateMixin
-from astrbot_plugin_private_companion.helpers import _flat_get
+from astrbot_plugin_private_companion.helpers import _flat_get, _now_ts
 from astrbot_plugin_private_companion.page_api import PrivateCompanionPageApi
 
 
@@ -49,10 +49,16 @@ class _AdvancedCycleHarness(DailyStateMixin):
     def _environment_now(self) -> datetime:
         return datetime(2026, 7, 20, 12, 0, 0)
 
+    def _environment_fromtimestamp(self, timestamp: float) -> datetime:
+        return datetime.fromtimestamp(timestamp)
+
     def _recent_diary_tags(self) -> set[str]:
         return set()
 
     def _weather_summary_text(self, _weather) -> str:
+        return ""
+
+    def _current_location_state_text(self, _state=None) -> str:
         return ""
 
     def _screen_diary_state_condition_spec(self):
@@ -70,10 +76,10 @@ class AdvancedCycleStrategyTests(unittest.IsolatedAsyncioTestCase):
         harness = _AdvancedCycleHarness()
         cases = {
             "处于月经期，身体更容易疲倦": "menstrual",
-            "处于卵泡期早，精力平稳回升": "follicular",
+            "处于卵泡期，精力平稳回升": "follicular",
             "处于排卵前期，身体逐渐轻盈": "pre_ovulation",
             "处于排卵期，精力较充足": "ovulation",
-            "处于黄体期早，情绪整体平稳": "luteal",
+            "处于黄体期，情绪整体平稳": "luteal",
             "处于 PMS 期，情绪波动稍明显": "pms",
         }
         for text, expected in cases.items():
@@ -159,7 +165,8 @@ class AdvancedCycleStrategyTests(unittest.IsolatedAsyncioTestCase):
             intensity=40,
         )
         advanced_result = harness._synchronize_body_cycle_strategy([legacy, marker], 1_700_000_000.0)
-        self.assertEqual([item["kind"] for item in advanced_result], ["manual_state"])
+        self.assertEqual([item["kind"] for item in advanced_result], ["manual_state", "body_cycle"])
+        self.assertEqual(advanced_result[-1]["phase"], "menstrual")
 
         advanced = harness._advanced_cycle_condition("pms")
         harness.enable_advanced_cycle_strategy = False
@@ -171,6 +178,210 @@ class AdvancedCycleStrategyTests(unittest.IsolatedAsyncioTestCase):
         profile = harness._body_cycle_behavior_profile("处于排卵期，精力较充足")
         self.assertIn("不据此强行增加主动消息或亲密程度", profile["influence"])
         self.assertNotIn("必须", profile["influence"])
+
+    def test_first_enable_auto_seeds_cycle_from_menstrual_day_one(self) -> None:
+        harness = _AdvancedCycleHarness()
+        result = harness._synchronize_body_cycle_strategy([], _now_ts())
+        cycle = next(item for item in result if item.get("kind") == "body_cycle")
+        self.assertEqual(cycle["phase"], "menstrual")
+        self.assertEqual(cycle["duration_hours"], 5 * 24)
+        self.assertGreater(harness.data["body_cycle_state"]["cycle_anchor_ts"], 0)
+
+    def test_anchor_drives_continuous_phase_position_without_conditions(self) -> None:
+        harness = _AdvancedCycleHarness()
+        harness.data["body_cycle_state"] = {"cycle_anchor_ts": _now_ts() - 7 * 86400}
+        runtime = harness._advanced_cycle_runtime()
+        self.assertEqual(runtime["phase"], "follicular")
+        self.assertEqual(runtime["day_in_phase"], 3)
+        self.assertEqual(runtime["phase_name"], "卵泡期")
+        self.assertEqual(runtime["cycle_day"], 8)
+        self.assertEqual(runtime["next_phase"], "pre_ovulation")
+        self.assertEqual(runtime["next_phase_name"], "排卵前期")
+
+    def test_runtime_is_empty_before_first_cycle(self) -> None:
+        harness = _AdvancedCycleHarness()
+        self.assertEqual(harness._advanced_cycle_runtime(), {})
+
+    def test_manual_offset_sets_cycle_anchor(self) -> None:
+        harness = _AdvancedCycleHarness()
+        harness.advanced_cycle_start_offset = 12
+        harness._synchronize_body_cycle_strategy([], _now_ts())
+        runtime = harness._advanced_cycle_runtime()
+        self.assertEqual(runtime["phase"], "pre_ovulation")
+        self.assertEqual(runtime["day_in_phase"], 2)
+        self.assertEqual(runtime["cycle_day"], 12)
+
+    def test_reconcile_realigns_stale_condition_to_anchor(self) -> None:
+        harness = _AdvancedCycleHarness()
+        anchor = _now_ts() - 9 * 86400  # cycle day 10 -> follicular day 5
+        harness.data["body_cycle_state"] = {"cycle_anchor_ts": anchor}
+        stale = harness._advanced_cycle_condition("menstrual", duration_hours=24)
+        conditions = harness._reconcile_advanced_cycle_condition([stale], _now_ts())
+        cycle = next(item for item in conditions if item.get("kind") == "body_cycle")
+        self.assertEqual(cycle["phase"], "follicular")
+        self.assertEqual(cycle["start_ts"], anchor + 5 * 86400)
+        self.assertEqual(cycle["end_ts"], anchor + 10 * 86400)
+
+    def test_compose_surfaces_phase_name_day_and_runtime(self) -> None:
+        harness = _AdvancedCycleHarness()
+        harness.data["body_cycle_state"] = {"cycle_anchor_ts": _now_ts() - 86400}
+        state = harness._compose_state_from_conditions()
+        self.assertEqual(state["body_cycle"], "月经期 第2天")
+        runtime = state["cycle_runtime"]
+        self.assertEqual(runtime["phase"], "menstrual")
+        self.assertEqual(runtime["day_in_phase"], 2)
+        self.assertEqual(runtime["phase_name"], "月经期")
+
+    def test_discomfort_picker_respects_toggles_and_phases(self) -> None:
+        harness = _AdvancedCycleHarness()
+        harness.data["body_cycle_state"] = {"cycle_anchor_ts": _now_ts()}
+        # Disabled by default.
+        self.assertIsNone(harness._maybe_pick_cycle_discomfort())
+        harness.advanced_cycle_discomfort_simulation = True
+        harness.advanced_cycle_discomfort_chance = 0
+        self.assertIsNone(harness._maybe_pick_cycle_discomfort())
+        # The zero-chance roll above consumed today's attempt; simulate the
+        # next day so the guaranteed roll below is not blocked by the dedup.
+        harness.data["body_cycle_state"]["last_discomfort_roll_date"] = "2000-01-01"
+        harness.advanced_cycle_discomfort_chance = 100
+        harness.advanced_cycle_discomfort_types = "痛经"
+        condition = harness._maybe_pick_cycle_discomfort()
+        self.assertIsNotNone(condition)
+        self.assertEqual(condition["kind"], "cycle_discomfort")
+        self.assertEqual(condition["phase"], "痛经")
+        self.assertLess(condition["energy_delta"], 0)
+        # A second roll the same day is skipped.
+        harness.data["state_conditions"] = [condition]
+        self.assertIsNone(harness._maybe_pick_cycle_discomfort())
+
+    def test_discomfort_rolls_at_most_once_per_day(self) -> None:
+        harness = _AdvancedCycleHarness()
+        harness.advanced_cycle_discomfort_simulation = True
+        harness.advanced_cycle_discomfort_chance = 100
+        harness.advanced_cycle_discomfort_types = "痛经"
+        harness.data["body_cycle_state"] = {"cycle_anchor_ts": _now_ts()}
+        first = harness._maybe_pick_cycle_discomfort()
+        self.assertIsNotNone(first)
+        # Even with no active discomfort left, the same day gets no second roll.
+        harness.data["state_conditions"] = []
+        self.assertIsNone(harness._maybe_pick_cycle_discomfort())
+
+    def test_discomfort_skipped_without_cycle_allowance_or_intensity(self) -> None:
+        harness = _AdvancedCycleHarness()
+        harness.advanced_cycle_discomfort_simulation = True
+        harness.advanced_cycle_discomfort_chance = 100
+        harness.advanced_cycle_discomfort_types = "痛经"
+        harness.data["body_cycle_state"] = {"cycle_anchor_ts": _now_ts()}
+        harness._persona_state_profile = lambda: {
+            "allow_hunger": False,
+            "allow_health": False,
+            "allow_cycle": False,
+        }
+        self.assertIsNone(harness._maybe_pick_cycle_discomfort())
+        harness._persona_state_profile = lambda: {
+            "allow_hunger": False,
+            "allow_health": False,
+            "allow_cycle": True,
+        }
+        harness.humanized_state_intensity = 0
+        self.assertIsNone(harness._maybe_pick_cycle_discomfort())
+
+    def test_cleanup_drops_cycle_discomfort_when_cycle_or_simulation_off(self) -> None:
+        def make_discomfort(harness: _AdvancedCycleHarness) -> dict:
+            return harness._make_condition(
+                kind="cycle_discomfort",
+                title="经期不适",
+                label="今天有点痛经",
+                mood="疲惫",
+                energy_delta=-12,
+                duration_hours=6,
+                intensity=60,
+                phase="痛经",
+            )
+
+        # allow_cycle off: discomfort pruned together with body_cycle.
+        harness = _AdvancedCycleHarness()
+        harness._persona_state_profile = lambda: {
+            "allow_hunger": False,
+            "allow_health": False,
+            "allow_cycle": False,
+        }
+        harness.data["state_conditions"] = [make_discomfort(harness)]
+        harness._cleanup_expired_conditions()
+        self.assertEqual(harness.data["state_conditions"], [])
+
+        # Advanced strategy off: lingering discomfort pruned.
+        harness = _AdvancedCycleHarness()
+        harness.enable_advanced_cycle_strategy = False
+        harness.advanced_cycle_discomfort_simulation = True
+        harness.data["state_conditions"] = [make_discomfort(harness)]
+        harness._cleanup_expired_conditions()
+        self.assertNotIn(
+            "cycle_discomfort",
+            [item.get("kind") for item in harness.data["state_conditions"] if isinstance(item, dict)],
+        )
+
+        # Simulation toggle off: lingering discomfort pruned.
+        harness = _AdvancedCycleHarness()
+        harness.advanced_cycle_discomfort_simulation = False
+        harness.data["body_cycle_state"] = {"cycle_anchor_ts": _now_ts()}
+        harness.data["state_conditions"] = [make_discomfort(harness)]
+        harness._cleanup_expired_conditions()
+        self.assertNotIn(
+            "cycle_discomfort",
+            [item.get("kind") for item in harness.data["state_conditions"] if isinstance(item, dict)],
+        )
+
+    def test_discomfort_picker_only_fires_in_matching_phases(self) -> None:
+        harness = _AdvancedCycleHarness()
+        harness.advanced_cycle_discomfort_simulation = True
+        harness.advanced_cycle_discomfort_chance = 100
+        harness.advanced_cycle_discomfort_types = "痛经"
+        # Cycle day 8 -> follicular, where 痛经 is not allowed.
+        harness.data["body_cycle_state"] = {"cycle_anchor_ts": _now_ts() - 7 * 86400}
+        self.assertIsNone(harness._maybe_pick_cycle_discomfort())
+
+    def test_cycle_discomfort_ignored_in_compose_without_cycle_allowance(self) -> None:
+        harness = _AdvancedCycleHarness()
+        harness.data["body_cycle_state"] = {"cycle_anchor_ts": _now_ts()}
+        harness._persona_state_profile = lambda: {
+            "allow_hunger": False,
+            "allow_health": False,
+            "allow_cycle": False,
+        }
+        condition = harness._make_condition(
+            kind="cycle_discomfort",
+            title="经期不适",
+            label="今天有点痛经",
+            mood="疲惫",
+            energy_delta=-12,
+            duration_hours=6,
+            intensity=60,
+            phase="痛经",
+        )
+        harness.data["state_conditions"] = [condition]
+        state = harness._compose_state_from_conditions()
+        self.assertFalse(state.get("cycle_runtime"))
+        self.assertEqual(state["body_cycle"], "生理期模拟未开启")
+
+    def test_cycle_discomfort_shows_up_in_composed_runtime(self) -> None:
+        harness = _AdvancedCycleHarness()
+        harness.data["body_cycle_state"] = {"cycle_anchor_ts": _now_ts()}
+        condition = harness._make_condition(
+            kind="cycle_discomfort",
+            title="经期不适",
+            label="今天有点痛经，小腹闷闷地不舒服",
+            mood="疲惫",
+            energy_delta=-14,
+            duration_hours=6,
+            intensity=60,
+            phase="痛经",
+        )
+        harness.data["state_conditions"] = [condition]
+        state = harness._compose_state_from_conditions()
+        discomfort = state["cycle_runtime"]["discomfort"]
+        self.assertEqual(discomfort[0]["type"], "痛经")
+        self.assertIn("痛经", discomfort[0]["label"])
 
 
 class AdvancedCycleConfigTests(unittest.TestCase):
@@ -208,6 +419,9 @@ class AdvancedCycleConfigTests(unittest.TestCase):
             "advanced_cycle_pms_prompt",
             "advanced_cycle_pms_mood",
             "advanced_cycle_pms_energy",
+            "advanced_cycle_discomfort_simulation",
+            "advanced_cycle_discomfort_chance",
+            "advanced_cycle_discomfort_types",
         }
         for key in expected:
             with self.subTest(key=key):
@@ -227,6 +441,9 @@ class AdvancedCycleConfigTests(unittest.TestCase):
             "advanced_cycle_pms_prompt": "语气稍微收一点",
             "advanced_cycle_pms_mood": "敏感",
             "advanced_cycle_pms_energy": -7,
+            "advanced_cycle_discomfort_simulation": True,
+            "advanced_cycle_discomfort_chance": 70,
+            "advanced_cycle_discomfort_types": "痛经,头痛",
         }
 
         with tempfile.TemporaryDirectory() as folder:

--- a/tests/test_cycle_injection.py
+++ b/tests/test_cycle_injection.py
@@ -117,7 +117,7 @@ class CycleInjectionTests(unittest.TestCase):
     def test_non_menstrual_phases_do_not_force_intimacy_refusal(self) -> None:
         for cycle_text in (
             "处于 PMS 期，精力有所下降",
-            "处于卵泡期早，精力平稳回升",
+            "处于卵泡期，精力平稳回升",
             "处于排卵期，精力较充足",
             "生理期后，慢慢回到稳定状态",
             "不处于生理期",

--- a/tests/test_humanized_schedule_ui_grouping.py
+++ b/tests/test_humanized_schedule_ui_grouping.py
@@ -72,7 +72,7 @@ class HumanizedScheduleUiGroupingTests(unittest.TestCase):
         self.assertIn("enable_passive_state_continuity_anchor: {", self.script)
 
     def test_advanced_cycle_settings_are_grouped_and_conditionally_visible(self) -> None:
-        for title in ("周期策略", "月经期", "卵泡期早", "排卵前期", "排卵期", "黄体期早", "PMS 期"):
+        for title in ("周期策略", "月经期", "卵泡期", "排卵前期", "排卵期", "黄体期", "PMS 期", "经期不适模拟"):
             self.assertIn(f'title: "{title}"', self.script)
         for key in (
             "enable_advanced_cycle_strategy",
@@ -86,9 +86,22 @@ class HumanizedScheduleUiGroupingTests(unittest.TestCase):
             "advanced_cycle_pms_prompt",
         ):
             self.assertIn(key, self.script)
+        self.assertIn(
+            'keys: ["advanced_cycle_discomfort_simulation", "advanced_cycle_discomfort_chance", "advanced_cycle_discomfort_types"]',
+            self.script,
+        )
         self.assertIn('settingKey === "enable_advanced_cycle_strategy") return boolSetting("enable_cycle_state")', self.script)
         self.assertIn('!boolSetting("enable_cycle_state") || !boolSetting("enable_advanced_cycle_strategy")', self.script)
         self.assertIn('manualCycleEnergyKeys.has(settingKey) && boolSetting("advanced_cycle_link_intensity")', self.script)
+
+    def test_cycle_discomfort_settings_grouped_right_after_pms_section(self) -> None:
+        marker = 'title: "PMS 期"'
+        pms_index = self.script.index(marker)
+        discomfort_marker = 'title: "经期不适模拟"'
+        discomfort_index = self.script.index(discomfort_marker)
+        self.assertGreater(discomfort_index, pms_index)
+        between = self.script[pms_index + len(marker) : discomfort_index]
+        self.assertNotIn('title: "', between)
 
     def test_advanced_cycle_controls_rerender_without_losing_draft(self) -> None:
         for key in ("enable_cycle_state", "enable_advanced_cycle_strategy", "advanced_cycle_link_intensity"):

--- a/tests/test_req021_q3_group_cycle_privacy.py
+++ b/tests/test_req021_q3_group_cycle_privacy.py
@@ -28,10 +28,10 @@ class GroupCycleBoundaryTests(unittest.TestCase):
     def test_six_phase_labels_classify_without_exposing_an_unrelated_phase(self) -> None:
         cases = {
             "处于月经期": "menstrual",
-            "处于卵泡期早": "follicular",
+            "处于卵泡期": "follicular",
             "处于排卵前期": "pre_ovulation",
             "处于排卵期": "ovulation",
-            "处于黄体期早": "luteal",
+            "处于黄体期": "luteal",
             "处于 PMS 期": "pms",
         }
         for label, phase in cases.items():
@@ -71,7 +71,7 @@ class GroupCycleBoundaryTests(unittest.TestCase):
         non_menstrual = build_group_cycle_boundary(
             enabled=True,
             group_allowed=True,
-            cycle_label="处于卵泡期早",
+            cycle_label="处于卵泡期",
             inbound_text="我们做爱吧",
         )
         self.assertFalse(non_menstrual["private_boundary"])


### PR DESCRIPTION
## 概述

本 PR 完善了六阶段生理周期模块，让当前阶段真正可见且连续，并新增可选的经期不适模拟。

## 主要改动

- **连续相位时间线**：周期以 `cycle_anchor_ts` 时间戳为锚点，当前阶段与第几天始终由锚点推导，停机离线后依然准确。开启策略时会自动播种月经期第 1 天；离线期间过期的周期状态会在恢复后自动对齐到锚点时间线。
- **按阶段展示状态**：总览、状态快照与面板标签现在会显示具体阶段名与天数（如「月经期 第2天」），不再只是笼统的「生理期/未生理期」。注入的提示词描述也改为对应的阶段档案（阶段 + 影响），不再是旧版措辞。
- **Bug 修复**：`next_phase_name` 之前通过阶段迁移键（如 `body_follicular`）查找，导致永远为空；现在会正确映射到阶段名。
- **经期不适模拟**（新增，默认关闭）：`advanced_cycle_discomfort_simulation` / `advanced_cycle_discomfort_chance` / `advanced_cycle_discomfort_types` 可模拟痛经、头痛、腰酸、乏力、情绪低落、恶心。每天最多触发一次，只在各类型允许的阶段内触发，并受 `allow_cycle` 门控。关闭周期策略或不适模拟时，残留的不适状态会被清理。
- **命名优化**：卵泡期/黄体期的显示名去掉了不一致的「早」字后缀。
- **前端面板**：三个新增设置归入新的「经期不适模拟」分组，紧跟在「PMS 期」之后，而不是落在无关的末尾。

## 测试

- 新增 9 个测试，覆盖锚点运行时、自动播种、状态对齐、不适触发去重、阶段门控、许可/强度门控、清理以及合成的运行时状态。
- 更新了前端分组测试，覆盖新分组的插入位置。
- 相关周期测试文件（注入、回复上下文、群聊隐私、前端分组）全部通过。

## 说明

- 本 PR 不包含任何生图模块的改动。