### PR TITLE
fix: 主动消息状态清单收束不再误伤对话式消息

### DIFF
--- a/proactive_message.py
+++ b/proactive_message.py
@@ -338,6 +338,13 @@ _PLATFORM_DISPLAY_NAMES = {
     "discord": "Discord",
 }
 
+# 直接问用户的措辞。复用处：
+#   _trim_performative_self_state_tail 的 asks_user 判据（有问句就不删状态尾巴）
+#   _is_conversational_proactive_text 的对话式守卫（有问句就不收束状态清单）
+_ASK_USER_PROACTIVE_PATTERN = re.compile(
+    r"(你那边|你呢|你那儿|你那里|你现在|你今天|你还|你有没有|你要不要|你是不是)"
+)
+
 
 @dataclass(frozen=True, slots=True)
 class _ProactiveSendOutcome:
@@ -15880,7 +15887,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
         tail = units[-1].strip()
         if not tail:
             return cleaned
-        asks_user = bool(re.search(r"(你那边|你呢|你那儿|你那里|你现在|你今天|你还|你有没有|你要不要|你是不是)", tail))
+        asks_user = bool(_ASK_USER_PROACTIVE_PATTERN.search(tail))
         if asks_user:
             return cleaned
         performative_tail = bool(
@@ -15931,6 +15938,31 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
             return "state"
         return ""
 
+    def _is_conversational_proactive_text(self, text: str) -> bool:
+        """判断主动消息是否为对话式消息，而非状态清单。
+
+        状态清单收束（_trim_proactive_status_inventory）只应作用于「纯陈述、多段自报」的
+        消息；含问句、颜文字/表情或直接问用户的消息是对话，收束会丢掉称呼、问句与情绪，
+        破坏一句话的完整性（例如一条「场景铺垫＋颜文字＋问句」的完整问候被削成只剩一句
+        场景描述）。
+        """
+        cleaned = str(text or "").strip()
+        if not cleaned:
+            return False
+        if _ASK_USER_PROACTIVE_PATTERN.search(cleaned):
+            return True
+        for unit in self._split_proactive_sentence_units(cleaned):
+            unit = unit.strip(" ，,、")
+            if not unit:
+                continue
+            # 问句：以问号结尾，或结尾带疑问语气词（覆盖省略主语的问句）
+            if re.search(r"[？?]$", unit) or re.search(r"[吗呢呀么]$", unit):
+                return True
+            # 颜文字/表情：括号内含非中文散文字符的短表达式，如 (≧▽≦) (◍•ᴗ•◍)
+            if re.search(r"[（(][^（）()\n]*[^一-鿿，。！？、\s][^（）()\n]*[)）]", unit):
+                return True
+        return False
+
     def _trim_proactive_status_inventory(self, text: str) -> str:
         cleaned = str(text or "").strip()
         if not cleaned:
@@ -15948,6 +15980,9 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
         if inventory_count < 2:
             return cleaned
         if len(units) == 2 and inventory_count < len(units):
+            return cleaned
+        # 对话式消息（含问句/颜文字/直接问用户）不是状态清单，收束会破坏其完整性，跳过
+        if self._is_conversational_proactive_text(cleaned):
             return cleaned
         opener = ""
         opener_match = re.match(r"^([\w\u4e00-\u9fffぁ-んァ-ヶー]{1,4}[，,])", units[0])


### PR DESCRIPTION
  ### 问题

  主动消息发送前的「状态清单收束」（`_trim_proactive_status_inventory`）会把一条完整的
  对话式消息误判为多段状态播报，折叠成只剩其中半截——称呼、问句和颜文字全部被丢掉，
  用户收到的是残缺的一句话。

  ### 原因

  收束器只按「≥2 个单元被分类为状态清单（scene/routine/clothing/state）」这一个条件
  触发，只数清单单元个数，不区分消息是不是对话。而场景分类（`_proactive_status_inventory_kind`）
  对词面匹配过宽：单字「雨」「外面」等都会命中 scene，于是一句话里提到两次天气场景，
  就满足了「≥2 个清单单元」的触发条件。`<称呼>＋<场景>＋<场景>＋<颜文字>＋<问句>`
  这类再正常不过的对话式消息，就被误当成状态清单折叠掉了。

  ### 复现方法

  构造一条含 ≥2 个 scene 关键词单元、且带颜文字或问句的主动消息，例如：

  > 雨停了，窗外空气特别清新～(๑•̀ㅂ•́)و 要不要出去走走？

  收束后只剩「窗外空气特别清新」，开头的场景铺垫、颜文字和问句全部丢失。

  ### 修复思路

  给收束器加一道**对话式守卫** `_is_conversational_proactive_text`：消息含问句、颜文字/表情，
  或直接问用户时，判定为对话式消息，跳过收束、整体保留。

  - 直接问用户的判据**复用** `_trim_performative_self_state_tail` 里已有的 asks_user 正则，
    提升为模块常量 `_ASK_USER_PROACTIVE_PATTERN` 两处共用（顺带消除同一正则写两遍的重复）；
  - 问句覆盖省略主语的情况（如「睡醒了吗？」），颜文字判定不误伤中文舞台提示
    （「（轻轻笑了笑）」这类不会触发）；
  - 只拦截「会真的破坏完整句子」的情况——纯陈述的状态清单（无问句、无颜文字、无直呼）