### PR TITLE
feat: 主动消息相似度去重支持配置（开关/策略/窗口/严格度）

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -6025,6 +6025,86 @@
       }
     }
   },
+  "proactive_dedup_config": {
+    "description": "主动消息相似度去重",
+    "type": "object",
+    "hint": "控制发送前正文相似度去重守卫的开关、作用策略、窗口与严格度。默认值与旧版写死行为一致；调低窗口或调高严格度可减少对关系关怀类主动消息的误拦。",
+    "items": {
+      "proactive_dedup_enabled": {
+        "description": "启用发送前相似度去重",
+        "type": "bool",
+        "hint": "关闭后主动消息发送前不再做正文相似度去重（仍保留时间复核、问候去重、人格判定、发送前复核等其他门禁）。",
+        "default": true
+      },
+      "proactive_dedup_policies": {
+        "description": "应用去重的路由策略",
+        "type": "string",
+        "hint": "逗号分隔的 duplicate_policy 列表，只有列出的策略参与正文相似度去重。默认 semantic,content_fingerprint,life_event（与旧版一致）。想放行关系关怀/习惯关心类主动消息就删掉 semantic，内容与生活类去重仍保留。",
+        "default": "semantic,content_fingerprint,life_event"
+      },
+      "proactive_dedup_sent_window_minutes": {
+        "description": "已发送主动话题去重窗口（分钟）",
+        "type": "int",
+        "hint": "在该窗口内，与近期主动发送过的话题相似的候选会被去重。默认 240（4 小时）。调小可减少误拦，0 = 不按时间限制。",
+        "slider": {
+          "min": 0,
+          "max": 1440,
+          "step": 30
+        },
+        "default": 240
+      },
+      "proactive_dedup_last_message_window_minutes": {
+        "description": "最后一条 Bot 消息去重窗口（分钟）",
+        "type": "int",
+        "hint": "在该窗口内，与 Bot 最后一条消息（含被动回复）相似的候选会被去重。默认 240（4 小时）。这是最严格的一层——被动回复也算；调小可让 Bot 在被动提过某话题几小时后仍能主动关心。",
+        "slider": {
+          "min": 0,
+          "max": 1440,
+          "step": 30
+        },
+        "default": 240
+      },
+      "proactive_dedup_last_message_enabled": {
+        "description": "对比最后一条 Bot 消息",
+        "type": "bool",
+        "hint": "关闭后不再对比 Bot 最后一条消息（含被动回复），只对比主动发送历史。想保留主动去重但放行「刚被动提过的话题」时关闭。",
+        "default": true
+      },
+      "proactive_dedup_weather_window_minutes": {
+        "description": "天气话题长时窗口（分钟）",
+        "type": "int",
+        "hint": "天气是特殊长活话题，窗口独立设置。默认 1080（18 小时），与旧版一致。",
+        "slider": {
+          "min": 0,
+          "max": 2880,
+          "step": 120
+        },
+        "default": 1080
+      },
+      "proactive_dedup_min_shared_tokens": {
+        "description": "小签名最少共享锚点数",
+        "type": "int",
+        "hint": "签名锚点数不超过 2 的小话题，达到多少个共享锚点才判重复。默认 1（1 个词重叠即判重复，与旧版一致）；调成 2 可显著减少不同话题的误判。",
+        "slider": {
+          "min": 1,
+          "max": 4,
+          "step": 1
+        },
+        "default": 1
+      },
+      "proactive_dedup_min_overlap_ratio": {
+        "description": "大签名最小重叠比例",
+        "type": "float",
+        "hint": "签名锚点数大于 2 的大话题，重叠比例达到多少才判重复（作为各分档阈值的下限）。默认 0 表示沿用原有 0.5/0.3/0.18 分档；调高（如 0.6）更难判重复。",
+        "slider": {
+          "min": 0,
+          "max": 1,
+          "step": 0.05
+        },
+        "default": 0.0
+      }
+    }
+  },
   "proactive_generation_config": {
     "description": "主动生成与人格判定",
     "type": "object",

--- a/daily_state.py
+++ b/daily_state.py
@@ -2590,13 +2590,15 @@ class DailyStateMixin(DailyStateTickMixin):
             return False
         common = left_set & right_set
         smaller_size = min(len(left_set), len(right_set))
+        min_shared_tokens = int(getattr(self, "proactive_dedup_min_shared_tokens", 1))
         if smaller_size <= 2:
-            return len(common) >= 1
+            return len(common) >= min_shared_tokens
+        overlap_floor = float(getattr(self, "proactive_dedup_min_overlap_ratio", 0.0))
         overlap = len(common) / smaller_size
         return bool(
-            (len(common) >= 2 and overlap >= 0.5)
-            or (len(common) >= 3 and overlap >= 0.3)
-            or (len(common) >= 4 and overlap >= 0.18)
+            (len(common) >= 2 and overlap >= max(0.5, overlap_floor))
+            or (len(common) >= 3 and overlap >= max(0.3, overlap_floor))
+            or (len(common) >= 4 and overlap >= max(0.18, overlap_floor))
             or len(common) >= 6
         )
 
@@ -2633,6 +2635,12 @@ class DailyStateMixin(DailyStateTickMixin):
         )
         del recent[:-12]
 
