### PR TITLE
统一生图场景感知与 NAI 路由隔离适配

### DIFF
--- a/nai_image_bridge.py
+++ b/nai_image_bridge.py
@@ -48,12 +48,32 @@ class NAIImageBridgeMixin:
                 pass
         return None
 
-    def _nai_image_selected(self) -> bool:
+    def _nai_image_selected(self, operation: str = "") -> bool:
         """Return whether the configured photo backend is the NAI direct link."""
-        return (
+        selected = (
             str(getattr(self, "photo_generation_backend", "") or "").strip().lower()
             == "nai"
         )
+        if not selected:
+            return False
+        image_api_getter = getattr(self, "_image_companion_api", None)
+        try:
+            image_api = image_api_getter() if callable(image_api_getter) else None
+            claims = getattr(image_api, "claims_model_profile", None)
+            if callable(claims):
+                claimed = (
+                    claims("nai", operation=str(operation or "").strip().lower())
+                    if str(operation or "").strip()
+                    else claims("nai")
+                )
+                if claimed:
+                    return False
+        except Exception as exc:
+            logger.warning(
+                "[PrivateCompanion] 查询统一 NAI 路线所有权失败，保留官方直连: error=%s",
+                _single_line(exc, 120),
+            )
+        return True
 
     def _nai_image_status(self) -> dict[str, Any]:
         api = self._nai_image_api()

--- a/proactive_message.py
+++ b/proactive_message.py
@@ -11557,7 +11557,7 @@ Output:
     ) -> tuple[str, str, str]:
         """Run image generation through the selected backend service."""
         nai_selected = getattr(self, "_nai_image_selected", None)
-        if callable(nai_selected) and nai_selected():
+        if callable(nai_selected) and nai_selected(kwargs.get("workflow_kind", "")):
             nai_bridge = getattr(self, "_nai_image_generate", None)
             if callable(nai_bridge):
                 return await nai_bridge(**kwargs)

--- a/scene_context.py
+++ b/scene_context.py
@@ -3,12 +3,47 @@ from __future__ import annotations
 
 from datetime import datetime
 from pathlib import Path
+import re
 from typing import Any
 
 from .helpers import _now_ts, _path_text, _safe_int, _single_line
 
 
-SCENE_CONTEXT_VERSION = 2
+SCENE_CONTEXT_VERSION = 3
+
+
+def _temperature_number(value: Any) -> float | None:
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _scene_temperature_facts(weather_data: dict[str, Any], weather_text: str) -> dict[str, Any]:
+    temperature = next(
+        (_temperature_number(weather_data.get(key)) for key in ("temperature_c", "temperature", "temp", "temp_c", "now_temp") if _temperature_number(weather_data.get(key)) is not None),
+        None,
+    )
+    feels_like = next(
+        (_temperature_number(weather_data.get(key)) for key in ("feels_like_c", "feels_like", "feelsLike", "feelslike", "apparent_temperature") if _temperature_number(weather_data.get(key)) is not None),
+        None,
+    )
+    text = str(weather_text or "")
+    if feels_like is None:
+        match = re.search(r"(?:体感(?:温度)?|feels[\s_-]*like)\s*[：:=]?\s*(-?\d+(?:\.\d+)?)", text, flags=re.I)
+        feels_like = _temperature_number(match.group(1)) if match else None
+    if temperature is None:
+        match = re.search(r"(?:当前(?:温度)?|实时(?:温度)?|气温|温度|temperature|temp)\s*[：:=]?\s*(-?\d+(?:\.\d+)?)", text, flags=re.I)
+        if not match:
+            match = re.search(r"(-?\d+(?:\.\d+)?)\s*(?:°\s*[cC]|℃|摄氏度)", text, flags=re.I)
+        temperature = _temperature_number(match.group(1)) if match else None
+    effective = feels_like if feels_like is not None else temperature
+    thermal = "unknown"
+    if effective is not None:
+        thermal = "hot" if effective >= 28 else "warm" if effective >= 24 else "mild" if effective >= 13 else "cool" if effective >= 5 else "cold"
+    return {"temperature_c": temperature, "feels_like_c": feels_like, "effective_c": effective, "thermal_level": thermal}
 
 
 def infer_companion_scene_category(schedule_text: Any = "", location_text: Any = "") -> tuple[str, str]:
