### PR TITLE
test: 补充跨插件参考图目录边界回归

### DIFF
--- a/tests/test_image_companion_bridge.py
+++ b/tests/test_image_companion_bridge.py
@@ -1,16 +1,388 @@
 from __future__ import annotations
 
+import asyncio
 import sys
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-
-from astrbot_plugin_private_companion.image_companion_bridge import ImageCompanionBridgeMixin
 from astrbot_plugin_image_companion.image_runtime import ImageGenerationRuntime
+from astrbot_plugin_image_companion.photo_reference_catalog import (
+    PhotoReference as ImagePhotoReference,
+)
+from astrbot_plugin_private_companion.image_companion_bridge import (
+    ImageCompanionBridgeMixin,
+)
+from astrbot_plugin_private_companion.photo_reference_catalog import (
+    load_catalog as load_private_catalog,
+)
 
 
 class _BridgeHarness(ImageCompanionBridgeMixin):
     context = None
+
+
+def _reference_catalog(
+    *,
+    persona_source: str = "persona.png",
+    library_source: str = "sleepwear.png",
+) -> list[dict[str, object]]:
+    return [
+        {
+            "id": "persona",
+            "kind": "persona",
+            "source": persona_source,
+            "note": "identity",
+            "reference_roles": ["identity"],
+            "outfit_category": "",
+            "outfit_lock_default": False,
+            "scene_categories": [],
+            "time_categories": [],
+            "preferred_preset": "",
+            "metadata_source": "configured",
+            "editor_intent": None,
+            "excluded_scene_categories": [],
+            "excluded_time_categories": [],
+            "selection_eligibility": "fallback_identity_only",
+        },
+        {
+            "id": "sleepwear",
+            "kind": "library",
+            "source": library_source,
+            "note": "sleepwear",
+            "reference_roles": ["identity", "outfit"],
+            "outfit_category": "sleepwear",
+            "outfit_lock_default": True,
+            "scene_categories": ["home", "bedroom"],
+            "time_categories": ["night", "bedtime"],
+            "preferred_preset": "",
+            "metadata_source": "configured",
+            "editor_intent": None,
+            "excluded_scene_categories": [],
+            "excluded_time_categories": [],
+            "selection_eligibility": "matching_only",
+        },
+    ]
+
+
+def _image_service(
+    data_dir: Path,
+    *,
+    settings: dict[str, object] | None = None,
+    reuse_private_companion_assets: bool = True,
+) -> SimpleNamespace:
+    configured = dict(settings or {})
+    return SimpleNamespace(
+        data_dir=str(data_dir),
+        reuse_private_companion_assets=reuse_private_companion_assets,
+        image_data_lock=asyncio.Lock(),
+        image_setting=lambda name, default: configured.get(name, default),
+        image_data_for=lambda _owner: {},
+    )
+
+
+def _isolate_reference_candidates(runtime, monkeypatch) -> None:
+    for name in (
+        "_photo_reference_role_asset_candidates",
+        "_photo_reference_relation_asset_candidates",
+        "_photo_reference_knowledge_asset_candidates",
+    ):
+        monkeypatch.setattr(runtime, name, lambda **_kwargs: [])
+
+
+@pytest.mark.asyncio
+async def test_split_runtime_accepts_private_companion_reference_catalog(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    private_data_dir = tmp_path / "private"
+    image_data_dir = tmp_path / "image"
+    private_data_dir.mkdir()
+    image_data_dir.mkdir()
+    (private_data_dir / "persona.png").write_bytes(b"png")
+    (private_data_dir / "sleepwear.png").write_bytes(b"png")
+
+    raw_catalog = _reference_catalog()
+    owner_catalog = load_private_catalog(
+        raw_catalog,
+        catalog_version=2,
+    ).references
+    assert all(not isinstance(item, ImagePhotoReference) for item in owner_catalog)
+
+    service = _image_service(image_data_dir)
+    owner = SimpleNamespace(
+        context=None,
+        data_dir=str(private_data_dir),
+        enable_photo_reference_image=True,
+        photo_reference_catalog_version=2,
+        photo_reference_catalog_user_cleared=False,
+        photo_reference_catalog=owner_catalog,
+    )
+    runtime = ImageGenerationRuntime(service, owner)
+
+    _isolate_reference_candidates(runtime, monkeypatch)
+
+    candidates = await runtime._photo_reference_candidates_async(
+        allow_daily_outfit=False,
+    )
+    by_id = {item["id"]: item for item in candidates}
+
+    assert set(by_id) == {"persona", "sleepwear"}
+    assert (
+        Path(by_id["persona"]["path"]) == (private_data_dir / "persona.png").resolve()
+    )
+    assert by_id["persona"]["reference_roles"] == ["identity"]
+    assert (
+        Path(by_id["sleepwear"]["path"])
+        == (private_data_dir / "sleepwear.png").resolve()
+    )
+    assert by_id["sleepwear"]["reference_roles"] == ["identity", "outfit"]
+    assert by_id["sleepwear"]["outfit_category"] == "sleepwear"
+    assert by_id["sleepwear"]["outfit_lock_default"] is True
+
+
+@pytest.mark.asyncio
+async def test_split_runtime_accepts_image_service_reference_catalog(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    image_data_dir = tmp_path / "image"
+    private_data_dir = tmp_path / "private"
+    image_data_dir.mkdir()
+    private_data_dir.mkdir()
+    (image_data_dir / "persona.png").write_bytes(b"png")
+    (image_data_dir / "sleepwear.png").write_bytes(b"png")
+
+    service = _image_service(
+        image_data_dir,
+        settings={"photo_reference_catalog": _reference_catalog()},
+        reuse_private_companion_assets=False,
+    )
+    owner = SimpleNamespace(
+        context=None,
+        data_dir=str(private_data_dir),
+        enable_photo_reference_image=True,
+        photo_reference_catalog_version=2,
+        photo_reference_catalog=_reference_catalog(
+            persona_source="owner-persona.png",
+            library_source="owner-sleepwear.png",
+        ),
+        photo_reference_catalog_user_cleared=False,
+    )
+    runtime = ImageGenerationRuntime(service, owner)
+    _isolate_reference_candidates(runtime, monkeypatch)
+
+    candidates = await runtime._photo_reference_candidates_async(
+        allow_daily_outfit=False,
+    )
+    by_id = {item["id"]: item for item in candidates}
+
+    assert all(
+        isinstance(item, ImagePhotoReference)
+        for item in runtime.photo_reference_catalog
+    )
+    assert set(by_id) == {"persona", "sleepwear"}
+    assert Path(by_id["persona"]["path"]) == (image_data_dir / "persona.png").resolve()
+    assert (
+        Path(by_id["sleepwear"]["path"]) == (image_data_dir / "sleepwear.png").resolve()
+    )
+
+
+@pytest.mark.asyncio
+async def test_split_runtime_preserves_owner_user_cleared_catalog(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    private_data_dir = tmp_path / "private"
+    image_data_dir = tmp_path / "image"
+    private_data_dir.mkdir()
+    image_data_dir.mkdir()
+    legacy_persona = private_data_dir / "legacy-persona.png"
+    legacy_persona.write_bytes(b"png")
+
+    runtime = ImageGenerationRuntime(
+        _image_service(image_data_dir),
+        SimpleNamespace(
+            context=None,
+            data_dir=str(private_data_dir),
+            enable_photo_reference_image=True,
+            photo_reference_catalog_version=2,
+            photo_reference_catalog=(),
+            photo_reference_catalog_user_cleared=True,
+            photo_persona_reference_image_path=str(legacy_persona),
+            photo_reference_library=[],
+        ),
+    )
+    _isolate_reference_candidates(runtime, monkeypatch)
+
+    candidates = await runtime._photo_reference_candidates_async(
+        allow_daily_outfit=False,
+    )
+
+    assert candidates == []
+
+
+@pytest.mark.asyncio
+async def test_split_runtime_preserves_legacy_fallback_without_catalog(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    private_data_dir = tmp_path / "private"
+    image_data_dir = tmp_path / "image"
+    private_data_dir.mkdir()
+    image_data_dir.mkdir()
+    legacy_persona = private_data_dir / "legacy-persona.png"
+    legacy_persona.write_bytes(b"png")
+
+    runtime = ImageGenerationRuntime(
+        _image_service(image_data_dir),
+        SimpleNamespace(
+            context=None,
+            data_dir=str(private_data_dir),
+            enable_photo_reference_image=True,
+            photo_reference_catalog=None,
+            photo_persona_reference_image_path=str(legacy_persona),
+            photo_reference_library=[],
+        ),
+    )
+    _isolate_reference_candidates(runtime, monkeypatch)
+
+    candidates = await runtime._photo_reference_candidates_async(
+        allow_daily_outfit=False,
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0]["id"] == "persona"
+    assert Path(candidates[0]["path"]) == legacy_persona.resolve()
+
+
+@pytest.mark.asyncio
+async def test_split_runtime_serializes_remote_catalog_before_owner_writeback(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    private_data_dir = tmp_path / "private"
+    image_data_dir = tmp_path / "image"
+    private_data_dir.mkdir()
+    image_data_dir.mkdir()
+    (private_data_dir / "persona.png").write_bytes(b"png")
+    stable_path = private_data_dir / "cached-sleepwear.png"
+    stable_path.write_bytes(b"png")
+    owner_catalog = load_private_catalog(
+        _reference_catalog(library_source="https://example.invalid/sleepwear.png"),
+        catalog_version=2,
+    ).references
+    received: list[object] = []
+
+    async def save_catalog(payload) -> bool:
+        received.append(payload)
+        return True
+
+    owner = SimpleNamespace(
+        context=None,
+        data_dir=str(private_data_dir),
+        enable_photo_reference_image=True,
+        photo_reference_catalog_version=2,
+        photo_reference_catalog_user_cleared=False,
+        photo_reference_catalog=owner_catalog,
+        _set_photo_reference_catalog_config=save_catalog,
+    )
+    runtime = ImageGenerationRuntime(_image_service(image_data_dir), owner)
+    _isolate_reference_candidates(runtime, monkeypatch)
+
+    async def resolve_remote(_source: str, *, stem: str) -> str:
+        assert stem == "sleepwear"
+        return str(stable_path)
+
+    monkeypatch.setattr(
+        runtime,
+        "_photo_reference_source_to_stable_path",
+        resolve_remote,
+        raising=False,
+    )
+
+    candidates = await runtime._photo_reference_candidates_async(
+        allow_daily_outfit=False,
+    )
+
+    assert len(received) == 1
+    assert isinstance(received[0], list)
+    assert all(isinstance(item, dict) for item in received[0])
+    assert all(not isinstance(item, ImagePhotoReference) for item in received[0])
+    persisted = load_private_catalog(received[0], catalog_version=2).references
+    persisted_sleepwear = next(item for item in persisted if item.id == "sleepwear")
+    assert persisted_sleepwear.source == str(stable_path)
+    candidate = next(item for item in candidates if item["id"] == "sleepwear")
+    assert Path(candidate["path"]) == stable_path.resolve()
+
+
+@pytest.mark.asyncio
+async def test_split_runtime_does_not_write_service_catalog_to_owner(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    private_data_dir = tmp_path / "private"
+    image_data_dir = tmp_path / "image"
+    private_data_dir.mkdir()
+    image_data_dir.mkdir()
+    stable_persona_path = image_data_dir / "cached-persona.png"
+    stable_persona_path.write_bytes(b"png")
+    stable_path = image_data_dir / "cached-sleepwear.png"
+    stable_path.write_bytes(b"png")
+    owner_writes: list[object] = []
+
+    async def save_owner_catalog(payload) -> bool:
+        owner_writes.append(("catalog", payload))
+        return True
+
+    async def save_owner_persona(path) -> bool:
+        owner_writes.append(("persona", path))
+        return True
+
+    service = _image_service(
+        image_data_dir,
+        settings={
+            "photo_reference_catalog": _reference_catalog(
+                persona_source="https://example.invalid/persona.png",
+                library_source="https://example.invalid/sleepwear.png",
+            )
+        },
+        reuse_private_companion_assets=False,
+    )
+    owner = SimpleNamespace(
+        context=None,
+        data_dir=str(private_data_dir),
+        enable_photo_reference_image=True,
+        photo_reference_catalog_version=2,
+        photo_reference_catalog_user_cleared=False,
+        photo_reference_catalog=None,
+        _set_photo_reference_catalog_config=save_owner_catalog,
+        _set_photo_reference_config_path=save_owner_persona,
+    )
+    runtime = ImageGenerationRuntime(service, owner)
+    _isolate_reference_candidates(runtime, monkeypatch)
+
+    async def resolve_remote(_source: str, *, stem: str) -> str:
+        return str(
+            stable_persona_path if stem == "config_url_reference" else stable_path
+        )
+
+    monkeypatch.setattr(
+        runtime,
+        "_photo_reference_source_to_stable_path",
+        resolve_remote,
+        raising=False,
+    )
+
+    candidates = await runtime._photo_reference_candidates_async(
+        allow_daily_outfit=False,
+    )
+
+    assert owner_writes == []
+    persona_candidate = next(item for item in candidates if item["id"] == "persona")
+    assert Path(persona_candidate["path"]) == stable_persona_path.resolve()
+    candidate = next(item for item in candidates if item["id"] == "sleepwear")
+    assert Path(candidate["path"]) == stable_path.resolve()
 
 
 @pytest.mark.asyncio
@@ -21,7 +393,12 @@ async def test_image_companion_bridge_preserves_legacy_result_shape() -> None:
         async def generate_for_companion(self, owner, request):
             received.update(request)
             assert isinstance(owner, _BridgeHarness)
-            return {"handled": True, "backend": "独立后端", "image_path": "C:/output.png", "note": "ok"}
+            return {
+                "handled": True,
+                "backend": "独立后端",
+                "image_path": "C:/output.png",
+                "note": "ok",
+            }
 
     module_name = "astrbot_plugin_image_companion.main"
     previous = sys.modules.get(module_name)
@@ -63,32 +440,46 @@ async def test_split_runtime_does_not_call_owner_legacy_executor(monkeypatch) ->
         data_dir = "C:/private-companion"
 
         async def _generate_photo_image_legacy(self, **_kwargs):
-            raise AssertionError("split runtime must not call the owner's legacy executor")
+            raise AssertionError(
+                "split runtime must not call the owner's legacy executor"
+            )
 
     async def split_executor(self, **kwargs):
         calls.append(kwargs)
         return "独立后端", "C:/output.png", "ok"
 
-    monkeypatch.setattr(ImageGenerationRuntime, "_generate_photo_image_legacy", split_executor)
+    monkeypatch.setattr(
+        ImageGenerationRuntime, "_generate_photo_image_legacy", split_executor
+    )
     runtime = ImageGenerationRuntime(Service(), Owner())
-    assert await runtime.generate({"workflow_kind": "selfie", "prompt_text": "test", "session_key": "umo"}) == (
+    assert await runtime.generate(
+        {"workflow_kind": "selfie", "prompt_text": "test", "session_key": "umo"}
+    ) == (
         "独立后端",
         "C:/output.png",
         "ok",
     )
-    assert calls == [{"workflow_kind": "selfie", "prompt_text": "test", "session_key": "umo"}]
+    assert calls == [
+        {"workflow_kind": "selfie", "prompt_text": "test", "session_key": "umo"}
+    ]
 
 
 @pytest.mark.asyncio
-async def test_production_image_bridge_returns_external_plugin_message_without_fallback() -> None:
+async def test_production_image_bridge_returns_external_plugin_message_without_fallback() -> (
+    None
+):
     class PrivateCompanionPlugin(ImageCompanionBridgeMixin):
         context = None
 
         async def _generate_photo_image_legacy(self, **_kwargs):
-            raise AssertionError("production host must not invoke the local image executor")
+            raise AssertionError(
+                "production host must not invoke the local image executor"
+            )
 
     host = PrivateCompanionPlugin()
-    result = await host._image_companion_generate(workflow_kind="selfie", prompt_text="test")
+    result = await host._image_companion_generate(
+        workflow_kind="selfie", prompt_text="test"
+    )
     assert result[0] == "独立生图服务"
     assert "astrbot_plugin_image_companion" in result[2]
 
@@ -106,7 +497,9 @@ def test_image_companion_status_is_unavailable_without_external_plugin() -> None
 
 
 @pytest.mark.asyncio
-async def test_image_companion_status_and_maintenance_delegate_to_external_api() -> None:
+async def test_image_companion_status_and_maintenance_delegate_to_external_api() -> (
+    None
+):
     calls: list[object] = []
 
     class Api:

--- a/tests/test_image_companion_bridge.py
+++ b/tests/test_image_companion_bridge.py
@@ -156,7 +156,7 @@ async def test_split_runtime_accepts_image_service_reference_catalog(
     service = _image_service(
         image_data_dir,
         settings={"photo_reference_catalog": _reference_catalog()},
-        reuse_private_companion_assets=False,
+        reuse_private_companion_assets=True,
     )
     owner = SimpleNamespace(
         context=None,
@@ -181,6 +181,7 @@ async def test_split_runtime_accepts_image_service_reference_catalog(
         isinstance(item, ImagePhotoReference)
         for item in runtime.photo_reference_catalog
     )
+    assert Path(runtime.data_dir) == private_data_dir
     assert set(by_id) == {"persona", "sleepwear"}
     assert Path(by_id["persona"]["path"]) == (image_data_dir / "persona.png").resolve()
     assert (
@@ -325,11 +326,15 @@ async def test_split_runtime_does_not_write_service_catalog_to_owner(
     image_data_dir = tmp_path / "image"
     private_data_dir.mkdir()
     image_data_dir.mkdir()
-    stable_persona_path = image_data_dir / "cached-persona.png"
+    image_reference_dir = image_data_dir / "photo_reference_images"
+    image_reference_dir.mkdir()
+    stable_persona_path = image_reference_dir / "cached-persona.png"
     stable_persona_path.write_bytes(b"png")
-    stable_path = image_data_dir / "cached-sleepwear.png"
+    stable_path = image_reference_dir / "cached-sleepwear.png"
     stable_path.write_bytes(b"png")
     owner_writes: list[object] = []
+    service_writes: list[object] = []
+    resolve_calls: list[str] = []
 
     async def save_owner_catalog(payload) -> bool:
         owner_writes.append(("catalog", payload))
@@ -338,6 +343,20 @@ async def test_split_runtime_does_not_write_service_catalog_to_owner(
     async def save_owner_persona(path) -> bool:
         owner_writes.append(("persona", path))
         return True
+
+    async def persist_remote(
+        _source: str,
+        target_dir: Path,
+        stem: str,
+        **_kwargs,
+    ) -> str:
+        resolve_calls.append(stem)
+        assert Path(target_dir).resolve() == image_reference_dir.resolve()
+        return str(
+            stable_persona_path
+            if stem.startswith("config_url_reference")
+            else stable_path
+        )
 
     service = _image_service(
         image_data_dir,
@@ -349,6 +368,17 @@ async def test_split_runtime_does_not_write_service_catalog_to_owner(
         },
         reuse_private_companion_assets=False,
     )
+
+    async def save_service_catalog(payload) -> bool:
+        service_writes.append(("catalog", payload))
+        return True
+
+    async def save_service_persona(path) -> bool:
+        service_writes.append(("persona", path))
+        return True
+
+    service._set_photo_reference_catalog_config = save_service_catalog
+    service._set_photo_reference_config_path = save_service_persona
     owner = SimpleNamespace(
         context=None,
         data_dir=str(private_data_dir),
@@ -358,31 +388,32 @@ async def test_split_runtime_does_not_write_service_catalog_to_owner(
         photo_reference_catalog=None,
         _set_photo_reference_catalog_config=save_owner_catalog,
         _set_photo_reference_config_path=save_owner_persona,
+        _persist_private_remote_image_source=persist_remote,
     )
     runtime = ImageGenerationRuntime(service, owner)
     _isolate_reference_candidates(runtime, monkeypatch)
 
-    async def resolve_remote(_source: str, *, stem: str) -> str:
-        return str(
-            stable_persona_path if stem == "config_url_reference" else stable_path
-        )
-
-    monkeypatch.setattr(
-        runtime,
-        "_photo_reference_source_to_stable_path",
-        resolve_remote,
-        raising=False,
-    )
-
     candidates = await runtime._photo_reference_candidates_async(
+        allow_daily_outfit=False,
+    )
+    cached_candidates = await runtime._photo_reference_candidates_async(
         allow_daily_outfit=False,
     )
 
     assert owner_writes == []
+    assert [kind for kind, _payload in service_writes] == ["catalog", "persona"]
+    catalog_payload = service_writes[0][1]
+    persisted = {
+        item["id"]: item for item in catalog_payload if isinstance(item, dict)
+    }
+    assert persisted["sleepwear"]["source"] == str(stable_path)
+    assert service_writes[1] == ("persona", str(stable_persona_path))
+    assert resolve_calls == ["sleepwear_remote", "config_url_reference_remote"]
     persona_candidate = next(item for item in candidates if item["id"] == "persona")
     assert Path(persona_candidate["path"]) == stable_persona_path.resolve()
     candidate = next(item for item in candidates if item["id"] == "sleepwear")
     assert Path(candidate["path"]) == stable_path.resolve()
+    assert {item["id"] for item in cached_candidates} == {"persona", "sleepwear"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 关联修复

- 生图插件实现 PR：https://github.com/menglimi/astrbot_plugin_image_companion/pull/1

## 修复内容

补充跨插件参考图目录的桥接回归测试，覆盖独立生图运行时与陪伴插件之间的数据边界，防止不同模块的 `PhotoReference` 类型、目录所有权和远程回写再次发生回归。

## 测试覆盖

- 陪伴插件 loader 产生的外部 dataclass 可标准化为生图插件自己的 `PhotoReference`，persona 与睡衣图库条目均进入候选。
- 独立生图服务直接提供的 `list[dict]` 目录优先于 owner，并能正确解析相对路径。
- owner 明确主动清空目录后，不会恢复旧版人设图。
- 标准目录缺失时，旧版人设图回退仍然有效。
- owner 的远程标准目录回写为普通 `list[dict]`，不包含生图插件 dataclass。
- service 自有的远程 persona 与 library 不会错误调用 owner setter，本次请求仍可使用已落地的本地路径。

## 红绿结果

方案最初指定的跨类标准化用例在当前基线上已是 `1 passed`，因为生图插件已有部分兼容逻辑。新增的目录所有权隔离用例在修复前稳定失败，完整桥接结果为 `1 failed, 10 passed`；应用关联实现后为 `11 passed`。

## 验证

- `pytest -q tests/test_image_companion_bridge.py`：`11 passed`。
- `pytest -q tests/test_photo_reference_catalog.py tests/test_photo_reference_integrations.py`：`32 passed`。
- `python -m py_compile tests/test_image_companion_bridge.py`：通过。
- `python -m ruff check tests/test_image_companion_bridge.py`：通过。
- `python -m ruff format --check tests/test_image_companion_bridge.py`：通过。
- `git diff --check upstream/main...HEAD`：通过。

仓库全量 Ruff 仍存在既有问题，本次仅修改桥接测试文件，未处理无关格式或 lint 项。