+    def _proactive_dedup_enabled_policies(self) -> frozenset[str]:
+        raw = str(getattr(self, "proactive_dedup_policies", "") or "").strip()
+        if not raw:
+            return frozenset({"semantic", "content_fingerprint", "life_event"})
+        return frozenset(part.strip() for part in raw.split(",") if part.strip())
+
     def _recent_proactive_text_duplicate_reason(
         self,
         user: dict[str, Any],
@@ -2642,6 +2650,8 @@ class DailyStateMixin(DailyStateTickMixin):
         motive: str = "",
         now: float | None = None,
     ) -> str:
+        if not bool(getattr(self, "proactive_dedup_enabled", True)):
+            return ""
         signature = self._proactive_topic_signature(text, topic, motive)
         if not signature:
             return ""
@@ -2651,7 +2661,11 @@ class DailyStateMixin(DailyStateTickMixin):
             if not self._topic_signature_similar(signature, old_signature):
                 continue
             age = check_now - _safe_float(item.get("ts"), 0)
-            duplicate_window = 18 * 3600 if signature == "ordinary_weather_topic" else 4 * 3600
+            duplicate_window = (
+                int(getattr(self, "proactive_dedup_weather_window_minutes", 1080)) * 60
+                if signature == "ordinary_weather_topic"
+                else int(getattr(self, "proactive_dedup_sent_window_minutes", 240)) * 60
+            )
             if age > duplicate_window:
                 continue
             old_text = _single_line(item.get("text"), 80)
@@ -2669,10 +2683,12 @@ class DailyStateMixin(DailyStateTickMixin):
             and user.get("proactive_sending")
         )
         if (
-            not unconfirmed_current_candidate
+            bool(getattr(self, "proactive_dedup_last_message_enabled", True))
+            and not unconfirmed_current_candidate
             and last_message
             and last_at > 0
-            and check_now - last_at <= 4 * 3600
+            and check_now - last_at
+            <= int(getattr(self, "proactive_dedup_last_message_window_minutes", 240)) * 60
         ):
             last_signature = self._proactive_topic_signature(last_message)
             if self._topic_signature_similar(signature, last_signature):

--- a/daily_state_tick.py
+++ b/daily_state_tick.py
@@ -30,14 +30,20 @@ class DailyStateTickMixin:
         action: str,
         timeliness: str,
         duplicate_policy: str,
+        enabled_policies: frozenset[str] | None = None,
     ) -> bool:
         """Burst follow-ups intentionally use a second angle, not duplicate text."""
