### PR TITLE
修复：天气预警功能拦截等级错位的问题；天气突变主动消息时间间隔控制失效的问题；

### DIFF
--- a/daily_state.py
+++ b/daily_state.py
@@ -4697,7 +4697,11 @@ class DailyStateMixin(DailyStateTickMixin):
                 if _safe_float(old_ts, 0) < cutoff:
                     recent_fingerprints.pop(old_key, None)
             recently_repeated = _safe_float(recent_fingerprints.get(fingerprint), 0) >= cutoff
-            too_soon = now - last_prompted_at < 20 * 60 and _safe_int(change.get("score"), 0) < 90
+            # 通用冷却：距上一次环境突变提示 < cooldown 内，非紧急（score<90）的变化不
+            # 重复开口。不同变化（雨停/下雨/雨势变大）指纹不同，recently_repeated 拦不住；
+            # 旧代码用写死的 20 分钟，cooldown_minutes 只对同指纹去重，360 分钟设置等于
+            # 形同虚设（实测 30-40 分钟就 offer 一条）。score>=90 的极端变化保留逃生口。
+            too_soon = now - last_prompted_at < cooldown_minutes * 60 and _safe_int(change.get("score"), 0) < 90
             if recently_repeated or too_soon:
                 self._schedule_data_save(delay=0.5)
                 return
@@ -5992,10 +5996,15 @@ class DailyStateMixin(DailyStateTickMixin):
             if not isinstance(item, dict):
                 continue
             color = item.get("color_code") or item.get("color") or item.get("level")
-            rank = max(
-                _qweather_alert_rank(color),
-                _qweather_alert_rank(item.get("severity")),
-            )
+            if color:
+                # 颜色等级为准（蓝<黄<橙<红）。不能与 severity 取 max——qweather 的
+                # severity 是国际档位（minor/moderate/severe/extreme），与国内颜色
+                # 错位一档（黄色预警 severity=moderate），max 会让黄色顶穿 orange 阈值
+                # （实测 08-14 黄色暴雨/雷电被误发）。颜色缺失（非中文/全球预警源）才
+                # 退回 severity。
+                rank = _qweather_alert_rank(color)
+            else:
+                rank = _qweather_alert_rank(item.get("severity"))
             if rank >= threshold:
                 result.append(item)
         return result

--- a/tests/test_environment_change_proactive.py
+++ b/tests/test_environment_change_proactive.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 import unittest
 from copy import deepcopy
 
@@ -126,6 +127,34 @@ class EnvironmentChangeProactiveTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(change["kind"], "precipitation_stopped")
         self.assertIn("停", change["topic"])
+
+    async def test_different_change_within_cooldown_is_blocked_but_urgent_escapes(self) -> None:
+        # 回归：旧代码 cooldown 只对同指纹去重，不同变化（雨停/下雨/雨势变大）指纹不同，
+        # 30-40 分钟就 offer 一条（实测 08-14 从 11:53 到 16:13 连发 6 条），360 分钟设置
+        # 形同虚设。修复后 cooldown 成为距上一次提示的通用间隔：非紧急（score<90）变化在
+        # 冷却内被挡；score>=90 的极端变化保留逃生口。
+        harness = self.harness
+        harness.weather_results = [self._weather("当前天气 晴，约 28°C。", 2)]
+        await harness._maybe_refresh_environment_change()
+        state = harness.data["environment_change_awareness"]
+        # 模拟 34 分钟前刚提示过一次环境变化：超过旧代码写死的 20 分钟窗口（旧代码会放行）、
+        # 但在 90 分钟冷却内（修复后应被挡）——正是实测「30-40 分钟连发」的场景。
+        prompted_at = time.time() - 34 * 60
+        state["last_prompted_at"] = prompted_at
+        state["next_check_at"] = 0
+
+        # 非紧急变化：晴→小雨（weather_to_rain，score 86 < 90）→ 冷却内被挡
+        harness.weather_results = [self._weather("当前天气 小雨，约 20°C。", 3)]
+        await harness._maybe_refresh_environment_change()
+        self.assertEqual(harness.offered, [])
+        self.assertEqual(state["last_prompted_at"], prompted_at)
+
+        # 紧急变化：小雨→大雨（weather_to_heavy_rain，score 92 >= 90）→ 突破冷却
+        state["next_check_at"] = 0
+        harness.weather_results = [self._weather("当前天气 大雨，约 20°C。", 4)]
+        await harness._maybe_refresh_environment_change()
+        self.assertEqual(len(harness.offered), 1)
+        self.assertEqual(harness.offered[0]["kind"], "weather_to_heavy_rain")
 
     async def test_environment_change_is_observation_not_external_share(self) -> None:
         semantics = EnvironmentSemanticHarness()._proactive_candidate_semantics(

--- a/tests/test_weather_alerts.py
+++ b/tests/test_weather_alerts.py
@@ -106,6 +106,22 @@ class WeatherAlertTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(self.harness._filter_weather_alerts([alert], "red")), 0)
         self.assertEqual(len(self.harness._filter_weather_alerts([alert], "orange")), 1)
 