@@ -400,7 +435,20 @@ class SceneContextMixin:
             )
         if weather == "暂无天气信息":
             weather = ""
+        temperature_facts = _scene_temperature_facts(weather_data, weather)
         weather_alerts = self._scene_context_weather_alert_snapshot(data)
+
+        sleep_runtime = state.get("sleep_runtime") if isinstance(state.get("sleep_runtime"), dict) else {}
+        sleep_phase = _single_line(sleep_runtime.get("phase"), 40)
+        sleep_label = _single_line(sleep_runtime.get("label"), 40)
+        if not sleep_phase:
+            sleep_text = f"{schedule_text} {coarse_location or location}".lower()
+            if re.search(r"准备睡|睡前|入睡|睡觉|bedtime|going to bed", sleep_text, flags=re.I):
+                sleep_phase, sleep_label = "falling_asleep", "准备入睡"
+            elif scene_category == "home" and (captured.hour >= 22 or captured.hour < 5):
+                sleep_phase, sleep_label = "preparing_for_sleep", "夜间居家"
+            else:
+                sleep_phase, sleep_label = "awake", "清醒"
 
         today = captured.strftime("%Y-%m-%d")
         outfit_item = data.get("daily_outfit_photo")
@@ -559,6 +607,13 @@ class SceneContextMixin:
             "weather": {
                 "text": weather,
                 "source": _single_line(weather_data.get("source"), 60),
+                **temperature_facts,
+            },
+            "sleep": {
+                "phase": sleep_phase,
+                "label": sleep_label,
+                "source": _single_line(sleep_runtime.get("source"), 40) or ("runtime" if sleep_runtime else "scene_inference"),
+                "last_event": _single_line(sleep_runtime.get("last_event"), 120),
             },
             "weather_alerts": weather_alerts,
             "outfit": {
@@ -611,6 +666,7 @@ class SceneContextMixin:
         schedule = scene.get("schedule") if isinstance(scene.get("schedule"), dict) else {}
         location = scene.get("location") if isinstance(scene.get("location"), dict) else {}
         weather = scene.get("weather") if isinstance(scene.get("weather"), dict) else {}
+        sleep = scene.get("sleep") if isinstance(scene.get("sleep"), dict) else {}
         weather_alerts = scene.get("weather_alerts") if isinstance(scene.get("weather_alerts"), dict) else {}
         outfit = scene.get("outfit") if isinstance(scene.get("outfit"), dict) else {}
         relationship = scene.get("relationship") if isinstance(scene.get("relationship"), dict) else {}
@@ -676,6 +732,19 @@ class SceneContextMixin:
                 )
         if _single_line(weather.get("text"), 220):
             parts.append(f"天气背景：{_single_line(weather.get('text'), 220)}")
