### PR TITLE
feat: enforce deterministic agenda semantics and runtime evidence

### DIFF
--- a/activity_capture.py
+++ b/activity_capture.py
@@ -110,6 +110,9 @@ class ActivityCapture:
                 "visibility": bucket["visibility"],
                 "certainty": "high" if bucket["count"] >= self.min_sustained_messages + 1 else "medium",
                 "status": "active",
+                "actor_type": "bot",
+                "subject_actor_id": "bot_self",
+                "source_actor_id": str(participant or "user").strip() or "system",
             },
             now=event_time,
         )
@@ -141,6 +144,9 @@ class ActivityCapture:
                 "visibility": visibility,
                 "certainty": certainty,
                 "status": "completed" if end_at else "active",
+                "actor_type": "bot",
+                "subject_actor_id": "bot_self",
+                "source_actor_id": str(source or "system").strip() or "system",
             },
             now=start_at,
         )

--- a/agenda_contracts.py
+++ b/agenda_contracts.py
@@ -8,9 +8,10 @@ stored by this module is a plain JSON-compatible dictionary or scalar.
 from __future__ import annotations
 
 from copy import deepcopy
-from datetime import date, datetime, time, timedelta
+from datetime import date, datetime, time, timedelta, timezone
 import hashlib
 import json
+from numbers import Real
 from typing import Any, Iterable
 from zoneinfo import ZoneInfo
 
@@ -29,10 +30,60 @@ except ImportError:  # direct test/import from the plugin directory
 
 
 AGENDA_VERSION = 1
+# ``agenda_version`` is the storage version used by the existing C3 store.  The
+# canonical fields below are additive so old readers can continue to consume
+# the payload.  Keep a separate semantic version for capability checks rather
+# than changing the old storage marker underneath them.
+CANONICAL_SCHEMA_VERSION = 2
+AGENDA_CONTRACT_VERSION = CANONICAL_SCHEMA_VERSION
+AGENDA_SCHEMA_VERSION = CANONICAL_SCHEMA_VERSION
 SCHEDULE_WINDOWS = tuple(_CONTRACT_WINDOWS)
 WINDOW_SLUGS = tuple(_CONTRACT_WINDOW_SLUGS)
 SOURCE_KINDS = {"planned", "observed", "projection", "reconciled"}
 EVIDENCE_LEVELS = {"L0", "L1", "L2", "L3", "L4", "L5"}
+TEMPORAL_PHASES = {"future", "current", "past"}
+EVIDENCE_KINDS = {
+    "none",
+    "interaction",
+    "self_state_commit",
+    "tool_action",
+    "external_record",
+    "external_commitment",
+}
+AUTHORITY_KINDS = {
+    "calendar",
+    "timetable",
+    "roster",
+    "appointment",
+    "user_confirmation",
+    "routine",
+    "persona",
+    "state",
+    "llm",
+}
+COMMITMENT_LEVELS = {"confirmed", "routine", "tentative"}
+EPISTEMIC_STATUSES = {"asserted", "inferred", "observed"}
+CONTENT_GRANULARITIES = {"commitment", "intent", "candidate", "scene"}
+MATERIALIZATION_STATES = {"none", "candidate", "active", "rejected", "expired"}
+FACT_ELIGIBILITIES = {
+    "none",
+    "schedule_commitment",
+    "current_internal",
+    "current_observed",
+    "history_observed",
+}
+ACTOR_TYPES = {"bot", "interlocutor_user", "external_party", "system"}
+# Explicit ``*_VALUES`` aliases make capability probing straightforward while
+# keeping the original set-style constants readable to existing consumers.
+TEMPORAL_PHASE_VALUES = TEMPORAL_PHASES
+EVIDENCE_KIND_VALUES = EVIDENCE_KINDS
+AUTHORITY_KIND_VALUES = AUTHORITY_KINDS
+COMMITMENT_LEVEL_VALUES = COMMITMENT_LEVELS
+EPISTEMIC_STATUS_VALUES = EPISTEMIC_STATUSES
+CONTENT_GRANULARITY_VALUES = CONTENT_GRANULARITIES
+MATERIALIZATION_STATE_VALUES = MATERIALIZATION_STATES
+FACT_ELIGIBILITY_VALUES = FACT_ELIGIBILITIES
+ACTOR_TYPE_VALUES = ACTOR_TYPES
 AGENDA_STATUSES = {
     "planned",
     "active",
@@ -44,6 +95,71 @@ AGENDA_STATUSES = {
     "cancelled",
     "unknown",
 }
+
+# The adapter lives in a small standalone module so callers that only need
+# source verification do not import the full agenda normalizer.  Re-export it
+# here as part of the canonical C3 contract surface.
+try:
+    from .schedule_authority import (
+        RejectedSource,
+        ScheduleAuthorityAdapter,
+        TrustedScheduleRef,
+        VerificationResult,
+        validate_structured_schedule_ref,
+    )
+except ImportError:  # direct test/import from the plugin directory
+    from schedule_authority import (
+        RejectedSource,
+        ScheduleAuthorityAdapter,
+        TrustedScheduleRef,
+        VerificationResult,
+        validate_structured_schedule_ref,
+    )
+
+STATUS_ALIASES = {
+    "in_progress": "active",
+    "in-progress": "active",
+    "ongoing": "active",
+    "done": "completed",
+    "complete": "completed",
+    "changed": "overridden",
+    "rescheduled": "overridden",
+    "postponed": "deferred",
+    "canceled": "cancelled",
+    "revoked": "cancelled",
+}
+
+# Fields are deliberately kept as independent dimensions.  This tuple is
+# useful to consumers that need to copy the canonical contract without
+# silently dropping a newly added field.
+CANONICAL_FIELDS = (
+    "source_kind",
+    "status",
+    "temporal_phase",
+    "evidence_kind",
+    "evidence_level",
+    "canonical_evidence_level",
+    "archive_evidence_level",
+    "evidence_level_mapping",
+    "authority_kind",
+    "commitment_level",
+    "epistemic_status",
+    "content_granularity",
+    "materialization_state",
+    "fact_eligibility",
+    "confidence",
+    "source_refs",
+    "runtime_origin_refs",
+    "expires_at",
+    "actor_type",
+    "subject_actor_id",
+    "object_actor_id",
+    "source_actor_id",
+    "target_user_id",
+    "participant_roles",
+    "decision_trace",
+    "canonical_schema_version",
+)
 
 
 class AgendaContractError(ValueError):
@@ -76,6 +192,114 @@ def _items(value: Any, limit: int = 40) -> list[Any]:
     return deepcopy(value[:limit])
 
 
+def _trace(code: str, message: str = "", **details: Any) -> dict[str, Any]:
+    """Create a compact, JSON-safe normalizer decision record."""
+
+    result: dict[str, Any] = {"code": _text(code, 96)}
+    if message:
+        result["message"] = _text(message, 240)
+    for key, value in details.items():
+        if value is not None:
+            result[key] = deepcopy(value)
+    return result
+
+
+def _trace_list(value: Any) -> list[dict[str, Any]]:
+    """Keep old trace values readable while normalizing new trace entries."""
+
+    if not isinstance(value, (list, tuple)):
+        return []
+    result: list[dict[str, Any]] = []
+    for item in value[:50]:
+        if isinstance(item, dict):
+            result.append(deepcopy(item))
+        elif _text(item, 240):
+            result.append(_trace("legacy_trace", _text(item, 240)))
+    return result
+
+
+def _enum(value: Any, choices: set[str], default: str) -> str:
+    candidate = _text(value, 64).lower()
+    return candidate if candidate in choices else default
+
+
+def _float_confidence(value: Any, default: float = 0.5) -> float:
+    if isinstance(value, bool):
+        return default
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return default
+    if number != number:  # NaN
+        return default
+    return max(0.0, min(1.0, number))
+
+
+def _certainty(value: Any, default: str = "medium") -> Any:
+    """Preserve legacy numeric certainty values exactly as numbers."""
+
+    if isinstance(value, Real) and not isinstance(value, bool):
+        return value
+    return _text(value, 24) or default
+
+
+def _normalize_participant_roles(value: Any, participants: Any = None) -> list[Any]:
+    """Normalize role entries without collapsing actor IDs into one user field."""
+
+    value = value if value is not None else participants
+    if isinstance(value, str):
+        value = [value]
+    if not isinstance(value, (list, tuple, set)):
+        return []
+    result: list[Any] = []
+    for item in value:
+        if isinstance(item, dict):
+            role = deepcopy(item)
+            if role.get("actor_id") is not None:
+                role["actor_id"] = _text(role.get("actor_id"), 120)
+            if role.get("actor_type") is not None:
+                role["actor_type"] = _enum(role.get("actor_type"), ACTOR_TYPES, "external_party")
+            if role.get("role") is not None:
+                role["role"] = _text(role.get("role"), 64)
+            result.append(role)
+        else:
+            item_text = _text(item, 120)
+            if item_text and item_text not in result:
+                result.append(item_text)
+        if len(result) >= 30:
+            break
+    return result
+
+
+def _actor_fields(raw: dict[str, Any], *, default_source_actor: str = "system") -> dict[str, Any]:
+    actor_type = _enum(raw.get("actor_type"), ACTOR_TYPES, "")
+    subject_actor_id = _text(raw.get("subject_actor_id") or raw.get("subject_id"), 120)
+    bot_id = _text(raw.get("bot_id"), 120)
+    if not actor_type and bot_id:
+        actor_type = "bot"
+    if actor_type == "bot" and not subject_actor_id:
+        subject_actor_id = bot_id
+    source_actor_id = _text(raw.get("source_actor_id"), 120) or default_source_actor
+    return {
+        "actor_type": actor_type,
+        "subject_actor_id": subject_actor_id,
+        "object_actor_id": _text(raw.get("object_actor_id"), 120),
+        "source_actor_id": source_actor_id,
+        "target_user_id": _text(raw.get("target_user_id"), 120),
+        "participant_roles": _normalize_participant_roles(raw.get("participant_roles"), raw.get("participants")),
+    }
+
+
+def _evidence_level_mapping(level: str) -> dict[str, Any]:
+    canonical = normalize_evidence_level(level, "L0")
+    archive = canonical if canonical in {"L0", "L1", "L2", "L3"} else "L3"
+    return {
+        "canonical_evidence_level": canonical,
+        "archive_evidence_level": archive,
+        "lossy": canonical != archive,
+    }
+
+
 def _version(value: Any, default: int = 1) -> int:
     try:
         return max(1, int(value or default))
@@ -86,7 +310,7 @@ def _version(value: Any, default: int = 1) -> int:
 def _now_iso(now: datetime | None = None) -> str:
     current = now or datetime.now().astimezone()
     if current.tzinfo is None:
-        current = current.replace(tzinfo=ZoneInfo("Asia/Shanghai"))
+        current = current.replace(tzinfo=timezone_or_default("Asia/Shanghai"))
     return current.isoformat(timespec="seconds")
 
 
@@ -113,7 +337,13 @@ def timezone_or_default(timezone_name: Any = "Asia/Shanghai") -> ZoneInfo:
     try:
         return ZoneInfo(_text(timezone_name, 64) or "Asia/Shanghai")
     except Exception:
-        return ZoneInfo("Asia/Shanghai")
+        # Minimal installations (including the bundled test runtime) may not
+        # ship tzdata.  A fixed +08:00 fallback preserves local calendar
+        # semantics instead of making normalization fail outright.
+        try:
+            return ZoneInfo("Asia/Shanghai")
+        except Exception:
+            return timezone(timedelta(hours=8))  # type: ignore[return-value]
 
 
 def normalize_window(value: Any) -> str:
@@ -249,23 +479,106 @@ def interval_overlaps_window(
 
     if not isinstance(item, dict):
         return False
-    try:
-        item_start = parse_datetime(item.get("start_at") or item.get("start"), timezone_name=timezone_name)
-    except AgendaContractError:
+    # Legacy daily-plan rows carry ``date`` plus bare ``time``/``end`` clocks.
+    # Resolve them through the same helper used by temporal-phase derivation so
+    # a 00:30 item remains attached to the preceding late-night window.
+    item_start = _item_datetime(
+        item,
+        ("start_at", "start", "starts_at", "time"),
+        timezone_name=timezone_name,
+    )
+    if item_start is None:
         return False
-    try:
-        item_end = parse_datetime(
-            item.get("end_at") or item.get("end"),
-            timezone_name=timezone_name,
-            default=item_start,
-        )
-    except AgendaContractError:
+    item_end = _item_datetime(
+        item,
+        ("end_at", "end", "ends_at", "end_time"),
+        timezone_name=timezone_name,
+        default=item_start,
+    )
+    if item_end is None:
         item_end = item_start
     if item_end <= item_start:
-        item_end = item_start + timedelta(seconds=1)
+        raw_start = _text(item.get("start_at") or item.get("start") or item.get("time"), 96)
+        raw_end = _text(item.get("end_at") or item.get("end") or item.get("end_time"), 96)
+        start_clock = raw_start.rsplit("T", 1)[-1][:5] if ":" in raw_start else ""
+        end_clock = raw_end.rsplit("T", 1)[-1][:5] if ":" in raw_end else ""
+        if start_clock and end_clock and end_clock <= start_clock:
+            item_end = item_end + timedelta(days=1)
+        else:
+            item_end = item_start + timedelta(seconds=1)
     start_local = parse_datetime(start, timezone_name=timezone_name)
     end_local = parse_datetime(end, timezone_name=timezone_name)
     return item_start < end_local and item_end > start_local
+
+
+def _item_datetime(
+    item: dict[str, Any],
+    keys: tuple[str, ...],
+    *,
+    timezone_name: str = "Asia/Shanghai",
+    default: datetime | None = None,
+) -> datetime | None:
+    """Resolve an item time, combining legacy ``date`` plus clock fields."""
+
+    value: Any = None
+    for key in keys:
+        if item.get(key) not in (None, ""):
+            value = item.get(key)
+            break
+    if value in (None, ""):
+        return default
+    text = _text(value, 96)
+    # A bare clock must use the plan's date when one is available.  Parsing it
+    # against today's date would make old daily-plan payloads drift silently.
+    if len(text) <= 8 and ":" in text and "T" not in text and "-" not in text:
+        date_text = _text(item.get("date") or item.get("window_date"), 32)
+        if date_text:
+            text = f"{date_text}T{text}"
+    try:
+        return parse_datetime(text, timezone_name=timezone_name, default=default)
+    except AgendaContractError:
+        return default
+
+
+def derive_temporal_phase(
+    item: dict[str, Any],
+    now: datetime | None = None,
+    *,
+    timezone_name: str = "Asia/Shanghai",
+) -> str:
+    """Derive ``future/current/past`` from time bounds only.
+
+    Missing time is conservatively treated as future for a plan (it can still
+    be shown by a future-schedule view) and does not create execution evidence.
+    """
+
+    if not isinstance(item, dict):
+        return "future"
+    current = parse_datetime(now or datetime.now().astimezone(), timezone_name=timezone_name)
+    start = _item_datetime(item, ("start_at", "start", "starts_at", "time"), timezone_name=timezone_name)
+    if start is None:
+        existing = _enum(item.get("temporal_phase"), TEMPORAL_PHASES, "")
+        return existing or "future"
+    end = _item_datetime(item, ("end_at", "end", "ends_at", "end_time"), timezone_name=timezone_name, default=start)
+    if end is None or end <= start:
+        raw_start = _text(item.get("start_at") or item.get("start") or item.get("time"), 96)
+        raw_end = _text(item.get("end_at") or item.get("end") or item.get("end_time"), 96)
+        start_clock = raw_start.rsplit("T", 1)[-1][:5] if ":" in raw_start else ""
+        end_clock = raw_end.rsplit("T", 1)[-1][:5] if ":" in raw_end else ""
+        if start_clock and end_clock and end_clock <= start_clock:
+            end = end + timedelta(days=1) if end is not None else start + timedelta(days=1)
+        else:
+            end = start + timedelta(seconds=1)
+    current = current.astimezone(start.tzinfo)
+    if current < start:
+        return "future"
+    if current >= end:
+        return "past"
+    return "current"
+
+
+def normalize_temporal_phase(value: Any, default: str = "future") -> str:
+    return _enum(value, TEMPORAL_PHASES, default)
 
 
 def normalize_source_kind(value: Any, default: str) -> str:
@@ -280,7 +593,42 @@ def normalize_evidence_level(value: Any, default: str) -> str:
 
 def _normalize_status(value: Any, default: str) -> str:
     candidate = _text(value, 32).lower()
+    candidate = STATUS_ALIASES.get(candidate, candidate)
     return candidate if candidate in AGENDA_STATUSES else default
+
+
+def normalize_status(value: Any, default: str = "unknown") -> str:
+    """Public status adapter shared by disclosure and compatibility readers."""
+
+    return _normalize_status(value, default)
+
+
+def normalize_evidence_kind(value: Any, default: str = "none") -> str:
+    return _enum(value, EVIDENCE_KINDS, default)
+
+
+def normalize_authority_kind(value: Any, default: str = "llm") -> str:
+    return _enum(value, AUTHORITY_KINDS, default)
+
+
+def normalize_commitment_level(value: Any, default: str = "tentative") -> str:
+    return _enum(value, COMMITMENT_LEVELS, default)
+
+
+def normalize_epistemic_status(value: Any, default: str = "inferred") -> str:
+    return _enum(value, EPISTEMIC_STATUSES, default)
+
+
+def normalize_content_granularity(value: Any, default: str = "intent") -> str:
+    return _enum(value, CONTENT_GRANULARITIES, default)
+
+
+def normalize_materialization_state(value: Any, default: str = "none") -> str:
+    return _enum(value, MATERIALIZATION_STATES, default)
+
+
+def normalize_fact_eligibility(value: Any, default: str = "none") -> str:
+    return _enum(value, FACT_ELIGIBILITIES, default)
 
 
 def normalize_plan_item(
@@ -289,27 +637,138 @@ def normalize_plan_item(
     plan_id: str = "",
     now: datetime | None = None,
 ) -> dict[str, Any]:
+    """Normalize an ordinary plan through the C3 write gate.
+
+    Plans describe intent only.  A caller cannot promote one to an observed or
+    completed fact by putting ``status``, ``source_kind`` or evidence fields in
+    JSON.  Reconciliation/authority adapters may write a later status while
+    retaining this normalized plan as their input.
+    """
+
     if not isinstance(raw, dict):
         raise AgendaContractError("plan item must be an object")
     title = _text(raw.get("title") or raw.get("activity") or raw.get("description"), 240)
     if not title:
         raise AgendaContractError("plan item requires a title")
     result = deepcopy(raw)
+    trace = _trace_list(raw.get("decision_trace"))
+    raw_status = _text(raw.get("status") or raw.get("lifecycle_status"), 32).lower()
+    raw_source_kind = _text(raw.get("source_kind"), 32).lower()
+    raw_evidence_kind = _text(raw.get("evidence_kind"), 48).lower()
+    if raw_source_kind and raw_source_kind != "planned":
+        trace.append(_trace("normalizer.forced_source_kind", "ordinary plan source_kind is always planned", requested=raw_source_kind))
+        result["legacy_source_kind"] = raw_source_kind
+    if raw_status and _normalize_status(raw_status, "planned") != "planned":
+        trace.append(_trace("normalizer.forced_status", "ordinary plan status is always planned", requested=raw_status))
+        result["legacy_status"] = raw_status
+    if raw.get("lifecycle_status") not in (None, ""):
+        result["legacy_lifecycle_status"] = _text(raw.get("lifecycle_status"), 32)
+        mapped = _normalize_status(raw.get("lifecycle_status"), "planned")
+        if mapped != "planned":
+            trace.append(_trace("normalizer.lifecycle_status_compat", "legacy lifecycle_status retained for compatibility", requested=mapped))
+    basis = _list(raw.get("basis"))
+    source_refs = _list(raw.get("source_refs"))
+    if basis and not source_refs:
+        trace.append(_trace("normalizer.basis_not_source_refs", "basis is generation input and cannot become evidence references", basis=basis))
+    elif basis:
+        trace.append(_trace("normalizer.basis_ignored", "basis retained as legacy input; source_refs remain explicit only", basis=basis))
+
+    actor = _actor_fields(raw)
+    if not actor["subject_actor_id"]:
+        trace.append(_trace("normalizer.missing_subject", "plan has no subject_actor_id and is diagnostic-only until bound"))
+    epistemic_default = "asserted" if actor.get("actor_type") == "interlocutor_user" else "inferred"
+
+    requested_authority = normalize_authority_kind(raw.get("authority_kind"), "llm")
+    external_authorities = {"calendar", "timetable", "roster", "appointment", "user_confirmation"}
+    explicit_trust = bool(
+        raw.get("source_refs_trusted")
+        or raw.get("trusted_source_refs")
+        or raw.get("trusted_source")
+        or raw.get("authority_verified")
+        or raw.get("source_adapter")
+    )
+    schedule_ref_status = "not_applicable"
+    schedule_ref_reason = ""
+    if requested_authority in external_authorities:
+        schedule_ref_status, schedule_ref_reason = validate_structured_schedule_ref(
+            raw.get("schedule_ref"),
+            source_refs=source_refs,
+            expected_authority=requested_authority,
+            expected_subject=actor.get("subject_actor_id"),
+            expected_target=raw.get("target_user_id"),
+            now=now,
+        )
+        trusted_refs = schedule_ref_status == "valid"
+    else:
+        trusted_refs = explicit_trust
+    authority = requested_authority
+    if requested_authority in external_authorities and not trusted_refs:
+        authority = "llm"
+        result["legacy_authority_kind"] = requested_authority
+        trace.append(
+            _trace(
+                "normalizer.untrusted_authority",
+                "external authority requires an adapter-issued source reference",
+                requested=requested_authority,
+            )
+        )
+    requested_commitment = normalize_commitment_level(raw.get("commitment_level"), "tentative")
+    commitment = requested_commitment
+    if authority in external_authorities and trusted_refs and source_refs:
+        commitment = "confirmed"
+    elif authority == "routine":
+        commitment = "routine"
+    elif authority not in external_authorities and commitment == "confirmed":
+        commitment = "tentative"
+        trace.append(_trace("normalizer.downgraded_commitment", "confirmed commitment requires trusted schedule authority"))
+    if raw_evidence_kind and raw_evidence_kind != "none":
+        trace.append(_trace("normalizer.plan_evidence_rejected", "ordinary plans cannot carry execution evidence", requested=raw_evidence_kind))
+    level = "L0"
+    if raw.get("evidence_level") not in (None, "", "L0", "l0", 0):
+        trace.append(_trace("normalizer.plan_evidence_level_reset", "ordinary plans use L0 until an evidence adapter writes a result", requested=raw.get("evidence_level")))
+    mapping = _evidence_level_mapping(level)
+    phase = derive_temporal_phase(raw, now=now)
+    granularity = normalize_content_granularity(raw.get("content_granularity"), "intent")
+    materialization = normalize_materialization_state(raw.get("materialization_state"), "none")
+    if granularity == "scene" and materialization == "none":
+        materialization = "candidate"
+        trace.append(_trace("normalizer.scene_candidate", "scene-level plan is candidate materialization only"))
+    expires_at = _text(raw.get("expires_at"), 96)
     result.update(
         {
             "plan_id": _text(plan_id or raw.get("plan_id") or raw.get("event_id"), 120)
             or stable_id("plan", title, raw.get("date"), raw.get("time"), raw.get("start_at")),
             "title": title,
             "source_kind": "planned",
-            "evidence_level": normalize_evidence_level(raw.get("evidence_level"), "L0"),
-            "status": _normalize_status(raw.get("status"), "planned"),
+            "status": "planned",
+            "temporal_phase": phase,
+            "evidence_kind": "none",
+            "evidence_level": level,
+            **mapping,
+            "evidence_level_mapping": mapping,
+            "authority_kind": authority,
+            "commitment_level": commitment,
+            "epistemic_status": normalize_epistemic_status(raw.get("epistemic_status"), epistemic_default),
+            "content_granularity": granularity,
+            "materialization_state": materialization,
+            "fact_eligibility": "none",
+            "confidence": _float_confidence(raw.get("confidence"), 0.4),
             "version": _version(raw.get("version")),
-            "source_refs": _list(raw.get("source_refs") or raw.get("basis")),
+            "source_refs": source_refs,
+            "source_refs_trusted": trusted_refs,
+            "schedule_ref_status": schedule_ref_status,
+            "schedule_ref_reason": schedule_ref_reason,
+            "runtime_origin_refs": _list(raw.get("runtime_origin_refs")),
+            "expires_at": expires_at,
+            **actor,
+            "decision_trace": trace,
+            "canonical_schema_version": CANONICAL_SCHEMA_VERSION,
             "visibility": _text(raw.get("visibility"), 32) or "private",
-            "certainty": _text(raw.get("certainty"), 24) or "medium",
+            "certainty": _certainty(raw.get("certainty"), "medium"),
             "updated_at": _text(raw.get("updated_at"), 64) or _now_iso(now),
         }
     )
+    result.pop("lossy", None)
     return result
 
 
@@ -325,6 +784,42 @@ def normalize_observed_activity(
         raise AgendaContractError("observed activity requires a title")
     source_refs = _list(raw.get("source_refs") or raw.get("evidence_refs"))
     result = deepcopy(raw)
+    trace = _trace_list(raw.get("decision_trace"))
+    source_text = _text(raw.get("source"), 64).lower()
+    kind_text = _text(raw.get("kind"), 64).lower()
+    requested_status = _normalize_status(raw.get("status") or raw.get("lifecycle_status"), "active")
+    if raw.get("lifecycle_status") not in (None, ""):
+        result["legacy_lifecycle_status"] = _text(raw.get("lifecycle_status"), 32)
+    if raw.get("status") not in (None, "") and _normalize_status(raw.get("status"), "active") != requested_status:
+        result["legacy_status"] = _text(raw.get("status"), 32)
+    evidence_kind = normalize_evidence_kind(raw.get("evidence_kind"), "")
+    if not evidence_kind:
+        if source_text in {"tool", "tool_action", "api", "browser"} or kind_text in {"tool", "tool_action"}:
+            evidence_kind = "tool_action"
+        elif source_text in {"self_state", "self_state_commit", "runtime"}:
+            evidence_kind = "self_state_commit"
+        elif source_text in {"conversation", "chat", "interaction", "message"} or kind_text in {"conversation", "chat", "interaction"}:
+            evidence_kind = "interaction"
+        else:
+            evidence_kind = "external_record"
+    if requested_status in {"active", "completed", "partially_completed"} and not source_refs and evidence_kind not in {"interaction", "self_state_commit"}:
+        requested_status = "unknown"
+        trace.append(_trace("normalizer.missing_evidence", "observed status requires a concrete evidence reference"))
+    actor = _actor_fields(raw)
+    if not actor["subject_actor_id"]:
+        trace.append(_trace("normalizer.missing_subject", "observed activity has no subject_actor_id and is diagnostic-only until bound"))
+    level = normalize_evidence_level(raw.get("evidence_level"), "L2")
+    mapping = _evidence_level_mapping(level)
+    phase_item = raw
+    if evidence_kind == "self_state_commit" and not any(raw.get(key) for key in ("start_at", "start", "time")):
+        phase_item = dict(raw)
+        phase_item["start_at"] = raw.get("committed_at") or raw.get("created_at")
+        phase_item["end_at"] = raw.get("valid_until") or raw.get("expires_at")
+    phase = derive_temporal_phase(phase_item, now=now)
+    granularity = normalize_content_granularity(raw.get("content_granularity"), "intent" if evidence_kind != "tool_action" else "commitment")
+    materialization = normalize_materialization_state(raw.get("materialization_state"), "active")
+    if evidence_kind == "self_state_commit":
+        materialization = "active"
     result.update(
         {
             "activity_id": _text(raw.get("activity_id") or raw.get("id"), 120)
@@ -335,14 +830,31 @@ def normalize_observed_activity(
             "source": _text(raw.get("source"), 64) or "conversation",
             "source_refs": source_refs,
             "participants": _list(raw.get("participants")),
-            "evidence_level": normalize_evidence_level(raw.get("evidence_level"), "L2"),
+            "evidence_kind": evidence_kind,
+            "evidence_level": level,
+            **mapping,
+            "evidence_level_mapping": mapping,
+            "temporal_phase": phase,
+            "authority_kind": normalize_authority_kind(raw.get("authority_kind"), "state"),
+            "commitment_level": normalize_commitment_level(raw.get("commitment_level"), "tentative"),
+            "epistemic_status": "asserted" if actor.get("actor_type") == "interlocutor_user" and evidence_kind == "interaction" else "observed",
+            "content_granularity": granularity,
+            "materialization_state": materialization,
+            "fact_eligibility": "none",
+            "confidence": _float_confidence(raw.get("confidence"), 0.75),
+            "runtime_origin_refs": _list(raw.get("runtime_origin_refs")),
+            "expires_at": _text(raw.get("expires_at"), 96),
+            **actor,
+            "decision_trace": trace,
+            "canonical_schema_version": CANONICAL_SCHEMA_VERSION,
             "visibility": _text(raw.get("visibility"), 32) or "private",
-            "certainty": _text(raw.get("certainty"), 24) or "medium",
-            "status": _normalize_status(raw.get("status"), "active"),
+            "certainty": _certainty(raw.get("certainty"), "medium"),
+            "status": requested_status,
             "version": _version(raw.get("version")),
             "updated_at": _text(raw.get("updated_at"), 64) or _now_iso(now),
         }
     )
+    result.pop("lossy", None)
     return result
 
 
@@ -358,6 +870,13 @@ def normalize_window_snapshot(
     if not window_date or not window:
         raise AgendaContractError("window snapshot requires window_date and window")
     result = deepcopy(raw)
+    trace = _trace_list(raw.get("decision_trace"))
+    actor = _actor_fields(raw)
+    if not actor["subject_actor_id"]:
+        trace.append(_trace("normalizer.missing_subject", "projection snapshot has no subject_actor_id"))
+    level = normalize_evidence_level(raw.get("evidence_level"), "L2")
+    mapping = _evidence_level_mapping(level)
+    phase = derive_temporal_phase(raw, now=now)
     result.update(
         {
             "snapshot_id": _text(raw.get("snapshot_id"), 160) or stable_id("agenda_snapshot", window_date, window),
@@ -370,15 +889,35 @@ def normalize_window_snapshot(
             "open_items": _list(raw.get("open_items")),
             "source_refs": _list(raw.get("source_refs")),
             "source_kind": "projection",
-            "evidence_level": normalize_evidence_level(raw.get("evidence_level"), "L2"),
+            "evidence_level": level,
+            **mapping,
+            "evidence_level_mapping": mapping,
+            "temporal_phase": phase,
+            "evidence_kind": "none",
+            "authority_kind": "state",
+            "commitment_level": "tentative",
+            "epistemic_status": "inferred",
+            "content_granularity": "intent",
+            "materialization_state": "none",
+            "fact_eligibility": "none",
+            "confidence": _float_confidence(raw.get("confidence"), 0.5),
+            "runtime_origin_refs": _list(raw.get("runtime_origin_refs")),
+            "expires_at": _text(raw.get("expires_at"), 96),
+            **actor,
+            "decision_trace": trace,
+            "canonical_schema_version": CANONICAL_SCHEMA_VERSION,
             "visibility": _text(raw.get("visibility"), 32) or "private",
-            "certainty": _text(raw.get("certainty"), 24) or "medium",
-            "status": _normalize_status(raw.get("status"), "completed"),
+            "certainty": _certainty(raw.get("certainty"), "medium"),
+            # A projection is a snapshot, not proof that every planned item
+            # completed.  Keep it in the C3 reconciliation state until an
+            # evidence adapter provides item-level completion.
+            "status": _normalize_status(raw.get("status"), "reconciled"),
             "version": _version(raw.get("version")),
             "generated_at": _text(raw.get("generated_at"), 64) or _now_iso(now),
             "timezone": _text(raw.get("timezone"), 64) or "Asia/Shanghai",
         }
     )
+    result.pop("lossy", None)
     return result
 
 
@@ -388,6 +927,16 @@ def normalize_reconciliation(raw: dict[str, Any], *, now: datetime | None = None
     window_date = _text(raw.get("window_date") or raw.get("date"), 20)
     window = normalize_window(raw.get("window") or raw.get("slug"))
     result = deepcopy(raw)
+    trace = _trace_list(raw.get("decision_trace"))
+    actor = _actor_fields(raw)
+    if not actor["subject_actor_id"]:
+        trace.append(_trace("normalizer.missing_subject", "reconciliation has no subject_actor_id"))
+    level = normalize_evidence_level(raw.get("evidence_level"), "L3")
+    mapping = _evidence_level_mapping(level)
+    phase = derive_temporal_phase(raw, now=now)
+    reconciliation_evidence_kind = normalize_evidence_kind(raw.get("evidence_kind"), "none")
+    if _list(raw.get("source_refs")) and reconciliation_evidence_kind == "none":
+        trace.append(_trace("normalizer.reconciliation_refs_not_execution", "snapshot/reconciliation refs do not prove execution without an evidence kind"))
     result.update(
         {
             "reconciliation_id": _text(raw.get("reconciliation_id"), 160)
@@ -396,15 +945,32 @@ def normalize_reconciliation(raw: dict[str, Any], *, now: datetime | None = None
             "date": _text(raw.get("date"), 20) or window_date,
             "window": window,
             "source_kind": "reconciled",
-            "evidence_level": normalize_evidence_level(raw.get("evidence_level"), "L3"),
+            "evidence_level": level,
+            **mapping,
+            "evidence_level_mapping": mapping,
+            "temporal_phase": phase,
+            "evidence_kind": reconciliation_evidence_kind,
+            "authority_kind": normalize_authority_kind(raw.get("authority_kind"), "state"),
+            "commitment_level": normalize_commitment_level(raw.get("commitment_level"), "tentative"),
+            "epistemic_status": "observed" if reconciliation_evidence_kind != "none" else "inferred",
+            "content_granularity": normalize_content_granularity(raw.get("content_granularity"), "intent"),
+            "materialization_state": normalize_materialization_state(raw.get("materialization_state"), "none"),
+            "fact_eligibility": "none",
+            "confidence": _float_confidence(raw.get("confidence"), 0.75),
+            "runtime_origin_refs": _list(raw.get("runtime_origin_refs")),
+            "expires_at": _text(raw.get("expires_at"), 96),
+            **actor,
+            "decision_trace": trace,
+            "canonical_schema_version": CANONICAL_SCHEMA_VERSION,
             "visibility": _text(raw.get("visibility"), 32) or "private",
-            "certainty": _text(raw.get("certainty"), 24) or "high",
-            "status": _normalize_status(raw.get("status"), "completed"),
+            "certainty": _certainty(raw.get("certainty"), "high"),
+            "status": _normalize_status(raw.get("status"), "reconciled"),
             "source_refs": _list(raw.get("source_refs")),
             "version": _version(raw.get("version")),
             "generated_at": _text(raw.get("generated_at"), 64) or _now_iso(now),
         }
     )
+    result.pop("lossy", None)
     return result
 
 
@@ -416,6 +982,7 @@ def migrate_store(data: dict[str, Any]) -> tuple[dict[str, Any], bool]:
     changed = False
     defaults: dict[str, Any] = {
         "agenda_version": AGENDA_VERSION,
+        "agenda_contract_version": CANONICAL_SCHEMA_VERSION,
         "observed_activities": [],
         "window_snapshots": [],
         "agenda_reconciliation_history": [],
@@ -440,6 +1007,13 @@ def migrate_store(data: dict[str, Any]) -> tuple[dict[str, Any], bool]:
     if current_version < AGENDA_VERSION:
         data["agenda_version"] = AGENDA_VERSION
         changed = True
+    try:
+        current_contract_version = max(0, int(data.get("agenda_contract_version") or 0))
+    except (TypeError, ValueError):
+        current_contract_version = 0
+    if current_contract_version < CANONICAL_SCHEMA_VERSION:
+        data["agenda_contract_version"] = CANONICAL_SCHEMA_VERSION
+        changed = True
 
     if isinstance(data.get("daily_plan"), dict) and isinstance(data["daily_plan"].get("items"), list):
         migrated_items: list[Any] = []
@@ -448,7 +1022,18 @@ def migrate_store(data: dict[str, Any]) -> tuple[dict[str, Any], bool]:
                 migrated_items.append(item)
                 continue
             try:
-                migrated_items.append(normalize_plan_item(item))
+                # ``daily_plan`` is the Bot-owned C3 edit store.  Bind legacy
+                # rows to that owner during migration so later ``setdefault``
+                # compatibility readers do not mistake an explicitly empty
+                # actor field for an unresolved subject.  Other normalizer
+                # entry points remain strict and keep missing subjects in the
+                # diagnostic view.
+                legacy_plan = dict(item)
+                if not legacy_plan.get("actor_type"):
+                    legacy_plan["actor_type"] = "bot"
+                if not legacy_plan.get("subject_actor_id"):
+                    legacy_plan["subject_actor_id"] = "bot_self"
+                migrated_items.append(normalize_plan_item(legacy_plan))
             except AgendaContractError:
                 migrated_items.append(deepcopy(item))
         if migrated_items != data["daily_plan"]["items"]:
@@ -458,37 +1043,85 @@ def migrate_store(data: dict[str, Any]) -> tuple[dict[str, Any], bool]:
 
 
 def agenda_entry_from_plan(plan: dict[str, Any], *, reason: str = "") -> dict[str, Any]:
+    plan_id = _text(plan.get("plan_id"), 120)
     result = {
-        "entry_id": stable_id("agenda_entry", "plan", plan.get("plan_id")),
+        "entry_id": stable_id("agenda_entry", "plan", plan_id),
         "title": _text(plan.get("title") or plan.get("activity"), 240),
         "kind": "planned",
         "status": _normalize_status(plan.get("status"), "planned"),
         "source_kind": "planned",
         "evidence_level": normalize_evidence_level(plan.get("evidence_level"), "L0"),
         "visibility": _text(plan.get("visibility"), 32) or "private",
-        "certainty": _text(plan.get("certainty"), 24) or "medium",
-        "source_refs": _list(plan.get("source_refs")) or [_text(plan.get("plan_id"), 120)],
+        "certainty": _certainty(plan.get("certainty"), "medium"),
+        # A plan ID identifies an intent, not execution evidence.  Do not put
+        # it into source_refs merely to make the list non-empty.
+        "source_refs": _list(plan.get("source_refs")),
+        "runtime_origin_refs": _list(plan.get("runtime_origin_refs")),
+        "temporal_phase": normalize_temporal_phase(plan.get("temporal_phase"), "future"),
+        "evidence_kind": normalize_evidence_kind(plan.get("evidence_kind"), "none"),
+        "canonical_evidence_level": normalize_evidence_level(plan.get("canonical_evidence_level") or plan.get("evidence_level"), "L0"),
+        "archive_evidence_level": normalize_evidence_level(plan.get("archive_evidence_level"), _evidence_level_mapping(plan.get("evidence_level"))["archive_evidence_level"]),
+        "evidence_level_mapping": deepcopy(plan.get("evidence_level_mapping") or _evidence_level_mapping(plan.get("evidence_level"))),
+        "authority_kind": normalize_authority_kind(plan.get("authority_kind"), "llm"),
+        "commitment_level": normalize_commitment_level(plan.get("commitment_level"), "tentative"),
+        "epistemic_status": normalize_epistemic_status(plan.get("epistemic_status"), "inferred"),
+        "content_granularity": normalize_content_granularity(plan.get("content_granularity"), "intent"),
+        "materialization_state": normalize_materialization_state(plan.get("materialization_state"), "none"),
+        "fact_eligibility": normalize_fact_eligibility(plan.get("fact_eligibility"), "none"),
+        "confidence": _float_confidence(plan.get("confidence"), 0.4),
+        "expires_at": _text(plan.get("expires_at"), 96),
+        "actor_type": _enum(plan.get("actor_type"), ACTOR_TYPES, ""),
+        "subject_actor_id": _text(plan.get("subject_actor_id"), 120),
+        "object_actor_id": _text(plan.get("object_actor_id"), 120),
+        "source_actor_id": _text(plan.get("source_actor_id"), 120) or "system",
+        "target_user_id": _text(plan.get("target_user_id"), 120),
+        "participant_roles": _normalize_participant_roles(plan.get("participant_roles"), plan.get("participants")),
+        "decision_trace": _trace_list(plan.get("decision_trace")),
+        "canonical_schema_version": _version(plan.get("canonical_schema_version"), CANONICAL_SCHEMA_VERSION),
     }
     if reason:
         result["reconciliation_reason"] = reason
-    for key in ("plan_id", "start_at", "end_at", "date", "time", "end", "participants", "version"):
+    for key in ("plan_id", "start_at", "end_at", "date", "time", "end", "participants", "version", "legacy_status", "legacy_lifecycle_status"):
         if key in plan:
             result[key] = deepcopy(plan[key])
     return result
 
 
 def agenda_entry_from_activity(activity: dict[str, Any], *, source_refs: Iterable[str] = ()) -> dict[str, Any]:
-    refs = _list(list(source_refs)) or _list(activity.get("source_refs")) or [_text(activity.get("activity_id"), 120)]
+    refs = _list(list(source_refs)) or _list(activity.get("source_refs"))
+    level = normalize_evidence_level(activity.get("evidence_level"), "L2")
     result = {
         "entry_id": stable_id("agenda_entry", "activity", activity.get("activity_id")),
         "title": _text(activity.get("title"), 240),
         "kind": "observed",
         "status": _normalize_status(activity.get("status"), "active"),
         "source_kind": "observed",
-        "evidence_level": normalize_evidence_level(activity.get("evidence_level"), "L2"),
+        "evidence_level": level,
+        "canonical_evidence_level": normalize_evidence_level(activity.get("canonical_evidence_level") or level, level),
+        "archive_evidence_level": normalize_evidence_level(activity.get("archive_evidence_level"), _evidence_level_mapping(level)["archive_evidence_level"]),
+        "evidence_level_mapping": deepcopy(activity.get("evidence_level_mapping") or _evidence_level_mapping(level)),
+        "temporal_phase": normalize_temporal_phase(activity.get("temporal_phase"), "current"),
+        "evidence_kind": normalize_evidence_kind(activity.get("evidence_kind"), "external_record"),
+        "authority_kind": normalize_authority_kind(activity.get("authority_kind"), "state"),
+        "commitment_level": normalize_commitment_level(activity.get("commitment_level"), "tentative"),
+        "epistemic_status": normalize_epistemic_status(activity.get("epistemic_status"), "observed"),
+        "content_granularity": normalize_content_granularity(activity.get("content_granularity"), "intent"),
+        "materialization_state": normalize_materialization_state(activity.get("materialization_state"), "active"),
+        "fact_eligibility": normalize_fact_eligibility(activity.get("fact_eligibility"), "none"),
+        "confidence": _float_confidence(activity.get("confidence"), 0.75),
         "visibility": _text(activity.get("visibility"), 32) or "private",
-        "certainty": _text(activity.get("certainty"), 24) or "medium",
+        "certainty": _certainty(activity.get("certainty"), "medium"),
         "source_refs": refs,
+        "runtime_origin_refs": _list(activity.get("runtime_origin_refs")),
+        "expires_at": _text(activity.get("expires_at"), 96),
+        "actor_type": _enum(activity.get("actor_type"), ACTOR_TYPES, ""),
+        "subject_actor_id": _text(activity.get("subject_actor_id"), 120),
+        "object_actor_id": _text(activity.get("object_actor_id"), 120),
+        "source_actor_id": _text(activity.get("source_actor_id"), 120) or "system",
+        "target_user_id": _text(activity.get("target_user_id"), 120),
+        "participant_roles": _normalize_participant_roles(activity.get("participant_roles"), activity.get("participants")),
+        "decision_trace": _trace_list(activity.get("decision_trace")),
+        "canonical_schema_version": _version(activity.get("canonical_schema_version"), CANONICAL_SCHEMA_VERSION),
     }
     for key in ("activity_id", "start_at", "end_at", "participants", "version", "kind"):
         if key in activity:

--- a/agenda_disclosure.py
+++ b/agenda_disclosure.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""Backward-compatible import alias for the canonical disclosure policy."""
+
+try:
+    from .agenda_disclosure_policy import *  # noqa: F401,F403
+except ImportError:
+    from agenda_disclosure_policy import *  # noqa: F401,F403
+

--- a/agenda_disclosure_policy.py
+++ b/agenda_disclosure_policy.py
@@ -1,0 +1,913 @@
+# -*- coding: utf-8 -*-
+"""Deterministic disclosure firewall for canonical C3 agenda records.
+
+The policy is intentionally independent from the reconciliation writer.  It
+computes a purpose-specific view from already stored agenda candidates and
+never upgrades a plan to an execution fact merely because its time has passed.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Any, Iterable, Iterator, Mapping
+
+try:
+    from .schedule_authority import ScheduleAuthorityAdapter, validate_structured_schedule_ref
+except ImportError:
+    from schedule_authority import ScheduleAuthorityAdapter, validate_structured_schedule_ref
+
+try:  # package import
+    from .agenda_contracts import (
+        ACTOR_TYPES,
+        AGENDA_STATUSES,
+        AUTHORITY_KINDS,
+        COMMITMENT_LEVELS,
+        CONTENT_GRANULARITIES,
+        EPISTEMIC_STATUSES,
+        EVIDENCE_KINDS,
+        FACT_ELIGIBILITIES,
+        MATERIALIZATION_STATES,
+        TEMPORAL_PHASES,
+        derive_temporal_phase,
+        normalize_authority_kind,
+        normalize_commitment_level,
+        normalize_content_granularity,
+        normalize_evidence_kind,
+        normalize_evidence_level,
+        normalize_epistemic_status,
+        normalize_fact_eligibility,
+        normalize_materialization_state,
+        normalize_status,
+        parse_datetime,
+        stable_id,
+        timezone_or_default,
+    )
+except ImportError:  # direct test/import from the plugin directory
+    from agenda_contracts import (
+        ACTOR_TYPES,
+        AGENDA_STATUSES,
+        AUTHORITY_KINDS,
+        COMMITMENT_LEVELS,
+        CONTENT_GRANULARITIES,
+        EPISTEMIC_STATUSES,
+        EVIDENCE_KINDS,
+        FACT_ELIGIBILITIES,
+        MATERIALIZATION_STATES,
+        TEMPORAL_PHASES,
+        derive_temporal_phase,
+        normalize_authority_kind,
+        normalize_commitment_level,
+        normalize_content_granularity,
+        normalize_evidence_kind,
+        normalize_evidence_level,
+        normalize_epistemic_status,
+        normalize_fact_eligibility,
+        normalize_materialization_state,
+        normalize_status,
+        parse_datetime,
+        stable_id,
+        timezone_or_default,
+    )
+
+
+DISCLOSURE_PURPOSES = frozenset(
+    {
+        "current_fact",
+        "history_fact",
+        "future_schedule",
+        "schedule_commitment",
+        "proactive",
+        "memory_write",
+        "diagnostic",
+    }
+)
+
+# This is deliberately data, not a second lifecycle state machine.  The
+# contract values are interpreted below and remain the single source of truth.
+DISCLOSURE_PURPOSE_MATRIX: dict[str, dict[str, Any]] = {
+    "current_fact": {
+        "eligibilities": {"current_observed", "current_internal"},
+        "description": "evidence-backed current activity or a short-lived Bot internal state",
+    },
+    "history_fact": {
+        "eligibilities": {"history_observed"},
+        "description": "evidence-backed completed or observed history",
+    },
+    "future_schedule": {
+        "eligibilities": {"schedule_commitment"},
+        "description": "future commitments and explicitly labelled soft plans",
+    },
+    "schedule_commitment": {
+        "eligibilities": {"schedule_commitment"},
+        "description": "valid external schedule commitment only",
+    },
+    "proactive": {
+        "eligibilities": {"schedule_commitment", "current_internal"},
+        "description": "near-term, minimum-necessary proactive context",
+    },
+    "memory_write": {
+        "eligibilities": {"current_observed", "history_observed", "schedule_commitment"},
+        "description": "structured hard facts and TTL-bound plans",
+    },
+    "diagnostic": {
+        "eligibilities": set(FACT_ELIGIBILITIES),
+        "description": "all candidates plus filtering decisions",
+    },
+}
+
+# Short alias used by callers that refer to the matrix as ``USE_MATRIX``.
+USE_MATRIX = DISCLOSURE_PURPOSE_MATRIX
+DISCLOSURE_MATRIX = DISCLOSURE_PURPOSE_MATRIX
+
+SELF_STATE_ALLOWED = frozenset({"在休息", "陪你聊天", "准备出门", "切到学习状态"})
+
+
+@dataclass
+class DisclosureView(Mapping[str, Any]):
+    """Stable, JSON-compatible result of :meth:`AgendaDisclosurePolicy.build_view`."""
+
+    entries: list[dict[str, Any]] = field(default_factory=list)
+    redactions: list[dict[str, Any]] = field(default_factory=list)
+    source_refs: list[str] = field(default_factory=list)
+    decision_trace: list[dict[str, Any]] = field(default_factory=list)
+    purpose: str = "diagnostic"
+    generated_at: str = ""
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "entries": deepcopy(self.entries),
+            "redactions": deepcopy(self.redactions),
+            "source_refs": list(self.source_refs),
+            "decision_trace": deepcopy(self.decision_trace),
+            "purpose": self.purpose,
+            "generated_at": self.generated_at,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return self.as_dict()
+
+    # Mapping compatibility makes the view convenient for old callers that
+    # expected a dictionary while exposing attributes for new code.
+    def __getitem__(self, key: str) -> Any:
+        return self.as_dict()[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(("entries", "redactions", "source_refs", "decision_trace", "purpose", "generated_at"))
+
+    def __len__(self) -> int:
+        return 6
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self.as_dict().get(key, default)
+
+
+class AgendaDisclosurePolicy:
+    """Apply actor, time, evidence and purpose gates to agenda candidates."""
+
+    PURPOSES = DISCLOSURE_PURPOSES
+    PURPOSE_MATRIX = DISCLOSURE_PURPOSE_MATRIX
+    USE_MATRIX = DISCLOSURE_PURPOSE_MATRIX
+    # Soft proactive content should be close to now; hard commitments can be
+    # surfaced across the configured future horizon.
+    proactive_soft_horizon = timedelta(hours=2)
+    proactive_hard_horizon = timedelta(hours=24)
+
+    def __init__(
+        self,
+        *,
+        bot_id: str = "",
+        target_user_id: str = "",
+        timezone_name: str = "Asia/Shanghai",
+        proactive_horizon: timedelta | None = None,
+        schedule_authority: Any = None,
+    ) -> None:
+        self.bot_id = str(bot_id or "").strip()
+        self.target_user_id = str(target_user_id or "").strip()
+        self.timezone_name = str(timezone_name or "Asia/Shanghai")
+        self.schedule_authority = schedule_authority if hasattr(schedule_authority, "verify") else None
+        if proactive_horizon is not None:
+            self.proactive_hard_horizon = proactive_horizon
+
+    def build_view(
+        self,
+        agenda: Mapping[str, Any] | Iterable[Mapping[str, Any]] | None,
+        now: datetime | None,
+        purpose: str,
+        target_user_id: str | None = None,
+        max_entries: int | None = None,
+    ) -> DisclosureView:
+        purpose_text = str(purpose or "").strip().lower()
+        if purpose_text not in DISCLOSURE_PURPOSES:
+            raise ValueError(f"unknown agenda disclosure purpose: {purpose!r}")
+        current = self._coerce_now(now)
+        context = agenda if isinstance(agenda, Mapping) else {}
+        bot_id = self.bot_id or str(context.get("bot_id") or "").strip()
+        effective_target_user_id = (
+            str(target_user_id).strip()
+            if target_user_id is not None
+            else self.target_user_id or str(context.get("target_user_id") or "").strip()
+        )
+        candidates = self._collect_candidates(agenda)
+        # Infer a Bot ID only from an explicitly typed Bot subject.  Never use
+        # target_user_id as the agenda owner.
+        if not bot_id:
+            for item in candidates:
+                if str(item.get("actor_type") or "").strip().lower() == "bot" and item.get("subject_actor_id"):
+                    bot_id = str(item.get("subject_actor_id"))
+                    break
+
+        canonical_candidates = [
+            self._canonical_candidate(raw, current, index=index)
+            for index, raw in enumerate(candidates)
+        ]
+        self._mark_stale_schedule_revisions(canonical_candidates, current)
+
+        entries: list[dict[str, Any]] = []
+        redactions: list[dict[str, Any]] = []
+        source_refs: list[str] = []
+        trace: list[dict[str, Any]] = []
+        for candidate in canonical_candidates:
+            candidate["_bot_id"] = bot_id
+            candidate["_target_user_id"] = effective_target_user_id
+            allowed, eligibility, reasons = self._decide(candidate, purpose_text, current)
+            candidate["fact_eligibility"] = eligibility
+            decision = {
+                "entry_id": candidate["entry_id"],
+                "purpose": purpose_text,
+                "temporal_phase": candidate["temporal_phase"],
+                "status": candidate["status"],
+                "evidence_kind": candidate["evidence_kind"],
+                "fact_eligibility": eligibility,
+                "allowed": bool(allowed),
+                "reasons": list(reasons),
+            }
+            trace.append(decision)
+            if allowed:
+                public = self._public_entry(candidate, purpose_text, eligibility)
+                entries.append(public)
+                for ref in public.get("source_refs") or []:
+                    if ref not in source_refs:
+                        source_refs.append(ref)
+            else:
+                redactions.append(
+                    {
+                        "entry_id": candidate["entry_id"],
+                        "purpose": purpose_text,
+                        "reason": reasons[0] if reasons else "purpose_filtered",
+                        "reasons": list(reasons) if reasons else ["purpose_filtered"],
+                    }
+                )
+
+            # Existing normalizer decisions are useful in diagnostics and in
+            # the audit trail, but never flow into the public entries.
+            for item_trace in candidate.get("decision_trace") or []:
+                trace.append(
+                    {
+                        "entry_id": candidate["entry_id"],
+                        "purpose": purpose_text,
+                        "allowed": bool(allowed),
+                        "stage": "normalizer",
+                        **deepcopy(item_trace),
+                    }
+                )
+
+        if purpose_text == "diagnostic":
+            # Diagnostic consumers need all source references, including ones
+            # rejected for ordinary disclosure, to explain a downgrade.
+            source_refs = []
+            for raw in candidates:
+                for ref in self._refs(raw.get("source_refs")):
+                    if ref not in source_refs:
+                        source_refs.append(ref)
+            diagnostic_entries: list[dict[str, Any]] = []
+            for i, raw in enumerate(candidates):
+                diagnostic_candidate = canonical_candidates[i]
+                diagnostic_candidate["_bot_id"] = bot_id
+                diagnostic_candidate["_target_user_id"] = effective_target_user_id
+                _diag_allowed, diag_eligibility, diag_reasons = self._decide(diagnostic_candidate, purpose_text, current)
+                diagnostic_candidate["fact_eligibility"] = diag_eligibility
+                diagnostic_candidate["diagnostic_reasons"] = diag_reasons
+                diagnostic_entries.append(self._diagnostic_entry(diagnostic_candidate))
+            entries = diagnostic_entries
+        if max_entries is not None:
+            try:
+                entries = entries[: max(0, int(max_entries))]
+            except (TypeError, ValueError):
+                pass
+        return DisclosureView(
+            entries=entries,
+            redactions=redactions,
+            source_refs=source_refs,
+            decision_trace=trace,
+            purpose=purpose_text,
+            generated_at=current.isoformat(timespec="seconds"),
+        )
+
+    def _coerce_now(self, now: datetime | None) -> datetime:
+        value = now or datetime.now().astimezone()
+        try:
+            return parse_datetime(value, timezone_name=self.timezone_name)
+        except Exception:
+            return value if value.tzinfo else value.replace(tzinfo=timezone_or_default(self.timezone_name))
+
+    @staticmethod
+    def _refs(value: Any) -> list[str]:
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, (list, tuple, set)):
+            return []
+        result: list[str] = []
+        for item in value:
+            text = str(item or "").strip()[:200]
+            if text and text not in result:
+                result.append(text)
+            if len(result) >= 50:
+                break
+        return result
+
+    def _collect_candidates(self, agenda: Any) -> list[dict[str, Any]]:
+        if isinstance(agenda, (list, tuple)):
+            return [deepcopy(item) for item in agenda if isinstance(item, Mapping)]
+        if not isinstance(agenda, Mapping):
+            return []
+        ordered: list[dict[str, Any]] = []
+        entries = agenda.get("entries")
+        if isinstance(entries, list) and entries:
+            ordered.extend(deepcopy(item) for item in entries if isinstance(item, Mapping))
+        else:
+            for key in ("plans", "planned", "activities", "observed", "reconciliations", "reconciled"):
+                value = agenda.get(key)
+                if isinstance(value, list):
+                    ordered.extend(deepcopy(item) for item in value if isinstance(item, Mapping))
+            if isinstance(agenda.get("current"), Mapping):
+                ordered.append(deepcopy(agenda["current"]))
+            if not ordered and any(agenda.get(key) not in (None, "") for key in ("title", "activity", "summary", "plan_id", "activity_id", "event_id")):
+                ordered.append(deepcopy(dict(agenda)))
+        # Keep same-ID plan and activity records separate, but avoid exact
+        # duplicates produced by nested C3 views.
+        result: list[dict[str, Any]] = []
+        seen: set[tuple[str, str]] = set()
+        for item in ordered:
+            ident = str(item.get("entry_id") or item.get("plan_id") or item.get("activity_id") or item.get("event_id") or "").strip()
+            kind = str(item.get("kind") or item.get("source_kind") or "").strip().lower()
+            key = (ident, kind) if ident else (stable_id("disclosure", item.get("title") or item.get("activity"), item.get("start_at") or item.get("start")), kind)
+            if key in seen:
+                continue
+            seen.add(key)
+            result.append(item)
+        return result
+
+    @staticmethod
+    def _revision_key(value: Any) -> tuple[Any, ...]:
+        import re
+
+        text = str(value or "").strip()[:80]
+        parts: list[tuple[int, Any]] = []
+        for part in re.split(r"([0-9]+)", text):
+            if part.isdigit():
+                parts.append((1, int(part)))
+            elif part:
+                parts.append((0, part.lower()))
+        return tuple(parts)
+
+    def _verify_schedule_ref(
+        self,
+        candidate: Mapping[str, Any],
+        refs: list[str],
+        now: datetime,
+    ) -> tuple[str, str, bool]:
+        """Verify the structured authority binding without trusting labels."""
+        status, reason = validate_structured_schedule_ref(
+            candidate.get("schedule_ref"),
+            source_refs=refs,
+            expected_authority=candidate.get("authority_kind"),
+            expected_subject=candidate.get("subject_actor_id"),
+            expected_target=candidate.get("target_user_id"),
+            now=now,
+            adapter=self.schedule_authority,
+        )
+        return status, reason, status != "invalid"
+
+    def _mark_stale_schedule_revisions(self, candidates: list[dict[str, Any]], now: datetime) -> None:
+        """Keep only the latest structurally valid source revision per event."""
+
+        groups: dict[tuple[str, str], list[dict[str, Any]]] = {}
+        for candidate in candidates:
+            if not candidate.get("_schedule_ref_structurally_valid"):
+                continue
+            ref = candidate.get("schedule_ref")
+            if not isinstance(ref, Mapping):
+                continue
+            key = (str(ref.get("namespace") or ""), str(ref.get("event_id") or ""))
+            if key != ("", ""):
+                groups.setdefault(key, []).append(candidate)
+        for group in groups.values():
+            if len(group) < 2:
+                continue
+
+            def rank(item: Mapping[str, Any]) -> tuple[Any, ...]:
+                ref = item.get("schedule_ref") if isinstance(item.get("schedule_ref"), Mapping) else {}
+                updated = str(ref.get("updated_at") or "")
+                try:
+                    updated_key: Any = parse_datetime(updated, timezone_name=self.timezone_name)
+                except Exception:
+                    updated_key = datetime.min.replace(tzinfo=now.tzinfo)
+                # Revision is the provider's explicit ordering; updated_at
+                # breaks ties for providers that reuse opaque revision IDs.
+                return (self._revision_key(ref.get("revision")), updated_key)
+
+            winner = max(group, key=rank)
+            for candidate in group:
+                if candidate is not winner:
+                    candidate["_schedule_revision_superseded"] = True
+                    candidate["_schedule_ref_reason"] = "schedule_revision_superseded"
+
+    def _canonical_candidate(self, raw: Mapping[str, Any], now: datetime, *, index: int = 0) -> dict[str, Any]:
+        candidate = deepcopy(dict(raw))
+        title = str(candidate.get("title") or candidate.get("activity") or candidate.get("summary") or candidate.get("description") or "").strip()[:240]
+        candidate["title"] = title
+        candidate["entry_id"] = str(candidate.get("entry_id") or candidate.get("plan_id") or candidate.get("activity_id") or candidate.get("event_id") or stable_id("disclosure", title, candidate.get("start_at") or candidate.get("start"), index))
+        source_kind = str(candidate.get("source_kind") or "").strip().lower()
+        if source_kind not in {"planned", "observed", "projection", "reconciled"}:
+            source_kind = "observed" if str(candidate.get("kind") or "").lower() == "observed" else "planned"
+        candidate["source_kind"] = source_kind
+        legacy_status = candidate.get("status") if candidate.get("status") not in (None, "") else candidate.get("lifecycle_status")
+        status = normalize_status(legacy_status, "active" if source_kind == "observed" else "planned")
+        evidence_kind = normalize_evidence_kind(candidate.get("evidence_kind"), "")
+        source_text = str(candidate.get("source") or "").strip().lower()
+        kind_text = str(candidate.get("kind") or "").strip().lower()
+        if not evidence_kind:
+            if source_kind == "planned":
+                evidence_kind = "none"
+            elif source_text in {"tool", "tool_action", "api", "browser"} or kind_text in {"tool", "tool_action"}:
+                evidence_kind = "tool_action"
+            elif source_text in {"self_state", "self_state_commit", "runtime"}:
+                evidence_kind = "self_state_commit"
+            elif source_text in {"conversation", "chat", "interaction", "message"} or kind_text in {"conversation", "chat", "interaction"}:
+                evidence_kind = "interaction"
+            else:
+                evidence_kind = "external_record" if source_kind == "observed" else "none"
+        candidate["evidence_kind"] = evidence_kind
+        # Statuses on ordinary plans are never evidence; leave reconciler
+        # results visible only when an explicit compatible evidence kind exists.
+        if source_kind == "planned" and status != "planned" and evidence_kind == "none":
+            candidate["legacy_status"] = legacy_status
+            status = "unknown"
+        candidate["status"] = status
+        refs = self._refs(candidate.get("source_refs"))
+        candidate["source_refs"] = refs
+        candidate["runtime_origin_refs"] = self._refs(candidate.get("runtime_origin_refs"))
+        # A reference is never trusted merely because it is non-empty.  Hard
+        # schedule authorities must carry a complete adapter-issued
+        # ``schedule_ref`` whose stable ref_id is present in source_refs.
+        trust_keys = ("source_refs_trusted", "trusted_source_refs", "authority_verified")
+        explicit_trust = any(bool(candidate.get(key)) for key in trust_keys)
+        explicit_denied = any(
+            key in candidate
+            and str(candidate.get(key)).strip().lower() in {"false", "no", "denied", "invalid", "revoked"}
+            for key in trust_keys
+        )
+        candidate["source_refs_trusted"] = explicit_trust
+        authority = normalize_authority_kind(candidate.get("authority_kind"), "llm" if source_kind == "planned" else "state")
+        candidate["authority_kind"] = authority
+        commitment = normalize_commitment_level(candidate.get("commitment_level"), "tentative")
+        if authority == "routine":
+            commitment = "routine"
+        candidate["_schedule_ref_status"] = "not_applicable"
+        candidate["_schedule_ref_reason"] = ""
+        candidate["_schedule_ref_structurally_valid"] = False
+        if authority in {"calendar", "timetable", "roster", "appointment", "user_confirmation"}:
+            schedule_status, schedule_reason, schedule_structural = self._verify_schedule_ref(candidate, refs, now)
+            candidate["_schedule_ref_status"] = schedule_status
+            candidate["_schedule_ref_reason"] = schedule_reason
+            candidate["_schedule_ref_structurally_valid"] = schedule_structural
+            candidate["source_refs_trusted"] = bool(schedule_status == "valid" and not explicit_denied)
+            if schedule_structural and isinstance(candidate.get("schedule_ref"), Mapping):
+                # Disclosure timing comes from the signed reference, not from
+                # caller-controlled duplicate clock fields.
+                candidate["start_at"] = candidate["schedule_ref"].get("effective_from")
+                candidate["end_at"] = candidate["schedule_ref"].get("effective_to")
+        if authority in {"calendar", "timetable", "roster", "appointment", "user_confirmation"} and refs and candidate["source_refs_trusted"]:
+            commitment = "confirmed"
+        elif authority in {"calendar", "timetable", "roster", "appointment", "user_confirmation"} and commitment == "confirmed":
+            commitment = "tentative"
+        elif authority not in {"calendar", "timetable", "roster", "appointment", "user_confirmation"} and commitment == "confirmed":
+            commitment = "tentative"
+        candidate["commitment_level"] = commitment
+        phase_item = candidate
+        if evidence_kind == "self_state_commit" and not any(candidate.get(key) for key in ("start_at", "start", "time")):
+            phase_item = dict(candidate)
+            phase_item["start_at"] = candidate.get("committed_at") or candidate.get("created_at")
+            phase_item["end_at"] = candidate.get("valid_until") or candidate.get("expires_at")
+        candidate["temporal_phase"] = derive_temporal_phase(phase_item, now=now, timezone_name=self.timezone_name)
+        candidate["evidence_level"] = normalize_evidence_level(candidate.get("evidence_level"), "L2" if source_kind == "observed" else "L0")
+        candidate["canonical_evidence_level"] = normalize_evidence_level(candidate.get("canonical_evidence_level") or candidate["evidence_level"], candidate["evidence_level"])
+        archive_default = candidate["canonical_evidence_level"] if candidate["canonical_evidence_level"] in {"L0", "L1", "L2", "L3"} else "L3"
+        candidate["archive_evidence_level"] = normalize_evidence_level(candidate.get("archive_evidence_level"), archive_default)
+        candidate["evidence_level_mapping"] = {
+            "canonical_evidence_level": candidate["canonical_evidence_level"],
+            "archive_evidence_level": candidate["archive_evidence_level"],
+            "lossy": candidate["canonical_evidence_level"] != candidate["archive_evidence_level"],
+        }
+        candidate["authority_kind"] = authority
+        candidate["epistemic_status"] = normalize_epistemic_status(candidate.get("epistemic_status"), "observed" if source_kind == "observed" else "inferred")
+        candidate["content_granularity"] = normalize_content_granularity(candidate.get("content_granularity"), "intent")
+        candidate["materialization_state"] = normalize_materialization_state(candidate.get("materialization_state"), "active" if source_kind == "observed" else "none")
+        candidate["fact_eligibility"] = "none"
+        try:
+            candidate["confidence"] = max(0.0, min(1.0, float(candidate.get("confidence", 0.75 if source_kind == "observed" else 0.4))))
+        except (TypeError, ValueError):
+            candidate["confidence"] = 0.75 if source_kind == "observed" else 0.4
+        candidate["actor_type"] = str(candidate.get("actor_type") or "").strip().lower()
+        if candidate["actor_type"] not in ACTOR_TYPES:
+            candidate["actor_type"] = ""
+        candidate["subject_actor_id"] = str(candidate.get("subject_actor_id") or "").strip()
+        candidate["object_actor_id"] = str(candidate.get("object_actor_id") or "").strip()
+        candidate["source_actor_id"] = str(candidate.get("source_actor_id") or "system").strip()
+        candidate["target_user_id"] = str(candidate.get("target_user_id") or "").strip()
+        candidate["participant_roles"] = deepcopy(candidate.get("participant_roles") if isinstance(candidate.get("participant_roles"), list) else candidate.get("participants") or [])
+        candidate["decision_trace"] = deepcopy(candidate.get("decision_trace") if isinstance(candidate.get("decision_trace"), list) else [])
+        try:
+            candidate["canonical_schema_version"] = max(1, int(candidate.get("canonical_schema_version") or 2))
+        except (TypeError, ValueError):
+            candidate["canonical_schema_version"] = 2
+        return candidate
+
+    def _actor_reasons(self, candidate: Mapping[str, Any]) -> list[str]:
+        subject = str(candidate.get("subject_actor_id") or "").strip()
+        actor_type = str(candidate.get("actor_type") or "").strip().lower()
+        bot_id = str(candidate.get("_bot_id") or "").strip()
+        target = str(candidate.get("_target_user_id") or "").strip()
+        candidate_target = str(candidate.get("target_user_id") or "").strip()
+        schedule_ref = candidate.get("schedule_ref")
+        schedule_target = (
+            str(schedule_ref.get("target_user_id") or "").strip()
+            if isinstance(schedule_ref, Mapping)
+            else ""
+        )
+        if target and candidate_target and candidate_target != target:
+            return ["schedule_target_mismatch"]
+        if target and schedule_target and schedule_target != target:
+            return ["schedule_target_mismatch"]
+        if candidate_target and schedule_target and candidate_target != schedule_target:
+            return ["schedule_target_mismatch"]
+        if not subject:
+            return ["missing_subject"]
+        if actor_type == "bot":
+            if bot_id and subject != bot_id:
+                return ["subject_mismatch_bot"]
+            return []
+        if actor_type == "interlocutor_user":
+            if target and subject == target:
+                return []
+            return ["subject_mismatch_user"]
+        # External/system statements cannot become a Bot/User execution fact.
+        return ["subject_scope_external"]
+
+    @staticmethod
+    def _interaction_is_scoped(candidate: Mapping[str, Any]) -> bool:
+        title = " ".join(str(candidate.get(key) or "").lower() for key in ("title", "activity", "summary"))
+        interaction_tokens = ("chat", "conversation", "interaction", "message", "聊天", "对话", "互动", "陪伴")
+        # When a concrete title exists, it must itself describe the
+        # interaction.  A generic ``source=conversation`` label cannot make
+        # an unrelated title such as "attend class" an execution fact.
+        if title.strip():
+            return any(token in title for token in interaction_tokens)
+        haystack = " ".join(str(candidate.get(key) or "").lower() for key in ("kind", "source"))
+        return any(token in haystack for token in interaction_tokens)
+
+    def _expiry_reason(self, candidate: Mapping[str, Any], now: datetime) -> str | None:
+        for key in ("expires_at", "valid_until", "effective_to"):
+            value = candidate.get(key)
+            if value in (None, ""):
+                continue
+            try:
+                if parse_datetime(value, timezone_name=self.timezone_name) <= now:
+                    return "expired"
+            except Exception:
+                return "invalid_expiry"
+        schedule_ref = candidate.get("schedule_ref")
+        if isinstance(schedule_ref, Mapping) and schedule_ref.get("expires_at"):
+            try:
+                if parse_datetime(schedule_ref.get("expires_at"), timezone_name=self.timezone_name) <= now:
+                    return "expired"
+            except Exception:
+                return "invalid_expiry"
+        return None
+
+    def _self_state_reasons(self, candidate: Mapping[str, Any], now: datetime) -> list[str]:
+        reasons: list[str] = []
+        if str(candidate.get("actor_type") or "").strip().lower() != "bot":
+            reasons.append("self_state_subject_not_bot")
+        if str(candidate.get("state") or candidate.get("title") or "").strip() not in SELF_STATE_ALLOWED:
+            reasons.append("self_state_state_not_allowed")
+        if AgendaDisclosurePolicy._refs(candidate.get("source_refs")):
+            reasons.append("self_state_source_refs_forbidden")
+        if not AgendaDisclosurePolicy._refs(candidate.get("runtime_origin_refs")):
+            reasons.append("self_state_origin_missing")
+        committed_raw = candidate.get("committed_at") or candidate.get("start_at") or candidate.get("start")
+        until_raw = candidate.get("valid_until") or candidate.get("end_at") or candidate.get("expires_at")
+        try:
+            committed = parse_datetime(committed_raw, timezone_name=self.timezone_name)
+            until = parse_datetime(until_raw, timezone_name=self.timezone_name)
+            if committed > now:
+                reasons.append("self_state_not_started")
+            if until <= now:
+                reasons.append("expired")
+            if until <= committed:
+                reasons.append("self_state_interval_invalid")
+        except Exception:
+            reasons.append("self_state_time_invalid")
+        # A self-state is deliberately a broad internal intent.  Reject
+        # obvious external-result claims even if a caller supplied the right
+        # evidence_kind label.
+        text = " ".join(str(candidate.get(key) or "") for key in ("state", "title", "activity", "summary")).lower()
+        forbidden = (
+            "付款",
+            "支付",
+            "发布",
+            "定位",
+            "签到",
+            "打卡",
+            "到场",
+            "通话",
+            "上课",
+            "上班",
+            "arrived",
+            "check-in",
+            "checked in",
+            "paid",
+            "publish",
+            "payment",
+            "location",
+            "call",
+        )
+        if any(token in text for token in forbidden):
+            reasons.append("self_state_external_result_forbidden")
+        return reasons
+
+    def _base_eligibility(self, candidate: Mapping[str, Any], now: datetime) -> tuple[str, list[str]]:
+        reasons: list[str] = []
+        reasons.extend(self._actor_reasons(candidate))
+        status = str(candidate.get("status") or "unknown")
+        phase = str(candidate.get("temporal_phase") or "future")
+        source_kind = str(candidate.get("source_kind") or "planned")
+        evidence_kind = str(candidate.get("evidence_kind") or "none")
+        refs = self._refs(candidate.get("source_refs"))
+        refs_trusted = bool(candidate.get("source_refs_trusted"))
+        expiry = self._expiry_reason(candidate, now)
+        if expiry:
+            reasons.append(expiry)
+        schedule_ref = candidate.get("schedule_ref")
+        source_state = candidate.get("source_state") or candidate.get("ref_state") or candidate.get("state")
+        if isinstance(schedule_ref, Mapping):
+            source_state = source_state or schedule_ref.get("state")
+        schedule_status = str(candidate.get("_schedule_ref_status") or "").lower()
+        schedule_reason = str(candidate.get("_schedule_ref_reason") or "").strip()
+        if schedule_status == "expired":
+            reasons.append("expired")
+        elif schedule_status in {"cancelled", "revoked"}:
+            reasons.append("status_cancelled")
+        elif schedule_status == "invalid" and candidate.get("authority_kind") in {
+            "calendar",
+            "timetable",
+            "roster",
+            "appointment",
+            "user_confirmation",
+        }:
+            reasons.append(schedule_reason or "invalid_schedule_ref")
+        if candidate.get("_schedule_revision_superseded"):
+            reasons.append("schedule_revision_superseded")
+        if str(source_state or "").strip().lower() in {"cancelled", "canceled", "revoked", "superseded"}:
+            reasons.append("status_cancelled")
+        if status in {"cancelled", "overridden", "deferred"}:
+            reasons.append(f"status_{status}")
+        if candidate.get("materialization_state") == "rejected":
+            reasons.append("materialization_rejected")
+
+        # Hard/soft schedule intent.  This is deliberately separate from
+        # execution eligibility: an untrusted soft plan may be summarized as a
+        # tentative future possibility but never as a current/history fact.
+        if source_kind == "projection":
+            reasons.append("projection_not_fact")
+        if source_kind == "planned" and phase in {"future", "current"} and status == "planned":
+            commitment = str(candidate.get("commitment_level") or "tentative")
+            if commitment in COMMITMENT_LEVELS and candidate.get("content_granularity") != "scene":
+                if commitment == "confirmed" and not (refs and refs_trusted):
+                    reasons.append("untrusted_schedule_source")
+                return "schedule_commitment", reasons
+
+        if candidate.get("materialization_state") == "candidate" and evidence_kind in {
+            "interaction",
+            "self_state_commit",
+            "tool_action",
+            "external_record",
+        }:
+            reasons.append("candidate_not_fact")
+            return "none", reasons
+
+        if evidence_kind == "interaction":
+            if not self._interaction_is_scoped(candidate):
+                reasons.append("interaction_scope_mismatch")
+                return "none", reasons
+            if phase == "current" and status in {"active", "partially_completed"} and refs:
+                return "current_observed", reasons
+            if phase == "past" and status in {"completed", "partially_completed", "active"} and refs:
+                # Conversation evidence can establish that the Bot was
+                # chatting with the current user earlier, but it cannot prove
+                # an unrelated external action.
+                return "history_observed", reasons
+            reasons.append("interaction_not_current")
+            return "none", reasons
+        if evidence_kind == "self_state_commit":
+            reasons.extend(self._self_state_reasons(candidate, now))
+            if (
+                not reasons
+                and phase == "current"
+                and status in {"active", "planned"}
+                and candidate.get("materialization_state") == "active"
+            ):
+                return "current_internal", reasons
+            if not reasons:
+                reasons.append("self_state_not_current")
+            return "none", reasons
+        if evidence_kind in {"tool_action", "external_record"}:
+            if not refs:
+                reasons.append("missing_evidence_refs")
+                return "none", reasons
+            if not refs_trusted:
+                reasons.append("untrusted_evidence_refs")
+                return "none", reasons
+            if phase == "current" and status in {"active", "partially_completed"}:
+                return "current_observed", reasons
+            if phase == "past" and status in {"completed", "partially_completed", "active"}:
+                return "history_observed", reasons
+            reasons.append("evidence_time_mismatch")
+            return "none", reasons
+        if evidence_kind == "external_commitment":
+            if not (refs and refs_trusted):
+                reasons.append("untrusted_schedule_source")
+                return "none", reasons
+            if candidate.get("commitment_level") in COMMITMENT_LEVELS and phase in {"future", "current"}:
+                return "schedule_commitment", reasons
+        if status in {"completed", "active", "partially_completed"}:
+            reasons.append("missing_execution_evidence")
+        return "none", reasons
+
+    def _decide(self, candidate: dict[str, Any], purpose: str, now: datetime) -> tuple[bool, str, list[str]]:
+        eligibility, reasons = self._base_eligibility(candidate, now)
+        phase = candidate["temporal_phase"]
+        status = candidate["status"]
+        commitment = candidate["commitment_level"]
+        # Diagnostics intentionally retain rejected/missing-subject candidates.
+        if purpose == "diagnostic":
+            return True, eligibility, reasons
+        if reasons and any(
+            reason
+            in {
+                "missing_subject",
+                "subject_mismatch_bot",
+                "subject_mismatch_user",
+                "subject_scope_external",
+                "expired",
+                "invalid_expiry",
+                "status_cancelled",
+                "status_revoked",
+                "status_overridden",
+                "status_deferred",
+                "materialization_rejected",
+                "invalid_schedule_ref",
+                "permission_denied",
+                "schedule_ref_not_in_source_refs",
+                "schedule_ref_incomplete",
+                "schedule_authority_mismatch",
+                "schedule_subject_mismatch",
+                "schedule_target_mismatch",
+                "schedule_revision_superseded",
+            }
+            for reason in reasons
+        ):
+            return False, "none", reasons
+        if purpose == "current_fact":
+            if eligibility in {"current_observed", "current_internal"} and phase == "current":
+                return True, eligibility, reasons
+            if eligibility == "schedule_commitment":
+                reasons = [*reasons, "planned_without_execution_evidence"]
+            return False, "none", reasons or ["future_plan_not_current"]
+        if purpose == "history_fact":
+            if eligibility == "history_observed" and phase == "past":
+                return True, eligibility, reasons
+            if candidate.get("source_kind") in {"planned", "projection", "reconciled"}:
+                reasons = [*reasons, "planned_without_execution_evidence"]
+            return False, "none", reasons or ["no_history_evidence"]
+        if purpose == "future_schedule":
+            if eligibility == "schedule_commitment" and phase in {"future", "current"} and commitment in COMMITMENT_LEVELS:
+                return True, eligibility, reasons
+            return False, "none", reasons or ["not_future_schedule"]
+        if purpose == "schedule_commitment":
+            hard_authority = candidate["authority_kind"] in {"calendar", "timetable", "roster", "appointment", "user_confirmation"}
+            if eligibility == "schedule_commitment" and hard_authority and candidate.get("source_refs") and candidate.get("source_refs_trusted") and status not in {"cancelled", "overridden", "deferred"}:
+                return True, eligibility, reasons
+            return False, "none", reasons or ["missing_trusted_schedule_source"]
+        if purpose == "proactive":
+            if eligibility == "current_internal" and phase == "current":
+                return True, eligibility, reasons
+            start_value = candidate.get("start_at") or candidate.get("start") or candidate.get("time")
+            try:
+                start = parse_datetime(start_value, timezone_name=self.timezone_name)
+            except Exception:
+                start = now
+            delta = start - now
+            horizon = self.proactive_soft_horizon if commitment == "tentative" else self.proactive_hard_horizon
+            if eligibility == "schedule_commitment" and phase == "future" and timedelta(0) <= delta <= horizon:
+                if candidate.get("content_granularity") != "scene":
+                    return True, eligibility, reasons
+            return False, "none", reasons or ["not_proactive_window"]
+        if purpose == "memory_write":
+            if eligibility == "history_observed" and phase == "past":
+                return True, eligibility, reasons
+            if eligibility == "current_observed" and phase == "current":
+                return True, eligibility, reasons
+            if eligibility == "schedule_commitment" and phase in {"future", "current"}:
+                # Soft plans require an explicit TTL.  A validated hard
+                # schedule has an adapter-owned absolute end time and may be
+                # archived as a commitment without becoming an execution
+                # history fact.
+                if candidate.get("expires_at"):
+                    return True, eligibility, reasons
+                hard_authority = candidate.get("authority_kind") in {
+                    "calendar",
+                    "timetable",
+                    "roster",
+                    "appointment",
+                    "user_confirmation",
+                }
+                schedule_ref = candidate.get("schedule_ref")
+                if hard_authority and candidate.get("source_refs_trusted") and isinstance(schedule_ref, Mapping) and schedule_ref.get("effective_to"):
+                    return True, eligibility, reasons
+            return False, "none", reasons or ["memory_requires_evidence_or_ttl"]
+        return False, "none", ["purpose_filtered"]
+
+    @staticmethod
+    def _public_entry(candidate: Mapping[str, Any], purpose: str, eligibility: str) -> dict[str, Any]:
+        result = deepcopy(dict(candidate))
+        for key in (
+            "_bot_id",
+            "_target_user_id",
+            "decision_trace",
+            "diagnostic_reasons",
+            "basis",
+            "scene_details",
+            "candidate_options",
+            "runtime_origin_refs",
+        ):
+            result.pop(key, None)
+        result["fact_eligibility"] = eligibility
+        result["disclosure_purpose"] = purpose
+        # Untrusted refs are useful in diagnostics but cannot be presented as
+        # evidence to a downstream language model.
+        if not candidate.get("source_refs_trusted"):
+            result["source_refs"] = []
+        if purpose in {"future_schedule", "proactive"} and result.get("content_granularity") == "scene":
+            result["content_granularity"] = "candidate"
+            result["materialization_state"] = "candidate"
+            result["title"] = str(result.get("title") or "").strip()[:120]
+        return result
+
+    @staticmethod
+    def _diagnostic_entry(candidate: Mapping[str, Any]) -> dict[str, Any]:
+        result = deepcopy(dict(candidate))
+        result.pop("_bot_id", None)
+        result.pop("_target_user_id", None)
+        return result
+
+
+def build_view(
+    agenda: Mapping[str, Any] | Iterable[Mapping[str, Any]] | None,
+    now: datetime | None,
+    purpose: str,
+    **policy_kwargs: Any,
+) -> DisclosureView:
+    """Small functional facade for callers that do not need a policy object."""
+
+    target_user_id = policy_kwargs.pop("target_user_id", None)
+    max_entries = policy_kwargs.pop("max_entries", None)
+    return AgendaDisclosurePolicy(**policy_kwargs).build_view(
+        agenda,
+        now,
+        purpose,
+        target_user_id=target_user_id,
+        max_entries=max_entries,
+    )
+
+
+__all__ = [
+    "AgendaDisclosurePolicy",
+    "DisclosureView",
+    "DISCLOSURE_PURPOSES",
+    "DISCLOSURE_PURPOSE_MATRIX",
+    "USE_MATRIX",
+    "DISCLOSURE_MATRIX",
+    "build_view",
+]

--- a/agenda_runtime.py
+++ b/agenda_runtime.py
@@ -21,6 +21,8 @@ try:
     )
     from .schedule_reconciler import reconcile
     from .unified_agenda import build_unified_agenda, format_agenda_context
+    from .agenda_disclosure_policy import AgendaDisclosurePolicy
+    from .runtime_scene_resolver import RuntimeSceneResolver
 except ImportError:
     from activity_capture import ActivityCapture
     from agenda_contracts import (
@@ -36,6 +38,8 @@ except ImportError:
     )
     from schedule_reconciler import reconcile
     from unified_agenda import build_unified_agenda, format_agenda_context
+    from agenda_disclosure_policy import AgendaDisclosurePolicy
+    from runtime_scene_resolver import RuntimeSceneResolver
 
 
 class AgendaRuntimeMixin:
@@ -68,6 +72,26 @@ class AgendaRuntimeMixin:
             self._agenda_migration_dirty = True
         if not isinstance(getattr(self, "_agenda_capture", None), ActivityCapture):
             self._agenda_capture = ActivityCapture()
+        bot_id = str(
+            getattr(self, "bot_id", "")
+            or getattr(self, "bot_personal_subject", "")
+            or "bot_self"
+        ).strip()
+        timezone_name = self._agenda_timezone_name()
+        policy = getattr(self, "_agenda_disclosure_policy", None)
+        if not isinstance(policy, AgendaDisclosurePolicy) or policy.bot_id != bot_id or policy.timezone_name != timezone_name:
+            self._agenda_disclosure_policy = AgendaDisclosurePolicy(bot_id=bot_id, timezone_name=timezone_name)
+        runtime_resolver = getattr(self, "_runtime_scene_resolver", None)
+        if (
+            not isinstance(runtime_resolver, RuntimeSceneResolver)
+            or runtime_resolver.bot_id != bot_id
+            or getattr(runtime_resolver, "timezone_name", timezone_name) != timezone_name
+        ):
+            self._runtime_scene_resolver = RuntimeSceneResolver(
+                bot_id=bot_id,
+                clock=self._agenda_now,
+                timezone_name=timezone_name,
+            )
 
     def _agenda_activities_store(self) -> list[dict[str, Any]]:
         self._agenda_prepare_store()
@@ -126,7 +150,11 @@ class AgendaRuntimeMixin:
 
     def _agenda_capture_hard_fact(self, activity: dict[str, Any]) -> dict[str, Any]:
         self._agenda_prepare_store()
-        normalized = normalize_observed_activity(activity, now=self._agenda_now())
+        payload = dict(activity or {})
+        payload.setdefault("actor_type", "bot")
+        payload.setdefault("subject_actor_id", self._agenda_disclosure_policy.bot_id)
+        payload.setdefault("source_actor_id", "system")
+        normalized = normalize_observed_activity(payload, now=self._agenda_now())
         activities = self._agenda_activities_store()
         existing = next((item for item in activities if item.get("activity_id") == normalized.get("activity_id")), None)
         if existing is None:
@@ -150,6 +178,8 @@ class AgendaRuntimeMixin:
                 continue
             item = deepcopy(raw)
             item.setdefault("date", plan_date)
+            item.setdefault("subject_actor_id", getattr(getattr(self, "_agenda_disclosure_policy", None), "bot_id", "bot_self"))
+            item.setdefault("actor_type", "bot")
             try:
                 normalized = normalize_plan_item(item, plan_id=str(item.get("plan_id") or f"{plan_date}:{index}"), now=self._agenda_now())
             except Exception:
@@ -175,8 +205,148 @@ class AgendaRuntimeMixin:
             timezone_name=self._agenda_timezone_name(),
         )
 
+    def _agenda_disclosure_view(
+        self,
+        purpose: str = "future_schedule",
+        *,
+        now: datetime | None = None,
+        target_user_id: str = "",
+        max_entries: int = 32,
+        date_key: str = "",
+    ) -> dict[str, Any]:
+        """Return the only agenda view that should cross a module boundary."""
+
+        self._agenda_prepare_store()
+        agenda = self._agenda_build(date_key=str(date_key or ""))
+        return self._agenda_disclosure_policy.build_view(
+            agenda,
+            now=now or self._agenda_now(),
+            purpose=purpose,
+            target_user_id=target_user_id,
+            max_entries=max_entries,
+        )
+
+    def _agenda_runtime_scene(
+        self,
+        *,
+        conversation_state: Any = None,
+        now: datetime | None = None,
+        hard_constraints: Any = None,
+    ) -> dict[str, Any] | None:
+        """Resolve a short-lived Bot-only current state without mutating plans."""
+
+        self._agenda_prepare_store()
+        agenda = self._agenda_build()
+        # A clock window or a soft plan is not a runtime state.  The resolver
+        # may only consume entries that the disclosure layer has already
+        # qualified as a Bot current fact.  This prevents ordinary planned
+        # activity text (for example, "上课" or "出门") from becoming a
+        # short-lived ``self_state_commit`` merely because its time arrived.
+        bot_id = str(getattr(self._agenda_disclosure_policy, "bot_id", "bot_self") or "bot_self")
+        candidates: list[dict[str, Any]] = []
+        for item in (
+            list(agenda.get("current_fact") or [])
+            + list(agenda.get("plans") or [])
+        ):
+            if not isinstance(item, dict):
+                continue
+            if str(item.get("subject_actor_id") or "") != bot_id:
+                continue
+            phase = str(item.get("temporal_phase") or "").lower()
+            eligibility = str(item.get("fact_eligibility") or "").lower()
+            if phase != "current" or eligibility not in {"current_internal", "current_observed"}:
+                continue
+            candidates.append(item)
+        return self._runtime_scene_resolver.resolve_now(
+            candidates,
+            conversation_state=conversation_state,
+            hard_constraints=hard_constraints,
+            now=now or self._agenda_now(),
+        )
+
+    @staticmethod
+    def _agenda_clock_from_value(value: Any) -> str:
+        text = str(value or "").strip()
+        if not text:
+            return ""
+        if len(text) >= 16 and "T" in text:
+            return text.split("T", 1)[1][:5]
+        return text[:5] if len(text) >= 5 and text[2:3] == ":" else ""
+
+    def _agenda_current_context_item(
+        self,
+        *,
+        conversation_state: Any = None,
+        now: datetime | None = None,
+        hard_constraints: Any = None,
+    ) -> dict[str, Any] | None:
+        """Return a Bot-only current item for behavior and scene consumers.
+
+        The result is either an evidence-backed ``current_fact`` or a
+        short-lived runtime commit.  Raw plan prose and future commitments are
+        deliberately never returned from this boundary.
+        """
+
+        current = now or self._agenda_now()
+        view = self._agenda_disclosure_view("current_fact", now=current, max_entries=32)
+        entries = getattr(view, "entries", None)
+        if entries is None and hasattr(view, "get"):
+            try:
+                entries = view.get("entries", [])
+            except Exception:
+                entries = []
+        bot_id = str(getattr(self._agenda_disclosure_policy, "bot_id", "bot_self") or "bot_self")
+        eligible = [
+            item
+            for item in entries
+            if isinstance(item, dict)
+            and str(item.get("subject_actor_id") or "") == bot_id
+            and str(item.get("temporal_phase") or "").lower() == "current"
+            and str(item.get("fact_eligibility") or "").lower() in {"current_internal", "current_observed"}
+        ]
+        if eligible:
+            selected = sorted(
+                eligible,
+                key=lambda item: (
+                    str(item.get("fact_eligibility") or "") != "current_observed",
+                    str(item.get("start_at") or item.get("committed_at") or ""),
+                ),
+            )[0]
+            title = str(selected.get("title") or selected.get("state") or selected.get("activity") or "").strip()[:120]
+            return {
+                **deepcopy(selected),
+                "time": str(selected.get("time") or self._agenda_clock_from_value(selected.get("start_at") or selected.get("committed_at")))[:12],
+                "end": str(selected.get("end") or self._agenda_clock_from_value(selected.get("end_at") or selected.get("valid_until")))[:12],
+                "activity": title,
+                "title": title,
+                "message_seed": "",
+            }
+
+        runtime = self._agenda_runtime_scene(
+            conversation_state=conversation_state,
+            hard_constraints=hard_constraints,
+            now=current,
+        )
+        if not isinstance(runtime, dict):
+            return None
+        title = str(runtime.get("state") or runtime.get("title") or "").strip()[:120]
+        if not title:
+            return None
+        return {
+            **deepcopy(runtime),
+            "time": self._agenda_clock_from_value(runtime.get("committed_at")),
+            "end": self._agenda_clock_from_value(runtime.get("valid_until")),
+            "activity": title,
+            "title": title,
+            "mood": "当前状态",
+            "message_seed": "",
+        }
+
     def _agenda_context_for_prompt(self, *, max_entries: int = 8) -> str:
-        return format_agenda_context(self._agenda_build(), max_entries=max_entries)
+        # Prompt consumers receive a filtered future view; diagnostics remain
+        # available through ``_agenda_disclosure_view('diagnostic')`` only.
+        view = self._agenda_disclosure_view("future_schedule", max_entries=max_entries)
+        return format_agenda_context({"entries": view.get("entries", []), "date": self._agenda_now().date().isoformat()}, max_entries=max_entries)
 
     def _agenda_snapshot_window(
         self,
@@ -207,6 +377,8 @@ class AgendaRuntimeMixin:
                 "reconciled": settled["reconciliations"],
                 "open_items": list(open_items or []),
                 "source_refs": [str(item.get("activity_id")) for item in settled["activities"] if item.get("activity_id")],
+                "subject_actor_id": self._agenda_disclosure_policy.bot_id,
+                "actor_type": "bot",
                 "certainty": "high" if settled["reconciliations"] else "medium",
             },
             now=now,
@@ -238,7 +410,9 @@ class AgendaRuntimeMixin:
                 "plans": settled["reconciliations"],
                 "observed_activity_ids": list(snapshot.get("source_refs") or []),
                 "source_refs": [snapshot_id],
-                "status": "completed",
+                "status": "reconciled",
+                "subject_actor_id": self._agenda_disclosure_policy.bot_id,
+                "actor_type": "bot",
             },
             now=now,
         )

--- a/bot_personal_contract.py
+++ b/bot_personal_contract.py
@@ -23,7 +23,7 @@ import hashlib
 import json
 
 CONTRACT_NAME = "bot_personal_archive"
-CONTRACT_REVISION = 1
+CONTRACT_REVISION = 2
 
 # ---------------------------------------------------------------------------
 # 一、日程分级（原「四段」→ 陪伴分支五段）
@@ -136,7 +136,50 @@ BOT_PERSONAL_MAX_PAYLOAD_BYTES = 16 * 1024
 BOT_PERSONAL_PAYLOAD_SCHEMA_VERSION = "1.0"
 # 信封字段 window 的**值域**变了（四段→五段）→ 能力版本必升，且必须在能力探测里
 # 回传 windows，让调用方启动时就能发现两侧值域不一致，而不是等到归档 invalid_window。
-BOT_PERSONAL_CAPABILITY_SCHEMA_VERSION = "1.1"
+BOT_PERSONAL_CAPABILITY_SCHEMA_VERSION = "1.2"
+
+# Canonical C3 agenda capability surface.  These values are deliberately
+# duplicated in the memory-side contract so startup negotiation can reject a
+# stale reader before it promotes archived payloads to facts.
+BOT_PERSONAL_CANONICAL_SCHEMA_VERSION = 2
+BOT_PERSONAL_CANONICAL_FIELDS: tuple[str, ...] = (
+    "source_kind",
+    "status",
+    "temporal_phase",
+    "evidence_kind",
+    "evidence_level",
+    "canonical_evidence_level",
+    "archive_evidence_level",
+    "evidence_level_mapping",
+    "authority_kind",
+    "commitment_level",
+    "epistemic_status",
+    "content_granularity",
+    "materialization_state",
+    "fact_eligibility",
+    "source_refs",
+    "runtime_origin_refs",
+    "expires_at",
+    "actor_type",
+    "subject_actor_id",
+    "object_actor_id",
+    "source_actor_id",
+    "target_user_id",
+    "participant_roles",
+    "decision_trace",
+)
+BOT_PERSONAL_CANONICAL_SOURCE_KINDS: tuple[str, ...] = ("planned", "observed", "projection", "reconciled")
+BOT_PERSONAL_CANONICAL_STATUSES: tuple[str, ...] = (
+    "planned", "active", "completed", "partially_completed", "overridden",
+    "reconciled", "deferred", "cancelled", "unknown",
+)
+BOT_PERSONAL_CANONICAL_EVIDENCE_KINDS: tuple[str, ...] = (
+    "none", "interaction", "self_state_commit", "tool_action",
+    "external_record", "external_commitment",
+)
+BOT_PERSONAL_CANONICAL_FACT_ELIGIBILITIES: tuple[str, ...] = (
+    "none", "schedule_commitment", "current_internal", "current_observed", "history_observed",
+)
 
 BOT_PERSONAL_MEMORY_TYPES: tuple[str, ...] = (
     "bot_schedule_plan",
@@ -207,6 +250,12 @@ def capability_descriptor(*, available: bool = True, read_only: bool = False) ->
         "contract_revision": CONTRACT_REVISION,
         "contract_fingerprint": CONTRACT_FINGERPRINT,
         "capability_schema_version": BOT_PERSONAL_CAPABILITY_SCHEMA_VERSION,
+        "canonical_schema_version": BOT_PERSONAL_CANONICAL_SCHEMA_VERSION,
+        "canonical_fields": list(BOT_PERSONAL_CANONICAL_FIELDS),
+        "canonical_source_kinds": list(BOT_PERSONAL_CANONICAL_SOURCE_KINDS),
+        "canonical_statuses": list(BOT_PERSONAL_CANONICAL_STATUSES),
+        "canonical_evidence_kinds": list(BOT_PERSONAL_CANONICAL_EVIDENCE_KINDS),
+        "canonical_fact_eligibilities": list(BOT_PERSONAL_CANONICAL_FACT_ELIGIBILITIES),
         "payload_schema_version": BOT_PERSONAL_PAYLOAD_SCHEMA_VERSION,
         "windows": list(WINDOW_SLUGS),
         "memory_types": list(BOT_PERSONAL_MEMORY_TYPES),
@@ -230,6 +279,12 @@ def _fingerprint_source() -> str:
         "max_payload_bytes": BOT_PERSONAL_MAX_PAYLOAD_BYTES,
         "payload_schema_version": BOT_PERSONAL_PAYLOAD_SCHEMA_VERSION,
         "capability_schema_version": BOT_PERSONAL_CAPABILITY_SCHEMA_VERSION,
+        "canonical_schema_version": BOT_PERSONAL_CANONICAL_SCHEMA_VERSION,
+        "canonical_fields": list(BOT_PERSONAL_CANONICAL_FIELDS),
+        "canonical_source_kinds": list(BOT_PERSONAL_CANONICAL_SOURCE_KINDS),
+        "canonical_statuses": list(BOT_PERSONAL_CANONICAL_STATUSES),
+        "canonical_evidence_kinds": list(BOT_PERSONAL_CANONICAL_EVIDENCE_KINDS),
+        "canonical_fact_eligibilities": list(BOT_PERSONAL_CANONICAL_FACT_ELIGIBILITIES),
         "memory_types": list(BOT_PERSONAL_MEMORY_TYPES),
         "type_contracts": {k: list(v) for k, v in TYPE_CONTRACTS.items()},
         "evidence_levels": list(EVIDENCE_LEVELS),
@@ -243,7 +298,7 @@ def compute_contract_fingerprint() -> str:
 
 
 # 由 compute_contract_fingerprint() 生成。改了上面任何常量都要重跑本文件更新它。
-CONTRACT_FINGERPRINT = "5b8a97c1527dcc62"
+CONTRACT_FINGERPRINT = "0ffe3a1ab69b659c"
 
 
 def contract_self_check() -> list[str]:

--- a/bot_personal_dto.py
+++ b/bot_personal_dto.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 import hashlib
 import json
 import re
@@ -19,6 +19,11 @@ from .bot_personal_contract import (
     normalize_window,
     window_for_minutes,
 )
+
+try:
+    from .schedule_authority import validate_structured_schedule_ref
+except ImportError:
+    from schedule_authority import validate_structured_schedule_ref
 
 
 FORBIDDEN_KEY_PARTS = {
@@ -149,6 +154,22 @@ def _derive_window(value: Any, occurred_at: str, now: datetime) -> str:
     return window_for_minutes(parsed.hour * 60 + parsed.minute)
 
 
+def _has_trusted_schedule_ref(payload: dict[str, Any], authority: str, now: datetime) -> bool:
+    """Accept only a complete adapter-shaped reference, never a trust label."""
+    try:
+        status, _reason = validate_structured_schedule_ref(
+            payload.get("schedule_ref"),
+            source_refs=payload.get("source_refs"),
+            expected_authority=authority,
+            expected_subject=BOT_PERSONAL_SUBJECT,
+            expected_target=payload.get("target_user_id"),
+            now=now,
+        )
+        return status == "valid"
+    except Exception:
+        return False
+
+
 @dataclass(frozen=True)
 class BotPersonalArchiveDTO:
     record_id: str
@@ -170,6 +191,28 @@ class BotPersonalArchiveDTO:
     idempotency_key: str
     payload_schema_version: str
     payload: dict[str, Any]
+    # Canonical agenda axes are additive.  ``certainty`` above intentionally
+    # remains the legacy numeric field for old memory consumers.
+    evidence_kind: str = "none"
+    canonical_evidence_level: str = "L0"
+    archive_evidence_level: str = "L0"
+    evidence_level_mapping: dict[str, Any] | None = None
+    authority_kind: str = "llm"
+    commitment_level: str = "tentative"
+    epistemic_status: str = "inferred"
+    content_granularity: str = "intent"
+    materialization_state: str = "none"
+    fact_eligibility: str = "none"
+    actor_type: str = "bot"
+    subject_actor_id: str = BOT_PERSONAL_SUBJECT
+    object_actor_id: str = ""
+    source_actor_id: str = "system"
+    target_user_id: str = ""
+    participant_roles: list[Any] | None = None
+    runtime_origin_refs: list[str] | None = None
+    expires_at: str = ""
+    decision_trace: list[dict[str, Any]] | None = None
+    canonical_schema_version: int = 2
 
     def envelope(self) -> dict[str, Any]:
         return {
@@ -192,6 +235,26 @@ class BotPersonalArchiveDTO:
             "idempotency_key": self.idempotency_key,
             "payload_schema_version": self.payload_schema_version,
             "payload": deepcopy(self.payload),
+            "evidence_kind": self.evidence_kind,
+            "canonical_evidence_level": self.canonical_evidence_level,
+            "archive_evidence_level": self.archive_evidence_level,
+            "evidence_level_mapping": deepcopy(self.evidence_level_mapping or {}),
+            "authority_kind": self.authority_kind,
+            "commitment_level": self.commitment_level,
+            "epistemic_status": self.epistemic_status,
+            "content_granularity": self.content_granularity,
+            "materialization_state": self.materialization_state,
+            "fact_eligibility": self.fact_eligibility,
+            "actor_type": self.actor_type,
+            "subject_actor_id": self.subject_actor_id,
+            "object_actor_id": self.object_actor_id,
+            "source_actor_id": self.source_actor_id,
+            "target_user_id": self.target_user_id,
+            "participant_roles": deepcopy(self.participant_roles or []),
+            "runtime_origin_refs": list(self.runtime_origin_refs or []),
+            "expires_at": self.expires_at,
+            "decision_trace": deepcopy(self.decision_trace or []),
+            "canonical_schema_version": self.canonical_schema_version,
         }
 
 
@@ -213,6 +276,16 @@ def build_bot_personal_dto(
     validate_bot_personal_key(idempotency_key)
     current = now or datetime.now().astimezone()
     safe = _safe_value(payload) or {}
+    subject_actor = _text(safe.get("subject_actor_id"), 120) or BOT_PERSONAL_SUBJECT
+    if subject_actor != BOT_PERSONAL_SUBJECT:
+        # This DTO is the Bot-owned archive boundary.  A user assertion or a
+        # foreign actor must not be silently rewritten into Bot history.
+        raise ValueError("subject_actor_id_mismatch")
+    safe["subject_actor_id"] = BOT_PERSONAL_SUBJECT
+    actor_type = _text(safe.get("actor_type"), 32) or "bot"
+    if actor_type != "bot":
+        raise ValueError("actor_type_mismatch")
+    safe["actor_type"] = "bot"
     occurred = _text(occurred_at, 80) or current.isoformat(timespec="seconds")
     date_key = _derive_date(safe.get("date") or safe.get("window_date"), occurred, current)
     window = _derive_window(safe.get("window"), occurred, current)
@@ -227,9 +300,132 @@ def build_bot_personal_dto(
         source_refs = [f"archive:{_text(idempotency_key, 240)}"]
     contract = TYPE_CONTRACTS[memory_type]
     source_kind, default_evidence, default_status = contract
-    evidence = "L0" if memory_type == "bot_schedule_plan" else (_text(safe.get("evidence_level"), 8).upper() or default_evidence)
-    if evidence not in {"L0", "L1", "L2", "L3"}:
-        evidence = default_evidence
+    # The archive envelope is also a write gate.  A plain schedule payload is
+    # an intent regardless of model-provided lifecycle/evidence fields; only a
+    # later C3 evidence adapter may create an observed/completed record.
+    schedule_trusted = False
+    if memory_type == "bot_schedule_plan":
+        raw_status = _text(safe.get("status"), 32).lower()
+        if raw_status and raw_status != "planned":
+            safe["legacy_status"] = raw_status
+        raw_source_kind = _text(safe.get("source_kind"), 32).lower()
+        if raw_source_kind and raw_source_kind != "planned":
+            safe["legacy_source_kind"] = raw_source_kind
+        raw_refs = list(safe.get("source_refs") or []) if isinstance(safe.get("source_refs"), list) else []
+        trusted_refs = _has_trusted_schedule_ref(safe, _text(safe.get("authority_kind"), 48), current)
+        schedule_trusted = trusted_refs
+        if raw_refs and not trusted_refs:
+            safe["legacy_source_refs"] = raw_refs[:30]
+            safe["source_refs"] = []
+        safe.update(
+            {
+                "source_kind": "planned",
+                "status": "planned",
+                "evidence_kind": "none",
+                "evidence_level": "L0",
+                "canonical_evidence_level": "L0",
+                "archive_evidence_level": "L0",
+                "fact_eligibility": "schedule_commitment" if schedule_trusted else "none",
+            }
+        )
+        source_refs = [_text(item, 240) for item in (safe.get("source_refs") or []) if _text(item, 240)]
+        if not source_refs:
+            source_refs = [f"archive:{_text(idempotency_key, 240)}"]
+    elif memory_type in {
+        "bot_window_snapshot",
+        "bot_schedule_reconciliation",
+        "bot_detail_fragment",
+        "bot_calendar_event",
+    }:
+        raw_status = _text(safe.get("status"), 32).lower()
+        raw_evidence_kind = _text(safe.get("evidence_kind"), 48).lower()
+        raw_eligibility = _text(safe.get("fact_eligibility"), 48).lower()
+        if memory_type == "bot_window_snapshot":
+            if raw_status and raw_status != "reconciled":
+                safe["legacy_status"] = raw_status
+            safe.update(
+                {
+                    "status": "reconciled",
+                    "evidence_kind": "none",
+                    "evidence_level": "L0",
+                    "canonical_evidence_level": "L0",
+                    "archive_evidence_level": "L0",
+                    "epistemic_status": "inferred",
+                    "fact_eligibility": "none",
+                }
+            )
+        elif memory_type == "bot_schedule_reconciliation":
+            compatible_fact = (
+                raw_evidence_kind in {"interaction", "tool_action", "external_record"}
+                and raw_eligibility in {"current_observed", "history_observed"}
+                and bool(safe.get("source_refs_trusted") or safe.get("authority_verified"))
+            )
+            if not compatible_fact:
+                if raw_status and raw_status != "reconciled":
+                    safe["legacy_status"] = raw_status
+                safe.update(
+                    {
+                        "status": "reconciled",
+                        "evidence_kind": "none",
+                        "evidence_level": "L0",
+                        "canonical_evidence_level": "L0",
+                        "archive_evidence_level": "L0",
+                        "epistemic_status": "inferred",
+                        "fact_eligibility": "none",
+                    }
+                )
+        elif memory_type == "bot_detail_fragment":
+            if raw_status and raw_status != "planned":
+                safe["legacy_status"] = raw_status
+            flags = [
+                _text(item, 64)
+                for item in (safe.get("legacy_flags") or [])
+                if _text(item, 64)
+            ]
+            for flag in ("short_ttl_candidate", "unverified_plan"):
+                if flag not in flags:
+                    flags.append(flag)
+            safe.update(
+                {
+                    "status": "planned",
+                    "evidence_kind": "none",
+                    "evidence_level": "L0",
+                    "canonical_evidence_level": "L0",
+                    "archive_evidence_level": "L0",
+                    "epistemic_status": "inferred",
+                    "content_granularity": "scene",
+                    "materialization_state": "candidate",
+                    "fact_eligibility": "none",
+                    "legacy_flags": flags,
+                }
+            )
+            if not _text(safe.get("expires_at"), 96):
+                safe["expires_at"] = (current + timedelta(hours=2)).isoformat(timespec="seconds")
+        else:  # bot_calendar_event
+            trusted_calendar = _has_trusted_schedule_ref(safe, "calendar", current)
+            safe.update(
+                {
+                    "status": "planned",
+                    "evidence_kind": "external_commitment",
+                    "epistemic_status": "asserted",
+                    "content_granularity": "commitment",
+                    "materialization_state": "none",
+                    "fact_eligibility": "schedule_commitment" if trusted_calendar else "none",
+                    "commitment_level": "confirmed" if trusted_calendar else "tentative",
+                }
+            )
+    # The archive contract only stores L0-L3.  Keep the original local level
+    # separately so lossy L4/L5 writes cannot be promoted on a later read.
+    requested_evidence = _text(safe.get("canonical_evidence_level") or safe.get("evidence_level"), 8).upper()
+    canonical_evidence = requested_evidence if requested_evidence in {"L0", "L1", "L2", "L3", "L4", "L5"} else default_evidence
+    evidence = "L0" if memory_type == "bot_schedule_plan" else (canonical_evidence if canonical_evidence in {"L0", "L1", "L2", "L3"} else "L3")
+    evidence_mapping = safe.get("evidence_level_mapping") if isinstance(safe.get("evidence_level_mapping"), dict) else {}
+    if not evidence_mapping:
+        evidence_mapping = {
+            "canonical_evidence_level": canonical_evidence,
+            "archive_evidence_level": evidence,
+            "lossy": canonical_evidence != evidence,
+        }
     created_at = _text(safe.get("created_at"), 80) or current.isoformat(timespec="seconds")
     updated_at = _text(safe.get("updated_at"), 80) or created_at
     canonical_key = _text(idempotency_key, 240)
@@ -237,6 +433,34 @@ def build_bot_personal_dto(
         f"{BOT_PERSONAL_MEMORY_DOMAIN}|{memory_type}|{canonical_key}".encode("utf-8")
     ).hexdigest()[:24]
     record_id = f"botmem_{record_digest}"
+    archive_status = (
+        "planned"
+        if memory_type in {"bot_schedule_plan", "bot_detail_fragment", "bot_calendar_event"}
+        else "reconciled"
+        if memory_type in {"bot_window_snapshot", "bot_schedule_reconciliation"}
+        else (_text(safe.get("status"), 32) or default_status)
+    )
+    archive_authority = _text(safe.get("authority_kind"), 48) or (
+        "llm"
+        if memory_type in {"bot_schedule_plan", "bot_detail_fragment"}
+        else "calendar"
+        if memory_type == "bot_calendar_event"
+        else "state"
+    )
+    archive_commitment = _text(safe.get("commitment_level"), 24) or ("tentative" if memory_type == "bot_schedule_plan" else "tentative")
+    if memory_type == "bot_schedule_plan" and not schedule_trusted:
+        if archive_authority in {"calendar", "timetable", "roster", "appointment", "user_confirmation"}:
+            safe["legacy_authority_kind"] = archive_authority
+            archive_authority = "llm"
+        if archive_commitment == "confirmed":
+            safe["legacy_commitment_level"] = archive_commitment
+            archive_commitment = "tentative"
+    if memory_type == "bot_schedule_plan":
+        safe["authority_kind"] = archive_authority
+        safe["commitment_level"] = archive_commitment
+        safe["epistemic_status"] = "inferred"
+        safe["content_granularity"] = "intent"
+        safe["materialization_state"] = "none"
     return BotPersonalArchiveDTO(
         record_id=record_id,
         memory_domain=BOT_PERSONAL_MEMORY_DOMAIN,
@@ -252,11 +476,33 @@ def build_bot_personal_dto(
         source_refs=source_refs,
         certainty=_certainty(safe.get("certainty"), 0.6),
         evidence_level=evidence,
-        status=_text(safe.get("status"), 32) or default_status,
+        status=archive_status,
         version=max(1, int(version or 1)),
         idempotency_key=_text(idempotency_key, 240),
         payload_schema_version=BOT_PERSONAL_PAYLOAD_SCHEMA_VERSION,
         payload=deepcopy(safe),
+        evidence_kind=_text(safe.get("evidence_kind"), 48) or (
+            "none" if memory_type in {"bot_schedule_plan", "bot_window_snapshot", "bot_schedule_reconciliation", "bot_detail_fragment"}
+            else "external_commitment" if memory_type == "bot_calendar_event" else "observed"
+        ),
+        canonical_evidence_level=canonical_evidence,
+        archive_evidence_level=evidence,
+        evidence_level_mapping=deepcopy(evidence_mapping),
+        authority_kind=archive_authority,
+        commitment_level=archive_commitment,
+        epistemic_status=_text(safe.get("epistemic_status"), 24) or ("inferred" if memory_type == "bot_schedule_plan" else "observed"),
+        content_granularity=_text(safe.get("content_granularity"), 24) or "intent",
+        materialization_state=_text(safe.get("materialization_state"), 24) or "none",
+        fact_eligibility=_text(safe.get("fact_eligibility"), 48) or "none",
+        actor_type=_text(safe.get("actor_type"), 32) or "bot",
+        subject_actor_id=_text(safe.get("subject_actor_id"), 120) or BOT_PERSONAL_SUBJECT,
+        object_actor_id=_text(safe.get("object_actor_id"), 120),
+        source_actor_id=_text(safe.get("source_actor_id"), 120) or "system",
+        target_user_id=_text(safe.get("target_user_id"), 120),
+        participant_roles=deepcopy(safe.get("participant_roles")) if isinstance(safe.get("participant_roles"), list) else [],
+        runtime_origin_refs=deepcopy(safe.get("runtime_origin_refs")) if isinstance(safe.get("runtime_origin_refs"), list) else [],
+        expires_at=_text(safe.get("expires_at"), 96),
+        decision_trace=deepcopy(safe.get("decision_trace")) if isinstance(safe.get("decision_trace"), list) else [],
     )
 
 

--- a/busy_reply_gate.py
+++ b/busy_reply_gate.py
@@ -224,9 +224,16 @@ class BusyReplyGateMixin:
             return {"busy": False, "reason": "disabled", "until": 0.0, "schedule": ""}
         data = getattr(self, "data", None)
         plan = data.get("daily_plan") if isinstance(data, dict) and isinstance(data.get("daily_plan"), dict) else {}
-        current_getter = getattr(self, "_get_current_plan_item", None)
+        current_getter = getattr(self, "_agenda_current_context_item", None)
+        legacy_getter = getattr(self, "_get_current_plan_item", None)
         try:
-            current_item = current_getter(plan) if callable(current_getter) else None
+            current_item = (
+                current_getter()
+                if callable(current_getter)
+                else legacy_getter(plan)
+                if callable(legacy_getter)
+                else None
+            )
         except Exception:
             current_item = None
         busy, reason = self._busy_reply_item_is_busy(current_item)

--- a/creative.py
+++ b/creative.py
@@ -197,7 +197,7 @@ class CreativeMixin:
         now_dt = datetime.now()
         if now_dt.hour < 7:
             return False
-        current_item = self._get_current_plan_item(self.data.get("daily_plan", {}))
+        current_item = self._creative_current_agenda_item()
         if self._is_sleepy_plan_item(current_item):
             return False
         activity = _single_line((current_item or {}).get("activity"), 100)
@@ -579,7 +579,7 @@ class CreativeMixin:
 
     def _creative_inspiration_source(self) -> dict[str, str] | None:
         active_projects = [p for p in self._creative_projects() if p.get("status") == "drafting"]
-        current_item = self._get_current_plan_item(self.data.get("daily_plan", {}))
+        current_item = self._creative_current_agenda_item()
         activity = _single_line((current_item or {}).get("activity"), 90)
         seed = _single_line((current_item or {}).get("message_seed"), 90)
         dream = self.data.get("daily_dream")
@@ -2094,3 +2094,17 @@ class CreativeMixin:
             changed = True
         return changed
 
+    def _creative_current_agenda_item(self) -> dict[str, Any] | None:
+        getter = getattr(self, "_agenda_current_context_item", None)
+        if callable(getter):
+            try:
+                item = getter()
+            except Exception:
+                return None
+            return item if isinstance(item, dict) else None
+        legacy_getter = getattr(self, "_get_current_plan_item", None)
+        try:
+            item = legacy_getter(self.data.get("daily_plan", {})) if callable(legacy_getter) else None
+        except Exception:
+            item = None
+        return item if isinstance(item, dict) else None

--- a/daily_state.py
+++ b/daily_state.py
@@ -109,6 +109,7 @@ from .helpers import _date_key, _normalize_outbound_punctuation_flow, _normalize
 from .domains.affect.affect_modulation import compose_affect_modulation
 from .daily_state_tick import DailyStateTickMixin
 from .memo_notes import memo_note_due_state, memo_note_sort_key, normalize_memo_note
+from .agenda_contracts import normalize_plan_item
 from .planning import (
     build_daily_plan_prompt,
     build_detail_enhancement_prompt,
@@ -894,7 +895,11 @@ class DailyStateMixin(DailyStateTickMixin):
                     plan=plan,
                 )
                 self._remember_detail_enhancement_history(plan_date, enhanced, story_plan)
-                self._refresh_daily_state_location_from_plan(plan=plan, detail=detail)
+                self._refresh_daily_state_location_from_plan(
+                    plan=plan,
+                    detail=detail,
+                    segment=segment,
+                )
                 self._reschedule_users_for_new_detail_events(segment)
                 self._save_data_sync()
                 last_detail = detail
@@ -1487,6 +1492,7 @@ class DailyStateMixin(DailyStateTickMixin):
                 self._refresh_daily_state_location_from_plan(
                     plan=current_plan if isinstance(current_plan, dict) else plan,
                     detail=detail,
+                    segment=segment,
                 )
                 self._save_data_sync()
                 label = self._schedule_segment_label(segment)
@@ -9564,7 +9570,7 @@ class DailyStateMixin(DailyStateTickMixin):
                 item["end"] = end_text
                 changed = True
             lifecycle = _single_line(item.get("lifecycle_status"), 20).lower()
-            if lifecycle not in {"planned", "changed", "cancelled"}:
+            if lifecycle not in {"planned", "changed", "cancelled", "deferred"}:
                 item["lifecycle_status"] = "planned"
                 changed = True
             basis = self._normalize_schedule_basis(item.get("basis"), default=["coarse_plan"])
@@ -9585,6 +9591,7 @@ class DailyStateMixin(DailyStateTickMixin):
             "completed": "completed", "完成": "completed", "已完成": "completed",
             "changed": "changed", "变更": "changed", "已变更": "changed",
             "cancelled": "cancelled", "canceled": "cancelled", "取消": "cancelled", "已取消": "cancelled",
+            "deferred": "deferred", "postponed": "deferred", "顺延": "deferred", "延期": "deferred",
         }
         return aliases.get(_single_line(value, 20).lower(), "")
 
@@ -9629,6 +9636,38 @@ class DailyStateMixin(DailyStateTickMixin):
         return runtime
 
     def _plan_item_runtime_status(self, plan: dict[str, Any], item: dict[str, Any], index: int = -1) -> str:
+        # Lifecycle display must come from canonical evidence, never from the
+        # clock alone.  Keep the legacy helper signature for callers, but map
+        # old lifecycle values through a conservative planned/unknown view.
+        if isinstance(item, dict):
+            legacy = self._normalize_schedule_lifecycle_status(item.get("lifecycle_status"))
+            if legacy == "cancelled":
+                return "cancelled"
+            if legacy == "changed":
+                return "changed"
+            if legacy == "deferred":
+                return "deferred"
+            evidence = _single_line(item.get("evidence_kind"), 48).lower()
+            eligibility = _single_line(item.get("fact_eligibility"), 48).lower()
+            status = _single_line(item.get("status"), 32).lower()
+            if evidence in {"interaction", "tool_action", "external_record"} and eligibility in {"current_observed", "history_observed"}:
+                if status in {"active", "completed", "partially_completed"}:
+                    return status
+            if evidence == "self_state_commit" and eligibility == "current_internal":
+                return "active"
+            plan_date = str((plan or {}).get("date") or item.get("date") or "")
+            try:
+                canonical = normalize_plan_item(
+                    {**item, "date": plan_date or _today_key(), "subject_actor_id": item.get("subject_actor_id") or "bot_self"},
+                    plan_id=str(item.get("plan_id") or ""),
+                    now=self._environment_now(),
+                )
+                phase = _single_line(canonical.get("temporal_phase"), 16).lower()
+                if phase == "past":
+                    return "unknown"
+                return "planned"
+            except Exception:
+                return "planned"
         items = plan.get("items") if isinstance(plan, dict) else None
         starts = self._normalized_plan_item_starts(items)
         start = starts[index] if isinstance(items, list) and 0 <= index < len(starts) else self._parse_hhmm_to_minutes(item.get("time"))
@@ -11421,7 +11460,8 @@ class DailyStateMixin(DailyStateTickMixin):
         detail: dict[str, Any] | None = None,
     ) -> str:
         candidates: list[str] = []
-        if isinstance(detail, dict):
+        detail_allowed = self._detail_model_location_policy_allowed(detail)
+        if isinstance(detail, dict) and detail_allowed:
             model_location = _single_line(detail.get("location"), 60)
             if model_location:
                 return model_location
@@ -11453,46 +11493,79 @@ class DailyStateMixin(DailyStateTickMixin):
                     if _single_line(current_item.get(key), 120)
                 )
             )
-        if isinstance(plan, dict) and isinstance(plan.get("items"), list):
-            now_minutes = self._effective_plan_now_minutes(str(plan.get("date") or ""))
-            nearby: list[tuple[int, str]] = []
-            plan_items = plan.get("items", [])
-            starts = self._normalized_plan_item_starts(plan_items)
-            for index, item in enumerate(plan_items):
-                if not isinstance(item, dict):
-                    continue
-                if self._normalize_schedule_lifecycle_status(item.get("lifecycle_status")) == "cancelled":
-                    continue
-                item_minutes = starts[index] if index < len(starts) else None
-                if item_minutes is None:
-                    continue
-                distance = abs(item_minutes - now_minutes) if now_minutes is not None else item_minutes
-                text = " ".join(
-                    _single_line(item.get(key), 120)
-                    for key in ("activity", "mood", "message_seed")
-                    if _single_line(item.get(key), 120)
-                )
-                if text:
-                    nearby.append((distance, text))
-            for _, text in sorted(nearby, key=lambda row: row[0])[:3]:
-                candidates.append(text)
+        # Do not inspect neighboring raw plan rows here.  They are future or
+        # unverified projections and their clock distance cannot establish the
+        # Bot's current location.  A current item above is already policy /
+        # runtime qualified; a generated detail location is handled separately
+        # by ``_refresh_daily_state_location_from_plan``.
         for text in candidates:
             inferred = self._infer_location_from_text(text)
             if inferred:
                 return inferred
         return ""
 
+    def _detail_model_location_policy_allowed(self, detail: dict[str, Any] | None = None) -> bool:
+        """Only evidence-backed detail may update production current location."""
+
+        policy_getter = getattr(self, "_agenda_disclosure_view", None)
+        if not callable(policy_getter):
+            # Lightweight harnesses and legacy callers do not have C3 policy;
+            # preserve their historical local projection behavior.
+            return True
+        payload = detail if isinstance(detail, dict) else {}
+        evidence_kind = _single_line(payload.get("evidence_kind"), 48).lower()
+        eligibility = _single_line(payload.get("fact_eligibility"), 48).lower()
+        refs = payload.get("source_refs")
+        has_refs = isinstance(refs, (list, tuple, set)) and any(_single_line(ref, 160) for ref in refs)
+        if evidence_kind not in {"tool_action", "external_record"} or eligibility != "current_observed" or not has_refs:
+            return False
+        try:
+            view = policy_getter("current_fact", now=self._environment_now(), max_entries=128)
+            entries = view.get("entries", []) if isinstance(view, dict) else getattr(view, "entries", [])
+        except Exception:
+            return False
+        for entry in entries if isinstance(entries, list) else []:
+            if not isinstance(entry, dict):
+                continue
+            if _single_line(entry.get("subject_actor_id"), 120) != "bot_self":
+                continue
+            if _single_line(entry.get("fact_eligibility"), 48).lower() != "current_observed":
+                continue
+            entry_refs = entry.get("source_refs")
+            if isinstance(entry_refs, str):
+                entry_refs = [entry_refs]
+            if isinstance(entry_refs, (list, tuple, set)) and any(
+                _single_line(ref, 160) in {_single_line(value, 160) for value in refs}
+                for ref in entry_refs
+            ):
+                return True
+        return False
+
     def _refresh_daily_state_location_from_plan(
         self,
         *,
         plan: dict[str, Any] | None = None,
         detail: dict[str, Any] | None = None,
+        segment: dict[str, Any] | None = None,
     ) -> bool:
         state = self.data.get("daily_state")
         if not isinstance(state, dict) or state.get("date") != _today_key():
             return False
+        # Detail generation intentionally runs in a lead window.  A future
+        # candidate may describe a likely place, but it is not current Bot
+        # state until the segment actually starts.
+        if isinstance(detail, dict) and isinstance(segment, dict):
+            plan_date = _single_line((plan or {}).get("date"), 16) if isinstance(plan, dict) else ""
+            now_minutes = self._effective_plan_now_minutes(plan_date)
+            start_minutes = _safe_int(segment.get("start"), -1, minimum=-1)
+            if now_minutes is not None and start_minutes >= 0 and now_minutes < start_minutes:
+                return False
         override_ts = _safe_float(state.get("location_override_ts"), 0)
-        model_location = _single_line(detail.get("location"), 60) if isinstance(detail, dict) else ""
+        model_location = (
+            _single_line(detail.get("location"), 60)
+            if isinstance(detail, dict) and self._detail_model_location_policy_allowed(detail)
+            else ""
+        )
         if override_ts > 0 and _now_ts() - override_ts < 4 * 3600 and not model_location:
             return False
         location = model_location or self._infer_location_from_plan_context(plan=plan, detail=detail)
@@ -11551,6 +11624,8 @@ class DailyStateMixin(DailyStateTickMixin):
         enhanced = self.data.get("detail_enhanced_segments", {})
         snapshot = enhanced.get(str(segment.get("key") or "")) if isinstance(enhanced, dict) else None
         if not isinstance(snapshot, dict) or _single_line(snapshot.get("status"), 24) != "done":
+            return ""
+        if not self._detail_model_location_policy_allowed(snapshot):
             return ""
         return _single_line(snapshot.get("location"), 60)
 
@@ -16253,6 +16328,23 @@ class DailyStateMixin(DailyStateTickMixin):
         items = sorted(items, key=lambda item: self._parse_hhmm_to_minutes(item["time"]) or 0)
         items = items[: self.daily_plan_item_count]
         self._normalize_plan_item_intervals(items)
+        # Pass every generated item through the C3 write gate.  LLM fields such
+        # as status, source_refs, authority and evidence are never trusted;
+        # canonical axes are retained so downstream views cannot silently lose
+        # the distinction between a plan and an observation.
+        today = _today_key()
+        for index, item in enumerate(items):
+            try:
+                canonical = normalize_plan_item(
+                    {**item, "title": item.get("activity"), "date": today, "subject_actor_id": "bot_self", "actor_type": "bot"},
+                    plan_id=f"{today}:{index}",
+                    now=self._environment_now(),
+                )
+            except Exception:
+                continue
+            item.update(canonical)
+            item["activity"] = _single_line(item.get("activity") or item.get("title"), 120)
+            item["date"] = today
         return items
 
     def _skill_levels_for_plan_bounds(self) -> dict[str, int]:
@@ -16476,6 +16568,63 @@ class DailyStateMixin(DailyStateTickMixin):
                 selected_start = item_minutes
                 break
         if isinstance(selected, dict):
+            # A clock window is not execution evidence.  Keep confirmed
+            # schedule commitments available through the future/schedule
+            # policy, but expose current plan text only when a compatible
+            # observation or a short-lived resolver commit exists.
+            policy_allows_current = True
+            policy_getter = getattr(self, "_agenda_disclosure_view", None)
+            if callable(policy_getter):
+                policy_allows_current = False
+                try:
+                    view = policy_getter("current_fact", now=self._environment_now(), max_entries=128)
+                    values = view.get("entries", []) if isinstance(view, dict) else getattr(view, "entries", [])
+                    selected_key = _single_line(selected.get("plan_id"), 120)
+                    selected_pair = (
+                        _single_line(selected.get("time"), 12),
+                        _single_line(selected.get("activity") or selected.get("title"), 120),
+                    )
+                    for value in values if isinstance(values, list) else []:
+                        if not isinstance(value, dict):
+                            continue
+                        value_key = _single_line(value.get("plan_id") or value.get("entry_id"), 120)
+                        value_pair = (
+                            _single_line(value.get("time"), 12),
+                            _single_line(value.get("title") or value.get("activity"), 120),
+                        )
+                        if (selected_key and selected_key == value_key) or (selected_pair == value_pair and all(selected_pair)):
+                            policy_allows_current = True
+                            break
+                except Exception:
+                    policy_allows_current = False
+            evidence_kind = _single_line(selected.get("evidence_kind"), 48).lower()
+            fact_eligibility = _single_line(selected.get("fact_eligibility"), 48).lower()
+            status = _single_line(selected.get("status"), 32).lower()
+            if not policy_allows_current or not (
+                evidence_kind in {"interaction", "tool_action", "external_record"}
+                and fact_eligibility in {"current_observed", "history_observed", ""}
+                and status in {"active", "completed", "partially_completed", ""}
+            ):
+                runtime_getter = getattr(self, "_agenda_runtime_scene", None)
+                if callable(runtime_getter):
+                    try:
+                        runtime = runtime_getter(now=self._environment_now())
+                    except Exception:
+                        runtime = None
+                    if isinstance(runtime, dict):
+                        return {
+                            "time": self._minutes_to_hhmm(current_minutes),
+                            "end": _single_line(runtime.get("valid_until"), 40),
+                            "activity": _single_line(runtime.get("state"), 120),
+                            "mood": "当前状态",
+                            "message_seed": "",
+                            "subject_actor_id": "bot_self",
+                            "evidence_kind": "self_state_commit",
+                            "fact_eligibility": "current_internal",
+                            "materialization_state": "active",
+                            "status": "active",
+                        }
+                return None
             plan_date = str(plan.get("date") or "").strip()
             if (
                 plan_date
@@ -16530,6 +16679,9 @@ class DailyStateMixin(DailyStateTickMixin):
             "completed": "已完成",
             "changed": "已变更",
             "cancelled": "已取消",
+            "deferred": "已顺延",
+            "unknown": "未核实",
+            "overridden": "已被新安排覆盖",
         }
         for index, item in enumerate(plan.get("items", [])):
             if not isinstance(item, dict):

--- a/dreaming.py
+++ b/dreaming.py
@@ -385,7 +385,18 @@ def fallback_dream_fragments_for_diary(plugin, state: dict[str, Any]) -> list[di
         _single_line(state.get("mood_bias"), 20),
         _single_line(plugin._weather_summary_text(plugin.data.get("daily_weather", {})), 36),
     ]
-    current_item = plugin._get_current_plan_item(plugin.data.get("daily_plan", {}))
+    current_getter = getattr(plugin, "_agenda_current_context_item", None)
+    legacy_getter = getattr(plugin, "_get_current_plan_item", None)
+    try:
+        current_item = (
+            current_getter()
+            if callable(current_getter)
+            else legacy_getter(plugin.data.get("daily_plan", {}))
+            if callable(legacy_getter)
+            else None
+        )
+    except Exception:
+        current_item = None
     if isinstance(current_item, dict):
         seed_candidates.extend(
             [
@@ -454,16 +465,23 @@ def build_dream_memory_fragments(plugin, count: int = 8) -> list[str]:
                     cleaned = _clean_dream_fragment_text(candidate)
                     if cleaned and _dream_fragment_is_useful(cleaned):
                         fragments.append(cleaned)
-    current_plan = plugin.data.get("daily_plan", {})
-    if isinstance(current_plan, dict):
-        items = current_plan.get("items", [])
-        if isinstance(items, list):
-            for item in items[-3:]:
+    # A raw daily plan is an intent/projection input.  It must not become
+    # dream or long-term memory material merely because its clock window has
+    # elapsed.  Only evidence-backed historical entries are eligible here.
+    disclosure = getattr(plugin, "_agenda_disclosure_view", None)
+    if callable(disclosure):
+        try:
+            view = disclosure("history_fact", max_entries=12)
+            entries = view.get("entries", []) if isinstance(view, dict) else getattr(view, "entries", [])
+        except Exception:
+            entries = []
+        if isinstance(entries, list):
+            for item in entries:
                 if not isinstance(item, dict):
                     continue
                 for candidate in (
-                    _single_line(item.get("activity"), 80),
-                    _single_line(item.get("message_seed"), 80),
+                    _single_line(item.get("title") or item.get("activity"), 80),
+                    _single_line(item.get("summary"), 80),
                 ):
                     cleaned = _clean_dream_fragment_text(candidate)
                     if cleaned and _dream_fragment_is_useful(cleaned):

--- a/event_dispatch.py
+++ b/event_dispatch.py
@@ -5308,7 +5308,19 @@ Bot 近期回复：
         fatigue = scene.get("wakeup_fatigue") if isinstance(scene.get("wakeup_fatigue"), dict) else {}
         fatigue_label = _single_line(fatigue.get("label"), 20)
         fatigue_suffix = f"；最近群聊唤醒疲劳为{fatigue_label},回应应更省力" if str(fatigue.get("level") or "") in {"medium", "high"} else ""
-        is_sleep_phase = phase in {"falling_asleep", "light_sleep", "sleeping_again", "woken"} or bool(self._is_sleepy_plan_item(self._get_current_plan_item(self.data.get("daily_plan", {}))))
+        current_getter = getattr(self, "_agenda_current_context_item", None)
+        legacy_getter = getattr(self, "_get_current_plan_item", None)
+        try:
+            current_item = (
+                current_getter()
+                if callable(current_getter)
+                else legacy_getter(self.data.get("daily_plan", {}))
+                if callable(legacy_getter)
+                else None
+            )
+        except Exception:
+            current_item = None
+        is_sleep_phase = phase in {"falling_asleep", "light_sleep", "sleeping_again", "woken"} or bool(self._is_sleepy_plan_item(current_item))
         if is_sleep_phase:
             runtime = self._mark_sleep_woken_by_group_wakeup(text, wakeup_type=wakeup_type)
             prior = _safe_int(runtime.get("woken_count"), 1, 1)

--- a/memory_companion_adapter.py
+++ b/memory_companion_adapter.py
@@ -7,6 +7,7 @@ import uuid
 import asyncio
 import re
 import time
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -1120,6 +1121,25 @@ class MemoryCompanionAdapterMixin:
         except Exception:
             return "", 0.0
 
+    def _memory_companion_current_agenda_item(self) -> dict[str, Any] | None:
+        """Return only a disclosed Bot current fact/runtime state."""
+
+        getter = getattr(self, "_agenda_current_context_item", None)
+        if callable(getter):
+            try:
+                item = getter()
+            except Exception:
+                return None
+            return item if isinstance(item, dict) else None
+        # Compatibility for isolated legacy harnesses.  Production instances
+        # always expose the policy/runtime accessor above.
+        legacy_getter = getattr(self, "_get_current_plan_item", None)
+        try:
+            item = legacy_getter(self.data.get("daily_plan", {})) if callable(legacy_getter) else None
+        except Exception:
+            item = None
+        return item if isinstance(item, dict) else None
+
     def _memory_companion_build_private_context(
         self,
         *,
@@ -1140,11 +1160,7 @@ class MemoryCompanionAdapterMixin:
                     role = ""
             except Exception:
                 role = ""
-        current_item = None
-        try:
-            current_item = self._get_current_plan_item(self.data.get("daily_plan", {}))
-        except Exception:
-            current_item = None
+        current_item = self._memory_companion_current_agenda_item()
         schedule_text = ""
         if isinstance(current_item, dict):
             try:
@@ -1642,17 +1658,79 @@ class MemoryCompanionAdapterMixin:
             "只在与本轮直接相关时自然接住；不要主动列举记忆、不要提及检索过程，也不要把它当作其他用户的信息。"
         )
 
+    def _memory_companion_agenda_memory_write_entries(
+        self,
+        *,
+        date_text: str = "",
+        now: datetime | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return only entries admitted by the canonical memory-write view."""
+
+        getter = getattr(self, "_agenda_disclosure_view", None)
+        if not callable(getter):
+            return []
+        current = now
+        if current is None:
+            try:
+                current = self._environment_now()
+            except Exception:
+                current = datetime.now().astimezone()
+        try:
+            try:
+                view = getter(
+                    "memory_write",
+                    now=current,
+                    max_entries=256,
+                    date_key=_single_line(date_text, 20),
+                )
+            except TypeError:
+                view = getter("memory_write", now=current, max_entries=256)
+        except Exception:
+            return []
+        entries = getattr(view, "entries", None)
+        if entries is None and isinstance(view, dict):
+            entries = view.get("entries")
+        return [dict(item) for item in entries if isinstance(item, dict)] if isinstance(entries, list) else []
+
+    @staticmethod
+    def _memory_companion_entry_ids(entries: list[dict[str, Any]]) -> set[str]:
+        ids: set[str] = set()
+        for item in entries:
+            for key in ("entry_id", "plan_id", "activity_id", "event_id"):
+                value = _single_line(item.get(key), 160)
+                if value:
+                    ids.add(value)
+        return ids
+
     async def _memory_companion_record_agenda_snapshot(self, snapshot: dict[str, Any]) -> dict[str, Any]:
         if not isinstance(snapshot, dict):
             return {"ok": False, "state": "invalid", "error_code": "invalid_snapshot"}
         date_text = _single_line(snapshot.get("window_date") or snapshot.get("date"), 20)
         window = _single_line(snapshot.get("window") or snapshot.get("slug"), 32)
         snapshot_id = _single_line(snapshot.get("snapshot_id"), 160) or f"agenda_snapshot:{date_text}:{window}"
+        allowed_entries = self._memory_companion_agenda_memory_write_entries(
+            date_text=date_text,
+        )
+        allowed_ids = self._memory_companion_entry_ids(allowed_entries)
+        if not allowed_ids:
+            return {
+                "ok": False,
+                "state": "filtered",
+                "error_code": "memory_write_filtered",
+                "idempotency_key": snapshot_id,
+            }
 
         def _compact(items: Any, field: str) -> list[dict[str, Any]]:
             result: list[dict[str, Any]] = []
             for item in items if isinstance(items, list) else []:
                 if not isinstance(item, dict):
+                    continue
+                item_ids = {
+                    _single_line(item.get(key), 160)
+                    for key in ("entry_id", "plan_id", "activity_id", "event_id")
+                    if _single_line(item.get(key), 160)
+                }
+                if not item_ids.intersection(allowed_ids):
                     continue
                 value = _single_line(item.get("title") or item.get("summary") or item.get(field), 180)
                 if not value:
@@ -1664,17 +1742,40 @@ class MemoryCompanionAdapterMixin:
                 })
             return result[:16]
 
+        planned = _compact(snapshot.get("planned"), "title")
+        observed = _compact(snapshot.get("observed"), "summary")
+        reconciled = _compact(snapshot.get("reconciled"), "reason")
+        if not planned and not observed and not reconciled:
+            return {
+                "ok": False,
+                "state": "filtered",
+                "error_code": "memory_write_entries_not_in_snapshot",
+                "idempotency_key": snapshot_id,
+            }
         payload = {
             "date": date_text,
             "window": window,
             "summary": f"{date_text} {window} 窗口快照",
-            "planned": _compact(snapshot.get("planned"), "title"),
-            "observed": _compact(snapshot.get("observed"), "summary"),
-            "reconciled": _compact(snapshot.get("reconciled"), "reason"),
+            "planned": planned,
+            "observed": observed,
+            "reconciled": reconciled,
             "open_items": [_single_line(item, 160) for item in (snapshot.get("open_items") or []) if _single_line(item, 160)][:12],
+            "memory_write_entry_ids": sorted(allowed_ids)[:32],
         }
         refs = [snapshot_id]
-        refs.extend(_single_line(item, 160) for item in (snapshot.get("source_refs") or []) if _single_line(item, 160))
+        refs.extend(
+            _single_line(item, 160)
+            for item in (snapshot.get("source_refs") or [])
+            if _single_line(item, 160) in allowed_ids
+        )
+        for item in allowed_entries:
+            raw_refs = item.get("source_refs")
+            if isinstance(raw_refs, str):
+                raw_refs = [raw_refs]
+            for ref in raw_refs if isinstance(raw_refs, (list, tuple, set)) else []:
+                safe_ref = _single_line(ref, 160)
+                if safe_ref and safe_ref not in refs:
+                    refs.append(safe_ref)
         return await self._memory_companion_record_bot_personal(
             memory_type="bot_window_snapshot",
             payload=payload,
@@ -1690,9 +1791,32 @@ class MemoryCompanionAdapterMixin:
         date_text = _single_line(reconciliation.get("window_date") or reconciliation.get("date"), 20)
         window = _single_line(reconciliation.get("window") or reconciliation.get("slug"), 32)
         record_id = _single_line(reconciliation.get("reconciliation_id"), 160) or f"reconciliation:{date_text}:{window}"
+        allowed_entries = self._memory_companion_agenda_memory_write_entries(
+            date_text=date_text,
+        )
+        allowed_ids = self._memory_companion_entry_ids(allowed_entries)
+        if not allowed_ids:
+            return {
+                "ok": False,
+                "state": "filtered",
+                "error_code": "memory_write_filtered",
+                "idempotency_key": record_id,
+            }
         plans = []
         for item in reconciliation.get("plans") if isinstance(reconciliation.get("plans"), list) else []:
             if not isinstance(item, dict):
+                continue
+            item_ids = {
+                _single_line(item.get(key), 160)
+                for key in ("entry_id", "plan_id", "activity_id", "event_id")
+                if _single_line(item.get(key), 160)
+            }
+            activity_ids = {
+                _single_line(value, 160)
+                for value in (item.get("activity_ids") or item.get("reconciled_activity_ids") or [])
+                if _single_line(value, 160)
+            }
+            if not (item_ids | activity_ids).intersection(allowed_ids):
                 continue
             plans.append({
                 "plan_id": _single_line(item.get("plan_id"), 120),
@@ -1700,15 +1824,40 @@ class MemoryCompanionAdapterMixin:
                 "reason": _single_line(item.get("reason") or item.get("reconciliation_reason"), 180),
                 "activity_ids": [_single_line(value, 120) for value in (item.get("activity_ids") or item.get("reconciled_activity_ids") or []) if _single_line(value, 120)][:12],
             })
+        observed_activity_ids = [
+            _single_line(value, 120)
+            for value in (reconciliation.get("observed_activity_ids") or [])
+            if _single_line(value, 120) in allowed_ids
+        ]
+        if not plans and not observed_activity_ids:
+            return {
+                "ok": False,
+                "state": "filtered",
+                "error_code": "memory_write_entries_not_in_reconciliation",
+                "idempotency_key": record_id,
+            }
         payload = {
             "date": date_text,
             "window": window,
             "summary": f"{date_text} {window} 计划与实际对账",
             "plans": plans[:16],
-            "observed_activity_ids": [_single_line(value, 120) for value in (reconciliation.get("observed_activity_ids") or []) if _single_line(value, 120)][:16],
+            "observed_activity_ids": observed_activity_ids[:16],
+            "memory_write_entry_ids": sorted(allowed_ids)[:32],
         }
         refs = [record_id]
-        refs.extend(_single_line(item, 160) for item in (reconciliation.get("source_refs") or []) if _single_line(item, 160))
+        refs.extend(
+            _single_line(item, 160)
+            for item in (reconciliation.get("source_refs") or [])
+            if _single_line(item, 160) in allowed_ids
+        )
+        for item in allowed_entries:
+            raw_refs = item.get("source_refs")
+            if isinstance(raw_refs, str):
+                raw_refs = [raw_refs]
+            for ref in raw_refs if isinstance(raw_refs, (list, tuple, set)) else []:
+                safe_ref = _single_line(ref, 160)
+                if safe_ref and safe_ref not in refs:
+                    refs.append(safe_ref)
         return await self._memory_companion_record_bot_personal(
             memory_type="bot_schedule_reconciliation",
             payload=payload,
@@ -1783,38 +1932,20 @@ class MemoryCompanionAdapterMixin:
                 "items": lines,
                 "source": _single_line(plan.get("source"), 40),
                 "item_count": len(lines),
+                "subject_actor_id": "bot_self",
+                "actor_type": "bot",
+                "content_granularity": "day",
+                "materialization_state": "candidate",
+                "fact_eligibility": "none",
+                "expires_at": (datetime.now().astimezone() + timedelta(hours=24)).isoformat(timespec="seconds"),
+                "legacy_flags": ["short_ttl_plan", "unverified_plan"],
             },
             idempotency_key=f"daily_plan:{date_text}",
             occurred_at=_single_line(plan.get("generated_at"), 80) or self._memory_companion_now_iso(),
             version=int(plan.get("version") or 1),
             source_refs=[f"companion:daily_plan:{date_text}"],
         )
-        bridge = self._memory_companion_bridge()
-        recorder = getattr(bridge, "record_schedule_fragment", None) if bridge is not None else None
-        if not callable(recorder):
-            return
-        content = f"{date_text} 的 Bot 当日生活日程已生成：\n" + "\n".join(f"- {line}" for line in lines)
-        try:
-            await recorder(
-                content=content,
-                scope="unknown",
-                session_id="private_companion:schedule",
-                message_id=f"private_companion_daily_plan_{date_text}",
-                memory_id=f"private_companion_daily_plan_{date_text}",
-                metadata={
-                    "date": date_text,
-                    "source": _single_line(plan.get("source"), 40),
-                    "item_count": len(lines),
-                    "provider_id": _single_line(plan.get("provider_id"), 120),
-                },
-                source_plugin="private_companion",
-                confidence=0.86,
-                importance=0.5,
-            )
-        except Exception as exc:
-            if self._memory_companion_optional_dependency_failed(exc, where="record_daily_plan"):
-                return
-            logger.debug("[PrivateCompanion] MemoryCompanion 日程写入失败: %s", _single_line(exc, 120))
+        return
 
     async def _memory_companion_record_detail_enhancement(
         self,
@@ -1869,45 +2000,18 @@ class MemoryCompanionAdapterMixin:
                 "proactive_events": proactive[:3],
                 "start": start_text,
                 "end": end_text,
+                "subject_actor_id": "bot_self",
+                "actor_type": "bot",
+                "content_granularity": "scene",
+                "materialization_state": "candidate",
+                "fact_eligibility": "none",
+                "expires_at": (datetime.now().astimezone() + timedelta(hours=2)).isoformat(timespec="seconds"),
+                "legacy_flags": ["short_ttl_candidate", "unverified_plan"],
             },
             idempotency_key=f"detail:{date_text}:{start}:{end}",
             occurred_at=self._memory_companion_now_iso(),
             source_refs=[f"companion:detail:{date_text}:{start}:{end}"],
         )
-        bridge = self._memory_companion_bridge()
-        recorder = getattr(bridge, "record_schedule_fragment", None) if bridge is not None else None
-        if not callable(recorder):
-            return
-        parts = [f"{date_text} {start_text}-{end_text} 的 Bot 日程细化："]
-        if summary:
-            parts.append(summary)
-        if events:
-            parts.append("生活片段：" + "；".join(events[:4]))
-        if proactive:
-            parts.append("可能主动念头：" + "；".join(proactive[:3]))
-        try:
-            await recorder(
-                content="\n".join(parts),
-                scope="unknown",
-                session_id="private_companion:schedule",
-                message_id=f"private_companion_detail_{date_text}_{start}_{end}",
-                memory_id=f"private_companion_detail_{date_text}_{start}_{end}",
-                metadata={
-                    "date": date_text,
-                    "start": start_text,
-                    "end": end_text,
-                    "summary": summary,
-                    "event_count": len(events),
-                    "proactive_count": len(proactive),
-                },
-                source_plugin="private_companion",
-                confidence=0.84,
-                importance=0.42,
-            )
-        except Exception as exc:
-            if self._memory_companion_optional_dependency_failed(exc, where="record_detail_enhancement"):
-                return
-            logger.debug("[PrivateCompanion] MemoryCompanion 细化写入失败: %s", _single_line(exc, 120))
 
     def _memory_companion_build_group_context(
         self,
@@ -1919,11 +2023,7 @@ class MemoryCompanionAdapterMixin:
         text: str,
         event: Any | None = None,
     ) -> dict[str, Any]:
-        current_item = None
-        try:
-            current_item = self._get_current_plan_item(self.data.get("daily_plan", {}))
-        except Exception:
-            current_item = None
+        current_item = self._memory_companion_current_agenda_item()
         schedule_text = ""
         if isinstance(current_item, dict):
             try:

--- a/news_exploration.py
+++ b/news_exploration.py
@@ -406,6 +406,21 @@ def _decode_news_response_text(
 class NewsExplorationMixin:
     """新闻阅读/网页探索"""
 
+    def _news_current_agenda_item(self) -> dict[str, Any] | None:
+        getter = getattr(self, "_agenda_current_context_item", None)
+        if callable(getter):
+            try:
+                item = getter()
+            except Exception:
+                return None
+            return item if isinstance(item, dict) else None
+        legacy_getter = getattr(self, "_get_current_plan_item", None)
+        try:
+            item = legacy_getter(self.data.get("daily_plan", {})) if callable(legacy_getter) else None
+        except Exception:
+            item = None
+        return item if isinstance(item, dict) else None
+
     def _clean_bilibili_share_field(self, value: Any, limit: int = 160) -> str:
         cleaner = getattr(self, "_clean_external_share_source_field", None)
         if callable(cleaner):
@@ -1311,7 +1326,7 @@ class NewsExplorationMixin:
         state = self.data.get("daily_state", {})
         energy = _safe_int(state.get("energy") if isinstance(state, dict) else 70, 70, 0, 100)
         mood = _single_line(state.get("mood_bias") if isinstance(state, dict) else "", 24)
-        current_item = self._get_current_plan_item(self.data.get("daily_plan", {}))
+        current_item = self._news_current_agenda_item()
         activity = _single_line((current_item or {}).get("activity"), 80)
         text = f"{mood} {activity}"
         boredom_tokens = ("无聊", "发呆", "摸鱼", "刷视频", "短视频", "休息", "闲", "空")
@@ -2863,7 +2878,7 @@ class NewsExplorationMixin:
 
     def _format_external_event_current_self_context(self) -> str:
         state = self.data.get("daily_state", {}) if isinstance(self.data.get("daily_state"), dict) else {}
-        current_item = self._get_current_plan_item(self.data.get("daily_plan", {}))
+        current_item = self._news_current_agenda_item()
         mood = _single_line(state.get("mood_bias"), 40)
         energy = _safe_int(state.get("energy"), 70, 0, 100)
         activity = _single_line((current_item or {}).get("activity"), 120)
@@ -3048,7 +3063,7 @@ class NewsExplorationMixin:
         state = self.data.get("daily_state", {})
         energy = _safe_int(state.get("energy") if isinstance(state, dict) else 70, 70, 0, 100)
         mood = _single_line(state.get("mood_bias") if isinstance(state, dict) else "", 24)
-        current_item = self._get_current_plan_item(self.data.get("daily_plan", {}))
+        current_item = self._news_current_agenda_item()
         activity = _single_line((current_item or {}).get("activity"), 80)
         text = f"{mood} {activity}"
         if any(token in text for token in ("无聊", "发呆", "摸鱼", "休息", "闲", "空", "刷")):
@@ -4120,7 +4135,7 @@ class NewsExplorationMixin:
         state = self.data.get("daily_state", {})
         mood = _single_line(state.get("mood_bias") if isinstance(state, dict) else "", 30)
         energy = _safe_int(state.get("energy") if isinstance(state, dict) else 70, 70, 0, 100)
-        current_item = self._get_current_plan_item(self.data.get("daily_plan", {}))
+        current_item = self._news_current_agenda_item()
         activity = _single_line((current_item or {}).get("activity"), 80)
         recent_user = ""
         users = self.data.get("users") if isinstance(self.data.get("users"), dict) else {}

--- a/page_api.py
+++ b/page_api.py
@@ -13184,6 +13184,7 @@ class PrivateCompanionPageApi(
                 self.plugin._refresh_daily_state_location_from_plan(
                     plan=current_plan if isinstance(current_plan, dict) else plan,
                     detail=detail,
+                    segment=segment,
                 )
                 self.plugin._save_data_sync()
                 data = self._overview_data_snapshot_locked(self.plugin.data)
@@ -27060,7 +27061,12 @@ class PrivateCompanionPageApi(
         current_item = {}
         current_lifecycle = ""
         try:
-            picked = self.plugin._get_current_plan_item(plan)
+            current_getter = getattr(self.plugin, "_agenda_current_context_item", None)
+            picked = (
+                current_getter()
+                if callable(current_getter)
+                else self.plugin._get_current_plan_item(plan)
+            )
             current_item = picked if isinstance(picked, dict) else {}
             items = plan.get("items") if isinstance(plan.get("items"), list) else []
             current_index = next((index for index, item in enumerate(items) if item is picked), -1)
@@ -27814,16 +27820,30 @@ class PrivateCompanionPageApi(
     def _timeline_story_items(self, value: Any, limit: int, plan_date: str) -> list[dict[str, Any]]:
         items = self._limited_story_items(value, limit)
         for item in items:
-            start, end = self.plugin._parse_window_minutes(str(item.get("window") or ""))
-            if start is None or end is None:
-                item["lifecycle"] = "planned"
+            # Story/detail entries are projections.  Their clock window only
+            # describes when a generated scene could occur; it is not an
+            # execution observation.  Never turn them into ``active`` or
+            # ``completed`` solely because the wall clock crossed the window.
+            # Preserve explicit editorial transitions (cancelled/changed/
+            # deferred), while evidence-backed canonical states may still be
+            # surfaced when a producer supplied the full evidence contract.
+            explicit = self._single_line(item.get("lifecycle_status"), 24).lower()
+            if explicit in {"cancelled", "canceled", "changed", "deferred", "postponed"}:
+                item["lifecycle"] = "cancelled" if explicit == "canceled" else (
+                    "deferred" if explicit == "postponed" else explicit
+                )
                 continue
-            item["lifecycle"] = self.plugin._schedule_window_runtime_status(
-                start,
-                end,
-                plan_date=plan_date,
-                explicit_status=item.get("lifecycle_status"),
-            )
+            evidence_kind = self._single_line(item.get("evidence_kind"), 48).lower()
+            eligibility = self._single_line(item.get("fact_eligibility"), 48).lower()
+            status = self._single_line(item.get("status"), 32).lower()
+            if (
+                evidence_kind in {"interaction", "tool_action", "external_record"}
+                and eligibility in {"current_observed", "history_observed"}
+                and status in {"active", "completed", "partially_completed"}
+            ):
+                item["lifecycle"] = status
+            else:
+                item["lifecycle"] = "planned"
         return items
 
     @staticmethod

--- a/planning.py
+++ b/planning.py
@@ -482,6 +482,17 @@ def normalize_story_items(plugin, raw_items: Any, text_key: str) -> list[dict[st
             text_key: text_value,
             "mood": _single_line(raw.get("mood"), 30),
             "lifecycle_status": lifecycle,
+            # Detail output is a temporary scene proposal.  It must never be
+            # mistaken for a current or historical Bot fact.
+            "status": "planned",
+            "source_kind": "planned",
+            "evidence_kind": "none",
+            "commitment_level": "tentative",
+            "content_granularity": "scene",
+            "materialization_state": "candidate",
+            "fact_eligibility": "none",
+            "subject_actor_id": "bot_self",
+            "actor_type": "bot",
             "basis": plugin._normalize_schedule_basis(raw.get("basis"), default=["coarse_plan"]),
             "confidence": min(1.0, max(0.0, float(raw.get("confidence") or 0.72)))
             if str(raw.get("confidence") or "").strip().replace(".", "", 1).isdigit()

--- a/private_reading.py
+++ b/private_reading.py
@@ -248,6 +248,21 @@ _PLATFORM_DISPLAY_NAMES = {
 class PrivateReadingMixin:
     """私密阅读/书架"""
 
+    def _private_reading_current_agenda_item(self) -> dict[str, Any] | None:
+        getter = getattr(self, "_agenda_current_context_item", None)
+        if callable(getter):
+            try:
+                item = getter()
+            except Exception:
+                return None
+            return item if isinstance(item, dict) else None
+        legacy_getter = getattr(self, "_get_current_plan_item", None)
+        try:
+            item = legacy_getter(self.data.get("daily_plan", {})) if callable(legacy_getter) else None
+        except Exception:
+            item = None
+        return item if isinstance(item, dict) else None
+
     def _jm_cosmos_plugin_dir(self) -> Path:
         candidates = [
             Path(__file__).resolve().parent.parent / "astrbot_plugin_jm_cosmos",
@@ -299,7 +314,7 @@ class PrivateReadingMixin:
         state = self.data.get("daily_state", {})
         energy = _safe_int(state.get("energy") if isinstance(state, dict) else 70, 70, 0, 100)
         mood = _single_line(state.get("mood_bias") if isinstance(state, dict) else "", 24)
-        current_item = self._get_current_plan_item(self.data.get("daily_plan", {}))
+        current_item = self._private_reading_current_agenda_item()
         activity = _single_line((current_item or {}).get("activity"), 80)
         hour = datetime.now().hour
         text = f"{mood} {activity}"

--- a/proactive_engine.py
+++ b/proactive_engine.py
@@ -243,6 +243,21 @@ _PLATFORM_DISPLAY_NAMES = {
 class ProactiveEngineMixin:
     """主动行为候选、决策、计划事件与动作选择"""
 
+    def _proactive_current_agenda_item(self) -> dict[str, Any] | None:
+        getter = getattr(self, "_agenda_current_context_item", None)
+        if callable(getter):
+            try:
+                item = getter()
+            except Exception:
+                return None
+            return item if isinstance(item, dict) else None
+        legacy_getter = getattr(self, "_get_current_plan_item", None)
+        try:
+            item = legacy_getter(self.data.get("daily_plan", {})) if callable(legacy_getter) else None
+        except Exception:
+            item = None
+        return item if isinstance(item, dict) else None
+
     def _proactive_candidate_pool(self) -> list[dict[str, Any]]:
         raw = self.data.setdefault("proactive_candidate_pool", [])
         if not isinstance(raw, list):
@@ -7128,7 +7143,7 @@ class ProactiveEngineMixin:
             user.get("planned_proactive_reason"),
             user.get("planned_proactive_motive"),
         ]
-        current_item = self._get_current_plan_item(self.data.get("daily_plan", {}))
+        current_item = self._proactive_current_agenda_item()
         if isinstance(current_item, dict):
             text_parts.extend(
                 [
@@ -7579,7 +7594,7 @@ class ProactiveEngineMixin:
         motive: str = "",
         planned_event: dict[str, Any] | None = None,
     ) -> dict[str, str]:
-        current_item = self._get_current_plan_item(self.data.get("daily_plan", {}))
+        current_item = self._proactive_current_agenda_item()
         current_text = self._format_plan_item_for_prompt(current_item)
         event_text = ""
         if isinstance(planned_event, dict):
@@ -7619,7 +7634,7 @@ class ProactiveEngineMixin:
             return "刚看到的一条新闻"
         if reason == "creative_share":
             return "刚写到的小说片段"
-        current_item = self._get_current_plan_item(self.data.get("daily_plan", {}))
+        current_item = self._proactive_current_agenda_item()
         activity = _single_line((current_item or {}).get("activity"), 36)
         if activity:
             return f"{activity}里自然冒出来的小内容"
@@ -7755,7 +7770,7 @@ class ProactiveEngineMixin:
         if reason == "creative_share":
             creative = user.get("creative_share_context") if isinstance(user.get("creative_share_context"), dict) else {}
             return _single_line(creative.get("title"), 48) or "刚写到的小说片段"
-        current_item = self._get_current_plan_item(self.data.get("daily_plan", {}))
+        current_item = self._proactive_current_agenda_item()
         snapshot = self._current_story_plan_snapshot()
         weather = self._weather_summary_text(self.data.get("daily_weather", {}))
         weather_topic_available = self._ordinary_weather_topic_available(user)
@@ -8102,7 +8117,7 @@ class ProactiveEngineMixin:
         action_profile = self._persona_action_profile()
         motive_bias = self._motive_action_bias(motive)
         affinity_bias = self._action_affinity_bias(user)
-        current_item = self._get_current_plan_item(self.data.get("daily_plan", {}))
+        current_item = self._proactive_current_agenda_item()
         current_item_text = self._format_plan_item_for_prompt(current_item)
 
         weighted: list[tuple[str, float]] = [("message", 0.82)]
@@ -8189,7 +8204,7 @@ class ProactiveEngineMixin:
         state = self.data.get("daily_state", {})
         weather = self._weather_summary_text(self.data.get("daily_weather", {}))
         weather_topic_available = self._ordinary_weather_topic_available(user)
-        current_item = self._get_current_plan_item(self.data.get("daily_plan", {}))
+        current_item = self._proactive_current_agenda_item()
         snapshot = self._current_story_plan_snapshot()
         last_user_message = _single_line(user.get("last_user_message"), 48)
         can_do = self.data.get("can_do", [])
@@ -8721,7 +8736,7 @@ class ProactiveEngineMixin:
         state = self.data.get("daily_state", {})
         energy = _safe_int(state.get("energy") if isinstance(state, dict) else 70, 70, 0, 100)
         active_conditions = state.get("conditions", []) if isinstance(state, dict) else []
-        current_item = self._get_current_plan_item(self.data.get("daily_plan", {}))
+        current_item = self._proactive_current_agenda_item()
         can_do = self.data.get("can_do", [])
         important_dates = self._get_relevant_important_dates()
         ignored_streak = _safe_int(user.get("ignored_streak"), 0)

--- a/proactive_message.py
+++ b/proactive_message.py
@@ -1959,6 +1959,54 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
         now_minutes = self._effective_plan_now_minutes(str(plan.get("date") or ""))
         if now_minutes is None:
             return {}
+        # The raw daily plan is an edit input.  Build a purpose-specific view
+        # before exposing any text to proactive generation so past/current
+        # facts require evidence and future scene prose is reduced to a small
+        # labelled summary.
+        current_ids: set[str] = set()
+        history_ids: set[str] = set()
+        proactive_entries: dict[str, dict[str, Any]] = {}
+        disclosure_available = callable(getattr(self, "_agenda_disclosure_view", None))
+        disclosure_keys: dict[tuple[str, str], str] = {}
+        disclosure = getattr(self, "_agenda_disclosure_view", None)
+        if callable(disclosure):
+            try:
+                for purpose, bucket in (("current_fact", current_ids), ("history_fact", history_ids)):
+                    view = disclosure(purpose, max_entries=64)
+                    values = view.get("entries", []) if isinstance(view, dict) else getattr(view, "entries", [])
+                    for value in values if isinstance(values, list) else []:
+                        if isinstance(value, dict):
+                            key = str(value.get("plan_id") or value.get("entry_id") or "").strip()
+                            if key:
+                                bucket.add(key)
+                            pair = (
+                                _single_line(value.get("time"), 12),
+                                _single_line(value.get("title") or value.get("activity"), 120),
+                            )
+                            if pair[0] and pair[1] and key:
+                                disclosure_keys[pair] = key
+                view = disclosure("proactive", max_entries=64)
+                values = view.get("entries", []) if isinstance(view, dict) else getattr(view, "entries", [])
+                for value in values if isinstance(values, list) else []:
+                    if isinstance(value, dict):
+                        key = str(value.get("plan_id") or value.get("entry_id") or "").strip()
+                        if key:
+                            proactive_entries[key] = value
+                        pair = (
+                            _single_line(value.get("time"), 12),
+                            _single_line(value.get("title") or value.get("activity"), 120),
+                        )
+                        if pair[0] and pair[1] and key:
+                            disclosure_keys[pair] = key
+            except Exception:
+                current_ids.clear()
+                history_ids.clear()
+                proactive_entries = {}
+                disclosure_keys = {}
+                # The policy is a disclosure firewall.  If it is present but
+                # unavailable, fail closed instead of falling back to raw
+                # daily-plan prose in a proactive prompt.
+                disclosure_available = True
         parsed: list[tuple[int, dict[str, Any]]] = []
         for item in items:
             if not isinstance(item, dict):
@@ -1966,6 +2014,30 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
             minute = self._parse_hhmm_to_minutes(item.get("time"))
             if minute is None:
                 continue
+            item_key = str(item.get("plan_id") or "").strip()
+            if not item_key and disclosure_available:
+                pair = (
+                    _single_line(item.get("time"), 12),
+                    _single_line(item.get("activity") or item.get("title"), 120),
+                )
+                item_key = disclosure_keys.get(pair, "")
+            if disclosure_available and minute <= now_minutes and item_key not in current_ids and item_key not in history_ids:
+                # A clock window alone is not a current/history fact.  This
+                # also prevents an unexecuted past plan from being presented
+                # as the "previous" item in proactive prompts.
+                continue
+            if disclosure_available and minute > now_minutes:
+                public = proactive_entries.get(item_key)
+                if not public:
+                    # The proactive view applies its horizon and commitment
+                    # gates.  Do not fall back to raw future scene prose.
+                    continue
+                safe = dict(item)
+                safe["activity"] = _single_line(public.get("title"), 100) or "临近时段可能有安排"
+                safe["message_seed"] = ""
+                safe["scene"] = ""
+                safe["candidates"] = []
+                item = safe
             parsed.append((minute, item))
         if not parsed:
             return {}
@@ -15704,6 +15776,18 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
     def _format_plan_item_for_prompt(self, item: dict[str, Any] | None) -> str:
         if not isinstance(item, dict):
             return "（暂无）"
+        phase = _single_line(item.get("temporal_phase"), 16).lower()
+        eligibility = _single_line(item.get("fact_eligibility"), 48).lower()
+        status = _single_line(item.get("status"), 24).lower()
+        commitment = _single_line(item.get("commitment_level"), 24).lower()
+        is_unverified_future = phase == "future" or (status in {"planned", "unknown", ""} and eligibility in {"", "none"})
+        if is_unverified_future and commitment not in {"confirmed", "routine"}:
+            return f"{_single_line(item.get('time'), 12)}｜临近时段可能有安排"
+        if phase == "future" and status in {"planned", ""} and commitment in {"confirmed", "routine"}:
+            label = _single_line(item.get("title") or item.get("activity"), 80)
+            label = re.split(r"[，,。；;：:]", label, maxsplit=1)[0].strip()[:50]
+            prefix = "按安排" if commitment == "confirmed" else "照平常"
+            return "｜".join(part for part in (_single_line(item.get("time"), 12), f"{prefix}{label}") if part)
         parts = [
             str(item.get("time", "")).strip(),
             str(item.get("activity", "")).strip(),

--- a/qzone_publish.py
+++ b/qzone_publish.py
@@ -471,7 +471,7 @@ class QzonePublishMixin:
 
         qzone_state = self._qzone_state_dict()
         daily_state = self.data.get("daily_state", {})
-        current_item = self._get_current_plan_item(self.data.get("daily_plan", {}))
+        current_item = self._qzone_current_agenda_item()
         diary_context = self._recent_diary_context(count=2)
         theme_hint = self._qzone_publish_theme_hint()
         temporal_context = self._qzone_temporal_context()
@@ -618,7 +618,7 @@ class QzonePublishMixin:
 
         state = self._qzone_state_dict()
         daily_state = self.data.get("daily_state", {})
-        current_item = self._get_current_plan_item(self.data.get("daily_plan", {}))
+        current_item = self._qzone_current_agenda_item()
         diary_context = self._recent_diary_context(count=2)
         public_state_hint = self._qzone_relationship_safe_source(
             self._qzone_public_state_hint(daily_state if isinstance(daily_state, dict) else {}),

--- a/qzone_schedule.py
+++ b/qzone_schedule.py
@@ -8,6 +8,7 @@ import random
 import re
 import sys
 import time
+from datetime import datetime
 from typing import Any
 
 from astrbot.api import logger
@@ -68,6 +69,37 @@ def _qzone_compat_constant(name: str) -> Any:
 
 class QzoneScheduleMixin:
     """Publish window planning and automated post lifecycle helpers."""
+
+    def _qzone_current_agenda_item(self) -> dict[str, Any] | None:
+        getter = getattr(self, "_agenda_current_context_item", None)
+        if callable(getter):
+            try:
+                item = getter()
+            except Exception:
+                return None
+            return item if isinstance(item, dict) else None
+        legacy_getter = getattr(self, "_get_current_plan_item", None)
+        try:
+            item = legacy_getter(self.data.get("daily_plan", {})) if callable(legacy_getter) else None
+        except Exception:
+            item = None
+        return item if isinstance(item, dict) else None
+
+    @staticmethod
+    def _qzone_agenda_timestamp(value: Any) -> float:
+        if isinstance(value, (int, float)):
+            return max(0.0, float(value))
+        text = str(value or "").strip()
+        if not text:
+            return 0.0
+        try:
+            parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+            if parsed.tzinfo is None:
+                parsed = parsed.astimezone()
+            return parsed.timestamp()
+        except (TypeError, ValueError, OSError):
+            return 0.0
+
     @classmethod
     def _qzone_parse_windows(cls, raw: Any) -> list[tuple[int, int]]:
         """Parse "HH:MM-HH:MM" lines into (start_minute, end_minute) pairs.
@@ -266,37 +298,43 @@ class QzoneScheduleMixin:
         return hour * 60 + minute
 
     def _qzone_schedule_candidates_for_today(self) -> list[dict[str, Any]]:
-        """Collect today's schedule fragments so each post can use a different one."""
-        data = getattr(self, "data", None)
-        plan = data.get("daily_plan") if isinstance(data, dict) else None
-        if not isinstance(plan, dict):
+        """Collect short-lived Bot current facts for a nearby publish slot."""
+        disclosure = getattr(self, "_agenda_disclosure_view", None)
+        if not callable(disclosure):
             return []
-        if _single_line(plan.get("date"), 24) != _today_key():
+        try:
+            view = disclosure("current_fact", max_entries=32)
+            items = getattr(view, "entries", None)
+            if items is None and hasattr(view, "get"):
+                items = view.get("entries", [])
+        except Exception:
             return []
-        items = plan.get("items")
-        if not isinstance(items, list):
-            return []
-        normalizer = getattr(self, "_normalize_schedule_lifecycle_status", None)
+        now = _now_ts()
         candidates: list[dict[str, Any]] = []
         for index, item in enumerate(items):
             if not isinstance(item, dict):
                 continue
-            if callable(normalizer):
-                try:
-                    if normalizer(item.get("lifecycle_status")) == "cancelled":
-                        continue
-                except Exception:
-                    pass
-            minutes = self._qzone_hhmm_to_minutes(item.get("time"))
-            activity = _single_line(item.get("activity"), 160)
-            if minutes is None or not activity:
+            eligibility = _single_line(item.get("fact_eligibility"), 40).lower()
+            phase = _single_line(item.get("temporal_phase"), 20).lower()
+            if eligibility not in {"current_internal", "current_observed"} or phase != "current":
+                continue
+            activity = _single_line(item.get("title") or item.get("state") or item.get("activity"), 160)
+            valid_from = self._qzone_agenda_timestamp(item.get("start_at") or item.get("committed_at") or item.get("created_at"))
+            valid_until = self._qzone_agenda_timestamp(item.get("end_at") or item.get("valid_until") or item.get("expires_at"))
+            if not activity or valid_until <= now or valid_until <= valid_from:
                 continue
             candidates.append(
                 {
-                    # Index keeps the key unique when two entries share a time.
-                    "key": f"{_single_line(item.get('time'), 8)}#{index}",
+                    "key": _single_line(
+                        item.get("entry_id") or item.get("activity_id") or item.get("id"),
+                        80,
+                    ) or f"current-fact#{index}",
                     "label": activity,
-                    "start_minutes": minutes,
+                    "start_minutes": datetime.fromtimestamp(valid_from).hour * 60 + datetime.fromtimestamp(valid_from).minute,
+                    "valid_from": valid_from,
+                    "valid_until": valid_until,
+                    "fact_eligibility": eligibility,
+                    "evidence_kind": _single_line(item.get("evidence_kind"), 40),
                 }
             )
         return candidates
@@ -315,6 +353,10 @@ class QzoneScheduleMixin:
         best_distance = float("inf")
         for candidate in candidates:
             if candidate.get("key") in used_keys:
+                continue
+            valid_from = _safe_float(candidate.get("valid_from"), 0.0)
+            valid_until = _safe_float(candidate.get("valid_until"), 0.0)
+            if valid_from <= 0 or valid_until <= planned_at or planned_at < valid_from:
                 continue
             distance = abs(float(candidate.get("start_minutes") or 0) - target_minutes)
             if distance < best_distance:
@@ -366,7 +408,7 @@ class QzoneScheduleMixin:
     def _qzone_backfill_plan_schedule_labels(self, plan: dict[str, Any]) -> bool:
         candidates = self._qzone_schedule_candidates_for_today()
         items = plan.get("items") if isinstance(plan, dict) else None
-        if not candidates or not isinstance(items, list):
+        if not isinstance(items, list):
             return False
         used_keys = {
             _single_line(item.get("schedule_key"), 80)
@@ -374,6 +416,40 @@ class QzoneScheduleMixin:
             if isinstance(item, dict) and _single_line(item.get("schedule_key"), 80)
         }
         changed = False
+        now = _now_ts()
+        for item in items:
+            if not isinstance(item, dict) or not _single_line(item.get("schedule_label"), 160):
+                continue
+            planned_at = _safe_float(item.get("planned_at"), 0.0)
+            valid_from = _safe_float(item.get("schedule_valid_from"), 0.0)
+            valid_until = _safe_float(item.get("schedule_valid_until"), 0.0)
+            eligibility = _single_line(item.get("schedule_fact_eligibility"), 40).lower()
+            if (
+                eligibility not in {"current_internal", "current_observed"}
+                or valid_until <= now
+                or valid_until <= valid_from
+                or (planned_at > 0 and (planned_at < valid_from or planned_at >= valid_until))
+            ):
+                item.pop("schedule_key", None)
+                item.pop("schedule_label", None)
+                item.pop("schedule_valid_from", None)
+                item.pop("schedule_valid_until", None)
+                item.pop("schedule_fact_eligibility", None)
+                item.pop("schedule_evidence_kind", None)
+                changed = True
+        used_keys = {
+            _single_line(item.get("schedule_key"), 80)
+            for item in items
+            if isinstance(item, dict) and _single_line(item.get("schedule_key"), 80)
+        }
+        if not candidates:
+            if changed:
+                plan["used_schedule_keys"] = sorted(
+                    _single_line(item.get("schedule_key"), 80)
+                    for item in items
+                    if isinstance(item, dict) and _single_line(item.get("schedule_key"), 80)
+                )
+            return changed
         for item in items:
             if not isinstance(item, dict) or item.get("status") != "planned" or _single_line(item.get("schedule_label"), 160):
                 continue
@@ -387,6 +463,10 @@ class QzoneScheduleMixin:
             key = _single_line(schedule.get("key"), 80)
             item["schedule_key"] = key
             item["schedule_label"] = _single_line(schedule.get("label"), 160)
+            item["schedule_valid_from"] = _safe_float(schedule.get("valid_from"), 0.0)
+            item["schedule_valid_until"] = _safe_float(schedule.get("valid_until"), 0.0)
+            item["schedule_fact_eligibility"] = _single_line(schedule.get("fact_eligibility"), 40)
+            item["schedule_evidence_kind"] = _single_line(schedule.get("evidence_kind"), 40)
             if key:
                 used_keys.add(key)
             changed = True
@@ -475,6 +555,10 @@ class QzoneScheduleMixin:
                     "planned_at": planned_at,
                     "schedule_key": str(schedule.get("key")) if schedule else "",
                     "schedule_label": _single_line(schedule.get("label"), 160) if schedule else "",
+                    "schedule_valid_from": _safe_float(schedule.get("valid_from"), 0.0) if schedule else 0.0,
+                    "schedule_valid_until": _safe_float(schedule.get("valid_until"), 0.0) if schedule else 0.0,
+                    "schedule_fact_eligibility": _single_line(schedule.get("fact_eligibility"), 40) if schedule else "",
+                    "schedule_evidence_kind": _single_line(schedule.get("evidence_kind"), 40) if schedule else "",
                     # Night posts stay short: a sleepless 2am note is a fragment.
                     "length_profile": "short" if night else profiles[index],
                     "night": night,
@@ -738,7 +822,14 @@ class QzoneScheduleMixin:
         schedule_label = ""
         if isinstance(plan_item, dict):
             length_profile = _single_line(plan_item.get("length_profile"), 16) or "medium"
-            schedule_label = _single_line(plan_item.get("schedule_label"), 160)
+            candidate_eligibility = _single_line(plan_item.get("schedule_fact_eligibility"), 40).lower()
+            candidate_valid_until = _safe_float(plan_item.get("schedule_valid_until"), 0.0)
+            schedule_label = (
+                _single_line(plan_item.get("schedule_label"), 160)
+                if candidate_eligibility in {"current_internal", "current_observed"}
+                and candidate_valid_until > now
+                else ""
+            )
             # The item stays "planned" until it reaches a terminal state, so an
             # early return below simply retries on a later tick instead of
             # stranding it. The attempt counter is what stops an endless loop.
@@ -762,7 +853,7 @@ class QzoneScheduleMixin:
             self._save_data_sync()
             return
         daily_state = self.data.get("daily_state", {})
-        current_item = self._get_current_plan_item(self.data.get("daily_plan", {}))
+        current_item = self._qzone_current_agenda_item()
         diary_context = self._recent_diary_context(count=2)
         theme_hint = self._qzone_publish_theme_hint()
         temporal_context = self._qzone_temporal_context()
@@ -1040,7 +1131,7 @@ class QzoneScheduleMixin:
             self._save_data_sync()
             return
         daily_state = self.data.get("daily_state", {})
-        current_item = self._get_current_plan_item(self.data.get("daily_plan", {}))
+        current_item = self._qzone_current_agenda_item()
         public_state_hint = self._qzone_relationship_safe_source(
             self._qzone_public_state_hint(daily_state if isinstance(daily_state, dict) else {}),
             source="qzone.emotional_vent.current_state",

--- a/runtime_scene_resolver.py
+++ b/runtime_scene_resolver.py
@@ -1,0 +1,363 @@
+# -*- coding: utf-8 -*-
+"""Bot-only current-state resolver with TTL and idempotent commits."""
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Callable
+from zoneinfo import ZoneInfo
+
+
+def _text(value: Any, limit: int = 240) -> str:
+    return str(value or "").strip()[:limit]
+
+
+def _now(value: datetime | None = None, timezone_name: str = "Asia/Shanghai") -> datetime:
+    current = value or datetime.now().astimezone()
+    try:
+        timezone = ZoneInfo(_text(timezone_name, 64) or "Asia/Shanghai")
+    except Exception:
+        timezone = datetime.now().astimezone().tzinfo
+    if current.tzinfo:
+        return current.astimezone(timezone)
+    return current.replace(tzinfo=timezone)
+
+
+def _safe_seconds(value: Any, default: int = 1800) -> int:
+    try:
+        return max(1, min(4 * 3600, int(float(value))))
+    except (TypeError, ValueError):
+        return default
+
+
+SELF_STATE_ALLOWED = frozenset({"在休息", "陪你聊天", "准备出门", "切到学习状态"})
+SELF_STATE_ALIASES = {
+    "在聊天": "陪你聊天",
+    "还在陪你聊天": "陪你聊天",
+    "休息": "在休息",
+    "出门": "准备出门",
+    "学习": "切到学习状态",
+}
+SELF_STATE_FORBIDDEN = (
+    "付款",
+    "支付",
+    "发布",
+    "定位",
+    "签到",
+    "打卡",
+    "到场",
+    "通话",
+    "上课",
+    "上班",
+    "刷穿搭",
+    "拉床帘",
+    "arrived",
+    "check-in",
+    "checked in",
+    "paid",
+    "publish",
+    "payment",
+    "location",
+    "call",
+)
+
+
+@dataclass(frozen=True)
+class SelfStateCommit:
+    actor_type: str
+    subject_actor_id: str
+    state: str
+    committed_at: str
+    valid_until: str
+    runtime_origin_refs: tuple[str, ...]
+    source_refs: tuple[str, ...] = ()
+    evidence_kind: str = "self_state_commit"
+    evidence_level: str = "L1"
+    fact_eligibility: str = "current_internal"
+    materialization_state: str = "active"
+    content_granularity: str = "intent"
+    idempotency_key: str = ""
+    state_version: int = 1
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "actor_type": self.actor_type,
+            "subject_actor_id": self.subject_actor_id,
+            "state": self.state,
+            "title": self.state,
+            "committed_at": self.committed_at,
+            "valid_until": self.valid_until,
+            "runtime_origin_refs": list(self.runtime_origin_refs),
+            "source_refs": list(self.source_refs),
+            "evidence_kind": self.evidence_kind,
+            "evidence_level": self.evidence_level,
+            "fact_eligibility": self.fact_eligibility,
+            "materialization_state": self.materialization_state,
+            "content_granularity": self.content_granularity,
+            "idempotency_key": self.idempotency_key,
+            "state_version": self.state_version,
+            # Runtime state is not a C3 lifecycle fact.  Keep it independent
+            # from active/completed/history statuses while exposing its
+            # current_internal eligibility.
+            "status": "planned",
+            "source_kind": "observed",
+        }
+
+
+class RuntimeSceneResolver:
+    """规则优先地把当前时段落定为宽泛 Bot 内部状态。
+
+    候选永远只是输入，只有本类在当前窗口通过 CAS 提交后才成为
+    ``current_internal``。提交不会修改原始计划，也不会写入历史或长期记忆。
+    """
+
+    def __init__(
+        self,
+        *,
+        bot_id: str = "bot_self",
+        clock: Callable[[], datetime] | None = None,
+        default_ttl_seconds: int = 1800,
+        timezone_name: str = "Asia/Shanghai",
+    ) -> None:
+        self.bot_id = _text(bot_id, 120) or "bot_self"
+        self._clock = clock or (lambda: datetime.now().astimezone())
+        self.default_ttl_seconds = _safe_seconds(default_ttl_seconds)
+        self.timezone_name = _text(timezone_name, 64) or "Asia/Shanghai"
+        self._commits: dict[str, dict[str, Any]] = {}
+        self._versions: dict[str, int] = {}
+        self._clock_skew_tolerance = timedelta(seconds=1)
+
+    def _current(self, now: datetime | None = None) -> datetime:
+        try:
+            value = self._clock() if now is None else now
+        except Exception:
+            value = now or datetime.now().astimezone()
+        return _now(value, self.timezone_name)
+
+    def _clock_current(self) -> datetime:
+        return self._current(None)
+
+    @staticmethod
+    def _normalize_state(value: Any) -> str:
+        text = _text(value, 120)
+        if text in SELF_STATE_ALLOWED:
+            return text
+        return SELF_STATE_ALIASES.get(text, "")
+
+    def _is_backfill(self, requested: datetime | None) -> bool:
+        if requested is None:
+            return False
+        return self._current(requested) < self._clock_current() - self._clock_skew_tolerance
+
+    @staticmethod
+    def _window_id(now: datetime, hard_constraints: Any = None) -> str:
+        if isinstance(hard_constraints, dict) and hard_constraints.get("window_id"):
+            return _text(hard_constraints.get("window_id"), 160)
+        return now.strftime("%Y-%m-%d:%H")
+
+    @staticmethod
+    def _conversation_active(state: Any) -> bool:
+        if isinstance(state, dict):
+            if state.get("interacting") or state.get("active") or state.get("conversation_active"):
+                return True
+            text = _text(state.get("last_user_message") or state.get("topic"), 300)
+            return bool(text)
+        return bool(state)
+
+    def _candidate_state(self, candidates: Any) -> str:
+        if not isinstance(candidates, (list, tuple)):
+            return ""
+        for candidate in candidates:
+            if not isinstance(candidate, dict):
+                continue
+            actor_type = _text(candidate.get("actor_type"), 32).lower()
+            subject = _text(candidate.get("subject_actor_id"), 120)
+            if actor_type != "bot" or subject != self.bot_id:
+                continue
+            state = _text(candidate.get("state") or candidate.get("intent") or candidate.get("title") or candidate.get("activity"), 120)
+            lowered = state.lower()
+            # Scene details are deliberately collapsed to a safe intent.
+            if any(token in lowered for token in ("chat", "conversation", "聊天", "对话", "陪聊")):
+                return "陪你聊天"
+            if any(token in lowered for token in ("rest", "sleep", "休息", "睡", "放松")):
+                return "在休息"
+            if any(token in lowered for token in ("study", "学习", "专注")):
+                return "切到学习状态"
+            if any(token in lowered for token in ("out", "leave", "出门", "准备出门")):
+                return "准备出门"
+        return ""
+
+    def _make_commit(
+        self,
+        *,
+        state: str,
+        now: datetime,
+        window_id: str,
+        state_version: int,
+        ttl_seconds: int,
+        origin_refs: list[str],
+    ) -> dict[str, Any]:
+        valid_until = now + timedelta(seconds=_safe_seconds(ttl_seconds, self.default_ttl_seconds))
+        key = f"runtime_commit:{self.bot_id}:{window_id}:{state_version}"
+        commit = SelfStateCommit(
+            actor_type="bot",
+            subject_actor_id=self.bot_id,
+            state=state,
+            committed_at=now.isoformat(timespec="seconds"),
+            valid_until=valid_until.isoformat(timespec="seconds"),
+            runtime_origin_refs=tuple(dict.fromkeys([_text(ref, 160) for ref in origin_refs if _text(ref, 160)])) or (f"resolver:{window_id}",),
+            idempotency_key=key,
+            state_version=state_version,
+        )
+        result = commit.to_dict()
+        result["window_id"] = window_id
+        return result
+
+    def commit(
+        self,
+        state: str,
+        *,
+        now: datetime | None = None,
+        window_id: str = "",
+        expected_version: int | None = None,
+        ttl_seconds: int | None = None,
+        origin_refs: list[str] | tuple[str, ...] | None = None,
+    ) -> dict[str, Any] | None:
+        if self._is_backfill(now):
+            return None
+        current = self._current(now)
+        raw_state = _text(state, 120)
+        if any(token in raw_state.lower() for token in SELF_STATE_FORBIDDEN):
+            return None
+        clean_state = self._normalize_state(raw_state)
+        if not clean_state:
+            return None
+        window = _text(window_id, 160) or self._window_id(current)
+        prior = self._commits.get(window)
+        prior_version = int(prior.get("state_version") or 0) if isinstance(prior, dict) else self._versions.get(window, 0)
+        if expected_version is not None:
+            try:
+                if int(expected_version) != prior_version:
+                    return None
+            except (TypeError, ValueError):
+                return None
+        if prior and self._is_valid(prior, current) and _text(prior.get("state"), 120) == clean_state:
+            return deepcopy(prior)
+        version = prior_version + 1
+        result = self._make_commit(
+            state=clean_state,
+            now=current,
+            window_id=window,
+            state_version=version,
+            ttl_seconds=ttl_seconds or self.default_ttl_seconds,
+            origin_refs=list(origin_refs or ()),
+        )
+        self._versions[window] = version
+        self._commits[window] = deepcopy(result)
+        return deepcopy(result)
+
+    def resolve_now(
+        self,
+        agenda_candidates: Any,
+        conversation_state: Any = None,
+        hard_constraints: Any = None,
+        now: datetime | None = None,
+    ) -> dict[str, Any] | None:
+        if self._is_backfill(now):
+            return None
+        current = self._current(now)
+        window = self._window_id(current, hard_constraints)
+        conversation_active = self._conversation_active(conversation_state)
+        prior = self._commits.get(window)
+        if prior and self._is_valid(prior, current):
+            # A new user turn interrupts a previously inferred state. Repeated
+            # calls with the same state remain idempotent within the window.
+            prior_state = _text(prior.get("state"), 120).lower()
+            chat_state = "陪你聊天"
+            if not conversation_active or prior_state in {chat_state.lower(), "chat", "conversation"}:
+                return deepcopy(prior)
+            return self.commit(
+                chat_state,
+                now=current,
+                window_id=window,
+                expected_version=int(prior.get("state_version") or 0),
+                origin_refs=[f"window:{window}", "conversation:true", "interruption:user_turn"],
+            )
+        if conversation_active:
+            state = "陪你聊天"
+        else:
+            state = self._candidate_state(agenda_candidates) or "在休息"
+        origin_refs = [f"window:{window}", f"conversation:{bool(conversation_active)}"]
+        if isinstance(hard_constraints, dict):
+            ref = _text(hard_constraints.get("event_id") or hard_constraints.get("id"), 160)
+            if ref:
+                origin_refs.append(f"constraint:{ref}")
+        return self.commit(state, now=current, window_id=window, origin_refs=origin_refs)
+
+    @staticmethod
+    def _is_valid(commit: dict[str, Any], now: datetime) -> bool:
+        if not isinstance(commit, dict):
+            return False
+        try:
+            if str(commit.get("actor_type") or "").strip().lower() != "bot":
+                return False
+            if not str(commit.get("subject_actor_id") or "").strip():
+                return False
+            if str(commit.get("state") or "").strip() not in SELF_STATE_ALLOWED:
+                return False
+            if commit.get("source_refs") not in (None, [], (), ""):
+                return False
+            if not commit.get("runtime_origin_refs"):
+                return False
+            committed = datetime.fromisoformat(str(commit.get("committed_at")).replace("Z", "+00:00"))
+            until = datetime.fromisoformat(str(commit.get("valid_until")).replace("Z", "+00:00"))
+            current = now if now.tzinfo else now.astimezone()
+            committed = committed if committed.tzinfo else committed.replace(tzinfo=current.tzinfo)
+            until = until if until.tzinfo else until.replace(tzinfo=current.tzinfo)
+            return committed <= current < until and commit.get("materialization_state") == "active" and commit.get("fact_eligibility") == "current_internal"
+        except (TypeError, ValueError):
+            return False
+
+    def get_current(self, now: datetime | None = None, *, window_id: str = "") -> dict[str, Any] | None:
+        if self._is_backfill(now):
+            return None
+        current = self._current(now)
+        window = _text(window_id, 160) or self._window_id(current)
+        item = self._commits.get(window)
+        return deepcopy(item) if item and self._is_valid(item, current) else None
+
+    def invalidate(
+        self,
+        *,
+        now: datetime | None = None,
+        window_id: str = "",
+        reason: str = "",
+        expected_version: int | None = None,
+    ) -> bool:
+        if self._is_backfill(now):
+            return False
+        current = self._current(now)
+        window = _text(window_id, 160) or self._window_id(current)
+        prior = self._commits.get(window)
+        if not prior:
+            return False
+        if expected_version is not None:
+            try:
+                if int(expected_version) != int(prior.get("state_version") or 0):
+                    return False
+            except (TypeError, ValueError):
+                return False
+        prior["materialization_state"] = "expired"
+        prior["valid_until"] = current.isoformat(timespec="seconds")
+        trace = prior.setdefault("decision_trace", [])
+        if isinstance(trace, list):
+            trace.append({"code": "invalidated", "reason": _text(reason, 160) or "runtime interruption"})
+        return True
+
+    def clear(self) -> None:
+        self._commits.clear()
+        self._versions.clear()
+
+
+__all__ = ["RuntimeSceneResolver", "SelfStateCommit"]

--- a/scene_context.py
+++ b/scene_context.py
@@ -80,10 +80,11 @@ class SceneContextMixin:
         plan: dict[str, Any],
     ) -> tuple[dict[str, Any], str, str]:
         current_item: dict[str, Any] = {}
-        getter = getattr(self, "_get_current_plan_item", None)
-        if callable(getter):
+        getter = getattr(self, "_agenda_current_context_item", None)
+        legacy_getter = getattr(self, "_get_current_plan_item", None)
+        if callable(getter) or callable(legacy_getter):
             try:
-                value = getter(plan)
+                value = getter() if callable(getter) else legacy_getter(plan)
                 if isinstance(value, dict):
                     current_item = value
             except Exception:
@@ -132,6 +133,34 @@ class SceneContextMixin:
         captured: datetime,
     ) -> list[dict[str, str]]:
         """Return today's started schedule items without treating cancelled plans as facts."""
+
+        disclosure = getattr(self, "_agenda_disclosure_view", None)
+        if callable(disclosure):
+            try:
+                view = disclosure("history_fact", now=captured, max_entries=24)
+                entries = getattr(view, "entries", None)
+                if entries is None and hasattr(view, "get"):
+                    entries = view.get("entries", [])
+            except Exception:
+                entries = []
+            history: list[dict[str, str]] = []
+            for item in entries if isinstance(entries, list) else []:
+                if not isinstance(item, dict):
+                    continue
+                start_at = _single_line(item.get("start_at") or item.get("start"), 48)
+                end_at = _single_line(item.get("end_at") or item.get("end"), 48)
+                start_text = start_at.split("T", 1)[1][:5] if "T" in start_at else _single_line(item.get("time"), 12)
+                end_text = end_at.split("T", 1)[1][:5] if "T" in end_at else _single_line(item.get("end"), 12)
+                history.append(
+                    {
+                        "time": start_text,
+                        "end": end_text,
+                        "status": _single_line(item.get("status"), 32),
+                        "activity": _single_line(item.get("title") or item.get("activity"), 160),
+                        "mood": _single_line(item.get("mood"), 32),
+                    }
+                )
+            return history[:24]
 
         today = captured.strftime("%Y-%m-%d")
         if _single_line(plan.get("date"), 20) != today:

--- a/schedule_authority.py
+++ b/schedule_authority.py
@@ -1,0 +1,659 @@
+# -*- coding: utf-8 -*-
+"""可信课程、班表、预约和用户确认适配器。
+
+LLM 或普通聊天文本不能直接签发 ``source_refs``。适配器只接受结构化输入，
+校验主体、时区、绝对时间和版本，并以幂等方式保留最新有效引用。
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, asdict
+from datetime import datetime
+import hashlib
+import json
+import re
+from typing import Any, Mapping
+from zoneinfo import ZoneInfo
+
+
+AUTHORITIES = {"calendar", "timetable", "roster", "appointment", "user_confirmation"}
+VALID_STATES = {"active", "cancelled", "revoked", "superseded"}
+VERIFICATION_STATES = {"valid", "expired", "cancelled", "revoked", "invalid"}
+
+
+def _text(value: Any, limit: int = 240) -> str:
+    return str(value or "").strip()[:limit]
+
+
+def _tz(value: Any) -> ZoneInfo | None:
+    name = _text(value, 80)
+    if not name:
+        return None
+    try:
+        return ZoneInfo(name)
+    except Exception:
+        return None
+
+
+def _moment(value: Any, timezone_name: str) -> datetime | None:
+    if isinstance(value, datetime):
+        current = value
+    else:
+        text = _text(value, 96)
+        if not text:
+            return None
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        try:
+            current = datetime.fromisoformat(text)
+        except ValueError:
+            return None
+    timezone = _tz(timezone_name)
+    if current.tzinfo is None:
+        if timezone is None:
+            return None
+        return current.replace(tzinfo=timezone)
+    return current.astimezone(timezone or current.tzinfo)
+
+
+def _iso(value: datetime) -> str:
+    return value.isoformat(timespec="seconds")
+
+
+def _ref_id(
+    namespace: str,
+    event_id: str,
+    revision: str,
+    provider: str = "",
+    subject_actor_id: str = "",
+    *,
+    updated_at: str = "",
+    timezone: str = "",
+    effective_from: str = "",
+    effective_to: str = "",
+    expires_at: str = "",
+    authority_kind: str = "",
+    confirmation_event_id: str = "",
+    confirmation_actor_id: str = "",
+    proposition: str = "",
+    confirmed_at: str = "",
+    target_user_id: str = "",
+) -> str:
+    raw = json.dumps(
+        {
+            "namespace": namespace,
+            "event_id": event_id,
+            "revision": revision,
+            "provider": provider,
+            "subject_actor_id": subject_actor_id,
+            "updated_at": updated_at,
+            "timezone": timezone,
+            "effective_from": effective_from,
+            "effective_to": effective_to,
+            "expires_at": expires_at,
+            "authority_kind": authority_kind,
+            "confirmation_event_id": confirmation_event_id,
+            "confirmation_actor_id": confirmation_actor_id,
+            "proposition": proposition,
+            "confirmed_at": confirmed_at,
+            "target_user_id": target_user_id,
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return "trusted_schedule:" + hashlib.sha256(raw).hexdigest()[:24]
+
+
+def _explicit_false(value: Any) -> bool:
+    if value is False or value == 0:
+        return True
+    return _text(value, 16).lower() in {"false", "no", "denied", "invalid", "revoked"}
+
+
+def _revision_key(value: Any) -> tuple[Any, ...]:
+    text = _text(value, 80)
+    parts = []
+    for part in re.split(r"([0-9]+)", text):
+        if part.isdigit():
+            parts.append((1, int(part)))
+        elif part:
+            parts.append((0, part.lower()))
+    return tuple(parts)
+
+
+@dataclass(frozen=True)
+class TrustedScheduleRef:
+    namespace: str
+    event_id: str
+    provider: str
+    revision: str
+    updated_at: str
+    timezone: str
+    subject_actor_id: str
+    effective_from: str
+    effective_to: str
+    recurrence: Any = None
+    state: str = "active"
+    issued_at: str = ""
+    expires_at: str = ""
+    authority_kind: str = "calendar"
+    confirmation_event_id: str = ""
+    confirmation_actor_id: str = ""
+    proposition: str = ""
+    confirmed_at: str = ""
+    revocation_of: str = ""
+    supersedes_ref_id: str = ""
+    revocation_reason: str = ""
+    target_user_id: str = ""
+    authorized: bool = True
+    permission_valid: bool = True
+    subject_authorized: bool = True
+    ref_id: str = ""
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def to_plan_fields(self) -> dict[str, Any]:
+        """Return the minimal canonical fields accepted by the C3 write gate."""
+
+        return {
+            "source_refs": [
+                self.ref_id
+                or _ref_id(
+                    self.namespace,
+                    self.event_id,
+                    self.revision,
+                    self.provider,
+                    self.subject_actor_id,
+                    updated_at=self.updated_at,
+                    timezone=self.timezone,
+                    effective_from=self.effective_from,
+                    effective_to=self.effective_to,
+                    expires_at=self.expires_at,
+                    authority_kind=self.authority_kind,
+                    confirmation_event_id=self.confirmation_event_id,
+                    confirmation_actor_id=self.confirmation_actor_id,
+                    proposition=self.proposition,
+                    confirmed_at=self.confirmed_at,
+                    target_user_id=self.target_user_id,
+                )
+            ],
+            "source_refs_trusted": True,
+            "trusted_source_refs": True,
+            "authority_kind": self.authority_kind,
+            "commitment_level": "confirmed",
+            "subject_actor_id": self.subject_actor_id,
+            "actor_type": "bot",
+            "schedule_ref": self.as_dict(),
+        }
+
+    def __getitem__(self, key: str) -> Any:
+        return self.as_dict()[key]
+
+
+@dataclass(frozen=True)
+class RejectedSource:
+    ok: bool = False
+    reason: str = "invalid_source"
+    decision_trace: tuple[dict[str, Any], ...] = ()
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"ok": self.ok, "reason": self.reason, "decision_trace": list(self.decision_trace)}
+
+    def __bool__(self) -> bool:
+        return False
+
+
+class VerificationResult(str):
+    def __new__(cls, status: str, ref: TrustedScheduleRef | None = None):
+        obj = str.__new__(cls, status)
+        obj.status = status
+        obj.ref = ref
+        return obj
+
+
+class ScheduleAuthorityAdapter:
+    """签发、验证、撤销和改期可信日程引用。"""
+
+    def __init__(self, *, namespace: str = "private_companion", provider: str = "local", clock: Any = None) -> None:
+        self.namespace = _text(namespace, 120) or "private_companion"
+        self.provider = _text(provider, 120) or "local"
+        self._clock = clock or (lambda: datetime.now().astimezone())
+        self._refs: dict[tuple[str, str, str], TrustedScheduleRef] = {}
+        self._latest: dict[tuple[str, str], str] = {}
+
+    def _now(self) -> datetime:
+        value = self._clock()
+        if not isinstance(value, datetime):
+            value = datetime.now().astimezone()
+        return value if value.tzinfo else value.astimezone()
+
+    def issue_or_update(
+        self,
+        raw_event: dict[str, Any],
+        subject_actor_id: str,
+        target_user_id: str = "",
+    ) -> TrustedScheduleRef | RejectedSource:
+        if not isinstance(raw_event, dict):
+            return RejectedSource(reason="event_not_object")
+        subject = _text(subject_actor_id, 120)
+        if not subject:
+            return RejectedSource(reason="subject_actor_id_required")
+        declared_subject = _text(raw_event.get("subject_actor_id"), 120)
+        if declared_subject and declared_subject != subject:
+            return RejectedSource(reason="subject_binding_conflict")
+        authority = _text(raw_event.get("authority_kind") or raw_event.get("authority"), 48).lower()
+        if authority not in AUTHORITIES:
+            return RejectedSource(reason="authority_not_supported")
+        namespace = _text(raw_event.get("namespace"), 120) or self.namespace
+        event_id = _text(raw_event.get("event_id") or raw_event.get("id"), 160)
+        provider = _text(raw_event.get("provider"), 120) or self.provider
+        revision = _text(raw_event.get("revision"), 80)
+        timezone_name = _text(raw_event.get("timezone"), 80)
+        if not event_id or not provider or not revision or not timezone_name:
+            return RejectedSource(reason="namespace_event_provider_revision_timezone_required")
+        if any(
+            _explicit_false(raw_event.get(key))
+            for key in ("authorized", "permission_valid", "subject_authorized")
+            if key in raw_event
+        ):
+            return RejectedSource(reason="permission_denied")
+        confirmation_event_id = _text(raw_event.get("confirmation_event_id"), 160)
+        confirmation_actor_id = _text(
+            raw_event.get("confirmation_actor_id")
+            or raw_event.get("confirmed_by")
+            or raw_event.get("confirmer_id")
+            or raw_event.get("source_actor_id"),
+            120,
+        )
+        proposition = _text(
+            raw_event.get("proposition")
+            or raw_event.get("title")
+            or raw_event.get("activity")
+            or raw_event.get("summary"),
+            240,
+        )
+        confirmed_at_raw = raw_event.get("confirmed_at") or raw_event.get("confirmation_time")
+        confirmed_at = _moment(confirmed_at_raw, timezone_name) if confirmed_at_raw else None
+        if authority == "user_confirmation" and (
+            not confirmation_event_id
+            or not confirmation_actor_id
+            or confirmation_actor_id == subject
+            or not proposition
+            or not confirmed_at
+        ):
+            return RejectedSource(reason="structured_confirmation_required")
+        timezone = _tz(timezone_name)
+        if timezone is None:
+            return RejectedSource(reason="invalid_timezone")
+        start = _moment(raw_event.get("effective_from") or raw_event.get("start_at") or raw_event.get("start"), timezone_name)
+        end = _moment(raw_event.get("effective_to") or raw_event.get("end_at") or raw_event.get("end"), timezone_name)
+        if start is None or end is None or end <= start:
+            return RejectedSource(reason="absolute_effective_interval_required")
+        state = _text(raw_event.get("state"), 24).lower() or "active"
+        if state not in VALID_STATES:
+            return RejectedSource(reason="invalid_state")
+        key = (namespace, event_id, revision)
+        existing = self._refs.get(key)
+        if existing is not None:
+            if existing.provider != provider or existing.subject_actor_id != subject:
+                return RejectedSource(reason="revision_binding_conflict")
+            return existing
+        now = self._now()
+        updated_raw = raw_event.get("updated_at")
+        if updated_raw in (None, ""):
+            return RejectedSource(reason="updated_at_required")
+        updated = _moment(updated_raw, timezone_name)
+        if updated is None:
+            return RejectedSource(reason="invalid_updated_at")
+        expires_raw = raw_event.get("expires_at")
+        expires = _moment(expires_raw, timezone_name) if expires_raw else None
+        if expires_raw and expires is None:
+            return RejectedSource(reason="invalid_expires_at")
+        ref_id = _ref_id(
+            namespace,
+            event_id,
+            revision,
+            provider,
+            subject,
+            updated_at=_iso(updated),
+            timezone=timezone_name,
+            effective_from=_iso(start),
+            effective_to=_iso(end),
+            expires_at=_iso(expires) if expires else "",
+            authority_kind=authority,
+            confirmation_event_id=confirmation_event_id,
+            confirmation_actor_id=confirmation_actor_id,
+            proposition=proposition,
+            confirmed_at=_iso(confirmed_at) if confirmed_at else "",
+            target_user_id=_text(target_user_id or raw_event.get("target_user_id"), 120),
+        )
+        ref = TrustedScheduleRef(
+            namespace=namespace,
+            event_id=event_id,
+            provider=provider,
+            revision=revision,
+            updated_at=_iso(updated),
+            timezone=timezone_name,
+            subject_actor_id=subject,
+            effective_from=_iso(start),
+            effective_to=_iso(end),
+            recurrence=deepcopy(raw_event.get("recurrence")),
+            state=state,
+            issued_at=_iso(now),
+            expires_at=_iso(expires) if expires else "",
+            authority_kind=authority,
+            confirmation_event_id=confirmation_event_id,
+            confirmation_actor_id=confirmation_actor_id,
+            proposition=proposition,
+            confirmed_at=_iso(confirmed_at) if confirmed_at else "",
+            revocation_of=_text(raw_event.get("revocation_of") or raw_event.get("revokes_event_id"), 160),
+            supersedes_ref_id=_text(raw_event.get("supersedes_ref_id"), 160),
+            revocation_reason=_text(raw_event.get("revocation_reason") or raw_event.get("reason"), 240),
+            target_user_id=_text(target_user_id or raw_event.get("target_user_id"), 120),
+            authorized=not _explicit_false(raw_event.get("authorized")),
+            permission_valid=not _explicit_false(raw_event.get("permission_valid")),
+            subject_authorized=not _explicit_false(raw_event.get("subject_authorized")),
+            ref_id=ref_id,
+        )
+        latest_key = (namespace, event_id)
+        old_revision = self._latest.get(latest_key)
+        if old_revision and old_revision != revision:
+            old = self._refs.get((namespace, event_id, old_revision))
+            if old is not None and _revision_key(revision) < _revision_key(old_revision):
+                ref = TrustedScheduleRef(**{**ref.as_dict(), "state": "superseded"})
+                self._refs[key] = ref
+                return ref
+            if old is not None and old.state == "active":
+                self._refs[(namespace, event_id, old_revision)] = TrustedScheduleRef(
+                    **{**old.as_dict(), "state": "superseded"}
+                )
+        self._refs[key] = ref
+        self._latest[latest_key] = revision
+        return ref
+
+    def verify(self, ref: TrustedScheduleRef | dict[str, Any] | str, now: datetime | None = None) -> VerificationResult:
+        candidate: TrustedScheduleRef | None
+        if isinstance(ref, TrustedScheduleRef):
+            candidate = ref
+        elif isinstance(ref, dict):
+            try:
+                candidate = TrustedScheduleRef(**{key: ref[key] for key in TrustedScheduleRef.__dataclass_fields__ if key in ref})
+            except Exception:
+                candidate = None
+        else:
+            value = _text(ref, 160)
+            candidate = next((item for item in self._refs.values() if item.ref_id == value), None)
+        if candidate is None:
+            return VerificationResult("invalid")
+        expected_ref_id = _ref_id(
+            candidate.namespace,
+            candidate.event_id,
+            candidate.revision,
+            candidate.provider,
+            candidate.subject_actor_id,
+            updated_at=candidate.updated_at,
+            timezone=candidate.timezone,
+            effective_from=candidate.effective_from,
+            effective_to=candidate.effective_to,
+            expires_at=candidate.expires_at,
+            authority_kind=candidate.authority_kind,
+            confirmation_event_id=candidate.confirmation_event_id,
+            confirmation_actor_id=candidate.confirmation_actor_id,
+            proposition=candidate.proposition,
+            confirmed_at=candidate.confirmed_at,
+            target_user_id=candidate.target_user_id,
+        )
+        # ``ref_id`` is the adapter's stable binding between the structured
+        # event and its source reference.  A copied or hand-built dataclass
+        # with a missing/mismatched ID is not a trusted source, even if its
+        # interval and state fields happen to look valid.
+        if not candidate.ref_id or candidate.ref_id != expected_ref_id:
+            return VerificationResult("invalid", candidate)
+        if (
+            not candidate.namespace
+            or not candidate.event_id
+            or not candidate.provider
+            or not candidate.revision
+            or not candidate.updated_at
+            or not candidate.timezone
+            or not candidate.subject_actor_id
+            or candidate.authority_kind not in AUTHORITIES
+            or _tz(candidate.timezone) is None
+            or _moment(candidate.updated_at, candidate.timezone) is None
+            or _explicit_false(candidate.authorized)
+            or _explicit_false(candidate.permission_valid)
+            or _explicit_false(candidate.subject_authorized)
+        ):
+            return VerificationResult("invalid", candidate)
+        # Always verify against the adapter's latest stored revision when the
+        # reference belongs to this adapter.  A caller may retain an old
+        # immutable dataclass after a reschedule; trusting that stale object
+        # would let a superseded commitment re-enter future views.
+        stored = self._refs.get((candidate.namespace, candidate.event_id, candidate.revision))
+        if stored is not None:
+            if candidate.ref_id and stored.ref_id and candidate.ref_id != stored.ref_id:
+                return VerificationResult("invalid", stored)
+            candidate = stored
+        state = _text(candidate.state, 24).lower()
+        latest_revision = self._latest.get((candidate.namespace, candidate.event_id))
+        if latest_revision and latest_revision != candidate.revision and state == "active":
+            return VerificationResult("revoked", candidate)
+        if state == "cancelled":
+            return VerificationResult("cancelled", candidate)
+        if state in {"revoked", "superseded"}:
+            return VerificationResult("revoked", candidate)
+        current = now or self._now()
+        if current.tzinfo is None:
+            current = current.astimezone()
+        start = _moment(candidate.effective_from, candidate.timezone)
+        end = _moment(candidate.effective_to, candidate.timezone)
+        if start is None or end is None or end <= start:
+            return VerificationResult("invalid", candidate)
+        expires = _moment(candidate.expires_at, candidate.timezone) if candidate.expires_at else None
+        if candidate.expires_at and expires is None:
+            return VerificationResult("invalid", candidate)
+        if expires is not None and current >= expires:
+            return VerificationResult("expired", candidate)
+        return VerificationResult("valid", candidate)
+
+    def revoke_or_reschedule(
+        self,
+        event_id: str,
+        revision: str,
+        reason: str,
+        effective_at: datetime | str | None = None,
+        *,
+        reschedule: dict[str, Any] | None = None,
+        subject_actor_id: str = "",
+    ) -> TrustedScheduleRef | RejectedSource:
+        event = _text(event_id, 160)
+        old_revision = _text(revision, 80)
+        key = (self.namespace, event, old_revision)
+        old = self._refs.get(key)
+        if old is None:
+            return RejectedSource(reason="source_not_found")
+        self._refs[key] = TrustedScheduleRef(**{**old.as_dict(), "state": "superseded"})
+        payload = deepcopy(reschedule or {})
+        payload.setdefault("event_id", event)
+        payload.setdefault("provider", old.provider)
+        payload.setdefault("namespace", old.namespace)
+        payload.setdefault("timezone", old.timezone)
+        payload.setdefault("authority_kind", old.authority_kind)
+        payload.setdefault("subject_actor_id", subject_actor_id or old.subject_actor_id)
+        payload.setdefault("effective_from", old.effective_from)
+        payload.setdefault("effective_to", old.effective_to)
+        payload.setdefault("target_user_id", old.target_user_id)
+        payload.setdefault("confirmation_event_id", old.confirmation_event_id)
+        payload.setdefault("confirmation_actor_id", old.confirmation_actor_id)
+        payload.setdefault("proposition", old.proposition)
+        payload.setdefault("confirmed_at", old.confirmed_at)
+        payload.setdefault("supersedes_ref_id", old.ref_id)
+        payload.setdefault("revocation_of", old.ref_id)
+        payload.setdefault("revocation_reason", _text(reason, 240))
+        payload.setdefault("revision", f"{old_revision}-next" if reschedule else f"{old_revision}-cancelled")
+        payload.setdefault("state", "active" if reschedule else "cancelled")
+        effective_value = (
+            effective_at.isoformat()
+            if isinstance(effective_at, datetime)
+            else _text(effective_at, 96)
+            if effective_at is not None
+            else _iso(self._now())
+        )
+        payload.setdefault("updated_at", effective_value)
+        return self.issue_or_update(payload, payload["subject_actor_id"])
+
+    def snapshot(self) -> list[dict[str, Any]]:
+        return [item.as_dict() for item in self._refs.values()]
+
+
+def validate_structured_schedule_ref(
+    ref: TrustedScheduleRef | Mapping[str, Any] | Any,
+    *,
+    source_refs: Any = None,
+    expected_authority: str = "",
+    expected_subject: str = "",
+    expected_target: str = "",
+    now: datetime | None = None,
+    adapter: ScheduleAuthorityAdapter | None = None,
+) -> tuple[str, str]:
+    """Validate an adapter-issued schedule reference at every trust boundary.
+
+    The legacy ``source_refs_trusted``/``authority_verified`` booleans remain
+    useful for diagnostics, but they are not evidence.  A hard schedule
+    commitment needs a complete structured reference, its stable ``ref_id``
+    in ``source_refs``, a matching actor/authority binding, and a valid
+    adapter signature.  The returned status is one of ``valid``, ``expired``,
+    ``cancelled``, ``revoked`` or ``invalid``.
+    """
+
+    if isinstance(ref, TrustedScheduleRef):
+        candidate = ref.as_dict()
+    elif isinstance(ref, Mapping):
+        candidate = dict(ref)
+    else:
+        return "invalid", "missing_schedule_ref"
+
+    def _refs(value: Any) -> set[str]:
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, (list, tuple, set)):
+            return set()
+        return {_text(item, 240) for item in value if _text(item, 240)}
+
+    ref_id = _text(candidate.get("ref_id"), 240)
+    if not ref_id or ref_id not in _refs(source_refs):
+        return "invalid", "schedule_ref_not_in_source_refs"
+
+    required = (
+        "namespace",
+        "event_id",
+        "provider",
+        "revision",
+        "updated_at",
+        "timezone",
+        "subject_actor_id",
+        "effective_from",
+        "effective_to",
+        "state",
+    )
+    missing = [key for key in required if not _text(candidate.get(key), 240)]
+    if missing:
+        return "invalid", "schedule_ref_incomplete"
+
+    timezone_name = _text(candidate.get("timezone"), 80)
+    timezone = _tz(timezone_name)
+    if timezone is None:
+        return "invalid", "invalid_timezone"
+    updated = _moment(candidate.get("updated_at"), timezone_name)
+    start = _moment(candidate.get("effective_from"), timezone_name)
+    end = _moment(candidate.get("effective_to"), timezone_name)
+    if updated is None or start is None or end is None or end <= start:
+        return "invalid", "absolute_effective_interval_required"
+    expires_raw = candidate.get("expires_at")
+    expires = _moment(expires_raw, timezone_name) if expires_raw not in (None, "") else None
+    if expires_raw not in (None, "") and expires is None:
+        return "invalid", "invalid_expires_at"
+
+    authority = _text(candidate.get("authority_kind"), 48).lower()
+    if authority not in AUTHORITIES:
+        return "invalid", "schedule_authority_invalid"
+    if expected_authority and authority != _text(expected_authority, 48).lower():
+        return "invalid", "schedule_authority_mismatch"
+    subject = _text(candidate.get("subject_actor_id"), 120)
+    if not _text(expected_subject, 120):
+        return "invalid", "schedule_subject_required"
+    if expected_subject and subject != _text(expected_subject, 120):
+        return "invalid", "schedule_subject_mismatch"
+    target = _text(candidate.get("target_user_id"), 120)
+    if expected_target and target != _text(expected_target, 120):
+        return "invalid", "schedule_target_mismatch"
+    if any(_explicit_false(candidate.get(key)) for key in ("authorized", "permission_valid", "subject_authorized")):
+        return "invalid", "permission_denied"
+
+    state = _text(candidate.get("state"), 24).lower()
+    if state not in VALID_STATES:
+        return "invalid", "invalid_state"
+
+    expected_ref_id = _ref_id(
+        _text(candidate.get("namespace"), 120),
+        _text(candidate.get("event_id"), 160),
+        _text(candidate.get("revision"), 80),
+        _text(candidate.get("provider"), 120),
+        subject,
+        updated_at=_iso(updated),
+        timezone=timezone_name,
+        effective_from=_iso(start),
+        effective_to=_iso(end),
+        expires_at=_iso(expires) if expires else "",
+        authority_kind=authority,
+        confirmation_event_id=_text(candidate.get("confirmation_event_id"), 160),
+        confirmation_actor_id=_text(candidate.get("confirmation_actor_id"), 120),
+        proposition=_text(candidate.get("proposition"), 240),
+        confirmed_at=_text(candidate.get("confirmed_at"), 96),
+        target_user_id=target,
+    )
+    if ref_id != expected_ref_id:
+        return "invalid", "schedule_ref_id_mismatch"
+
+    if authority == "user_confirmation":
+        confirmer = _text(candidate.get("confirmation_actor_id"), 120)
+        proposition = _text(candidate.get("proposition"), 240)
+        confirmed_at = _text(candidate.get("confirmed_at"), 96)
+        if (
+            not _text(candidate.get("confirmation_event_id"), 160)
+            or not confirmer
+            or confirmer == subject
+            or not proposition
+            or not confirmed_at
+            or _moment(confirmed_at, _text(candidate.get("timezone"), 80)) is None
+        ):
+            return "invalid", "structured_confirmation_required"
+
+    verifier = adapter or ScheduleAuthorityAdapter(clock=lambda: now or datetime.now().astimezone())
+    try:
+        result = verifier.verify(candidate, now=now)
+        status = _text(getattr(result, "status", result), 24).lower()
+    except Exception:
+        return "invalid", "schedule_ref_verification_error"
+    if status not in VERIFICATION_STATES:
+        return "invalid", "schedule_ref_verification_error"
+    if status == "valid":
+        return status, ""
+    reason = {
+        "expired": "expired",
+        "cancelled": "status_cancelled",
+        "revoked": "status_revoked",
+        "invalid": "invalid_schedule_ref",
+    }[status]
+    return status, reason
+
+
+__all__ = [
+    "ScheduleAuthorityAdapter",
+    "TrustedScheduleRef",
+    "RejectedSource",
+    "VerificationResult",
+    "validate_structured_schedule_ref",
+]

--- a/schedule_reconciler.py
+++ b/schedule_reconciler.py
@@ -1,5 +1,11 @@
 # -*- coding: utf-8 -*-
-"""Deterministic plan/actual reconciliation for the local C3 agenda."""
+"""Deterministic plan/actual reconciliation for the local C3 agenda.
+
+The reconciler is deliberately conservative.  A plan describes a future
+commitment only; clock time, title similarity, confidence, or an LLM supplied
+status cannot turn it into an execution fact.  Only an explicitly linked and
+compatible observation can update the plan's C3 status.
+"""
 from __future__ import annotations
 
 from datetime import datetime, timedelta
@@ -10,22 +16,62 @@ try:
     from .agenda_contracts import (
         agenda_entry_from_activity,
         agenda_entry_from_plan,
-        interval_overlaps_window,
         normalize_observed_activity,
         normalize_plan_item,
         parse_datetime,
         stable_id,
+        validate_structured_schedule_ref,
     )
 except ImportError:
     from agenda_contracts import (
         agenda_entry_from_activity,
         agenda_entry_from_plan,
-        interval_overlaps_window,
         normalize_observed_activity,
         normalize_plan_item,
         parse_datetime,
         stable_id,
+        validate_structured_schedule_ref,
     )
+
+
+EVIDENCE_KINDS = {
+    "none",
+    "interaction",
+    "self_state_commit",
+    "tool_action",
+    "external_record",
+    "external_commitment",
+}
+HARD_SCHEDULE_AUTHORITIES = {"calendar", "timetable", "roster", "appointment", "user_confirmation"}
+EXECUTION_EVIDENCE_KINDS = {"tool_action", "external_record"}
+CHAT_EVIDENCE_KINDS = {"interaction"}
+PRESERVED_PLAN_STATUSES = {"planned", "cancelled", "deferred", "overridden", "unknown"}
+STATUS_ALIASES = {
+    "canceled": "cancelled",
+    "postponed": "deferred",
+    "changed": "overridden",
+    "rescheduled": "overridden",
+    "revoked": "cancelled",
+}
+CHAT_HINTS = {
+    "chat",
+    "conversation",
+    "interaction",
+    "talk",
+    "message",
+    "聊天",
+    "对话",
+    "陪聊",
+    "交流",
+    "沟通",
+    "说话",
+    "继续聊",
+}
+INTERNAL_HINTS = {"rest", "sleep", "study", "休息", "睡觉", "学习", "陪伴", "聊天"}
+
+
+def _trace_event(code: str, message: str) -> dict[str, str]:
+    return {"code": code, "message": message}
 
 
 def _normalized_text(value: Any) -> str:
@@ -37,22 +83,47 @@ def _tokens(value: Any) -> set[str]:
     if not text:
         return set()
     tokens = {text}
-    tokens.update(text[index:index + 2] for index in range(max(0, len(text) - 1)))
-    tokens.update(text[index:index + 3] for index in range(max(0, len(text) - 2)))
+    tokens.update(text[index : index + 2] for index in range(max(0, len(text) - 1)))
+    tokens.update(text[index : index + 3] for index in range(max(0, len(text) - 2)))
     return {token for token in tokens if len(token) >= 2}
 
 
 def _interval(item: dict[str, Any], now: datetime) -> tuple[datetime | None, datetime | None]:
+    def _value(keys: tuple[str, ...]) -> Any:
+        for key in keys:
+            value = item.get(key)
+            if value not in (None, ""):
+                return value
+        return None
+
+    start_value = _value(("start_at", "start", "starts_at", "time"))
+    end_value = _value(("end_at", "end", "ends_at", "end_time"))
     try:
-        start = parse_datetime(item.get("start_at") or item.get("start"), default=now)
+        # Legacy daily-plan rows use ``date`` plus bare clocks.  Attach the
+        # date before parsing; otherwise a 23:30-00:30 item is interpreted as
+        # a same-day interval and immediately becomes past.
+        if isinstance(start_value, str) and len(start_value.strip()) <= 8 and ":" in start_value and "T" not in start_value and "-" not in start_value:
+            date_value = str(item.get("date") or item.get("window_date") or now.date().isoformat()).strip()
+            if date_value:
+                start_value = f"{date_value}T{start_value.strip()}"
+        start = parse_datetime(start_value, default=now)
     except Exception:
         return None, None
     try:
-        end = parse_datetime(item.get("end_at") or item.get("end"), default=start)
+        if isinstance(end_value, str) and len(end_value.strip()) <= 8 and ":" in end_value and "T" not in end_value and "-" not in end_value:
+            date_value = str(item.get("date") or item.get("window_date") or now.date().isoformat()).strip()
+            if date_value:
+                end_value = f"{date_value}T{end_value.strip()}"
+        end = parse_datetime(end_value, default=start)
     except Exception:
         end = start
     if end <= start:
-        end = start + timedelta(seconds=1)
+        raw_start = str(start_value or "").rsplit("T", 1)[-1][:5]
+        raw_end = str(end_value or "").rsplit("T", 1)[-1][:5]
+        if raw_start and raw_end and raw_end <= raw_start:
+            end = end + timedelta(days=1)
+        else:
+            end = start + timedelta(seconds=1)
     return start, end
 
 
@@ -69,22 +140,421 @@ def _title_similarity(plan: dict[str, Any], activity: dict[str, Any]) -> float:
         return 0.0
     if plan_text in activity_text or activity_text in plan_text:
         return 1.0
-    shared = _tokens(plan_text).intersection(_tokens(activity_text))
+    plan_tokens = _tokens(plan_text)
+    activity_tokens = _tokens(activity_text)
+    shared = plan_tokens.intersection(activity_tokens)
     if not shared:
         return 0.0
-    return len(shared) / max(1, len(_tokens(plan_text).union(_tokens(activity_text))))
+    return len(shared) / max(1, len(plan_tokens.union(activity_tokens)))
+
+
+def _refs(item: dict[str, Any]) -> set[str]:
+    value = item.get("source_refs") or item.get("evidence_refs") or []
+    if isinstance(value, str):
+        value = [value]
+    if not isinstance(value, (list, tuple, set)):
+        return set()
+    return {str(ref).strip() for ref in value if str(ref).strip()}
+
+
+def _revision_key(value: Any) -> tuple[Any, ...]:
+    parts: list[tuple[int, Any]] = []
+    for part in re.split(r"([0-9]+)", str(value or "").strip()[:80]):
+        if part.isdigit():
+            parts.append((1, int(part)))
+        elif part:
+            parts.append((0, part.lower()))
+    return tuple(parts)
+
+
+def _mark_superseded_revisions(plans: list[dict[str, Any]], *, now: datetime) -> None:
+    """Hide older valid schedule revisions before direct reconciliation output."""
+
+    groups: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for plan in plans:
+        if str(plan.get("schedule_ref_status") or "").lower() != "valid":
+            continue
+        ref = plan.get("schedule_ref")
+        if not isinstance(ref, dict):
+            continue
+        key = (str(ref.get("namespace") or ""), str(ref.get("event_id") or ""))
+        if key != ("", ""):
+            groups.setdefault(key, []).append(plan)
+    for items in groups.values():
+        if len(items) < 2:
+            continue
+
+        def rank(item: dict[str, Any]) -> tuple[Any, ...]:
+            ref = item.get("schedule_ref") if isinstance(item.get("schedule_ref"), dict) else {}
+            try:
+                updated = parse_datetime(ref.get("updated_at"), default=now)
+            except Exception:
+                updated = now
+            return (_revision_key(ref.get("revision")), updated)
+
+        latest = max(items, key=rank)
+        for item in items:
+            if item is latest:
+                continue
+            item["schedule_ref_status"] = "revoked"
+            item["schedule_ref_reason"] = "schedule_revision_superseded"
+            item["status"] = "overridden"
+            item["commitment_level"] = "tentative"
+            item["fact_eligibility"] = "none"
+            item.setdefault("decision_trace", []).append(
+                _trace_event("reconciler.schedule_revision_superseded", "older schedule revision hidden")
+            )
 
 
 def _same_source(plan: dict[str, Any], activity: dict[str, Any]) -> bool:
     plan_id = str(plan.get("plan_id") or plan.get("event_id") or "").strip()
-    plan_refs = {str(ref) for ref in (plan.get("source_refs") or []) if str(ref)}
-    activity_refs = {str(ref) for ref in (activity.get("source_refs") or []) if str(ref)}
-    return bool((plan_id and plan_id in activity_refs) or plan_refs.intersection(activity_refs))
+    plan_refs = _refs(plan)
+    activity_refs = _refs(activity)
+    authority = str(plan.get("authority_kind") or "").strip().lower()
+    declared_authority = str(plan.get("legacy_authority_kind") or "").strip().lower() or authority
+    # A hard calendar/timetable/appointment commitment cannot be used as an
+    # execution link unless its structured reference passed the authority
+    # adapter.  This check must precede the convenient plan_id shortcut.
+    if declared_authority in HARD_SCHEDULE_AUTHORITIES and (
+        str(plan.get("schedule_ref_status") or "").strip().lower() != "valid"
+        or not bool(plan.get("source_refs_trusted"))
+    ):
+        return False
+    # A plan's own source_refs are untrusted generation input unless a
+    # schedule/evidence adapter marked them trusted.  An activity may still
+    # explicitly target the canonical plan_id, which is the unambiguous link
+    # used by tool/action adapters.
+    if plan_id and plan_id in activity_refs:
+        return True
+    if plan_refs.intersection(activity_refs):
+        # For an ordinary intent, a concrete observation carrying the same
+        # external/evidence reference is an explicit link.  It can support
+        # execution status through ``_supports_execution`` but never promotes
+        # the plan's schedule commitment or authority.
+        return True
+    return False
 
 
 def _plan_is_past(plan: dict[str, Any], now: datetime) -> bool:
     _start, end = _interval(plan, now)
     return bool(end and end <= now)
+
+
+def _temporal_phase(item: dict[str, Any], now: datetime) -> str:
+    start, end = _interval(item, now)
+    if start is None:
+        return "future" if item.get("source_kind") == "planned" else "unknown"
+    try:
+        current = parse_datetime(now)
+    except Exception:
+        current = now
+    if current < start:
+        return "future"
+    if end is not None and current >= end:
+        return "past"
+    return "current"
+
+
+def _evidence_kind(item: dict[str, Any]) -> str:
+    candidate = str(item.get("evidence_kind") or "").strip().lower()
+    if candidate in EVIDENCE_KINDS:
+        return candidate
+    source = _normalized_text(item.get("source") or item.get("kind"))
+    if any(token in source for token in ("selfstate", "selfcommit", "internalstate", "内部状态")):
+        return "self_state_commit"
+    if any(token in source for token in ("tool", "action", "工具", "执行")):
+        return "tool_action"
+    if any(token in source for token in ("calendar", "timetable", "roster", "appointment", "日历", "课表", "班表", "预约")):
+        return "external_record"
+    if any(token in source for token in ("commitment", "承诺", "安排")):
+        return "external_commitment"
+    if any(token in source for token in ("conversation", "chat", "message", "interaction", "聊天", "对话", "互动")):
+        return "interaction"
+    # Captured C3 activities historically defaulted to conversation.
+    if item.get("source_kind") == "observed":
+        return "interaction"
+    return "none"
+
+
+def _actor_compatible(plan: dict[str, Any], activity: dict[str, Any]) -> bool:
+    plan_actor = str(plan.get("subject_actor_id") or "").strip()
+    activity_actor = str(activity.get("subject_actor_id") or "").strip()
+    # A missing subject cannot inherit the other record's actor.  Two legacy
+    # unbound records may still be reconciled for compatibility, but the
+    # resulting view remains diagnostic until an actor is attached.
+    if bool(plan_actor) != bool(activity_actor):
+        return False
+    return not plan_actor or plan_actor == activity_actor
+
+
+def _actor_bound(item: dict[str, Any]) -> bool:
+    return bool(
+        str(item.get("subject_actor_id") or "").strip()
+        and str(item.get("actor_type") or "").strip().lower() in {"bot", "interlocutor_user", "external_party", "system"}
+    )
+
+
+def _has_hint(value: Any, hints: set[str]) -> bool:
+    raw = str(value or "").lower()
+    normalized = _normalized_text(value)
+    return any(hint in raw or _normalized_text(hint) in normalized for hint in hints)
+
+
+def _is_chat_plan(plan: dict[str, Any]) -> bool:
+    if str(plan.get("evidence_kind") or "").lower() == "interaction":
+        return True
+    for key in ("kind", "category", "activity_type", "type", "title", "activity"):
+        if _has_hint(plan.get(key), CHAT_HINTS):
+            return True
+    return False
+
+
+def _is_internal_plan(plan: dict[str, Any]) -> bool:
+    granularity = str(plan.get("content_granularity") or "").lower()
+    if granularity == "scene":
+        return False
+    if str(plan.get("authority_kind") or "").lower() in {"state", "persona"}:
+        return True
+    return any(_has_hint(plan.get(key), INTERNAL_HINTS) for key in ("title", "activity", "kind", "category"))
+
+
+def _supports_execution(plan: dict[str, Any], activity: dict[str, Any], *, explicit_ref: bool) -> bool:
+    kind = _evidence_kind(activity)
+    if kind in EXECUTION_EVIDENCE_KINDS:
+        return True
+    if kind == "interaction":
+        # Conversation evidence proves only a chat-like plan.  A source
+        # reference resolves which record is being discussed, but cannot turn
+        # chat text into proof of an unrelated external action.
+        return _is_chat_plan(plan)
+    if kind == "self_state_commit":
+        # SelfStateCommit is a standalone short-lived internal state.  It may
+        # be disclosed as ``current_internal`` through the activity record,
+        # but it must never mutate a plan to active/completed or create a
+        # reconciliation that can later be replayed as execution evidence.
+        return False
+    # A commitment (calendar/timetable/appointment) proves an arrangement,
+    # never attendance or execution.
+    return False
+
+
+def _evidence_level(items: list[dict[str, Any]]) -> str:
+    levels = {str(item.get("evidence_level") or "").upper() for item in items}
+    for level in ("L5", "L4", "L3", "L2", "L1", "L0"):
+        if level in levels:
+            return level
+    return "L0"
+
+
+def _coverage_ratio(plan: dict[str, Any], activities: list[dict[str, Any]], now: datetime) -> float:
+    plan_start, plan_end = _interval(plan, now)
+    if not plan_start or not plan_end:
+        return 0.0
+    duration = max(1.0, (plan_end - plan_start).total_seconds())
+    covered: list[tuple[datetime, datetime]] = []
+    for activity in activities:
+        start, end = _interval(activity, now)
+        if not start or not end:
+            continue
+        left, right = max(plan_start, start), min(plan_end, end)
+        if left < right:
+            covered.append((left, right))
+    if not covered:
+        return 0.0
+    covered.sort()
+    total = 0.0
+    current_start, current_end = covered[0]
+    for start, end in covered[1:]:
+        if start <= current_end:
+            current_end = max(current_end, end)
+        else:
+            total += (current_end - current_start).total_seconds()
+            current_start, current_end = start, end
+    total += (current_end - current_start).total_seconds()
+    return min(1.0, total / duration)
+
+
+def _entry_semantics(entry: dict[str, Any], item: dict[str, Any]) -> dict[str, Any]:
+    """Copy canonical fields onto legacy agenda entries without changing API shape."""
+
+    fields = (
+        "temporal_phase",
+        "evidence_kind",
+        "authority_kind",
+        "commitment_level",
+        "epistemic_status",
+        "content_granularity",
+        "materialization_state",
+        "fact_eligibility",
+        "confidence",
+        "subject_actor_id",
+        "source_actor_id",
+        "target_user_id",
+        "participant_roles",
+        "runtime_origin_refs",
+        "expires_at",
+        "decision_trace",
+    )
+    for field in fields:
+        if field in item:
+            entry[field] = item[field]
+    return entry
+
+
+def _prepare_plan(raw: dict[str, Any], *, now: datetime) -> dict[str, Any]:
+    plan = normalize_plan_item(raw, now=now)
+    raw_status = str(raw.get("status") or raw.get("lifecycle_status") or "").strip().lower()
+    canonical_status = STATUS_ALIASES.get(raw_status, raw_status)
+    if raw_status and canonical_status not in PRESERVED_PLAN_STATUSES:
+        plan["legacy_status"] = raw_status
+        plan["status"] = "planned"
+        plan.setdefault("decision_trace", []).append(
+            _trace_event("reconciler.plan_status_ignored", "plan status ignored until compatible evidence")
+        )
+    elif canonical_status in PRESERVED_PLAN_STATUSES:
+        plan["status"] = canonical_status
+    plan["temporal_phase"] = _temporal_phase(plan, now)
+    plan["evidence_kind"] = "none"
+    plan["epistemic_status"] = str(plan.get("epistemic_status") or "asserted").lower()
+    authority = str(plan.get("authority_kind") or "").lower()
+    source_refs = _refs(plan)
+    schedule_ref = plan.get("schedule_ref") if isinstance(plan.get("schedule_ref"), dict) else {}
+    ref_state = str(schedule_ref.get("state") or "").lower()
+    schedule_ref_status = str(plan.get("schedule_ref_status") or "not_applicable")
+    schedule_ref_reason = str(plan.get("schedule_ref_reason") or "")
+    if authority in {"calendar", "timetable", "roster", "appointment", "user_confirmation"}:
+        schedule_ref_status, schedule_ref_reason = validate_structured_schedule_ref(
+            schedule_ref,
+            source_refs=source_refs,
+            expected_authority=authority,
+            expected_subject=plan.get("subject_actor_id"),
+            expected_target=plan.get("target_user_id"),
+            now=now,
+        )
+        plan["source_refs_trusted"] = schedule_ref_status == "valid"
+        if schedule_ref_status != "valid":
+            plan["authority_kind"] = "llm"
+            authority = "llm"
+            plan["commitment_level"] = "tentative"
+            plan.setdefault("decision_trace", []).append(
+                _trace_event(
+                    "reconciler.untrusted_schedule_ref",
+                    "hard schedule authority requires a valid structured schedule_ref",
+                )
+            )
+        elif isinstance(schedule_ref, dict):
+            # The signed absolute interval is authoritative.  Adapter
+            # ``to_plan_fields()`` intentionally need not duplicate clocks;
+            # populate them here so date/window projections remain stable and
+            # caller-controlled duplicate times cannot move a commitment.
+            signed_start = str(schedule_ref.get("effective_from") or "").strip()
+            signed_end = str(schedule_ref.get("effective_to") or "").strip()
+            if signed_start and signed_end:
+                plan["start_at"] = signed_start
+                plan["end_at"] = signed_end
+                plan["temporal_phase"] = _temporal_phase(plan, now)
+    plan["schedule_ref_status"] = schedule_ref_status
+    plan["schedule_ref_reason"] = schedule_ref_reason
+    ref_state = ref_state or "active"
+    if ref_state in {"cancelled", "revoked"}:
+        plan["status"] = "cancelled"
+        plan["commitment_level"] = "tentative"
+        plan["fact_eligibility"] = "none"
+        plan.setdefault("decision_trace", []).append(
+            _trace_event("reconciler.schedule_ref_inactive", "inactive schedule reference cannot remain confirmed")
+        )
+    elif ref_state == "superseded":
+        plan["status"] = "overridden"
+        plan["commitment_level"] = "tentative"
+        plan["fact_eligibility"] = "none"
+        plan.setdefault("decision_trace", []).append(
+            _trace_event("reconciler.schedule_ref_superseded", "superseded schedule reference is hidden")
+        )
+    if plan.get("status") in {"cancelled", "overridden"}:
+        plan["commitment_level"] = "tentative"
+    elif authority in {"calendar", "timetable", "roster", "appointment", "user_confirmation"} and plan.get("source_refs_trusted"):
+        plan["commitment_level"] = "confirmed"
+    elif authority == "routine":
+        plan["commitment_level"] = "routine"
+    elif str(plan.get("commitment_level") or "").lower() not in {"confirmed", "routine", "tentative"}:
+        plan["commitment_level"] = "tentative"
+    granularity = str(raw.get("content_granularity") or "").lower()
+    plan["content_granularity"] = granularity if granularity in {"commitment", "intent", "candidate", "scene"} else (
+        "commitment" if plan["commitment_level"] == "confirmed" else "intent"
+    )
+    plan["materialization_state"] = str(plan.get("materialization_state") or "none").lower()
+    if plan["materialization_state"] not in {"none", "candidate", "active", "rejected", "expired"}:
+        plan["materialization_state"] = "none"
+    expires_at = str(plan.get("expires_at") or "").strip()
+    if expires_at:
+        try:
+            if parse_datetime(expires_at) <= parse_datetime(now):
+                plan["materialization_state"] = "expired"
+                plan["commitment_level"] = "tentative"
+                plan["fact_eligibility"] = "none"
+                plan.setdefault("decision_trace", []).append(
+                    _trace_event("reconciler.plan_expired", "expired plan is excluded from future commitments")
+                )
+        except Exception:
+            pass
+    plan["fact_eligibility"] = "schedule_commitment" if plan["commitment_level"] in {"confirmed", "routine"} else "none"
+    if plan["materialization_state"] == "expired":
+        plan["fact_eligibility"] = "none"
+    plan.setdefault("decision_trace", [])
+    if not isinstance(plan["decision_trace"], list):
+        plan["decision_trace"] = [_trace_event("reconciler.trace_coerced", str(plan["decision_trace"]))]
+    return plan
+
+
+def _prepare_activity(raw: dict[str, Any], *, now: datetime) -> dict[str, Any]:
+    activity = normalize_observed_activity(raw, now=now)
+    activity["temporal_phase"] = _temporal_phase(activity, now)
+    activity["evidence_kind"] = _evidence_kind(activity)
+    # Calendar-shaped payloads are commitments, not attendance evidence.
+    raw_source = str(raw.get("source") or "").strip().lower()
+    if raw_source in {"calendar", "timetable", "roster", "appointment"} and not raw.get("evidence_kind"):
+        activity["evidence_kind"] = "external_commitment"
+    activity["epistemic_status"] = "observed"
+    if activity["evidence_kind"] in {"none", "external_commitment"} or activity["temporal_phase"] == "future":
+        activity["fact_eligibility"] = "none"
+    elif activity["evidence_kind"] == "self_state_commit" and activity["temporal_phase"] == "current":
+        activity["fact_eligibility"] = "current_internal"
+    elif activity["temporal_phase"] == "past" and activity["evidence_kind"] != "self_state_commit":
+        activity["fact_eligibility"] = "history_observed"
+    elif activity["evidence_kind"] == "self_state_commit":
+        activity["fact_eligibility"] = "none"
+    else:
+        activity["fact_eligibility"] = "current_observed"
+    activity.setdefault(
+        "content_granularity",
+        "commitment" if activity["evidence_kind"] == "external_commitment" else "intent",
+    )
+    activity.setdefault("commitment_level", "tentative")
+    activity.setdefault("materialization_state", "none")
+    activity.setdefault("decision_trace", [])
+    if not isinstance(activity["decision_trace"], list):
+        activity["decision_trace"] = [_trace_event("reconciler.trace_coerced", str(activity["decision_trace"]))]
+    return activity
+
+
+def _set_evidence_levels(item: dict[str, Any], level: str) -> None:
+    """Keep canonical and archive evidence projections in sync after matching."""
+
+    normalized = str(level or "L0").upper()
+    item["evidence_level"] = normalized
+    item["canonical_evidence_level"] = normalized
+    item["archive_evidence_level"] = normalized if normalized in {"L0", "L1", "L2", "L3"} else "L3"
+    mapping = item.get("evidence_level_mapping")
+    if not isinstance(mapping, dict):
+        mapping = {}
+    mapping.update(
+        {
+            "canonical_evidence_level": item["canonical_evidence_level"],
+            "archive_evidence_level": item["archive_evidence_level"],
+            "lossy": item["archive_evidence_level"] != normalized,
+        }
+    )
+    item["evidence_level_mapping"] = mapping
 
 
 def reconcile(
@@ -93,64 +563,219 @@ def reconcile(
     *,
     now: datetime,
 ) -> dict[str, Any]:
+    """Reconcile C3 plans against compatible evidence.
+
+    Exact source references are verified links.  Time/title-only matches are
+    returned as diagnostic candidates and never mutate plan status or fact
+    eligibility.  This keeps future intent out of current/history views.
+    """
+
     normalized_plans: list[dict[str, Any]] = []
     for raw in plans or []:
         try:
-            normalized_plans.append(normalize_plan_item(raw, now=now))
+            if isinstance(raw, dict):
+                normalized_plans.append(_prepare_plan(raw, now=now))
         except Exception:
             continue
+    _mark_superseded_revisions(normalized_plans, now=now)
     normalized_activities: list[dict[str, Any]] = []
     for raw in activities or []:
         try:
-            normalized_activities.append(normalize_observed_activity(raw, now=now))
+            if isinstance(raw, dict):
+                normalized_activities.append(_prepare_activity(raw, now=now))
         except Exception:
             continue
 
     used_activity_ids: set[str] = set()
     reconciled_plans: list[dict[str, Any]] = []
     reconciliations: list[dict[str, Any]] = []
+    reconciliation_candidates: list[dict[str, Any]] = []
     entries: list[dict[str, Any]] = []
     matched: dict[str, list[str]] = {}
 
     for plan in normalized_plans:
         plan_id = str(plan.get("plan_id") or stable_id("plan", plan.get("title")))
-        exact = [activity for activity in normalized_activities if _same_source(plan, activity)]
-        overlap_candidates = [activity for activity in normalized_activities if _overlaps(plan, activity, now)]
-        similar = [activity for activity in overlap_candidates if _title_similarity(plan, activity) >= 0.18]
-        selected = exact or similar
         plan_result = dict(plan)
-        if selected:
-            ids = [str(item.get("activity_id")) for item in selected]
+        trace = list(plan_result.get("decision_trace") or [])
+        explicit = [
+            activity
+            for activity in normalized_activities
+            if _same_source(plan, activity) and _actor_compatible(plan, activity)
+            and (_overlaps(plan, activity, now) or not _interval(plan, now)[0] or not _interval(activity, now)[0])
+        ]
+        executable = [
+            activity
+            for activity in explicit
+            if _temporal_phase(plan, now) != "future"
+            and _temporal_phase(activity, now) != "future"
+            and str(activity.get("status") or "active").lower()
+            in {"active", "completed", "partially_completed"}
+            and _supports_execution(plan, activity, explicit_ref=True)
+        ]
+        # Similarity is useful for diagnostics, but it is never execution
+        # evidence and must not consume an activity or alter status.
+        similar = [
+            activity
+            for activity in normalized_activities
+            if str(activity.get("activity_id")) not in {str(item.get("activity_id")) for item in explicit}
+            and _actor_compatible(plan, activity)
+            and _overlaps(plan, activity, now)
+            and _title_similarity(plan, activity) >= 0.18
+        ]
+        if similar:
+            similar = similar[:3]
+            reconciliation_candidates.append(
+                {
+                    "candidate_id": stable_id(
+                        "reconciliation_candidate",
+                        plan_id,
+                        [item.get("activity_id") for item in similar],
+                    ),
+                    "plan_id": plan_id,
+                    "activity_ids": [str(item.get("activity_id")) for item in similar],
+                    "status": "pending_verification",
+                    "source_kind": "reconciled",
+                    "temporal_phase": _temporal_phase(plan, now),
+                    "evidence_kind": _evidence_kind(similar[0]),
+                    "epistemic_status": "inferred",
+                    "fact_eligibility": "none",
+                    "subject_actor_id": plan.get("subject_actor_id", ""),
+                    "reason": "time overlap/title similarity requires verification",
+                    "decision_trace": [
+                        _trace_event("reconciler.similarity_candidate", "similarity is diagnostic only")
+                    ],
+                }
+            )
+            trace.append(
+                _trace_event("reconciler.similarity_withheld", "similarity candidate withheld from execution status")
+            )
+
+        if executable:
+            ids = [str(item.get("activity_id")) for item in executable]
             matched[plan_id] = ids
             used_activity_ids.update(ids)
-            all_completed = all(str(item.get("status")) == "completed" for item in selected)
-            plan_result["status"] = "completed" if all_completed else "active"
-            reason = "plan_id/source_refs matched" if exact else "time overlap and controlled title similarity"
-            plan_result["reconciliation_reason"] = reason
+            actors_bound = _actor_bound(plan_result) and all(_actor_bound(item) for item in executable)
+            if not actors_bound:
+                for item in executable:
+                    item["fact_eligibility"] = "none"
+            evidence_kind = _evidence_kind(executable[0])
+            statuses = {str(item.get("status") or "active") for item in executable}
+            coverage = _coverage_ratio(plan, executable, now)
+            has_completed = "completed" in statuses
+            has_partial = "partially_completed" in statuses
+            if has_completed:
+                next_status = "completed" if coverage >= 0.95 or not _interval(plan, now)[0] else "partially_completed"
+            elif has_partial:
+                next_status = "partially_completed"
+            else:
+                next_status = "active"
+            plan_result["status"] = next_status
+            plan_result["evidence_kind"] = evidence_kind
+            _set_evidence_levels(plan_result, _evidence_level(executable))
+            plan_result["epistemic_status"] = "observed"
+            plan_result["fact_eligibility"] = (
+                "history_observed"
+                if next_status in {"completed", "partially_completed"}
+                and _plan_is_past(plan_result, now)
+                else "current_internal" if evidence_kind == "self_state_commit"
+                else "current_observed"
+            )
+            if not actors_bound:
+                plan_result["fact_eligibility"] = "none"
+            plan_result["reconciliation_reason"] = (
+                "explicit source reference matched compatible evidence"
+            )
             plan_result["reconciled_activity_ids"] = ids
+            plan_result["decision_trace"] = trace + [
+                _trace_event("reconciler.compatible_evidence", "status produced by compatible evidence")
+            ]
+            source_refs: list[str] = []
+            for item in executable:
+                for ref in _refs(item):
+                    if ref not in source_refs:
+                        source_refs.append(ref)
             reconciliation = {
                 "reconciliation_id": stable_id("reconciliation", plan_id, ids),
                 "plan_id": plan_id,
-                "status": plan_result["status"],
+                "status": next_status,
                 "source_kind": "reconciled",
-                "evidence_level": "L3" if any(item.get("evidence_level") in {"L3", "L4", "L5"} for item in selected) else "L2",
-                "source_refs": [plan_id, *ids],
+                "temporal_phase": _temporal_phase(plan_result, now),
+                "evidence_kind": evidence_kind,
+                "evidence_level": _evidence_level(executable),
+                "epistemic_status": "observed",
+                "authority_kind": plan_result.get("authority_kind") or executable[0].get("authority_kind", "state"),
+                "commitment_level": plan_result.get("commitment_level", "tentative"),
+                "content_granularity": plan_result.get("content_granularity", "intent"),
+                "materialization_state": plan_result.get("materialization_state", "none"),
+                "confidence": max(
+                    float(plan_result.get("confidence") or 0.0),
+                    max(float(item.get("confidence") or 0.0) for item in executable),
+                ),
+                "fact_eligibility": plan_result["fact_eligibility"],
+                "source_refs": source_refs,
+                "runtime_origin_refs": [
+                    *[str(ref) for ref in plan_result.get("runtime_origin_refs") or [] if str(ref)],
+                    f"reconcile:{plan_id}",
+                ],
                 "activity_ids": ids,
-                "reason": reason,
+                "reason": plan_result["reconciliation_reason"],
+                "decision_trace": plan_result["decision_trace"],
+                "subject_actor_id": plan_result.get("subject_actor_id") or executable[0].get("subject_actor_id"),
+                "source_actor_id": plan_result.get("source_actor_id") or executable[0].get("source_actor_id", "system"),
+                "target_user_id": plan_result.get("target_user_id") or executable[0].get("target_user_id", ""),
+                "participant_roles": plan_result.get("participant_roles") or executable[0].get("participant_roles", []),
+                "expires_at": plan_result.get("expires_at", ""),
             }
+            if not actors_bound:
+                plan_result["decision_trace"] = trace + [
+                    _trace_event("reconciler.missing_subject_withheld", "unbound records remain diagnostic-only")
+                ]
+                reconciliation["decision_trace"] = plan_result["decision_trace"]
+            _set_evidence_levels(reconciliation, reconciliation["evidence_level"])
             reconciliations.append(reconciliation)
-            entries.append(agenda_entry_from_plan(plan_result, reason=reason))
-            entries.extend(agenda_entry_from_activity(item, source_refs=[plan_id, *ids]) for item in selected)
+            entries.append(
+                _entry_semantics(
+                    agenda_entry_from_plan(plan_result, reason=plan_result["reconciliation_reason"]),
+                    plan_result,
+                )
+            )
+            entries.extend(
+                _entry_semantics(agenda_entry_from_activity(item, source_refs=_refs(item)), item)
+                for item in executable
+            )
         else:
-            if plan_result.get("status") not in {"cancelled", "deferred"} and _plan_is_past(plan_result, now):
-                plan_result["status"] = "unknown"
-                plan_result["reconciliation_reason"] = "window ended without observed evidence"
-            entries.append(agenda_entry_from_plan(plan_result, reason=plan_result.get("reconciliation_reason", "")))
+            # Raw active/completed fields are ignored by the plan normalizer;
+            # a past window without evidence becomes unknown, never complete.
+            if plan_result.get("status") not in {"cancelled", "deferred", "overridden"}:
+                if _plan_is_past(plan_result, now):
+                    plan_result["status"] = "unknown"
+                    trace.append(
+                        _trace_event("reconciler.no_evidence", "window ended without compatible observed evidence")
+                    )
+                else:
+                    plan_result["status"] = "planned"
+            plan_result["evidence_kind"] = "none"
+            plan_result["fact_eligibility"] = (
+                "schedule_commitment" if plan_result.get("commitment_level") in {"confirmed", "routine"} else "none"
+            )
+            plan_result["decision_trace"] = trace
+            reason = (
+                "window ended without observed evidence"
+                if plan_result.get("status") == "unknown"
+                else "planned; no compatible execution evidence"
+            )
+            plan_result["reconciliation_reason"] = plan_result.get("reconciliation_reason") or reason
+            entries.append(
+                _entry_semantics(
+                    agenda_entry_from_plan(plan_result, reason=plan_result["reconciliation_reason"]),
+                    plan_result,
+                )
+            )
         reconciled_plans.append(plan_result)
 
     for activity in normalized_activities:
         if str(activity.get("activity_id")) not in used_activity_ids:
-            entries.append(agenda_entry_from_activity(activity))
+            entries.append(_entry_semantics(agenda_entry_from_activity(activity), activity))
 
     entries.sort(key=lambda item: (str(item.get("start_at") or ""), 0 if item.get("kind") == "observed" else 1))
     return {
@@ -159,4 +784,5 @@ def reconcile(
         "entries": entries,
         "matched": matched,
         "reconciliations": reconciliations,
+        "reconciliation_candidates": reconciliation_candidates,
     }

--- a/self_timeline.py
+++ b/self_timeline.py
@@ -139,6 +139,33 @@ class SelfTimelineMixin:
         return [item[2] for item in scored]
 
     def _self_timeline_from_daily_plan(self, data: dict[str, Any]) -> list[dict[str, Any]]:
+        disclosure = getattr(self, "_agenda_disclosure_view", None)
+        if callable(disclosure):
+            try:
+                view = disclosure("history_fact", max_entries=32)
+                entries = view.get("entries", []) if isinstance(view, dict) else getattr(view, "entries", [])
+                if isinstance(entries, list):
+                    result: list[dict[str, Any]] = []
+                    for item in entries:
+                        if not isinstance(item, dict):
+                            continue
+                        result.append(
+                            {
+                                "source": "日程",
+                                "date": _single_line(item.get("date"), 24),
+                                "time": _single_line(item.get("time"), 12),
+                                "minutes": self._self_timeline_parse_hhmm(item.get("time")),
+                                "when": self._self_timeline_when(_single_line(item.get("date"), 24), _single_line(item.get("time"), 12)),
+                                "summary": _single_line(item.get("title") or item.get("activity"), 140),
+                                "detail": "",
+                                "keywords": "日程 做了什么 干嘛 忙 " + _single_line(item.get("title") or item.get("activity"), 140),
+                            }
+                        )
+                    return result
+            except Exception:
+                # A policy failure must not reactivate the legacy path that
+                # interpreted every elapsed plan row as Bot history.
+                return []
         plan = data.get("daily_plan") if isinstance(data.get("daily_plan"), dict) else {}
         items = plan.get("items") if isinstance(plan.get("items"), list) else plan.get("schedule")
         if not isinstance(items, list):
@@ -173,6 +200,8 @@ class SelfTimelineMixin:
         entries = []
         for key, snapshot in enhanced.items():
             if not isinstance(snapshot, dict):
+                continue
+            if str(snapshot.get("fact_eligibility") or "none").lower() not in {"history_observed", "current_observed"}:
                 continue
             start, window = self._self_timeline_segment_window(str(key), snapshot)
             summary = _single_line(snapshot.get("summary") or snapshot.get("event"), 160)

--- a/tests/test_agenda_contracts_policy.py
+++ b/tests/test_agenda_contracts_policy.py
@@ -1,0 +1,172 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+import sys
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from agenda_contracts import (
+    interval_overlaps_window,
+    normalize_observed_activity,
+    normalize_plan_item,
+    window_bounds,
+)
+from agenda_disclosure_policy import AgendaDisclosurePolicy
+from schedule_authority import ScheduleAuthorityAdapter
+
+
+NOW = datetime.fromisoformat("2026-07-30T21:34:00+08:00")
+
+
+class AgendaContractCanonicalTests(unittest.TestCase):
+    def test_ordinary_plan_is_forced_to_intent(self) -> None:
+        item = normalize_plan_item(
+            {
+                "title": "pull curtain",
+                "source_kind": "observed",
+                "status": "completed",
+                "evidence_kind": "tool_action",
+                "basis": ["persona"],
+                "actor_type": "bot",
+                "subject_actor_id": "bot-1",
+            },
+            now=NOW,
+        )
+        self.assertEqual(item["source_kind"], "planned")
+        self.assertEqual(item["status"], "planned")
+        self.assertEqual(item["evidence_kind"], "none")
+        self.assertEqual(item["source_refs"], [])
+        self.assertEqual(item["subject_actor_id"], "bot-1")
+        self.assertIn("normalizer.basis_not_source_refs", {entry["code"] for entry in item["decision_trace"]})
+        self.assertEqual(item["legacy_status"], "completed")
+
+    def test_numeric_certainty_is_not_retyped(self) -> None:
+        item = normalize_observed_activity(
+            {
+                "title": "tool action",
+                "source": "tool",
+                "source_refs": ["tool-1"],
+                "certainty": 0.8,
+                "actor_type": "bot",
+                "subject_actor_id": "bot-1",
+            },
+            now=NOW,
+        )
+        self.assertEqual(item["certainty"], 0.8)
+        self.assertEqual(item["evidence_kind"], "tool_action")
+
+    def test_legacy_date_and_clock_fields_reach_the_correct_window(self) -> None:
+        morning_start, morning_end = window_bounds("2026-07-30", "morning")
+        self.assertTrue(
+            interval_overlaps_window(
+                {"date": "2026-07-30", "time": "09:00", "end": "10:00"},
+                morning_start,
+                morning_end,
+            )
+        )
+        late_start, late_end = window_bounds("2026-07-30", "late_night")
+        self.assertTrue(
+            interval_overlaps_window(
+                {"date": "2026-07-30", "time": "23:30", "end": "00:30"},
+                late_start,
+                late_end,
+            )
+        )
+
+
+class AgendaDisclosurePolicyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.policy = AgendaDisclosurePolicy(bot_id="bot-1", target_user_id="user-1")
+
+    def test_future_plan_never_enters_current_or_history(self) -> None:
+        future = {
+            "entry_id": "future",
+            "title": "scene detail",
+            "source_kind": "planned",
+            "status": "planned",
+            "start_at": "2026-07-30T22:30:00+08:00",
+            "end_at": "2026-07-30T23:00:00+08:00",
+            "actor_type": "bot",
+            "subject_actor_id": "bot-1",
+        }
+        current = self.policy.build_view({"entries": [future]}, NOW, "current_fact")
+        history = self.policy.build_view({"entries": [future]}, NOW, "history_fact")
+        self.assertEqual(current.entries, [])
+        self.assertEqual(history.entries, [])
+        self.assertIn(current.redactions[0]["reason"], {"future_plan_not_current", "planned_without_execution_evidence"})
+
+    def test_hard_schedule_is_separate_from_execution(self) -> None:
+        adapter = ScheduleAuthorityAdapter(clock=lambda: NOW)
+        ref = adapter.issue_or_update(
+            {
+                "authority_kind": "calendar",
+                "event_id": "event-1",
+                "revision": "1",
+                "timezone": "Asia/Shanghai",
+                "updated_at": "2026-07-30T21:34:00+08:00",
+                "effective_from": "2026-07-31T09:00:00+08:00",
+                "effective_to": "2026-07-31T10:00:00+08:00",
+            },
+            "bot-1",
+        )
+        assert hasattr(ref, "to_plan_fields")
+        hard = {
+            "entry_id": "class-1",
+            "title": "class",
+            "source_kind": "planned",
+            "status": "planned",
+            **ref.to_plan_fields(),
+            "start_at": "2026-07-31T09:00:00+08:00",
+            "end_at": "2026-07-31T10:00:00+08:00",
+            "actor_type": "bot",
+            "subject_actor_id": "bot-1",
+        }
+        policy = AgendaDisclosurePolicy(bot_id="bot-1", schedule_authority=adapter)
+        schedule = policy.build_view({"entries": [hard]}, NOW, "schedule_commitment")
+        current = policy.build_view({"entries": [hard]}, NOW, "current_fact")
+        self.assertEqual([entry["entry_id"] for entry in schedule.entries], ["class-1"])
+        self.assertEqual(current.entries, [])
+
+    def test_user_subject_does_not_leak_into_bot_view(self) -> None:
+        user_fact = {
+            "entry_id": "user-1",
+            "title": "user action",
+            "source_kind": "observed",
+            "status": "completed",
+            "evidence_kind": "external_record",
+            "source_refs": ["user-record-1"],
+            "start_at": "2026-07-30T20:00:00+08:00",
+            "end_at": "2026-07-30T20:30:00+08:00",
+            "actor_type": "interlocutor_user",
+            "subject_actor_id": "user-2",
+        }
+        view = self.policy.build_view({"entries": [user_fact]}, NOW, "history_fact")
+        self.assertEqual(view.entries, [])
+        self.assertIn("subject_mismatch_user", view.redactions[0]["reasons"])
+
+    def test_interaction_evidence_cannot_prove_unrelated_activity(self) -> None:
+        activity = {
+            "entry_id": "chat-evidence",
+            "title": "attend class",
+            "kind": "conversation",
+            "source_kind": "observed",
+            "status": "active",
+            "evidence_kind": "interaction",
+            "source_refs": ["message-1"],
+            "start_at": "2026-07-30T21:30:00+08:00",
+            "end_at": "2026-07-30T22:00:00+08:00",
+            "actor_type": "bot",
+            "subject_actor_id": "bot-1",
+        }
+        view = self.policy.build_view({"entries": [activity]}, NOW, "current_fact")
+        self.assertEqual(view.entries, [])
+        self.assertIn("interaction_scope_mismatch", view.redactions[0]["reasons"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bot_personal_agenda_semantics.py
+++ b/tests/test_bot_personal_agenda_semantics.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import sys
+import types
+from datetime import datetime
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE = "agenda_dto_contract_tests"
+if PACKAGE not in sys.modules:
+    package = types.ModuleType(PACKAGE)
+    package.__path__ = [str(ROOT)]
+    sys.modules[PACKAGE] = package
+
+from agenda_dto_contract_tests.bot_personal_dto import build_bot_personal_dto
+from schedule_authority import ScheduleAuthorityAdapter
+
+
+NOW = datetime.fromisoformat("2026-07-30T21:34:00+08:00")
+
+
+def _build(memory_type: str, payload: dict, key: str):
+    return build_bot_personal_dto(
+        memory_type=memory_type,
+        payload=payload,
+        idempotency_key=key,
+        occurred_at="2026-07-30T21:34:00+08:00",
+        now=NOW,
+    )
+
+
+def test_schedule_plan_keeps_commitment_only_for_adapter_marked_reference() -> None:
+    adapter = ScheduleAuthorityAdapter(clock=lambda: NOW)
+    ref = adapter.issue_or_update(
+        {
+            "authority_kind": "timetable",
+            "event_id": "class-1",
+            "revision": "1",
+            "timezone": "Asia/Shanghai",
+            "updated_at": "2026-07-30T21:34:00+08:00",
+            "effective_from": "2026-07-31T09:00:00+08:00",
+            "effective_to": "2026-07-31T10:00:00+08:00",
+        },
+        "bot_self",
+    )
+    assert hasattr(ref, "to_plan_fields")
+    trusted = _build(
+        "bot_schedule_plan",
+        {
+            "date": "2026-07-31",
+            **ref.to_plan_fields(),
+            "status": "completed",
+            "subject_actor_id": "bot_self",
+        },
+        "daily_plan:trusted",
+    )
+    assert trusted.status == "planned"
+    assert trusted.fact_eligibility == "schedule_commitment"
+    assert trusted.commitment_level == "confirmed"
+
+    untrusted = _build(
+        "bot_schedule_plan",
+        {
+            "date": "2026-07-31",
+            "source_refs": ["model-invented"],
+            "authority_kind": "timetable",
+            "commitment_level": "confirmed",
+            "subject_actor_id": "bot_self",
+        },
+        "daily_plan:untrusted",
+    )
+    assert untrusted.status == "planned"
+    assert untrusted.fact_eligibility == "none"
+    assert untrusted.commitment_level == "tentative"
+
+
+def test_projection_reconciliation_and_detail_do_not_become_history() -> None:
+    snapshot = _build(
+        "bot_window_snapshot",
+        {"date": "2026-07-30", "window": "evening", "status": "completed"},
+        "agenda_snapshot:2026-07-30:evening",
+    )
+    assert snapshot.status == "reconciled"
+    assert snapshot.fact_eligibility == "none"
+
+    reconciliation = _build(
+        "bot_schedule_reconciliation",
+        {
+            "date": "2026-07-30",
+            "window": "evening",
+            "status": "completed",
+            "fact_eligibility": "history_observed",
+        },
+        "reconciliation:2026-07-30:evening",
+    )
+    assert reconciliation.status == "reconciled"
+    assert reconciliation.fact_eligibility == "none"
+
+    detail = _build(
+        "bot_detail_fragment",
+        {
+            "date": "2026-07-30",
+            "window": "evening",
+            "summary": "possible scene",
+            "status": "active",
+            "fact_eligibility": "history_observed",
+            "content_granularity": "scene",
+            "subject_actor_id": "bot_self",
+        },
+        "detail:2026-07-30:1260:1320",
+    )
+    assert detail.status == "planned"
+    assert detail.fact_eligibility == "none"
+    assert detail.materialization_state == "candidate"
+    assert detail.expires_at
+
+
+def test_calendar_event_without_trusted_schedule_ref_is_not_a_commitment() -> None:
+    event = _build(
+        "bot_calendar_event",
+        {
+            "date": "2026-07-31",
+            "window": "morning",
+            "authority_kind": "calendar",
+            "commitment_level": "confirmed",
+            "source_refs": ["calendar:invented"],
+            "subject_actor_id": "bot_self",
+        },
+        "calendar:event-1",
+    )
+    assert event.status == "planned"
+    assert event.fact_eligibility == "none"
+    assert event.commitment_level == "tentative"

--- a/tests/test_c1_contract.py
+++ b/tests/test_c1_contract.py
@@ -8,8 +8,16 @@ from pathlib import Path
 COMPANION_ROOT = Path(__file__).resolve().parents[1]
 PEIBAN_ROOT = COMPANION_ROOT.parents[1]
 CONTRACT_PATH = COMPANION_ROOT / "bot_personal_contract.py"
-MEMORY_CONTRACT_PATH = PEIBAN_ROOT / "astrbot_plugin_memory_companion-main" / "core" / "bot_personal_contract.py"
-SHARED_CONTRACT_PATH = PEIBAN_ROOT / "doc" / "shared" / "bot_personal_contract.py"
+_MEMORY_CONTRACT_CANDIDATES = (
+    PEIBAN_ROOT / "astrbot_plugin_memory_companion-main" / "core" / "bot_personal_contract.py",
+    COMPANION_ROOT.parent / "我会牢牢记住你" / "core" / "bot_personal_contract.py",
+)
+MEMORY_CONTRACT_PATH = next((path for path in _MEMORY_CONTRACT_CANDIDATES if path.is_file()), _MEMORY_CONTRACT_CANDIDATES[0])
+_SHARED_CONTRACT_CANDIDATES = (
+    PEIBAN_ROOT / "doc" / "shared" / "bot_personal_contract.py",
+    MEMORY_CONTRACT_PATH,
+)
+SHARED_CONTRACT_PATH = next((path for path in _SHARED_CONTRACT_CANDIDATES if path.is_file()), _SHARED_CONTRACT_CANDIDATES[0])
 
 
 def load_contract(path: Path, name: str):
@@ -35,9 +43,9 @@ def test_contract_bytes_match_authority_and_other_side():
 
 def test_frozen_contract_values_and_self_check():
     for module in (contract, memory_contract):
-        assert module.CONTRACT_FINGERPRINT == "5b8a97c1527dcc62"
-        assert module.CONTRACT_REVISION == 1
-        assert module.BOT_PERSONAL_CAPABILITY_SCHEMA_VERSION == "1.1"
+        assert module.CONTRACT_FINGERPRINT == "0ffe3a1ab69b659c"
+        assert module.CONTRACT_REVISION == 2
+        assert module.BOT_PERSONAL_CAPABILITY_SCHEMA_VERSION == "1.2"
         assert module.BOT_PERSONAL_PAYLOAD_SCHEMA_VERSION == "1.0"
         assert module.BOT_PERSONAL_MEMORY_DOMAIN == "bot_self_schedule"
         assert len(module.BOT_PERSONAL_MEMORY_TYPES) == 12
@@ -82,9 +90,10 @@ def test_descriptor_fields_and_cross_side_descriptor_equality():
     companion = contract.capability_descriptor()
     memory = memory_contract.capability_descriptor()
     assert companion == memory
-    assert companion["contract_fingerprint"] == "5b8a97c1527dcc62"
-    assert companion["contract_revision"] == 1
-    assert companion["capability_schema_version"] == "1.1"
+    assert companion["contract_fingerprint"] == "0ffe3a1ab69b659c"
+    assert companion["contract_revision"] == 2
+    assert companion["capability_schema_version"] == "1.2"
+    assert companion["canonical_schema_version"] == 2
     assert companion["payload_schema_version"] == "1.0"
     assert companion["memory_domain"] == "bot_self_schedule"
     assert companion["windows"] == list(contract.WINDOW_SLUGS)

--- a/tests/test_c3_agenda.py
+++ b/tests/test_c3_agenda.py
@@ -130,7 +130,8 @@ def test_normalizers_preserve_contract_fields_and_stable_id() -> None:
     raw = {"title": "x", "status": "completed", "version": 4, "source_refs": ["a"], "visibility": "private", "certainty": "high", "evidence_level": "L3"}
     normalized = normalize_plan_item(raw)
     assert normalized["source_kind"] == "planned"
-    assert normalized["status"] == "completed"
+    assert normalized["status"] == "planned"
+    assert normalized["legacy_status"] == "completed"
     assert normalized["version"] == 4
     assert normalized["source_refs"] == ["a"]
     assert stable_id("x", {"b": 2, "a": 1}) == stable_id("x", {"a": 1, "b": 2})

--- a/tests/test_daily_schedule_segment_api.py
+++ b/tests/test_daily_schedule_segment_api.py
@@ -485,7 +485,9 @@ class DailyScheduleSegmentApiTests(unittest.IsolatedAsyncioTestCase):
         timeline = self.api._daily_timeline_summary(self.plugin.data)
 
         self.assertEqual([item["window"] for item in timeline["segments"]], ["22:00-23:00", "23:00-00:30", "00:30-01:30"])
-        self.assertEqual(timeline["segments"][2]["lifecycle"], "active")
+        # Crossing the clock boundary identifies the current window, but a
+        # planned row without execution evidence remains unknown.
+        self.assertEqual(timeline["segments"][2]["lifecycle"], "unknown")
         current = self.plugin._current_detail_segment_for_update()
         self.assertIsNotNone(current)
         self.assertEqual(current["index"], 2)

--- a/tests/test_detail_model_location.py
+++ b/tests/test_detail_model_location.py
@@ -71,6 +71,24 @@ class DetailModelLocationTests(unittest.TestCase):
         self.assertEqual(0.93, state["location_confidence"])
         self.assertEqual(0.0, state["location_override_ts"])
 
+    def test_future_detail_does_not_update_current_location(self) -> None:
+        harness = _DetailLocationHarness()
+        harness._effective_plan_now_minutes = lambda _date: 20 * 60 + 55
+        detail = {
+            "location": "宿舍卧室",
+            "location_basis": ["coarse_plan"],
+            "location_confidence": 0.93,
+        }
+
+        changed = harness._refresh_daily_state_location_from_plan(
+            plan=harness.data["daily_plan"],
+            detail=detail,
+            segment={"start": 21 * 60 + 10},
+        )
+
+        self.assertFalse(changed)
+        self.assertEqual("工作场所", harness.data["daily_state"]["location"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_runtime_scene_resolver.py
+++ b/tests/test_runtime_scene_resolver.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from runtime_scene_resolver import RuntimeSceneResolver
+from schedule_authority import ScheduleAuthorityAdapter, TrustedScheduleRef
+from schedule_reconciler import reconcile
+
+
+def test_resolver_is_bot_only_idempotent_and_ttl_bound() -> None:
+    now = datetime.fromisoformat("2026-07-30T21:34:00+08:00")
+    resolver = RuntimeSceneResolver(bot_id="bot-1", clock=lambda: now, default_ttl_seconds=120)
+    first = resolver.resolve_now(
+        [{"activity": "可能刷穿搭", "subject_actor_id": "bot-1"}],
+        conversation_state={"active": True},
+        now=now,
+    )
+    second = resolver.resolve_now([], conversation_state=False, now=now)
+    assert first == second
+    assert first["actor_type"] == "bot"
+    assert first["subject_actor_id"] == "bot-1"
+    assert first["source_refs"] == []
+    assert first["fact_eligibility"] == "current_internal"
+    assert resolver.get_current(now=now + timedelta(seconds=121)) is None
+
+
+def test_user_turn_interrupts_a_previous_internal_state() -> None:
+    now = datetime.fromisoformat("2026-07-30T21:34:00+08:00")
+    resolver = RuntimeSceneResolver(bot_id="bot-1", clock=lambda: now, default_ttl_seconds=120)
+    resting = resolver.resolve_now(
+        [{"activity": "rest", "actor_type": "bot", "subject_actor_id": "bot-1"}],
+        conversation_state=False,
+        now=now,
+    )
+    interrupted = resolver.resolve_now([], conversation_state=True, now=now)
+    assert resting["state"] != interrupted["state"]
+    assert "interruption:user_turn" in interrupted["runtime_origin_refs"]
+    assert interrupted["state_version"] == resting["state_version"] + 1
+
+
+def test_resolver_ignores_unbound_or_user_candidates() -> None:
+    now = datetime.fromisoformat("2026-07-30T21:34:00+08:00")
+    resolver = RuntimeSceneResolver(bot_id="bot-1", clock=lambda: now)
+    result = resolver.resolve_now(
+        [
+            {"activity": "user is studying", "actor_type": "interlocutor_user", "subject_actor_id": "user-1"},
+            {"activity": "unbound study scene"},
+        ],
+        conversation_state=False,
+        now=now,
+    )
+    assert result["subject_actor_id"] == "bot-1"
+    assert result["state"] == "在休息"
+
+
+def test_schedule_authority_requires_structured_absolute_source_and_is_idempotent() -> None:
+    now = datetime.fromisoformat("2026-07-30T21:34:00+08:00")
+    adapter = ScheduleAuthorityAdapter(clock=lambda: now)
+    rejected = adapter.issue_or_update(
+        {"authority_kind": "calendar", "event_id": "class-1", "revision": "1"},
+        "bot-1",
+    )
+    assert not rejected
+    payload = {
+        "authority_kind": "calendar",
+        "event_id": "class-1",
+        "revision": "1",
+        "timezone": "Asia/Shanghai",
+        "updated_at": "2026-07-30T21:34:00+08:00",
+        "effective_from": "2026-07-31T09:00:00+08:00",
+        "effective_to": "2026-07-31T10:00:00+08:00",
+    }
+    ref = adapter.issue_or_update(payload, "bot-1")
+    assert isinstance(ref, TrustedScheduleRef)
+    assert adapter.issue_or_update(payload, "bot-1") == ref
+    assert adapter.verify(ref, now=now) == "valid"
+    fields = ref.to_plan_fields()
+    assert fields["commitment_level"] == "confirmed"
+    assert fields["source_refs_trusted"] is True
+
+
+def test_schedule_authority_rejects_forged_or_unstructured_confirmation() -> None:
+    now = datetime.fromisoformat("2026-07-30T21:34:00+08:00")
+    adapter = ScheduleAuthorityAdapter(clock=lambda: now)
+    base = {
+        "authority_kind": "user_confirmation",
+        "event_id": "confirmed-1",
+        "revision": "1",
+        "timezone": "Asia/Shanghai",
+        "updated_at": "2026-07-30T21:34:00+08:00",
+        "effective_from": "2026-07-31T09:00:00+08:00",
+        "effective_to": "2026-07-31T10:00:00+08:00",
+    }
+    assert not adapter.issue_or_update(base, "bot-1")
+    ref = adapter.issue_or_update(
+        {
+            **base,
+            "updated_at": "2026-07-30T21:34:00+08:00",
+            "confirmation_event_id": "msg-1",
+            "confirmation_actor_id": "user-1",
+            "proposition": "Bot 明早九点有课",
+            "confirmed_at": "2026-07-30T21:34:00+08:00",
+        },
+        "bot-1",
+    )
+    assert isinstance(ref, TrustedScheduleRef)
+    forged = TrustedScheduleRef(**{**ref.as_dict(), "ref_id": "trusted_schedule:forged"})
+    assert adapter.verify(forged, now=now) == "invalid"
+
+
+def test_rescheduled_reference_invalidates_the_immutable_old_object() -> None:
+    now = datetime.fromisoformat("2026-07-30T21:34:00+08:00")
+    adapter = ScheduleAuthorityAdapter(clock=lambda: now)
+    first = adapter.issue_or_update(
+        {
+            "authority_kind": "calendar",
+            "event_id": "appointment-1",
+            "revision": "1",
+            "timezone": "Asia/Shanghai",
+            "updated_at": "2026-07-30T21:34:00+08:00",
+            "effective_from": "2026-07-31T09:00:00+08:00",
+            "effective_to": "2026-07-31T10:00:00+08:00",
+        },
+        "bot-1",
+    )
+    assert isinstance(first, TrustedScheduleRef)
+    replacement = adapter.revoke_or_reschedule(
+        "appointment-1",
+        "1",
+        "moved",
+        now,
+        reschedule={
+            "revision": "2",
+            "effective_from": "2026-07-31T11:00:00+08:00",
+            "effective_to": "2026-07-31T12:00:00+08:00",
+        },
+    )
+    assert isinstance(replacement, TrustedScheduleRef)
+    assert adapter.verify(first, now=now) == "revoked"
+    assert adapter.verify(replacement, now=now) == "valid"
+
+
+def test_untrusted_plan_reference_does_not_trigger_execution_reconciliation() -> None:
+    result = reconcile(
+        [
+            {
+                "plan_id": "soft-refs",
+                "title": "整理桌面",
+                "source_refs": ["model-invented-ref"],
+                "start_at": "2026-07-30T20:00:00+08:00",
+                "end_at": "2026-07-30T21:00:00+08:00",
+            }
+        ],
+        [
+            {
+                "activity_id": "activity-1",
+                "title": "整理桌面",
+                "source": "conversation",
+                "source_refs": ["model-invented-ref"],
+                "status": "completed",
+                "start_at": "2026-07-30T20:00:00+08:00",
+                "end_at": "2026-07-30T21:00:00+08:00",
+            }
+        ],
+        now=datetime.fromisoformat("2026-07-30T21:34:00+08:00"),
+    )
+    assert result["matched"] == {}
+    assert result["plans"][0]["status"] == "unknown"

--- a/tests/test_schedule_authority_disclosure_security.py
+++ b/tests/test_schedule_authority_disclosure_security.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timedelta
+
+from agenda_disclosure_policy import AgendaDisclosurePolicy
+from runtime_scene_resolver import RuntimeSceneResolver
+from schedule_authority import (
+    ScheduleAuthorityAdapter,
+    TrustedScheduleRef,
+    validate_structured_schedule_ref,
+)
+
+
+NOW = datetime.fromisoformat("2026-07-30T21:34:00+08:00")
+
+
+def _adapter() -> ScheduleAuthorityAdapter:
+    return ScheduleAuthorityAdapter(clock=lambda: NOW)
+
+
+def _event(event_id: str = "event-1", revision: str = "1", **extra: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "authority_kind": "calendar",
+        "event_id": event_id,
+        "revision": revision,
+        "timezone": "Asia/Shanghai",
+        "updated_at": "2026-07-30T21:34:00+08:00",
+        "effective_from": "2026-07-31T09:00:00+08:00",
+        "effective_to": "2026-07-31T10:00:00+08:00",
+    }
+    payload.update(extra)
+    return payload
+
+
+def _entry(ref: TrustedScheduleRef, *, entry_id: str = "entry-1") -> dict[str, object]:
+    return {
+        "entry_id": entry_id,
+        "title": "class",
+        "source_kind": "planned",
+        "status": "planned",
+        **ref.to_plan_fields(),
+        "actor_type": "bot",
+        "subject_actor_id": "bot-1",
+    }
+
+
+def test_forged_trust_marker_without_structured_ref_is_rejected() -> None:
+    policy = AgendaDisclosurePolicy(bot_id="bot-1")
+    view = policy.build_view(
+        {
+            "entries": [
+                {
+                    "entry_id": "forged",
+                    "title": "class",
+                    "source_kind": "planned",
+                    "status": "planned",
+                    "authority_kind": "calendar",
+                    "commitment_level": "confirmed",
+                    "source_refs": ["model-ref"],
+                    "source_refs_trusted": True,
+                    "actor_type": "bot",
+                    "subject_actor_id": "bot-1",
+                    "start_at": "2026-07-31T09:00:00+08:00",
+                    "end_at": "2026-07-31T10:00:00+08:00",
+                }
+            ]
+        },
+        NOW,
+        "schedule_commitment",
+    )
+    assert not view.entries
+    assert "missing_schedule_ref" in view.redactions[0]["reasons"]
+
+
+def test_expired_permission_and_invalid_timezone_refs_are_not_confirmed() -> None:
+    adapter = _adapter()
+    valid = adapter.issue_or_update(
+        _event(expires_at="2026-07-30T20:00:00+08:00"),
+        "bot-1",
+    )
+    assert isinstance(valid, TrustedScheduleRef)
+    policy = AgendaDisclosurePolicy(bot_id="bot-1", schedule_authority=adapter)
+    expired = policy.build_view({"entries": [_entry(valid)]}, NOW, "schedule_commitment")
+    assert not expired.entries
+    assert "expired" in expired.redactions[0]["reasons"]
+
+    denied = replace(valid, authorized=False)
+    denied_view = policy.build_view({"entries": [_entry(denied, entry_id="denied")]}, NOW, "schedule_commitment")
+    assert not denied_view.entries
+    assert "invalid_schedule_ref" in denied_view.redactions[0]["reasons"] or "permission_denied" in denied_view.redactions[0]["reasons"]
+
+    bad_tz = replace(valid, timezone="Not/AZone")
+    bad_tz_view = policy.build_view({"entries": [_entry(bad_tz, entry_id="bad-tz")]}, NOW, "schedule_commitment")
+    assert not bad_tz_view.entries
+
+    forged_interval = replace(valid, effective_from="2026-07-31T13:00:00+08:00")
+    assert adapter.verify(forged_interval, now=NOW) == "invalid"
+
+
+def test_structured_gate_checks_ref_id_before_delegating_to_verifier() -> None:
+    adapter = _adapter()
+    ref = adapter.issue_or_update(_event(), "bot-1")
+    assert isinstance(ref, TrustedScheduleRef)
+
+    class PermissiveVerifier:
+        def verify(self, _ref: object, *, now: datetime | None = None) -> str:
+            return "valid"
+
+    forged = ref.as_dict()
+    forged["ref_id"] = "trusted_schedule:forged"
+    status, reason = validate_structured_schedule_ref(
+        forged,
+        source_refs=[forged["ref_id"]],
+        expected_authority="calendar",
+        expected_subject="bot-1",
+        now=NOW,
+        adapter=PermissiveVerifier(),
+    )
+    assert status == "invalid"
+    assert reason == "schedule_ref_id_mismatch"
+
+
+def test_cancel_and_revision_only_leave_latest_valid_reference_visible() -> None:
+    adapter = _adapter()
+    first = adapter.issue_or_update(_event(event_id="same"), "bot-1")
+    assert isinstance(first, TrustedScheduleRef)
+    second = adapter.issue_or_update(
+        _event(
+            event_id="same",
+            revision="2",
+            updated_at="2026-07-30T21:35:00+08:00",
+            effective_from="2026-07-31T11:00:00+08:00",
+            effective_to="2026-07-31T12:00:00+08:00",
+        ),
+        "bot-1",
+    )
+    assert isinstance(second, TrustedScheduleRef)
+    policy = AgendaDisclosurePolicy(bot_id="bot-1", schedule_authority=adapter)
+    view = policy.build_view({"entries": [_entry(first, entry_id="old"), _entry(second, entry_id="new")]}, NOW, "schedule_commitment")
+    assert [item["entry_id"] for item in view.entries] == ["new"]
+    cancelled = adapter.revoke_or_reschedule("same", "2", "cancelled", NOW)
+    assert isinstance(cancelled, TrustedScheduleRef)
+    assert cancelled.revision != second.revision
+    assert cancelled.state == "cancelled"
+    assert adapter.verify(second, now=NOW) == "revoked"
+    assert adapter.verify(cancelled, now=NOW) == "cancelled"
+
+
+def test_user_confirmation_requires_structured_proposition_actor_and_time() -> None:
+    adapter = _adapter()
+    base = _event(authority_kind="user_confirmation", event_id="confirm")
+    assert not adapter.issue_or_update({**base, "confirmation_event_id": "chat-only"}, "bot-1")
+    result = adapter.issue_or_update(
+        {
+            **base,
+            "confirmation_event_id": "message-1",
+            "confirmation_actor_id": "user-1",
+            "proposition": "Bot 明早九点有课",
+            "confirmed_at": "2026-07-30T21:34:00+08:00",
+        },
+        "bot-1",
+    )
+    assert isinstance(result, TrustedScheduleRef)
+
+
+def test_schedule_target_binding_is_checked_against_disclosure_user() -> None:
+    adapter = _adapter()
+    ref = adapter.issue_or_update(_event(event_id="private-event"), "bot-1", target_user_id="user-1")
+    assert isinstance(ref, TrustedScheduleRef)
+    policy = AgendaDisclosurePolicy(
+        bot_id="bot-1",
+        target_user_id="user-2",
+        schedule_authority=adapter,
+    )
+    view = policy.build_view({"entries": [_entry(ref)]}, NOW, "schedule_commitment")
+    assert not view.entries
+    assert "schedule_target_mismatch" in view.redactions[0]["reasons"]
+
+
+def test_self_state_is_current_only_and_cannot_claim_external_results() -> None:
+    resolver = RuntimeSceneResolver(bot_id="bot-1", clock=lambda: NOW, default_ttl_seconds=120)
+    state = resolver.commit("在休息", now=NOW, window_id="w", origin_refs=["resolver:w"])
+    assert state is not None
+    assert state["status"] == "planned"
+    assert state["idempotency_key"] == "runtime_commit:bot-1:w:1"
+    assert resolver.commit("付款", now=NOW, window_id="w") is None
+    assert resolver.commit("在休息", now=NOW - timedelta(minutes=1), window_id="w") is None
+    assert resolver.commit("准备出门", now=NOW, window_id="w", expected_version=0) is None
+
+    policy = AgendaDisclosurePolicy(bot_id="bot-1")
+    current = policy.build_view({"entries": [state]}, NOW, "current_fact")
+    history = policy.build_view({"entries": [state]}, NOW + timedelta(minutes=3), "history_fact")
+    memory = policy.build_view({"entries": [state]}, NOW, "memory_write")
+    assert len(current.entries) == 1
+    assert not history.entries
+    assert not memory.entries
+    forged = dict(state)
+    forged["source_refs"] = ["external"]
+    assert not policy.build_view({"entries": [forged]}, NOW, "current_fact").entries
+
+
+def test_self_state_ttl_and_user_turn_override() -> None:
+    resolver = RuntimeSceneResolver(bot_id="bot-1", clock=lambda: NOW, default_ttl_seconds=60)
+    resting = resolver.resolve_now([], conversation_state=False, now=NOW)
+    assert resting is not None
+    assert resolver.get_current(now=NOW + timedelta(seconds=61)) is None
+    interrupted = resolver.resolve_now([], conversation_state={"last_user_message": "hello"}, now=NOW)
+    assert interrupted is not None
+    assert interrupted["state"] == "陪你聊天"
+    assert interrupted["state_version"] == resting["state_version"] + 1

--- a/tests/test_schedule_reconciler_semantics.py
+++ b/tests/test_schedule_reconciler_semantics.py
@@ -1,0 +1,440 @@
+# -*- coding: utf-8 -*-
+from datetime import datetime
+
+from schedule_authority import ScheduleAuthorityAdapter
+from schedule_reconciler import reconcile
+from unified_agenda import build_unified_agenda
+
+
+def _dt(value: str) -> datetime:
+    return datetime.fromisoformat(value)
+
+
+def _trusted_timetable_fields() -> dict:
+    adapter = ScheduleAuthorityAdapter(clock=lambda: _dt("2026-07-30T21:34:00+08:00"))
+    ref = adapter.issue_or_update(
+        {
+            "namespace": "test",
+            "event_id": "class-1",
+            "provider": "school",
+            "revision": "1",
+            "authority_kind": "timetable",
+            "timezone": "Asia/Shanghai",
+            "updated_at": "2026-07-30T08:00:00+08:00",
+            "effective_from": "2026-07-31T09:00:00+08:00",
+            "effective_to": "2026-07-31T10:00:00+08:00",
+            "title": "明早有课",
+        },
+        "bot-1",
+    )
+    assert hasattr(ref, "to_plan_fields")
+    return ref.to_plan_fields()
+
+
+def test_adapter_schedule_ref_supplies_signed_interval_to_future_view() -> None:
+    result = build_unified_agenda(
+        plans=[
+            {
+                "plan_id": "signed-class",
+                "title": "明早有课",
+                "actor_type": "bot",
+                "subject_actor_id": "bot-1",
+                **_trusted_timetable_fields(),
+            }
+        ],
+        activities=[],
+        now=_dt("2026-07-30T21:34:00+08:00"),
+        date_key="2026-07-31",
+    )
+    commitment = next(item for item in result["schedule_commitment"] if item["plan_id"] == "signed-class")
+    assert commitment["start_at"] == "2026-07-31T09:00:00+08:00"
+    assert commitment["end_at"] == "2026-07-31T10:00:00+08:00"
+
+
+def test_raw_completed_plan_without_evidence_is_unknown_after_window() -> None:
+    result = reconcile(
+        [
+            {
+                "plan_id": "soft-1",
+                "title": "睡前放松",
+                "start_at": "2026-07-30T20:30:00+08:00",
+                "end_at": "2026-07-30T21:00:00+08:00",
+                "status": "completed",
+            }
+        ],
+        [],
+        now=_dt("2026-07-30T21:34:00+08:00"),
+    )
+    plan = result["plans"][0]
+    assert plan["status"] == "unknown"
+    assert plan["temporal_phase"] == "past"
+    assert plan["evidence_kind"] == "none"
+    assert plan["fact_eligibility"] == "none"
+
+
+def test_similarity_only_activity_is_diagnostic_and_does_not_complete_plan() -> None:
+    result = reconcile(
+        [
+            {
+                "plan_id": "soft-2",
+                "title": "睡前放松刷穿搭",
+                "start_at": "2026-07-30T20:30:00+08:00",
+                "end_at": "2026-07-30T21:30:00+08:00",
+            }
+        ],
+        [
+            {
+                "activity_id": "chat-1",
+                "title": "刷穿搭",
+                "start_at": "2026-07-30T21:00:00+08:00",
+                "end_at": "2026-07-30T21:10:00+08:00",
+                "source": "conversation",
+            }
+        ],
+        now=_dt("2026-07-30T21:34:00+08:00"),
+    )
+    assert result["matched"] == {}
+    assert result["plans"][0]["status"] == "unknown"
+    assert result["reconciliation_candidates"][0]["status"] == "pending_verification"
+
+
+def test_future_tool_activity_cannot_materialize_a_future_plan() -> None:
+    result = reconcile(
+        [
+            {
+                "plan_id": "future-1",
+                "title": "整理桌面",
+                "start_at": "2026-07-30T22:30:00+08:00",
+                "end_at": "2026-07-30T23:00:00+08:00",
+            }
+        ],
+        [
+            {
+                "activity_id": "tool-future",
+                "title": "整理桌面",
+                "start_at": "2026-07-30T22:30:00+08:00",
+                "end_at": "2026-07-30T23:00:00+08:00",
+                "source": "tool",
+                "source_refs": ["future-1"],
+                "status": "completed",
+                "evidence_level": "L3",
+            }
+        ],
+        now=_dt("2026-07-30T21:34:00+08:00"),
+    )
+    assert result["matched"] == {}
+    assert result["plans"][0]["status"] == "planned"
+
+
+def test_self_state_commit_is_current_only_and_never_history() -> None:
+    result = reconcile(
+        [
+            {
+                "plan_id": "internal-1",
+                "title": "休息",
+                "authority_kind": "state",
+                "start_at": "2026-07-30T20:30:00+08:00",
+                "end_at": "2026-07-30T21:00:00+08:00",
+            }
+        ],
+        [
+            {
+                "activity_id": "state-1",
+                "title": "休息",
+                "source": "self_state_commit",
+                "source_refs": ["internal-1"],
+                "start_at": "2026-07-30T20:30:00+08:00",
+                "end_at": "2026-07-30T21:00:00+08:00",
+                "status": "completed",
+            }
+        ],
+        now=_dt("2026-07-30T21:34:00+08:00"),
+    )
+    assert result["plans"][0]["status"] == "unknown"
+    assert result["activities"][0]["fact_eligibility"] == "none"
+    assert result["reconciliations"] == []
+
+
+def test_current_self_state_does_not_activate_the_plan() -> None:
+    result = reconcile(
+        [
+            {
+                "plan_id": "internal-current",
+                "title": "rest",
+                "actor_type": "bot",
+                "subject_actor_id": "bot-1",
+                "start_at": "2026-07-30T21:00:00+08:00",
+                "end_at": "2026-07-30T22:00:00+08:00",
+            }
+        ],
+        [
+            {
+                "activity_id": "state-current",
+                "title": "resting state",
+                "actor_type": "bot",
+                "subject_actor_id": "bot-1",
+                "source": "self_state_commit",
+                "source_refs": ["internal-current"],
+                "runtime_origin_refs": ["runtime:state-current"],
+                "committed_at": "2026-07-30T21:30:00+08:00",
+                "valid_until": "2026-07-30T21:40:00+08:00",
+                "status": "active",
+            }
+        ],
+        now=_dt("2026-07-30T21:34:00+08:00"),
+    )
+    assert result["matched"] == {}
+    assert result["plans"][0]["status"] == "planned"
+    assert result["plans"][0]["fact_eligibility"] == "none"
+    assert result["activities"][0]["fact_eligibility"] == "current_internal"
+    assert result["reconciliations"] == []
+
+
+def test_user_evidence_cannot_reconcile_a_bot_plan() -> None:
+    result = reconcile(
+        [
+            {
+                "plan_id": "bot-class",
+                "title": "上课",
+                "subject_actor_id": "bot-1",
+                "start_at": "2026-07-30T10:00:00+08:00",
+                "end_at": "2026-07-30T11:00:00+08:00",
+            }
+        ],
+        [
+            {
+                "activity_id": "user-class",
+                "title": "上课",
+                "subject_actor_id": "user-1",
+                "source": "tool",
+                "source_refs": ["bot-class"],
+                "status": "completed",
+                "start_at": "2026-07-30T10:00:00+08:00",
+                "end_at": "2026-07-30T11:00:00+08:00",
+            }
+        ],
+        now=_dt("2026-07-30T14:00:00+08:00"),
+    )
+    assert result["matched"] == {}
+    assert result["plans"][0]["status"] == "unknown"
+
+
+def test_calendar_commitment_reference_does_not_prove_attendance() -> None:
+    result = reconcile(
+        [
+            {
+                "plan_id": "calendar-1",
+                "title": "上课",
+                "subject_actor_id": "bot-1",
+                "start_at": "2026-07-30T10:00:00+08:00",
+                "end_at": "2026-07-30T11:00:00+08:00",
+            }
+        ],
+        [
+            {
+                "activity_id": "calendar-ref",
+                "title": "上课",
+                "subject_actor_id": "bot-1",
+                "source": "calendar",
+                "source_refs": ["calendar-1"],
+                "status": "completed",
+                "start_at": "2026-07-30T10:00:00+08:00",
+                "end_at": "2026-07-30T11:00:00+08:00",
+            }
+        ],
+        now=_dt("2026-07-30T14:00:00+08:00"),
+    )
+    assert result["matched"] == {}
+    assert result["plans"][0]["status"] == "unknown"
+
+
+def test_interaction_fact_is_rendered_as_interaction_not_scene_action() -> None:
+    result = build_unified_agenda(
+        plans=[],
+        activities=[
+            {
+                "activity_id": "chat-now",
+                "title": "刷穿搭",
+                "source": "conversation",
+                "start_at": "2026-07-30T21:20:00+08:00",
+                "end_at": "2026-07-30T21:40:00+08:00",
+                "status": "active",
+            }
+        ],
+        now=_dt("2026-07-30T21:34:00+08:00"),
+        date_key="2026-07-30",
+    )
+    assert result["current"]["title"] == "与用户互动"
+    assert all(item.get("title") != "刷穿搭" for item in result["current_fact"])
+
+
+def test_cancelled_schedule_ref_cannot_remain_confirmed() -> None:
+    result = reconcile(
+        [
+            {
+                "plan_id": "cancelled-class",
+                "title": "上课",
+                "authority_kind": "timetable",
+                "source_refs": ["class-1"],
+                "source_refs_trusted": True,
+                "schedule_ref": {"state": "cancelled"},
+                "start_at": "2026-07-31T09:00:00+08:00",
+                "end_at": "2026-07-31T10:00:00+08:00",
+            }
+        ],
+        [],
+        now=_dt("2026-07-30T21:34:00+08:00"),
+    )
+    plan = result["plans"][0]
+    assert plan["status"] == "cancelled"
+    assert plan["commitment_level"] == "tentative"
+    assert plan["fact_eligibility"] == "none"
+
+
+def test_cancelled_observation_cannot_reconcile_as_active() -> None:
+    result = reconcile(
+        [
+            {
+                "plan_id": "cancelled-observation",
+                "title": "运行工具",
+                "start_at": "2026-07-30T10:00:00+08:00",
+                "end_at": "2026-07-30T11:00:00+08:00",
+            }
+        ],
+        [
+            {
+                "activity_id": "cancelled-tool",
+                "title": "运行工具",
+                "source": "tool",
+                "source_refs": ["cancelled-observation"],
+                "status": "cancelled",
+                "start_at": "2026-07-30T10:00:00+08:00",
+                "end_at": "2026-07-30T11:00:00+08:00",
+            }
+        ],
+        now=_dt("2026-07-30T14:00:00+08:00"),
+    )
+    assert result["matched"] == {}
+    assert result["plans"][0]["status"] == "unknown"
+
+
+def test_reconciler_hides_older_valid_schedule_revision() -> None:
+    adapter = ScheduleAuthorityAdapter(clock=lambda: _dt("2026-07-30T21:34:00+08:00"))
+    first = adapter.issue_or_update(
+        {
+            "namespace": "test",
+            "event_id": "revisioned-class",
+            "provider": "school",
+            "revision": "1",
+            "authority_kind": "timetable",
+            "timezone": "Asia/Shanghai",
+            "updated_at": "2026-07-30T08:00:00+08:00",
+            "effective_from": "2026-07-31T09:00:00+08:00",
+            "effective_to": "2026-07-31T10:00:00+08:00",
+        },
+        "bot-1",
+    )
+    second = adapter.issue_or_update(
+        {
+            "namespace": "test",
+            "event_id": "revisioned-class",
+            "provider": "school",
+            "revision": "2",
+            "authority_kind": "timetable",
+            "timezone": "Asia/Shanghai",
+            "updated_at": "2026-07-30T08:05:00+08:00",
+            "effective_from": "2026-07-31T11:00:00+08:00",
+            "effective_to": "2026-07-31T12:00:00+08:00",
+        },
+        "bot-1",
+    )
+    assert hasattr(first, "to_plan_fields") and hasattr(second, "to_plan_fields")
+    result = reconcile(
+        [
+            {"plan_id": "old", "title": "class", "actor_type": "bot", "subject_actor_id": "bot-1", **first.to_plan_fields()},
+            {"plan_id": "new", "title": "class", "actor_type": "bot", "subject_actor_id": "bot-1", **second.to_plan_fields()},
+        ],
+        [],
+        now=_dt("2026-07-30T21:34:00+08:00"),
+    )
+    by_id = {item["plan_id"]: item for item in result["plans"]}
+    assert by_id["old"]["status"] == "overridden"
+    assert by_id["old"]["schedule_ref_reason"] == "schedule_revision_superseded"
+    assert by_id["new"]["status"] == "planned"
+    assert by_id["new"]["fact_eligibility"] == "schedule_commitment"
+
+
+def test_explicit_tool_evidence_populates_history_view_only_after_completion() -> None:
+    payload = {
+        "plans": [
+            {
+                "plan_id": "done-1",
+                "title": "运行工具",
+                "actor_type": "bot",
+                "subject_actor_id": "bot-1",
+                "start_at": "2026-07-30T20:30:00+08:00",
+                "end_at": "2026-07-30T21:00:00+08:00",
+            },
+            {
+                "plan_id": "future-2",
+                "title": "明早有课",
+                "actor_type": "bot",
+                "subject_actor_id": "bot-1",
+                "start_at": "2026-07-31T09:00:00+08:00",
+                "end_at": "2026-07-31T10:00:00+08:00",
+                **_trusted_timetable_fields(),
+            },
+        ],
+        "activities": [
+            {
+                "activity_id": "done-activity",
+                "title": "运行工具",
+                "actor_type": "bot",
+                "subject_actor_id": "bot-1",
+                "start_at": "2026-07-30T20:30:00+08:00",
+                "end_at": "2026-07-30T21:00:00+08:00",
+                "source": "tool",
+                "source_refs": ["done-1"],
+                "status": "completed",
+                "evidence_level": "L3",
+            }
+        ],
+        "now": _dt("2026-07-30T21:34:00+08:00"),
+    }
+    result = build_unified_agenda(
+        **payload,
+        date_key="2026-07-30",
+    )
+    assert any(item["plan_id"] == "done-1" for item in result["history_fact"])
+    assert not any(item.get("plan_id") == "future-2" for item in result["history_fact"])
+    tomorrow = build_unified_agenda(**payload, date_key="2026-07-31")
+    assert any(item["plan_id"] == "future-2" for item in tomorrow["schedule_commitment"])
+
+
+def test_legacy_clock_plan_keeps_cross_midnight_phase_current() -> None:
+    plan = {
+        "plan_id": "midnight-1",
+        "title": "late rest",
+        "date": "2026-07-30",
+        "time": "23:30",
+        "end": "00:30",
+        "actor_type": "bot",
+        "subject_actor_id": "bot-1",
+    }
+    for now, expected_phase in (
+        ("2026-07-30T23:45:00+08:00", "current"),
+        ("2026-07-31T00:15:00+08:00", "current"),
+        ("2026-07-31T00:31:00+08:00", "past"),
+    ):
+        result = reconcile([plan], [], now=_dt(now))
+        assert result["plans"][0]["temporal_phase"] == expected_phase
+        assert result["plans"][0]["status"] == ("unknown" if expected_phase == "past" else "planned")
+
+
+def test_bare_clock_plan_without_date_uses_now_date_for_interval_resolution() -> None:
+    result = reconcile(
+        [{"plan_id": "midnight-no-date", "title": "late rest", "time": "23:30", "end": "00:30"}],
+        [],
+        now=_dt("2026-07-30T23:45:00+08:00"),
+    )
+    assert result["plans"][0]["temporal_phase"] == "current"

--- a/unified_agenda.py
+++ b/unified_agenda.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
-"""Read model and prompt formatter for the local C3 agenda."""
+"""Read model and prompt formatter for the local C3 agenda.
+
+The write-side reconciler keeps plan, evidence, and temporal phase separate.
+This module exposes purpose-specific views so callers do not accidentally use
+a future plan as a current or historical fact.
+"""
 from __future__ import annotations
 
 from datetime import datetime
@@ -15,8 +20,136 @@ try:
     )
     from .schedule_reconciler import reconcile
 except ImportError:
-    from agenda_contracts import SCHEDULE_WINDOWS, interval_overlaps_window, parse_datetime, window_bounds, window_for_datetime
+    from agenda_contracts import (
+        SCHEDULE_WINDOWS,
+        interval_overlaps_window,
+        parse_datetime,
+        window_bounds,
+        window_for_datetime,
+    )
     from schedule_reconciler import reconcile
+
+
+_CURRENT_FACT_ELIGIBILITY = {"current_internal", "current_observed"}
+_HISTORY_FACT_ELIGIBILITY = {"history_observed"}
+_SCHEDULE_COMMITMENT_LEVELS = {"confirmed", "routine"}
+
+
+def _fact_projection(item: dict[str, Any]) -> dict[str, Any]:
+    """Keep interaction evidence from being rendered as an arbitrary action."""
+
+    result = dict(item)
+    if str(item.get("evidence_kind") or "").lower() == "interaction":
+        result["title"] = "与用户互动"
+        result["content_granularity"] = "commitment"
+        result["evidence_summary"] = "interaction only"
+        for key in ("activity", "description", "scene_details", "message_seed", "raw_text"):
+            result.pop(key, None)
+    return result
+
+
+def _entry_phase(item: dict[str, Any], now: datetime) -> str:
+    phase = str(item.get("temporal_phase") or "").lower()
+    if phase in {"future", "current", "past"}:
+        return phase
+    # Legacy entries may have been built before temporal_phase was introduced.
+    try:
+        start = parse_datetime(item.get("start_at") or item.get("start"), default=now)
+        end = parse_datetime(item.get("end_at") or item.get("end"), default=start)
+    except Exception:
+        return "future"
+    if end <= start:
+        end = start
+    current = parse_datetime(now).astimezone(start.tzinfo)
+    if current < start:
+        return "future"
+    if current >= end:
+        return "past"
+    return "current"
+
+
+def _is_current_fact(item: dict[str, Any], now: datetime) -> bool:
+    if _entry_phase(item, now) != "current":
+        return False
+    eligibility = str(item.get("fact_eligibility") or "").lower()
+    if eligibility in _CURRENT_FACT_ELIGIBILITY:
+        return True
+    # Compatibility for old observed entries.  A planned item is never
+    # considered current merely because its interval contains ``now``.
+    return item.get("kind") == "observed" and str(item.get("status") or "") in {"active", "partially_completed"}
+
+
+def _is_history_fact(item: dict[str, Any], now: datetime) -> bool:
+    if _entry_phase(item, now) != "past":
+        return False
+    eligibility = str(item.get("fact_eligibility") or "").lower()
+    if eligibility in _HISTORY_FACT_ELIGIBILITY:
+        return True
+    return (
+        item.get("kind") == "observed"
+        and str(item.get("status") or "") == "completed"
+        and str(item.get("evidence_kind") or "").lower() != "self_state_commit"
+    )
+
+
+def _is_schedule_item(item: dict[str, Any]) -> bool:
+    if item.get("kind") not in {"planned", None} and item.get("source_kind") != "planned":
+        return False
+    status = str(item.get("status") or "planned").lower()
+    materialization = str(item.get("materialization_state") or "none").lower()
+    return status in {"planned"} and materialization != "expired"
+
+
+def _is_future_schedule(item: dict[str, Any], now: datetime) -> bool:
+    if not _is_schedule_item(item):
+        return False
+    return _entry_phase(item, now) in {"future", "current"}
+
+
+def _is_commitment(item: dict[str, Any]) -> bool:
+    return (
+        _is_schedule_item(item)
+        and str(item.get("commitment_level") or "").lower() in _SCHEDULE_COMMITMENT_LEVELS
+        and str(item.get("fact_eligibility") or "schedule_commitment").lower() == "schedule_commitment"
+    )
+
+
+def _item_for_date(item: dict[str, Any], target_date: str, *, timezone_name: str) -> bool:
+    if not target_date:
+        return True
+    explicit_date = str(item.get("date") or item.get("window_date") or "")[:10]
+    if explicit_date == target_date:
+        return True
+    # A late-night window is keyed by its starting date but extends into the
+    # next calendar day.  Checking all canonical windows handles that case and
+    # avoids dropping 00:30 entries from a requested prior-day agenda.
+    for slug, _name, _start_minute, _end_minute in SCHEDULE_WINDOWS:
+        try:
+            start, end = window_bounds(target_date, slug, timezone_name=timezone_name)
+        except Exception:
+            continue
+        if interval_overlaps_window(item, start, end, timezone_name=timezone_name):
+            return True
+    return False
+
+
+def _dedupe_entries(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        key = str(item.get("entry_id") or item.get("plan_id") or item.get("activity_id") or "")
+        if key and key in seen:
+            continue
+        if key:
+            seen.add(key)
+        result.append(item)
+    return result
+
+
+def _entry_key(item: dict[str, Any]) -> str:
+    return str(item.get("entry_id") or item.get("plan_id") or item.get("activity_id") or "")
 
 
 def build_unified_agenda(
@@ -28,35 +161,54 @@ def build_unified_agenda(
     timezone_name: str = "Asia/Shanghai",
 ) -> dict[str, Any]:
     result = reconcile(plans or [], activities or [], now=now)
-    current_slug, current_window_date, _current_start, _current_end = window_for_datetime(now, timezone_name=timezone_name)
-    target_date = date_key or current_window_date
-    entries = [
-        item for item in result["entries"]
-        if not target_date or str(item.get("date") or item.get("start_at") or "")[:10] == target_date
-    ]
+    current_slug, current_window_date, _current_start, _current_end = window_for_datetime(
+        now,
+        timezone_name=timezone_name,
+    )
+    target_date = str(date_key or current_window_date)[:10]
+
+    all_entries = [item for item in result["entries"] if _item_for_date(item, target_date, timezone_name=timezone_name)]
+    current_facts = [_fact_projection(item) for item in all_entries if _is_current_fact(item, now)]
+    history_facts = [_fact_projection(item) for item in all_entries if _is_history_fact(item, now)]
+    future_raw = [item for item in all_entries if _is_future_schedule(item, now)]
+    future_schedule = [_future_projection(item) for item in future_raw]
+    current_ids = {
+        _entry_key(item)
+        for item in current_facts
+    }
+    history_ids = {
+        _entry_key(item)
+        for item in history_facts
+    }
+    future_ids = {
+        _entry_key(item)
+        for item in future_raw
+    }
+    schedule_commitments = [item for item in future_schedule if _is_commitment(item)]
+    # ``memory_write`` is intentionally narrower than the complete agenda:
+    # projections, plans, and unresolved candidates cannot become history.
+    memory_write = [item for item in history_facts if item.get("fact_eligibility") in _HISTORY_FACT_ELIGIBILITY]
     current = None
-    for item in sorted(result["entries"], key=lambda value: str(value.get("start_at") or "")):
-        if item.get("status") in {"cancelled", "unknown"}:
+    for item in sorted(current_facts, key=lambda value: str(value.get("start_at") or "")):
+        if str(item.get("status") or "").lower() in {"cancelled", "unknown", "deferred", "overridden"}:
             continue
-        try:
-            start_text = item.get("start_at") or item.get("start")
-            end_text = item.get("end_at") or item.get("end")
-            item_start = parse_datetime(start_text, timezone_name=timezone_name)
-            item_end = parse_datetime(end_text, timezone_name=timezone_name, default=item_start)
-            if item_start <= now.astimezone(item_start.tzinfo) < item_end:
-                current = item
-                break
-        except Exception:
-            continue
+        current = item
+        break
 
     windows: list[dict[str, Any]] = []
     for slug, _name, _start_minute, _end_minute in SCHEDULE_WINDOWS:
         start, end = window_bounds(target_date, slug, timezone_name=timezone_name)
-        window_plans = [item for item in result["plans"] if interval_overlaps_window(item, start, end, timezone_name=timezone_name)]
-        window_activities = [item for item in result["activities"] if interval_overlaps_window(item, start, end, timezone_name=timezone_name)]
+        window_plans = [
+            item for item in result["plans"] if interval_overlaps_window(item, start, end, timezone_name=timezone_name)
+        ]
+        window_activities = [
+            item
+            for item in result["activities"]
+            if interval_overlaps_window(item, start, end, timezone_name=timezone_name)
+        ]
+        plan_ids = {str(item.get("plan_id")) for item in window_plans}
         window_reconciliations = [
-            item for item in result["reconciliations"]
-            if any(str(plan.get("plan_id")) in {str(p.get("plan_id")) for p in window_plans} for plan in [item])
+            item for item in result["reconciliations"] if str(item.get("plan_id")) in plan_ids
         ]
         windows.append(
             {
@@ -68,6 +220,36 @@ def build_unified_agenda(
                 "planned": window_plans,
                 "observed": window_activities,
                 "reconciled": window_reconciliations,
+                "current_fact": [_fact_projection(item) for item in window_activities if _is_current_fact(item, now)],
+                "history_fact": [_fact_projection(item) for item in window_activities if _is_history_fact(item, now)],
+                "future_schedule": [
+                    _future_projection(item)
+                    for item in window_plans
+                    if _is_future_schedule(item, now)
+                ],
+                "schedule_commitment": [_future_projection(item) for item in window_plans if _is_commitment(item)],
+            }
+        )
+
+    disclosure_trace = []
+    for item in all_entries:
+        disclosure_trace.append(
+            {
+                "entry_id": item.get("entry_id"),
+                "plan_id": item.get("plan_id"),
+                "activity_id": item.get("activity_id"),
+                "temporal_phase": _entry_phase(item, now),
+                "status": item.get("status"),
+                "fact_eligibility": item.get("fact_eligibility") or "none",
+                "decision": (
+                    "current_fact"
+                    if _entry_key(item) in current_ids
+                    else "history_fact"
+                    if _entry_key(item) in history_ids
+                    else "future_schedule"
+                    if _entry_key(item) in future_ids
+                    else "diagnostic"
+                ),
             }
         )
 
@@ -77,35 +259,127 @@ def build_unified_agenda(
         "window_date": target_date,
         "current_window": current_slug if target_date == current_window_date else "",
         "current": current,
-        "entries": entries,
+        "current_fact": _dedupe_entries(current_facts),
+        "history_fact": _dedupe_entries(history_facts),
+        "future_schedule": _dedupe_entries(future_schedule),
+        "schedule_commitment": _dedupe_entries(schedule_commitments),
+        "memory_write": _dedupe_entries(memory_write),
+        "entries": all_entries,
         "plans": result["plans"],
         "activities": result["activities"],
         "matched": result["matched"],
         "reconciliations": result["reconciliations"],
+        "reconciliation_candidates": result.get("reconciliation_candidates", []),
+        "disclosure_trace": disclosure_trace,
         "windows": windows,
     }
 
 
+def _safe_future_title(item: dict[str, Any]) -> str:
+    granularity = str(item.get("content_granularity") or "").lower()
+    materialization = str(item.get("materialization_state") or "").lower()
+    if granularity in {"scene", "candidate"} or materialization == "candidate":
+        return "临近时段的软安排"
+    return str(item.get("title") or "未命名安排")[:80]
+
+
+def _future_projection(item: dict[str, Any]) -> dict[str, Any]:
+    """Redact scene prose from the ordinary future-schedule projection."""
+
+    result = dict(item)
+    granularity = str(item.get("content_granularity") or "").lower()
+    materialization = str(item.get("materialization_state") or "").lower()
+    if granularity in {"scene", "candidate"} or materialization == "candidate":
+        result["title"] = "临近时段的软安排"
+        result["content_granularity"] = "candidate"
+        result["materialization_state"] = "candidate"
+        result["disclosure_reason"] = "scene detail withheld from ordinary future view"
+        for key in (
+            "activity",
+            "description",
+            "scene",
+            "scene_details",
+            "message_seed",
+            "candidates",
+            "chain",
+            "raw",
+            "raw_text",
+        ):
+            result.pop(key, None)
+    return result
+
+
 def format_agenda_context(agenda: dict[str, Any], *, max_entries: int = 8) -> str:
+    """Format a safe, purpose-neutral prompt context.
+
+    Current and historical lines come from evidence views.  Future lines are
+    limited to confirmed/routine commitments; tentative scene candidates stay
+    in diagnostics and cannot leak into a current/history prompt.
+    """
+
     if not isinstance(agenda, dict):
         return ""
-    lines = [f"C3日程（{agenda.get('window_date') or agenda.get('date') or '未知日期'}）"]
+    date_text = agenda.get("window_date") or agenda.get("date") or "unknown"
+    # Keep the established marker so existing prompt consumers and regression
+    # fixtures can identify this context block.
+    lines = [f"C3日程（{date_text}）"]
     current = agenda.get("current")
+    if isinstance(current, dict):
+        current_evidence = str(current.get("evidence_kind") or "").lower()
+        current_eligibility = str(current.get("fact_eligibility") or "").lower()
+        current_phase = str(current.get("temporal_phase") or "current").lower()
+        if current_phase != "current":
+            current = None
+        elif current.get("kind") != "observed" and current_eligibility not in _CURRENT_FACT_ELIGIBILITY:
+            current = None
+        elif current_evidence == "none" and current_eligibility not in _CURRENT_FACT_ELIGIBILITY:
+            current = None
     if isinstance(current, dict):
         lines.append(
             f"当前实际：{str(current.get('title') or '未命名')[:80]} "
             f"[{current.get('evidence_level') or 'L?'}|{current.get('status') or 'unknown'}]"
         )
-    entries = agenda.get("entries") if isinstance(agenda.get("entries"), list) else []
-    for item in entries[: max(0, int(max_entries))]:
-        if not isinstance(item, dict):
-            continue
-        kind = "实际" if item.get("kind") == "observed" else "计划"
+    entries: list[dict[str, Any]] = []
+    if isinstance(agenda.get("current_fact"), list):
+        entries.extend(item for item in agenda["current_fact"] if isinstance(item, dict))
+    if isinstance(agenda.get("history_fact"), list):
+        entries.extend(item for item in agenda["history_fact"] if isinstance(item, dict))
+    if isinstance(agenda.get("schedule_commitment"), list):
+        entries.extend(item for item in agenda["schedule_commitment"] if isinstance(item, dict))
+    if isinstance(agenda.get("future_schedule"), list):
+        entries.extend(
+            item
+            for item in agenda["future_schedule"]
+            if isinstance(item, dict)
+            and str(item.get("commitment_level") or "tentative").lower() == "tentative"
+        )
+    # Compatibility with agendas built by older callers that do not expose
+    # purpose-specific lists yet.
+    if not entries and isinstance(agenda.get("entries"), list):
+        entries.extend(
+            item for item in agenda["entries"]
+            if isinstance(item, dict)
+            and (
+                item.get("kind") == "observed"
+                or str(item.get("commitment_level") or "").lower() in _SCHEDULE_COMMITMENT_LEVELS
+                or (
+                    str(item.get("commitment_level") or "").lower() == "tentative"
+                    and str(item.get("temporal_phase") or "future").lower() in {"future", "current"}
+                )
+            )
+        )
+    for item in _dedupe_entries(entries)[: max(0, int(max_entries))]:
+        is_actual = item.get("kind") == "observed"
+        kind = "实际" if is_actual else (
+            "可能安排" if str(item.get("commitment_level") or "").lower() == "tentative" else "安排"
+        )
         title = str(item.get("title") or "未命名")[:80]
+        if not is_actual:
+            title = _safe_future_title(item)
         status = str(item.get("status") or "unknown")
         reason = str(item.get("reconciliation_reason") or "")
-        suffix = f"；{reason}" if reason else ""
+        suffix = f"；{reason}" if reason and is_actual else ""
         lines.append(f"- {kind}：{title} [{status}]{suffix}")
     if len(lines) == 1:
-        lines.append("- 暂无记录")
+        lines.append("- 暂无已确认日程或可用观察")
     return "\n".join(lines)


### PR DESCRIPTION
## 背景与目标

现有日程、场景细化、主动消息和长期记忆之间缺少统一的事实边界，模型生成的计划文本、相似标题或布尔信任标记可能被误当成已经发生的事实。本次变更建立统一的 C3 日程语义：明确区分“未来承诺”“当前内部状态”“外部观测事实”“历史事实”和“仅供推断的候选场景”，让拟人化表达建立在可验证、可追溯的状态之上。

## 新增能力

### 1. 统一日程与证据语义

- 为日程记录补齐来源类型、生命周期、时间阶段、证据类型、规范证据等级、权威类型、承诺强度、认知状态、内容粒度、物化状态和事实资格等统一字段。
- 明确计划、投影、已观测活动和对账结果之间的转换条件，避免仅凭标题相似、时间到达或模型声明把计划升级为事实。
- 将主体、客体、来源方、目标用户和参与者角色纳入统一语义，防止用户侧陈述被错误写成 Bot 自身经历。

### 2. 可信日程权威引用

- 支持日历、课表、值班表、预约和用户结构化确认五类权威来源。
- 引用签名绑定命名空间、事件、版本、提供方、Bot 主体、更新时间、时区、绝对起止时间、有效期、权威类型、确认信息和目标用户。
- 校验授权状态、主体权限、时区、绝对时间区间、有效期、撤销状态和目标用户绑定；普通模型文本或布尔信任字段不能替代结构化引用。
- 支持撤销、取消、改期和版本演进；同一事件只保留最新有效 revision 参与未来日程披露，旧版本保留诊断轨迹但不再重新进入有效视图。

### 3. 按用途隔离的披露策略

- 提供当前事实、历史事实、未来日程、硬日程承诺、主动消息、记忆写入和诊断七类用途视图。
- 每类视图按主体、目标用户、时间阶段、证据类型和事实资格独立过滤，只暴露完成当前用途所需的最小信息。
- 主动消息仅使用近期待办或短期 Bot 内部状态；未来软计划不会被描述成已发生事实。
- 诊断输出保留过滤原因、来源引用和决策轨迹，便于定位为什么某条记录被降级或拒绝。

### 4. 运行时场景解析

- 新增仅面向 Bot 当前状态的场景解析流程，候选场景只有在当前窗口成功提交后才能成为短期内部状态。
- 使用 TTL 控制状态寿命，并通过 CAS、状态版本和幂等键避免并发或重复解析造成状态跳变。
- 用户新一轮消息会中断此前推断的内部场景并生成新的状态版本，过期或被打断的场景不会继续影响回复。
- 缺少 Bot 主体绑定、运行来源或有效窗口的候选会被拒绝，不会物化为当前事实。

### 5. 证据驱动的日程对账

- 对账只接受交互记录、工具动作、外部记录或明确的内部状态提交等兼容证据。
- 禁止仅凭时间已经过去、计划标题相似、模型自填完成状态或信任布尔字段生成“已完成”历史。
- 对取消、部分完成、覆盖和未知状态保留明确语义，并输出可追溯的决策理由。

### 6. 全链路接入

- 忙碌回复、日程生成、主动消息、创作/阅读/资讯活动、空间发布、梦境、时间线、每日状态和页面展示统一消费规范视图。
- 场景细化只作为短 TTL 候选；未来细化内容在对应时间段到达前不能提前改变当前位置。
- Bot Personal 记忆桥接改用结构化证据轴，旧的自由文本日程片段不再作为主流程写入入口。
- 保留旧调用方需要的兼容字段和诊断信息，降低合同升级期间的迁移风险。

## 关键安全边界

- 无结构化权威引用时，外部日程只能保持 tentative，不能成为 confirmed 承诺。
- 无兼容观测证据时，计划、窗口投影和场景候选均不得写成当前或历史事实。
- 无主体记录仅可进入诊断视图；用户主体记录不能泄漏进 Bot 自身视图。
- 目标用户和互动范围不匹配时，相关记录会被过滤，避免跨用户串线。

## 兼容性

- 共享 Bot Personal 合同升级为 revision 2、capability schema 1.2，payload schema 仍保持 1.0。
- 新增字段为增量扩展；旧状态、来源和证据声明仅保留作兼容诊断，不再拥有事实升级权限。
- 配套记忆插件 PR：menglimi/astrbot_plugin_memory_companion#11。
