### PR TITLE
feat: 将按模式区分的提示词书写规范附加到 pc_generate_photo 工具描述

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import copy
 from contextlib import asynccontextmanager
 import contextvars
 import functools
@@ -199,6 +200,9 @@ from .relationship_policy import normalize_relationship_stage_policy
 
 
 _ACTIVE_PERSONA_ID = contextvars.ContextVar("private_companion_active_persona_id", default="")
+# 幂等标记：写入 pc_generate_photo 工具描述的“提示词表达方式”块，
+# 用于在工具 schema 里直接携带书写格式要求，不依赖条件注入。
+_PHOTO_TOOL_PROMPT_FORMAT_MARKER = "<!-- private_companion_prompt_format_req_v1 -->"
 _PERSONA_PROFILE_FORBIDDEN_FILENAME_CHARS = frozenset('<>:"/\\|?*%')
 _WINDOWS_RESERVED_FILENAME_STEMS = frozenset(
     {
@@ -15228,6 +15232,78 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                 replaced,
                 dropped,
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
+            )
+
+    @filter.on_llm_request(priority=-251000)
+    @_multi_persona_event_context
+    async def annotate_photo_tool_prompt_format(self, event: AstrMessageEvent, req: ProviderRequest, *args, **kwargs):
+        """按当前配置的“提示词表达方式”标注 pc_generate_photo 工具描述。
+
+        工具一旦出现在 schema 里，模型就能看到 prompt 参数的书写格式要求
+        （nai / natural_language / traditional 各自不同的规范），不再依赖
+        关键词命中后的条件注入。标注块用幂等标记包裹：重复执行或切换
+        模式时先剥掉旧块再追加，不会叠加残留。
+        """
+        if self is None or req is None or not bool(getattr(self, "enabled", False)):
+            return
+        tool_set = getattr(req, "func_tool", None)
+        get_tool = getattr(tool_set, "get_tool", None) if tool_set is not None else None
+        if not callable(get_tool):
+            return
+        try:
+            tool = get_tool("pc_generate_photo")
+        except Exception:
+            return
+        if tool is None or not bool(getattr(tool, "active", True)):
+            return
+        instruction_getter = getattr(self, "_photo_generation_prompt_format_instruction", None)
+        if not callable(instruction_getter):
+            return
+        instruction = re.sub(r"\s+", " ", str(instruction_getter() or "")).strip()
+        if not instruction:
+            return
+        marker = _PHOTO_TOOL_PROMPT_FORMAT_MARKER
+        description = str(getattr(tool, "description", "") or "")
+        description = re.sub(
+            rf"\n*\s*{re.escape(marker)}.*?{re.escape(marker)}\s*",
+            "",
+            description,
+            flags=re.DOTALL,
+        ).strip()
+        suffix = (
+            f"\n\n{marker}"
+            f"【提示词表达方式】prompt 参数必须按下述格式书写：{instruction}"
+            f"{marker}"
+        )
+        annotated = f"{description}{suffix}"
+        if getattr(tool, "handler", None) is None:
+            # 默认路径：ToolSet 里是每请求新建的 _PermissionGuardedTool 包装
+            # （handler 恒为 None），description 独立于全局注册表，直接改写即可。
+            try:
+                tool.description = annotated
+            except Exception as exc:
+                logger.debug(
+                    "[PrivateCompanion] pc_generate_photo 工具描述标注失败: %s",
+                    _single_line(exc, 120),
+                )
+            return
+        # 人格自定义工具列表路径直接引用全局注册对象（handler 非空）：
+        # 复制一份后按原下标替换，既不污染全局工具描述，也保持工具在
+        # schema 中的顺序，且不存在“先移除后添加失败”的窗口。
+        tools_list = getattr(tool_set, "tools", None)
+        if not isinstance(tools_list, list):
+            return
+        try:
+            for index, existing in enumerate(tools_list):
+                if existing is tool:
+                    replace_tool = copy.copy(tool)
+                    replace_tool.description = annotated
+                    tools_list[index] = replace_tool
+                    break
+        except Exception as exc:
+            logger.debug(
+                "[PrivateCompanion] pc_generate_photo 共享工具描述标注失败: %s",
+                _single_line(exc, 120),
             )
 
     @filter.on_llm_request()

--- a/proactive_message.py
+++ b/proactive_message.py
@@ -10808,24 +10808,19 @@ Output:
         mode = self._photo_generation_prompt_format_mode()
         if mode == "nai":
             return (
-                "使用 NAI（NovelAI 4/4.5）联动写法：以英文 danbooru 风格标签为主、逗号分隔，精简到能讲清构图即可，不堆砌重复或无意义 tag。"
-                "加权用花括号 {tag} 提升、方括号 [tag] 降低，可叠层；也可用 权重::标签:: 对一个或多个标签整体加权（示例 1.5::red dress, long dress::），"
-                "可以使用较高权重值（2、5 甚至 10 以上）强调关键元素。移除物体或翻转概念用负向权重（示例 -1::unwanted object::）；"
-                "混合 3 个以上画师风格时可加 -2::artist collaboration:: 降低鬼图概率。已知二次元角色用 角色名 (作品名) 形式（示例 texas the omertosa (arknights)），"
-                "特征不全时多补几个描述词；情绪词有效，可加入增强表情。多角色（最多 6 名）时每个角色分别用 {人物 [该角色的画风/动作/神态/外貌 tags] 人物} 包裹，"
-                "块内两个占位符“人物”不能删除，可用 {位置中} {位置左} {位置右上} 等位置标签（5x5 共 25 种）指定站位，角色专属负面词条写 ntags = [tags]；"
-                "角色互动动作用 source#/target#/mutual# 前缀（示例 source#hug 发起拥抱, target#hug 被拥抱, mutual#hug 互相拥抱）。"
-                "需要画面英文文字用 Text: 内容, ；不需要文字加 no text, 。直接输出可投喂生图后端的提示词字符串，"
-                "不要输出 Positive prompt/Negative prompt 标题，也不要写解释性段落。"
+                "NAI4.5：danbooru标签精简勿堆砌；加权用{}、降权用[]，"
+                "1.5::tags::加权可用高权重(2/5/10)，-1::负向移除；"
+                "已知角色用 人物名(作品名)；情绪词有效；"
+                "多角色{人物[tags]人物}(勿删)；互动source#/target#/mutual#"
             )
         if mode == "natural_language":
             return (
-                "使用自然语言描述：用连贯、具体的英文句子描述主体、外观、动作、场景、光线、镜头、构图和风格；"
-                "不要输出标签堆、权重语法或 Positive prompt/Negative prompt 标题。需要避免的内容可在末句用 Avoid ... 自然表达。"
+                "自然语言描述：连贯具体的英文句子，覆盖主体、外观、动作、场景、光线、镜头、构图与风格；"
+                "不要标签堆或权重语法；要避免的内容在末句用 Avoid ... 表达。"
             )
         return (
-            "使用传统文生图提示词：英文短词组和逗号分隔标签，按主体、外观、服装、场景、光线、镜头、构图、风格排列；"
-            "使用 Positive prompt: ... Negative prompt: ... 结构，不要写解释性段落。"
+            "传统文生图写法：英文短词组按主体、外观、服装、场景、光线、镜头、构图、风格排列，逗号分隔；"
+            "用 Positive prompt: ... Negative prompt: ... 结构，不写解释段落。"
         )
 
     @staticmethod


### PR DESCRIPTION
## 问题

当 `photo_generation_prompt_format` 设为 `nai` 时，模型调用 `pc_generate_photo` 写出的仍是自然语言提示词。根因（已逐一核对源码）：

1. 提示词书写格式规范唯一的注入点是关键词门控（`_photo_generation_instruction_matches`）命中后的系统提示注入块——“还想看看你”这类软性请求不会命中，注入门不打开。
2. 工具 schema 本身不带格式要求，工具执行层也原样透传，链路上没有其他环节教模型（或强制模型）按格式书写。
3. NAI 后端的陪伴直连路径对 tag 模式提示词原样提交（`enable_translate=False` 是设计行为），自然语言直接进生图模型。

## 改动

**`main.py`** —— 新增 `annotate_photo_tool_prompt_format` hook（`on_llm_request`，priority = -251000）：

- 把当前配置的按模式书写规范（nai / natural_language / traditional）追加到 `pc_generate_photo` 工具描述，工具只要出现在 schema 里模型就能看到书写规则，完全不依赖关键词命中。
- 追加块用幂等标记（`<!-- private_companion_prompt_format_req_v1 -->`）包裹：重复执行先剥旧块再追加，不叠加；切换模式无残留。
- 两条工具集路径都正确处理：每请求新建的 `_PermissionGuardedTool` 包装（`handler is None`）直接原地改写；人格自定义工具列表引用的全局注册对象则浅拷贝后按列表下标替换——全局注册表不被污染、schema 中工具顺序保持、不存在“先移除后添加失败”的窗口。
- 全程防御式写法：任何失败只记 debug 日志并退回原有行为。

**`proactive_message.py`** —— 压缩 `_photo_generation_prompt_format_instruction()` 文案：

- nai：707 → 137 字，只保留有官方文档出处的 NAI 4/5 语法（danbooru 标签、`{}`/`[]` 加降权、`1.5::tags::`、负向权重、`人物名(作品名)`、高权重值、情绪词、多角色 `{人物 [tags] 人物}`、`source#/target#/mutual#`）；删去文档外的内容（位置标签、`ntags`、标题禁令）。
- natural_language / traditional 同比例精简（123 → 78、108 → 99 字）。
- 三个共用该文案的注入点合计节省约 70% 的 token 开销。

## 验证

- 在当前 `main`（v6.2.5）基线上：`py_compile` + 插件模块完整导入（hook 注册成功）。
- 用真实 AstrBot `ToolSet`/`FunctionTool` 做 harness 验证：标注进入 `openai_schema()`、重复执行幂等、切换模式无残留、工具顺序保持、全局注册表对象零改动、inactive 工具/无工具/插件禁用路径安全跳过——12/12 通过。
- 未触碰匹配器及其他生产代码路径。

## 说明

- 有意不改动 NAI 侧插件：tag 模式提示词原样提交是其文档写明的设计行为。
- 本方案属于 schema 层的模型引导；对无视规范的提示词不做执行层强制转换。