### PR TITLE
fix: harden proactive dedup configuration

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -6039,13 +6039,13 @@
       "proactive_dedup_policies": {
         "description": "应用去重的路由策略",
         "type": "string",
-        "hint": "逗号分隔的 duplicate_policy 列表，只有列出的策略参与正文相似度去重。默认 semantic,content_fingerprint,life_event（与旧版一致）。想放行关系关怀/习惯关心类主动消息就删掉 semantic，内容与生活类去重仍保留。",
+        "hint": "逗号分隔的 duplicate_policy 列表，只有列出的策略参与正文相似度去重。默认 semantic,content_fingerprint,life_event。想放行关系关怀/习惯关心类主动消息就删掉 semantic，内容与生活类去重仍保留。",
         "default": "semantic,content_fingerprint,life_event"
       },
       "proactive_dedup_sent_window_minutes": {
         "description": "已发送主动话题去重窗口（分钟）",
         "type": "int",
-        "hint": "在该窗口内，与近期主动发送过的话题相似的候选会被去重。默认 240（4 小时）。调小可减少误拦，0 = 不按时间限制。",
+        "hint": "在该窗口内，与近期主动发送过的话题相似的候选会被去重。默认 240（4 小时）。设为 0 表示不按时间限制。",
         "slider": {
           "min": 0,
           "max": 1440,
@@ -6056,7 +6056,7 @@
       "proactive_dedup_last_message_window_minutes": {
         "description": "最后一条 Bot 消息去重窗口（分钟）",
         "type": "int",
-        "hint": "在该窗口内，与 Bot 最后一条消息（含被动回复）相似的候选会被去重。默认 240（4 小时）。这是最严格的一层——被动回复也算；调小可让 Bot 在被动提过某话题几小时后仍能主动关心。",
+        "hint": "在该窗口内，与 Bot 最后一条消息（含被动回复）相似的候选会被去重。默认 240（4 小时）；设为 0 表示不按时间限制。",
         "slider": {
           "min": 0,
           "max": 1440,
@@ -6067,13 +6067,13 @@
       "proactive_dedup_last_message_enabled": {
         "description": "对比最后一条 Bot 消息",
         "type": "bool",
-        "hint": "关闭后不再对比 Bot 最后一条消息（含被动回复），只对比主动发送历史。想保留主动去重但放行「刚被动提过的话题」时关闭。",
+        "hint": "关闭后不再对比 Bot 最后一条消息（含被动回复），只对比主动发送历史。",
         "default": true
       },
       "proactive_dedup_weather_window_minutes": {
         "description": "天气话题长时窗口（分钟）",
         "type": "int",
-        "hint": "天气是特殊长活话题，窗口独立设置。默认 1080（18 小时），与旧版一致。",
+        "hint": "天气是特殊长活话题，窗口独立设置。默认 1080（18 小时）；设为 0 表示不按时间限制。",
         "slider": {
           "min": 0,
           "max": 2880,
@@ -6084,7 +6084,7 @@
       "proactive_dedup_min_shared_tokens": {
         "description": "小签名最少共享锚点数",
         "type": "int",
-        "hint": "签名锚点数不超过 2 的小话题，达到多少个共享锚点才判重复。默认 1（1 个词重叠即判重复，与旧版一致）；调成 2 可显著减少不同话题的误判。",
+        "hint": "签名锚点数不超过 2 的小话题，达到多少个共享锚点才判重复。默认 1；调成 2 可减少误判。",
         "slider": {
           "min": 1,
           "max": 4,
@@ -6095,7 +6095,7 @@
       "proactive_dedup_min_overlap_ratio": {
         "description": "大签名最小重叠比例",
         "type": "float",
-        "hint": "签名锚点数大于 2 的大话题，重叠比例达到多少才判重复（作为各分档阈值的下限）。默认 0 表示沿用原有 0.5/0.3/0.18 分档；调高（如 0.6）更难判重复。",
+        "hint": "签名锚点数大于 2 的大话题，重叠比例达到多少才判重复。默认 0 表示沿用原有分档；调高更难判重复。",
         "slider": {
           "min": 0,
           "max": 1,

--- a/daily_state.py
+++ b/daily_state.py
@@ -2567,7 +2567,12 @@ class DailyStateMixin(DailyStateTickMixin):
             if signature == "morning_weather_check" or derived_signature == "ordinary_weather_topic":
                 signature = "ordinary_weather_topic"
                 item["signature"] = signature
-            retention = 18 * 3600 if signature == "ordinary_weather_topic" else 6 * 3600
+            if signature == "ordinary_weather_topic":
+                configured_minutes = self._proactive_dedup_window_minutes("weather", 1080)
+                retention = 30 * 24 * 3600 if configured_minutes <= 0 else max(18 * 3600, configured_minutes * 60)
+            else:
+                configured_minutes = self._proactive_dedup_window_minutes("sent", 240)
+                retention = 30 * 24 * 3600 if configured_minutes <= 0 else max(6 * 3600, configured_minutes * 60)
             if now - _safe_float(item.get("ts"), 0) > retention:
                 continue
             if callable(meta_leak_checker) and (
@@ -2579,7 +2584,27 @@ class DailyStateMixin(DailyStateTickMixin):
         user["recent_proactive_topics"] = kept[-12:]
         return user["recent_proactive_topics"]
 
-    def _topic_signature_similar(self, left: str, right: str) -> bool:
+    def _proactive_dedup_window_minutes(self, kind: str, default: int) -> int:
+        key = (
+            "proactive_dedup_weather_window_minutes"
+            if kind == "weather"
+            else "proactive_dedup_last_message_window_minutes"
+            if kind == "last_message"
+            else "proactive_dedup_sent_window_minutes"
+        )
+        raw = getattr(self, key, None)
+        if raw is None:
+            return max(0, int(default))
+        try:
+            return max(0, int(raw))
+        except (TypeError, ValueError):
+            return max(0, int(default))
+
+    @staticmethod
+    def _proactive_dedup_age_allowed(age: float, window_minutes: int) -> bool:
+        return window_minutes <= 0 or age <= window_minutes * 60
+
+    def _topic_signature_similar(self, left: str, right: str, *, use_proactive_dedup_config: bool = False) -> bool:
         if not left or not right:
             return False
         if left == right:
@@ -2590,16 +2615,25 @@ class DailyStateMixin(DailyStateTickMixin):
             return False
         common = left_set & right_set
         smaller_size = min(len(left_set), len(right_set))
-        min_shared_tokens = int(getattr(self, "proactive_dedup_min_shared_tokens", 1))
+        min_shared_tokens = 1
+        overlap_floor = 0.0
+        if use_proactive_dedup_config:
+            try:
+                min_shared_tokens = max(1, min(4, int(getattr(self, "proactive_dedup_min_shared_tokens", 1))))
+            except (TypeError, ValueError):
+                min_shared_tokens = 1
+            try:
+                overlap_floor = max(0.0, min(1.0, float(getattr(self, "proactive_dedup_min_overlap_ratio", 0.0))))
+            except (TypeError, ValueError):
+                overlap_floor = 0.0
         if smaller_size <= 2:
             return len(common) >= min_shared_tokens
-        overlap_floor = float(getattr(self, "proactive_dedup_min_overlap_ratio", 0.0))
         overlap = len(common) / smaller_size
         return bool(
             (len(common) >= 2 and overlap >= max(0.5, overlap_floor))
             or (len(common) >= 3 and overlap >= max(0.3, overlap_floor))
             or (len(common) >= 4 and overlap >= max(0.18, overlap_floor))
-            or len(common) >= 6
+            or (len(common) >= 6 and overlap >= overlap_floor)
         )
 
     def _recent_proactive_topic_repeated(self, user: dict[str, Any], signature: str, *, now: float | None = None) -> bool:
@@ -2608,10 +2642,14 @@ class DailyStateMixin(DailyStateTickMixin):
         check_now = now or _now_ts()
         for item in self._cleanup_recent_proactive_topics(user, now=check_now):
             item_signature = str(item.get("signature") or "")
-            max_age = 18 * 3600 if signature == "ordinary_weather_topic" or item_signature == "ordinary_weather_topic" else 6 * 3600
-            if check_now - _safe_float(item.get("ts"), 0) > max_age:
+            is_weather = signature == "ordinary_weather_topic" or item_signature == "ordinary_weather_topic"
+            window_minutes = self._proactive_dedup_window_minutes(
+                "weather" if is_weather else "sent",
+                1080 if is_weather else 240,
+            )
+            if not self._proactive_dedup_age_allowed(check_now - _safe_float(item.get("ts"), 0), window_minutes):
                 continue
-            if self._topic_signature_similar(signature, item_signature):
+            if self._topic_signature_similar(signature, item_signature, use_proactive_dedup_config=True):
                 return True
         return False
 
@@ -2636,10 +2674,11 @@ class DailyStateMixin(DailyStateTickMixin):
         del recent[:-12]
 
     def _proactive_dedup_enabled_policies(self) -> frozenset[str]:
-        raw = str(getattr(self, "proactive_dedup_policies", "") or "").strip()
-        if not raw:
+        raw_value = getattr(self, "proactive_dedup_policies", None)
+        if raw_value is None:
             return frozenset({"semantic", "content_fingerprint", "life_event"})
-        return frozenset(part.strip() for part in raw.split(",") if part.strip())
+        raw = str(raw_value).strip().lower()
+        return frozenset(part for part in re.split(r"[,，;；\s]+", raw) if part)
 
     def _recent_proactive_text_duplicate_reason(
         self,
@@ -2658,15 +2697,14 @@ class DailyStateMixin(DailyStateTickMixin):
         check_now = now or _now_ts()
         for item in self._cleanup_recent_proactive_topics(user, now=check_now):
             old_signature = str(item.get("signature") or "")
-            if not self._topic_signature_similar(signature, old_signature):
+            if not self._topic_signature_similar(signature, old_signature, use_proactive_dedup_config=True):
                 continue
             age = check_now - _safe_float(item.get("ts"), 0)
-            duplicate_window = (
-                int(getattr(self, "proactive_dedup_weather_window_minutes", 1080)) * 60
-                if signature == "ordinary_weather_topic"
-                else int(getattr(self, "proactive_dedup_sent_window_minutes", 240)) * 60
+            duplicate_window = self._proactive_dedup_window_minutes(
+                "weather" if signature == "ordinary_weather_topic" else "sent",
+                1080 if signature == "ordinary_weather_topic" else 240,
             )
-            if age > duplicate_window:
+            if not self._proactive_dedup_age_allowed(age, duplicate_window):
                 continue
             old_text = _single_line(item.get("text"), 80)
             if signature == "ordinary_weather_topic":
@@ -2687,11 +2725,13 @@ class DailyStateMixin(DailyStateTickMixin):
             and not unconfirmed_current_candidate
             and last_message
             and last_at > 0
-            and check_now - last_at
-            <= int(getattr(self, "proactive_dedup_last_message_window_minutes", 240)) * 60
+            and self._proactive_dedup_age_allowed(
+                check_now - last_at,
+                self._proactive_dedup_window_minutes("last_message", 240),
+            )
         ):
             last_signature = self._proactive_topic_signature(last_message)
-            if self._topic_signature_similar(signature, last_signature):
+            if self._topic_signature_similar(signature, last_signature, use_proactive_dedup_config=True):
                 age = check_now - last_at
                 return f"近 {max(1, int(age // 60))} 分钟聊天里已经说过相似内容：{_single_line(last_message, 80)}"
         return ""

--- a/plugin_bootstrap.py
+++ b/plugin_bootstrap.py
@@ -1062,16 +1062,16 @@ def _initialize_proactive_and_reaction_config(self: Any, c: Any) -> None:
         "semantic,content_fingerprint,life_event",
     )
     self.proactive_dedup_sent_window_minutes = self._cfg_int(
-        c, "proactive_dedup_sent_window_minutes", 240, 0, 2880
+        c, "proactive_dedup_sent_window_minutes", 240, 0, 1440
     )
     self.proactive_dedup_last_message_window_minutes = self._cfg_int(
-        c, "proactive_dedup_last_message_window_minutes", 240, 0, 2880
+        c, "proactive_dedup_last_message_window_minutes", 240, 0, 1440
     )
     self.proactive_dedup_last_message_enabled = self._cfg_bool(
         c, "proactive_dedup_last_message_enabled", True
     )
     self.proactive_dedup_weather_window_minutes = self._cfg_int(
-        c, "proactive_dedup_weather_window_minutes", 1080, 0, 8640
+        c, "proactive_dedup_weather_window_minutes", 1080, 0, 2880
     )
     self.proactive_dedup_min_shared_tokens = self._cfg_int(
         c, "proactive_dedup_min_shared_tokens", 1, 1, 4

--- a/tests/test_proactive_duplicate_guard.py
+++ b/tests/test_proactive_duplicate_guard.py
@@ -156,9 +156,7 @@ def test_dedup_disabled_returns_no_reason():
         "recent_proactive_topics": [],
     }
 
-    reason = harness._recent_proactive_text_duplicate_reason(user, text=text, now=now)
-
-    assert reason == ""
+    assert harness._recent_proactive_text_duplicate_reason(user, text=text, now=now) == ""
 
 
 def test_dedup_last_message_window_config():
@@ -174,10 +172,7 @@ def test_dedup_last_message_window_config():
         "recent_proactive_topics": [],
     }
 
-    reason = harness._recent_proactive_text_duplicate_reason(user, text=text, now=now)
-
-    # 10 分钟前最后一条消息，超出 5 分钟配置窗口 → 不判重复
-    assert reason == ""
+    assert harness._recent_proactive_text_duplicate_reason(user, text=text, now=now) == ""
 
 
 def test_dedup_last_message_enabled_off():
@@ -193,20 +188,27 @@ def test_dedup_last_message_enabled_off():
         "recent_proactive_topics": [],
     }
 
-    reason = harness._recent_proactive_text_duplicate_reason(user, text=text, now=now)
-
-    # Layer-2 关闭后不再对比最后一条消息（默认窗口内本应判重）
-    assert reason == ""
+    assert harness._recent_proactive_text_duplicate_reason(user, text=text, now=now) == ""
 
 
-def test_dedup_min_shared_tokens_config():
+def test_dedup_min_shared_tokens_is_scoped_to_proactive_guard():
     harness = _DuplicateGuardHarness()
     harness.proactive_dedup_min_shared_tokens = 2
 
-    assert harness._topic_signature_similar("冲浪|休息", "冲浪|做饭") is False
-
-    harness.proactive_dedup_min_shared_tokens = 1
     assert harness._topic_signature_similar("冲浪|休息", "冲浪|做饭") is True
+    assert harness._topic_signature_similar(
+        "冲浪|休息", "冲浪|做饭", use_proactive_dedup_config=True
+    ) is False
+
+
+def test_dedup_overlap_floor_applies_even_with_six_shared_tokens():
+    harness = _DuplicateGuardHarness()
+    harness.proactive_dedup_min_overlap_ratio = 0.8
+    left = "a|b|c|d|e|f|g|h|i|j"
+    right = "a|b|c|d|e|f|k|l|m|n"
+
+    assert harness._topic_signature_similar(left, right) is True
+    assert harness._topic_signature_similar(left, right, use_proactive_dedup_config=True) is False
 
 
 def test_dedup_policies_exclude_semantic():
@@ -214,8 +216,6 @@ def test_dedup_policies_exclude_semantic():
     harness.proactive_dedup_policies = "content_fingerprint,life_event"
     policies = harness._proactive_dedup_enabled_policies()
 
-    assert "semantic" not in policies
-    # semantic 被移除 → 关系关怀不再参与去重
     assert harness._proactive_similarity_guard_enabled(
         {"planned_proactive_burst": False},
         is_troubleshooting=False,
@@ -224,7 +224,6 @@ def test_dedup_policies_exclude_semantic():
         duplicate_policy="semantic",
         enabled_policies=policies,
     ) is False
-    # content_fingerprint 仍在列表 → 内容去重保留
     assert harness._proactive_similarity_guard_enabled(
         {"planned_proactive_burst": False},
         is_troubleshooting=False,
@@ -233,3 +232,23 @@ def test_dedup_policies_exclude_semantic():
         duplicate_policy="content_fingerprint",
         enabled_policies=policies,
     ) is True
+
+
+def test_zero_sent_window_keeps_recent_history_available_without_age_limit():
+    harness = _DuplicateGuardHarness()
+    harness.proactive_dedup_sent_window_minutes = 0
+    now = 1_000_100.0
+    text = "揉了下眼睛，忽然想起刚刷到的有趣视频。"
+    user = {
+        "recent_proactive_topics": [
+            {
+                "ts": now - 2 * 24 * 3600,
+                "signature": harness._proactive_topic_signature(text),
+                "text": text,
+            }
+        ]
+    }
+
+    reason = harness._recent_proactive_text_duplicate_reason(user, text=text, now=now)
+
+    assert "已发送相似主动" in reason


### PR DESCRIPTION
基于已合并的 PR 142，补充主动消息去重配置的边界修正：\n\n- 配置阈值只影响主动消息去重，不改变群聊/记忆共享相似度判断\n- 窗口 0 按配置文案表示不受时间限制\n- 自定义窗口同步历史保留周期，避免配置失效\n- 补充相关回归测试