### PR TITLE
Fix/personality sync leak

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -527,8 +527,34 @@ def _text_looks_garbled(text: Any) -> bool:
     return control_count >= 2
 
 
+_PERSONALITY_SYNC_COMMENT_PATTERN = re.compile(
+    r"<!--\s*private_companion_personality_sync_v1\s*-->",
+    re.IGNORECASE,
+)
+_PERSONALITY_SYNC_BLOCK_PATTERN = re.compile(
+    r"<\s*personality_sync\b[^>]*>[\s\S]*?<\s*/\s*personality_sync\s*>",
+    re.IGNORECASE,
+)
+
+
+def _strip_personality_sync_blocks(text: Any) -> str:
+    """Remove complete or truncated internal personality synchronization blocks."""
+    normalized = str(text or "")
+    normalized = _PERSONALITY_SYNC_COMMENT_PATTERN.sub("", normalized)
+    normalized = _PERSONALITY_SYNC_BLOCK_PATTERN.sub("", normalized)
+    # A generation can be cut off before the closing tag is produced.
+    normalized = re.sub(
+        r"<\s*personality_sync\b[^>]*>[\s\S]*$",
+        "",
+        normalized,
+        flags=re.IGNORECASE,
+    )
+    return normalized
+
+
 def _strip_internal_message_blocks(text: Any) -> str:
     normalized = str(text or "")
+    normalized = _strip_personality_sync_blocks(normalized)
     normalized = _strip_group_member_safety_markers(normalized)
     normalized = _strip_history_media_markers(normalized)
     normalized = re.sub(r"\[\[TTSBLOCK:[^\]]*\]\]", "", normalized)
@@ -667,6 +693,7 @@ def _strip_outbound_control_blocks(
     allowed_private_tts_tokens: set[str] | None = None,
 ) -> str:
     normalized = str(text or "")
+    normalized = _strip_personality_sync_blocks(normalized)
     normalized = _strip_group_member_safety_markers(normalized)
     normalized = _strip_history_media_markers(normalized)
     normalized = re.sub(r"\[\[TTSBLOCK:[^\]]*\]\]", "", normalized)

--- a/tests/test_personality_sync_cleanup.py
+++ b/tests/test_personality_sync_cleanup.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import logging
+import sys
+import types
+import unittest
+
+try:
+    from astrbot.api import logger as _astrbot_logger  # noqa: F401
+except ModuleNotFoundError:
+    astrbot_module = types.ModuleType("astrbot")
+    astrbot_api_module = types.ModuleType("astrbot.api")
+    astrbot_api_module.logger = logging.getLogger("personality-sync-cleanup-test")
+    astrbot_module.api = astrbot_api_module
+    sys.modules.setdefault("astrbot", astrbot_module)
+    sys.modules.setdefault("astrbot.api", astrbot_api_module)
+
+from astrbot_plugin_private_companion.helpers import (
+    _strip_internal_message_blocks,
+    _strip_outbound_control_blocks,
+)
+
+
+class PersonalitySyncCleanupTests(unittest.TestCase):
+    def test_complete_block_and_comment_are_removed(self) -> None:
+        raw = """算啦，原谅你了。
+<!-- private_companion_personality_sync_v1 -->
+<personality_sync>
+{"last_interaction_mood": "warm_tease"}
+</personality_sync>"""
+
+        self.assertEqual("算啦，原谅你了。", _strip_internal_message_blocks(raw))
+        self.assertEqual("算啦，原谅你了。", _strip_outbound_control_blocks(raw))
+
+    def test_truncated_block_is_removed(self) -> None:
+        raw = (
+            "我还记得呢。\n"
+            "<personality_sync>\n"
+            '{"last_interaction_mood": "warm_tease"'
+        )
+
+        self.assertEqual("我还记得呢。", _strip_internal_message_blocks(raw))
+        self.assertEqual("我还记得呢。", _strip_outbound_control_blocks(raw))
+
+    def test_case_and_spacing_variants_are_removed(self) -> None:
+        raw = "可见正文< PERSONALITY_SYNC >secret< / PERSONALITY_SYNC >"
+
+        self.assertEqual("可见正文", _strip_outbound_control_blocks(raw))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_personality_sync_cleanup.py
+++ b/tests/test_personality_sync_cleanup.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
-"""Regression tests for internal ``personality_sync`` metadata cleanup.
+"""内部 ``personality_sync`` 元数据清理的回归测试。
 
-Purpose:
-    Ensure internal personality synchronization comments, complete blocks, and
-    truncated blocks never appear in user-visible outbound chat text, while
-    preserving the surrounding visible reply.
+测试目的：
+    确保人格同步注释、完整同步块及被截断的同步块不会出现在用户可见的
+    出站聊天内容中，同时保留同步块前后的正常回复正文。
 