+        active_policies = (
+            {"semantic", "content_fingerprint", "life_event"}
+            if enabled_policies is None
+            else enabled_policies
+        )
         return bool(
             not is_troubleshooting
             and (action or "message") == "message"
             and not bool(user.get("planned_proactive_burst"))
             and timeliness == "routine"
-            and duplicate_policy in {"semantic", "content_fingerprint", "life_event"}
+            and duplicate_policy in active_policies
         )
 
     """Execute one user's proactive tick outside the daily-state capability module."""
@@ -1022,6 +1028,7 @@ class DailyStateTickMixin:
                     action=effective_action_for_send or planned_action_for_send or "message",
                     timeliness=timeliness,
                     duplicate_policy=duplicate_policy,
+                    enabled_policies=self._proactive_dedup_enabled_policies(),
                 ):
                     similar_note = self._recent_proactive_text_duplicate_reason(
                         current_for_similarity_guard,

--- a/plugin_bootstrap.py
+++ b/plugin_bootstrap.py
@@ -1054,6 +1054,32 @@ def _initialize_proactive_and_reaction_config(self: Any, c: Any) -> None:
         "external_image_download_use_environment_proxy",
         False,
     )
+    self.proactive_dedup_enabled = self._cfg_bool(c, "proactive_dedup_enabled", True)
+    self.proactive_dedup_policies = self._cfg_str(
+        c,
+        "proactive_dedup_policies",
+        "semantic,content_fingerprint,life_event",
+        "semantic,content_fingerprint,life_event",
+    )
+    self.proactive_dedup_sent_window_minutes = self._cfg_int(
+        c, "proactive_dedup_sent_window_minutes", 240, 0, 2880
+    )
+    self.proactive_dedup_last_message_window_minutes = self._cfg_int(
+        c, "proactive_dedup_last_message_window_minutes", 240, 0, 2880
+    )
+    self.proactive_dedup_last_message_enabled = self._cfg_bool(
+        c, "proactive_dedup_last_message_enabled", True
+    )
+    self.proactive_dedup_weather_window_minutes = self._cfg_int(
+        c, "proactive_dedup_weather_window_minutes", 1080, 0, 8640
+    )
+    self.proactive_dedup_min_shared_tokens = self._cfg_int(
+        c, "proactive_dedup_min_shared_tokens", 1, 1, 4
+    )
+    self.proactive_dedup_min_overlap_ratio = min(
+        1.0,
+        max(0.0, self._cfg_float(c, "proactive_dedup_min_overlap_ratio", 0.0, 0.0)),
+    )
 
 def _initialize_photo_and_expression_config(self: Any, c: Any) -> None:
     self._external_image_download_session = None

--- a/tests/test_proactive_duplicate_guard.py
+++ b/tests/test_proactive_duplicate_guard.py
@@ -141,3 +141,95 @@ def test_same_scene_rephrased_with_shared_recipient_address_is_still_duplicate()
     reason = harness._recent_proactive_text_duplicate_reason(user, text=candidate, now=now)
 
     assert "已发送相似主动" in reason