+    def test_yellow_alert_with_global_severity_does_not_pass_orange_threshold(self) -> None:
+        # 回归：qweather 国际 severity 档位与国内颜色错位一档（黄色预警 severity=moderate），
+        # 旧代码 max(color, severity) 让黄色顶穿 orange 阈值（实测 08-14 黄色暴雨/雷电被误发）。
+        # 修复后颜色等级为准：黄色=1 < orange=2，必须被挡。
+        yellow = {"id": "y1", "color": "黄色", "color_code": "yellow", "severity": "moderate"}
+        orange = {"id": "o1", "color": "橙色", "color_code": "orange", "severity": "severe"}
+        blue = {"id": "b1", "color": "蓝色", "color_code": "blue", "severity": "minor"}
+        self.assertEqual(len(self.harness._filter_weather_alerts([yellow], "orange")), 0)
+        self.assertEqual(len(self.harness._filter_weather_alerts([orange], "orange")), 1)
+        self.assertEqual(len(self.harness._filter_weather_alerts([blue], "orange")), 0)
+        self.assertEqual(len(self.harness._filter_weather_alerts([yellow, orange], "orange")), 1)
+        # 颜色缺失（非中文/全球预警源）时退回 severity 兜底
+        sev_only = {"id": "s1", "severity": "extreme"}
+        self.assertEqual(len(self.harness._filter_weather_alerts([sev_only], "orange")), 1)
+        self.assertEqual(len(self.harness._filter_weather_alerts([sev_only], "red")), 1)
+
     def test_legacy_warning_payload_and_duplicate_revision_are_supported(self) -> None:
         old_payload = {
             "code": "200",


### PR DESCRIPTION
  ## 问题

  天气/环境主动消息长期占比过高。收紧配置
  `weather_alert_min_severity=orange`、`environment_change_cooldown_minutes=360`
  后，**黄色预警仍会发送、环境突变仍 30-40 分钟一条**，实测被发出的消息：
  - 黄色暴雨 / 黄色雷电预警（本应被 orange 阈值拦截）
  - 雨停 → 下雨 → 雨势变大，一天内连发 6 条（本应被 360 分钟冷却拦住）

  ## 根因与修复

  **1. 预警严重度过滤的量纲错位**（`daily_state.py::_filter_weather_alerts`）
  QWeather 同时返回国内颜色（蓝<黄<橙<红）与国际 severity
  （minor/moderate/severe/extreme）。旧代码取 `max(color_rank, severity_rank)`，
  但两个量纲错位一档：**黄色预警的 severity=moderate，其 rank 恰好等于橙色阈值**，
  于是黄色预警顶穿 orange。修复：**颜色等级为准**，severity 仅在颜色缺失时兜底。

  **2. 环境突变冷却只封同指纹重复**（`daily_state.py::_maybe_refresh_environment_change`）
  `environment_change_cooldown_minutes` 只对相同指纹去重；不同变化（雨停/下雨/雨势变大）
  指纹互不相同，且通用间隔是写死的 20 分钟。修复：**冷却成为距上一次提示的通用间隔**，
  保留 `score>=90` 极端变化的逃生口。

  ## 测试

  新增两个回归测试：
  - `test_yellow_alert_with_global_severity_does_not_pass_orange_threshold`
    —— 黄色+moderate 在 orange 阈值下被拦截；颜色缺失时 severity 兜底仍可用。
  - `test_different_change_within_cooldown_is_blocked_but_urgent_escapes`
    —— 冷却内不同变化被挡，score>=90 可突破。

  两个测试在旧代码下失败、修复后通过；受影响模块测试全绿。

  ## 备注

  旧代码在测试里没暴露问题：`test_weather_alert_lifecycle.py` 的 `_payload()`
  只设 `color` 不设 `severity`，真实 qweather 数据才带 `severity` 字段——
  回归测试补上了这个盲区。