-Run from the parent directory of this plugin package:
+使用方法：
+    在插件目录的上一级执行：
+
     python -m pytest -q \
         astrbot_plugin_private_companion/tests/test_personality_sync_cleanup.py
 
-How it works:
-    Each test passes representative model output directly through the same two
-    cleanup functions used by internal-history and outbound-message pipelines,
-    then compares the result with the exact visible text expected by users.
-    This makes future regressions fail during the test suite before release.
+测试原理：
+    每项测试都会将具有代表性的模型输出传入内部历史和出站消息管线实际
+    使用的两个清理函数，再把处理结果与用户应当看到的正文进行精确比较。
+    如果后续改动导致内部同步数据再次泄漏，测试套件会在发布前直接失败。
 """
 
 from __future__ import annotations

--- a/tests/test_personality_sync_cleanup.py
+++ b/tests/test_personality_sync_cleanup.py
@@ -1,4 +1,22 @@
 # -*- coding: utf-8 -*-
+"""Regression tests for internal ``personality_sync`` metadata cleanup.
+
+Purpose:
+    Ensure internal personality synchronization comments, complete blocks, and
+    truncated blocks never appear in user-visible outbound chat text, while
+    preserving the surrounding visible reply.
+
+Run from the parent directory of this plugin package:
+    python -m pytest -q \
+        astrbot_plugin_private_companion/tests/test_personality_sync_cleanup.py
+
+How it works:
+    Each test passes representative model output directly through the same two
+    cleanup functions used by internal-history and outbound-message pipelines,
+    then compares the result with the exact visible text expected by users.
+    This makes future regressions fail during the test suite before release.
+"""
+
 from __future__ import annotations
 
 import logging


### PR DESCRIPTION
## 问题描述

私聊回复偶发携带内部人格同步数据，并被原样发送到聊天平台：

```html
<!-- private_companion_personality_sync_v1 -->
<personality_sync>
{
  "last_interaction_mood": "warm_tease",
  "perceived_user_state": "apologetic_guilty",
  "relationship_pulse": "stable_intimacy",
  "current_sydney_focus": "reassuring_user"
}
</personality_sync>
```

用户最终会同时看到正常回复和内部 JSON 状态。

## 根因分析

`helpers.py` 中的 `_strip_outbound_control_blocks` 当前会清理：

- `<timer>...</timer>`
- `<think>...</think>`
- `<reasoning>...</reasoning>`
- `[[TTSBLOCK:...]]`
- 部分未知自闭合标签，例如 `<bubble/>`

但 `personality_sync` 使用的是成对标签：

```html
<personality_sync>...</personality_sync>
```

它不属于现有的自闭合标签匹配范围。

同时，前面的 HTML 注释：

```html
<!-- private_companion_personality_sync_v1 -->
```

也没有对应的清理规则。

当模型输出被截断，只生成起始标签而没有结束标签时，现有逻辑同样不能清理残留内容。

## 修复内容

### `helpers.py`

新增统一的 `_strip_personality_sync_blocks` 清理函数：

1. 清理人格同步 HTML 注释标记。
2. 清理完整的 `<personality_sync>...</personality_sync>` 数据块。
3. 清理缺少结束标签的截断数据块。
4. 兼容标签大小写、空格和跨行 JSON。
5. 保留同步块前后的正常可见正文。
6. 同时接入 `_strip_internal_message_blocks` 和 `_strip_outbound_control_blocks`，避免不同消息链路行为不一致。

## 测试

新增测试文件：

```text
tests/test_personality_sync_cleanup.py
```

文件顶部包含中文说明，标明了测试目的、使用方法和测试原理。

测试覆盖：

- 完整注释和完整同步块的清理。
- 正常可见正文的保留。
- 多行 JSON 的清理。
- 缺少结束标签的截断块清理。
- 标签大小写及空格变体。
- 两个出站清理入口的行为一致性。

### 使用方法

在插件目录的上一级执行：

```bash
python -m pytest -q astrbot_plugin_private_companion/tests/test_personality_sync_cleanup.py
```

### 测试原理

测试会将包含完整、截断及格式变体的 `personality_sync` 模拟输出，分别传入内部历史与出站消息实际使用的清理函数，再将处理结果与用户应当看到的正文进行精确比较。

如果后续修改导致内部同步数据再次泄漏，测试将直接失败。

本地验证结果：

```text
3 passed in 0.31s
EXIT_STATUS=0
```

另外执行原项目相关兼容性测试后：

```text
4 passed
```

## 验证结果

### 修复前

```text
算啦，原谅你了。<!-- private_companion_personality_sync_v1 -->
<personality_sync>{"last_interaction_mood":"warm_tease"}</personality_sync>
```

### 修复后

```text
算啦，原谅你了。
```

正常聊天正文得到保留，HTML 注释、人格同步标签和内部 JSON 状态不会进入最终发送消息。