+
+
+def test_dedup_disabled_returns_no_reason():
+    harness = _DuplicateGuardHarness()
+    harness.proactive_dedup_enabled = False
+    now = 1_000_100.0
+    text = "揉了下眼睛，忽然想起刚刷到的有趣视频。"
+    user = {
+        "last_companion_message": text,
+        "last_companion_message_at": now - 120,
+        "proactive_sending": True,
+        "proactive_sending_started_at": now - 30,
+        "recent_proactive_topics": [],
+    }
+
+    reason = harness._recent_proactive_text_duplicate_reason(user, text=text, now=now)
+
+    assert reason == ""
+
+
+def test_dedup_last_message_window_config():
+    harness = _DuplicateGuardHarness()
+    harness.proactive_dedup_last_message_window_minutes = 5
+    now = 1_000_100.0
+    text = "揉了下眼睛，忽然想起刚刷到的有趣视频。"
+    user = {
+        "last_companion_message": text,
+        "last_companion_message_at": now - 600,
+        "proactive_sending": True,
+        "proactive_sending_started_at": now - 30,
+        "recent_proactive_topics": [],
+    }
+
+    reason = harness._recent_proactive_text_duplicate_reason(user, text=text, now=now)
+
+    # 10 分钟前最后一条消息，超出 5 分钟配置窗口 → 不判重复
+    assert reason == ""
+
+
+def test_dedup_last_message_enabled_off():
+    harness = _DuplicateGuardHarness()
+    harness.proactive_dedup_last_message_enabled = False
+    now = 1_000_100.0
+    text = "揉了下眼睛，忽然想起刚刷到的有趣视频。"
+    user = {
+        "last_companion_message": text,
+        "last_companion_message_at": now - 120,
+        "proactive_sending": True,
+        "proactive_sending_started_at": now - 30,
+        "recent_proactive_topics": [],
+    }
+
+    reason = harness._recent_proactive_text_duplicate_reason(user, text=text, now=now)
+
+    # Layer-2 关闭后不再对比最后一条消息（默认窗口内本应判重）
+    assert reason == ""
+
+
+def test_dedup_min_shared_tokens_config():
+    harness = _DuplicateGuardHarness()
+    harness.proactive_dedup_min_shared_tokens = 2
+
+    assert harness._topic_signature_similar("冲浪|休息", "冲浪|做饭") is False
+
+    harness.proactive_dedup_min_shared_tokens = 1
+    assert harness._topic_signature_similar("冲浪|休息", "冲浪|做饭") is True
+
+
+def test_dedup_policies_exclude_semantic():
+    harness = _DuplicateGuardHarness()
+    harness.proactive_dedup_policies = "content_fingerprint,life_event"
+    policies = harness._proactive_dedup_enabled_policies()
+
+    assert "semantic" not in policies
+    # semantic 被移除 → 关系关怀不再参与去重
+    assert harness._proactive_similarity_guard_enabled(
+        {"planned_proactive_burst": False},
+        is_troubleshooting=False,
+        action="message",
+        timeliness="routine",
+        duplicate_policy="semantic",
+        enabled_policies=policies,
+    ) is False
+    # content_fingerprint 仍在列表 → 内容去重保留
+    assert harness._proactive_similarity_guard_enabled(
+        {"planned_proactive_burst": False},
+        is_troubleshooting=False,
+        action="message",
+        timeliness="routine",
+        duplicate_policy="content_fingerprint",
+        enabled_policies=policies,
+    ) is True


### PR DESCRIPTION
  ## 背景

  发送链的正文相似度去重守卫把窗口、阈值、作用策略全部写死：默认 4h 窗口 + 小签名
  1 个共享锚点即判相似，且会对比最后一条 Bot 消息（含被动回复）。对关系关怀/习惯关心
  类主动消息（duplicate_policy=semantic）过于激进——候选与几小时前被动回复话题相近就
  会被取消，取消后 0.5-1.5h 重试又撞同一窗口，可能导致整个下午无任何主动消息。

  ## 改动

  新增 `proactive_dedup_config` 配置组，全部默认值与旧版写死行为一致（不调即零变化）：

  - `enabled`：发送链相似度去重总开关
  - `policies`：按 duplicate_policy 作用（默认 `semantic,content_fingerprint,life_event`；
    删掉 `semantic` 即放行关系关怀，内容/生活类去重仍保留）
  - `sent_window_minutes` / `last_message_window_minutes` / `weather_window_minutes`：
    三层去重窗口（默认 240/240/1080 分钟）
  - `last_message_enabled`：是否对比最后一条 Bot 消息（含被动回复）
  - `min_shared_tokens` / `min_overlap_ratio`：相似度严格度（默认 1/0，0 表示沿用原分档阈值）

  ## 测试

  - `tests/test_proactive_duplicate_guard.py` 新增 5 个配置生效测试
  - 既有 8 个测试在默认值下全部保持通过（共 13/13）