+        temperature = weather.get("temperature_c")
+        feels_like = weather.get("feels_like_c")
+        temperature_parts = []
+        if isinstance(temperature, (int, float)):
+            temperature_parts.append(f"当前温度 {temperature:g}°C")
+        if isinstance(feels_like, (int, float)):
+            temperature_parts.append(f"体感温度 {feels_like:g}°C")
+        if temperature_parts:
+            parts.append("天气温度：" + "，".join(temperature_parts))
+        if _single_line(sleep.get("phase"), 40) not in {"", "awake"}:
+            parts.append(
+                f"睡眠阶段：{_single_line(sleep.get('label'), 40) or _single_line(sleep.get('phase'), 40)}"
+            )
         alert_items = weather_alerts.get("alerts") if isinstance(weather_alerts.get("alerts"), list) else []
         if alert_items:
             alert_text = "；".join(

--- a/tests/test_nai_image_bridge.py
+++ b/tests/test_nai_image_bridge.py
@@ -76,6 +76,27 @@ def test_nai_image_selected_follows_configured_backend() -> None:
     assert harness._nai_image_selected() is False
 
 
+def test_active_unified_nai_route_can_claim_selection_without_double_call() -> None:
+    harness = _BridgeHarness()
+    harness._image_companion_api = lambda: SimpleNamespace(
+        claims_model_profile=lambda profile, **kwargs: (
+            profile == "nai" and kwargs.get("operation", "selfie") == "selfie"
+        )
+    )
+
+    assert harness._nai_image_selected("selfie") is False
+    assert harness._nai_image_selected("text2img") is True
+
+
+def test_failed_unified_route_ownership_check_keeps_official_direct_nai() -> None:
+    harness = _BridgeHarness()
+    harness._image_companion_api = lambda: SimpleNamespace(
+        claims_model_profile=lambda _profile: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+
+    assert harness._nai_image_selected() is True
+
+
 @pytest.mark.asyncio
 async def test_nai_image_status_and_maintenance_delegate_to_external_api() -> None:
     calls: list[object] = []

--- a/tests/test_scene_context_schedule_history.py
+++ b/tests/test_scene_context_schedule_history.py
@@ -74,6 +74,23 @@ class _SceneHarness(SceneContextMixin):
         return "completed" if now >= end else "active"
 
     @staticmethod
+    def _get_current_plan_item(plan):
+        items = plan.get("items") if isinstance(plan, dict) else None
+        return items[0] if isinstance(items, list) and items else {}
+
+    @staticmethod
+    def _format_plan_item_for_prompt(item):
+        return f"{item.get('time', '')}-{item.get('end', '')} {item.get('activity', '')}".strip()
+
+    @staticmethod
+    def _current_location_state_text(state):
+        return str(state.get("location") or "")
+
+    @staticmethod
+    def _weather_summary_text(weather):
+        return str(weather.get("prompt") or "")
+
+    @staticmethod
     def _minutes_to_hhmm(minutes):
         minutes %= 24 * 60
         return f"{minutes // 60:02d}:{minutes % 60:02d}"
@@ -106,6 +123,31 @@ class SceneContextScheduleHistoryTests(unittest.TestCase):
         self.harness.data["daily_plan"] = plan
         snapshot = self.harness._build_companion_scene_snapshot(now=self.captured)
         self.assertEqual(snapshot["schedule"]["history"], history)
+
+    def test_snapshot_exposes_numeric_weather_and_sleep_phase(self) -> None:
+        self.harness.data = {
+            "daily_state": {
+                "location": "卧室",
+                "sleep_runtime": {"phase": "falling_asleep", "label": "准备入睡", "source": "schedule"},
+            },
+            "daily_plan": {
+                "date": "2026-08-15",
+                "items": [{"time": "00:00", "end": "01:00", "activity": "洗漱后准备睡觉"}],
+            },
+            "daily_weather": {
+                "prompt": "山东淄博晴，当前 33°C，体感温度 36°C",
+                "source": "qweather",
+            },
+        }
+        captured = datetime(2026, 8, 15, 0, 8)
+        snapshot = self.harness._build_companion_scene_snapshot(now=captured)
+        self.assertEqual(33, snapshot["weather"]["temperature_c"])
+        self.assertEqual(36, snapshot["weather"]["feels_like_c"])
+        self.assertEqual("hot", snapshot["weather"]["thermal_level"])
+        self.assertEqual("falling_asleep", snapshot["sleep"]["phase"])
+        formatted = self.harness._format_companion_scene_snapshot(snapshot, purpose="selfie_scene")
+        self.assertIn("体感温度 36°C", formatted)
+        self.assertIn("睡眠阶段：准备入睡", formatted)
 
     def test_history_requires_today_and_limits_valid_items_to_24(self) -> None:
         yesterday = {"date": "2026-07-28", "items": [{"time": "08:00", "activity": "昨天"}]}


### PR DESCRIPTION
## 背景

统一生图引擎需要陪伴插件提供可验证的“此刻事实”，而不是仅依赖整段自然语言：当前时间、地点、正在执行的日程、睡眠阶段、当前温度和体感温度都会影响画面与穿搭。与此同时，官方最新版新增 NAI 生图插件直连，需要与 image-companion 的统一 NAI 路线明确隔离，否则可能发生绕过统一编译或重复提交。

## 关联 PR 与建议顺序

1. [ComfyUI 公共服务 PR](https://github.com/cjxzdzh/astrbot_plugin_comfyui/pull/2)。
2. [image-companion 统一引擎 PR](https://github.com/menglimi/astrbot_plugin_image_companion/pull/2)。
3. 当前 PR：场景事实与 NAI 路由入口。

## 更新内容

- 场景快照升级为 v3，新增数值型：
  - `temperature_c`；
  - `feels_like_c`；
  - 有效温度和热感等级；
  - 睡眠阶段、标签、来源和最近事件。
- 天气字段优先读取结构化数据，并兼容从中英文天气文本提取温度/体感温度。
- 当前日程继续使用正在执行的计划项，不把全天计划当作当前活动。
- 睡眠状态优先使用运行时证据；缺少证据时根据睡前语义、地点和时段保守推断。
- 场景文本输出当前/体感温度和非清醒睡眠阶段，供旧文本链路兼容使用。
- NAI 直连增加统一路线所有权查询：
  - Legacy、Shadow、即时回滚和无匹配路线继续走官方 NAI 插件；
  - 只有 Active 且当前操作存在有效 NAI 路线时委托 image-companion；
  - 查询异常时保守回到官方直连。

## 解决的问题

- 生图后端不再只能从“晴、炎热”等模糊词判断季节穿搭。
- 00:08、卧室、准备睡觉等场景可以稳定传递睡眠阶段。
- 避免全天日程覆盖当前实际活动。
- 避免官方 NAI 直连与统一 NAI 路线同时调用和潜在重复计费。
- 新旧 image-companion 版本可以渐进升级：旧版本没有所有权接口时，官方 NAI 直连行为保持不变。

## 安全阀门

- 结构化天气读取失败时返回 `None/unknown`，不伪造温度。
- 睡眠推断只在明确睡前语义或夜间居家条件下触发。
- 统一 NAI 所有权查询失败时保留官方直连，不中断现有功能。
- 所有权按当前操作匹配，自拍路线不会抢占文生图直连。
- 本 PR 不包含密钥、不调用后端、不启用统一引擎 Active。

## 验证

- NAI 直连/所有权：7 项通过。
- 场景快照与运行时场景：5 项通过。
- 配置 Schema JSON 解析、Python 编译和 `git diff --check` 通过。
- 覆盖淄博 33°C/体感 36°C、00:08 准备睡觉、Active NAI 接管、不同操作不接管和所有权查询异常回退。

## 兼容性与发布建议

- image-companion 未安装或版本较旧时，NAI 继续走官方直连。
- image-companion 保持 Legacy/Shadow 时，不改变现有 NAI 行为。
- 建议在 image-companion PR 合并后再启用统一 NAI Active 路线。

## 已知风险

- 上游 companion 同期包含较多日程和运行时改动，本 PR 只覆盖生图交界的定向回归。
- 不同天气提供商的字段命名可能继续扩展；未知字段会安全降级为无数值温度。
- 真实 AstrBot、真实 NAI 插件和生产主动消息链路尚未实机验证。

## 回滚

- 回退本 PR 后，场景快照恢复 v2，NAI 恢复官方最新版的直接选择逻辑。
- image-companion 的 Legacy 模式不依赖 v3 场景快照，回滚不会破坏旧生图链路。
