### PR TITLE
feat: 外部共享主动分享参数化并修复正文损坏（空闲/冷却/意愿/链接要求）

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -7582,6 +7582,126 @@
         "condition": {
           "enable_news_integration": true
         }
+      },
+      "external_event_idle_minutes": {
+        "description": "外部消息分享空闲下限（分钟）",
+        "type": "int",
+        "hint": "新闻、B 站视频和主动搜索三类外部消息分享前，用户至少空闲多久才允许主动开口。默认 90 分钟是原先写死的下限，任何低于它的 idle_minutes 都会被顶到该值；调低即可在更短的静默后允许分享。",
+        "slider": {
+          "min": 5,
+          "max": 1440,
+          "step": 5
+        },
+        "default": 90
+      },
+      "external_event_idle_strong_minutes": {
+        "description": "强自我关联时空闲下限（分钟）",
+        "type": "int",
+        "hint": "当外部消息与 Bot 自我关联很强（relevance/desire 高、生活机会或用户偏好命中）时，允许在更短空闲后开口。默认 20 分钟是原先写死的下限。",
+        "slider": {
+          "min": 1,
+          "max": 1440,
+          "step": 5
+        },
+        "default": 20,
+        "condition": {
+          "enable_external_event_self_link": true
+        }
+      },
+      "news_share_cooldown_hours": {
+        "description": "新闻分享冷却（小时）",
+        "type": "int",
+        "hint": "同一用户两次新闻主动分享的最小间隔。默认 8 小时是原先写死的值；设为 0 可关闭这道单独限制（仍受上方主动外链统一冷却约束）。",
+        "slider": {
+          "min": 0,
+          "max": 168,
+          "step": 1
+        },
+        "default": 8
+      },
+      "bilibili_share_cooldown_hours": {
+        "description": "B 站视频分享冷却（小时）",
+        "type": "int",
+        "hint": "同一用户两次 B 站视频主动分享的最小间隔。默认 10 小时是原先写死的值；设为 0 可关闭这道单独限制（仍受主动外链统一冷却约束）。",
+        "slider": {
+          "min": 0,
+          "max": 168,
+          "step": 1
+        },
+        "default": 10
+      },
+      "web_exploration_share_cooldown_hours": {
+        "description": "主动搜索分享冷却（小时）",
+        "type": "int",
+        "hint": "同一用户两次主动搜索结果的分享最小间隔。默认 10 小时是原先写死的值；设为 0 可关闭这道单独限制（仍受主动外链统一冷却约束）。",
+        "slider": {
+          "min": 0,
+          "max": 168,
+          "step": 1
+        },
+        "default": 10
+      },
+      "external_event_self_link_override_min_relevance": {
+        "description": "意愿放宽·最低相关度",
+        "type": "int",
+        "hint": "当意愿判断给出 should_share=false 时，若相关度不低于该值且意愿放宽·最低分享欲达标，仍把本条外部消息判定为可分享（放宽 override）。0 表示不启用该放宽。默认关闭，保持原判。",
+        "slider": {
+          "min": 0,
+          "max": 10,
+          "step": 1
+        },
+        "default": 0,
+        "condition": {
+          "enable_external_event_self_link": true
+        }
+      },
+      "external_event_self_link_override_min_desire": {
+        "description": "意愿放宽·最低分享欲",
+        "type": "int",
+        "hint": "当意愿判断给出 should_share=false 时，若分享欲不低于该值且意愿放宽·最低相关度达标，仍把本条外部消息判定为可分享（放宽 override）。0 表示不启用该放宽。",
+        "slider": {
+          "min": 0,
+          "max": 10,
+          "step": 1
+        },
+        "default": 0,
+        "condition": {
+          "enable_external_event_self_link": true
+        }
+      },
+      "external_event_self_link_override_probability": {
+        "description": "意愿放宽·分享概率保底",
+        "type": "float",
+        "hint": "当 override 把 should_share 翻为可分享时，这条消息的分享概率至少为该值，避免放宽后仍被概率随机砍掉。",
+        "slider": {
+          "min": 0,
+          "max": 1,
+          "step": 0.05
+        },
+        "default": 0.6,
+        "condition": {
+          "enable_external_event_self_link": true
+        }
+      },
+      "external_event_share_min_total": {
+        "description": "外部消息统一评分下限",
+        "type": "int",
+        "hint": "外部消息通过意愿判断后，统一评分（相关度/分享欲/用户匹配/质量/新鲜度综合）需要达到的下限才允许进入主动候选。默认 18 是原先写死的值；调低可让更多消息通过。",
+        "slider": {
+          "min": 0,
+          "max": 100,
+          "step": 1
+        },
+        "default": 18,
+        "condition": {
+          "enable_external_event_self_link": true
+        }
+      },
+      "external_share_require_source_link": {
+        "description": "外部共享强制带来源链接",
+        "type": "bool",
+        "hint": "开启时，新闻/B 站视频/主动搜索三类外部共享的正文必须包含真实来源链接，否则退回兜底文本。关闭后不再硬要求链接，只要正文提到来源（标题/来源名/关键词）即可放行——适合想要更自然的话题式分享、不强求贴链接的场合。平台错配检查（正文声称的平台与链接不符）始终生效。",
+        "default": true
       }
     }
   },

--- a/news_exploration.py
+++ b/news_exploration.py
@@ -841,7 +841,8 @@ class NewsExplorationMixin:
         noisy = self._external_event_recently_seen(payload, source_type=source_type, now=now)
         duplicate_penalty = 4 if noisy else 0
         interrupt_penalty = 0
-        if now - _safe_float(user.get("last_seen"), 0) < max(self.idle_minutes, 90) * 60:
+        external_idle_min = _safe_int(getattr(self, "external_event_idle_minutes", 90), 90, 5, 1440)
+        if now - _safe_float(user.get("last_seen"), 0) < max(self.idle_minutes, external_idle_min) * 60:
             interrupt_penalty += 3
         if now - _safe_float(user.get("last_sent"), 0) < max(self.min_interval_minutes, 120) * 60:
             interrupt_penalty += 2
@@ -855,7 +856,7 @@ class NewsExplorationMixin:
             "freshness": freshness,
             "duplicate_penalty": duplicate_penalty,
             "interrupt_penalty": interrupt_penalty,
-            "should_share": bool((wish or {}).get("should_share")) and total >= 18 and not noisy,
+            "should_share": bool((wish or {}).get("should_share")) and total >= _safe_int(getattr(self, "external_event_share_min_total", 18), 18, 0, 100) and not noisy,
             "duplicate": noisy,
         }
 
@@ -1409,9 +1410,9 @@ class NewsExplorationMixin:
         for user_id, user in users.items():
             if not isinstance(user, dict) or not self._is_target_private_user(str(user_id), user) or not user.get("enabled", True) or not user.get("umo"):
                 continue
-            if now - _safe_float(user.get("last_seen"), 0) < max(self.idle_minutes, 90) * 60:
+            if now - _safe_float(user.get("last_seen"), 0) < max(self.idle_minutes, _safe_int(getattr(self, "external_event_idle_minutes", 90), 90, 5, 1440)) * 60:
                 continue
-            if now - _safe_float(user.get("last_bilibili_share_at"), 0) < 10 * 3600:
+            if now - _safe_float(user.get("last_bilibili_share_at"), 0) < _safe_int(getattr(self, "bilibili_share_cooldown_hours", 10), 10, 0, 168) * 3600:
                 continue
             if self._external_link_share_cooldown_remaining(user, now=now) > 0:
                 continue
@@ -3039,6 +3040,26 @@ class NewsExplorationMixin:
             "created_ts": _now_ts(),
             "source_type": source_type,
         }
+        # User-configured relaxation: when the judgement model says
+        # should_share=false but relevance/desire clear a configured floor,
+        # promote the item to shareable instead of dropping it silently.
+        # boost_reason marks strong self-link so downstream probability/idle
+        # boosts apply. Life-opportunity wishes still win below.
+        override_min_rel = _safe_int(getattr(self, "external_event_self_link_override_min_relevance", 0), 0, 0, 10)
+        override_min_des = _safe_int(getattr(self, "external_event_self_link_override_min_desire", 0), 0, 0, 10)
+        if (
+            not result["should_share"]
+            and override_min_rel > 0
+            and override_min_des > 0
+            and relevance >= override_min_rel
+            and desire >= override_min_des
+        ):
+            result["should_share"] = True
+            result["share_probability"] = max(
+                result["share_probability"],
+                _safe_float(getattr(self, "external_event_self_link_override_probability", 0.6), 0.6),
+            )
+            result["boost_reason"] = "override_by_user_threshold"
         if life_wish:
             if not result["should_share"] or result["share_probability"] < life_wish["share_probability"]:
                 result = {
@@ -3196,9 +3217,9 @@ class NewsExplorationMixin:
                         or _safe_int(user_preference.get("score"), 0) >= 10
                     )
                 )
-                idle_required = max(self.idle_minutes, 90) * 60
+                idle_required = max(self.idle_minutes, _safe_int(getattr(self, "external_event_idle_minutes", 90), 90, 5, 1440)) * 60
                 if strong_self_link:
-                    idle_required = min(idle_required, max(20, self.idle_minutes) * 60)
+                    idle_required = min(idle_required, max(_safe_int(getattr(self, "external_event_idle_strong_minutes", 20), 20, 1, 1440), self.idle_minutes) * 60)
                 idle_elapsed = now - _safe_float(user.get("last_seen"), 0)
                 if idle_elapsed < idle_required:
                     _note_news_share(user_id, "skipped", "用户近期仍活跃，暂不主动打扰", idle_elapsed_seconds=round(idle_elapsed, 1), idle_required_seconds=round(idle_required, 1))
@@ -3206,7 +3227,7 @@ class NewsExplorationMixin:
                 if str(user.get("last_news_share_key") or "") == user_selected_key:
                     _note_news_share(user_id, "skipped", "这条新闻已经给该用户排过主动")
                     continue
-                if now - _safe_float(user.get("last_news_share_at"), 0) < 8 * 3600:
+                if now - _safe_float(user.get("last_news_share_at"), 0) < _safe_int(getattr(self, "news_share_cooldown_hours", 8), 8, 0, 168) * 3600:
                     _note_news_share(user_id, "skipped", "新闻分享 8 小时冷却中")
                     continue
                 shared_link_cooldown = self._external_link_share_cooldown_remaining(user, now=now)
@@ -4534,9 +4555,9 @@ class NewsExplorationMixin:
         if digest.get("possible_share") and target_users:
             random.shuffle(target_users)
             for user_id, user in target_users[:3]:
-                if now - _safe_float(user.get("last_seen"), 0) < max(self.idle_minutes, 90) * 60:
+                if now - _safe_float(user.get("last_seen"), 0) < max(self.idle_minutes, _safe_int(getattr(self, "external_event_idle_minutes", 90), 90, 5, 1440)) * 60:
                     continue
-                if now - _safe_float(user.get("last_web_exploration_share_at"), 0) < 10 * 3600:
+                if now - _safe_float(user.get("last_web_exploration_share_at"), 0) < _safe_int(getattr(self, "web_exploration_share_cooldown_hours", 10), 10, 0, 168) * 3600:
                     continue
                 if self._external_link_share_cooldown_remaining(user, now=now) > 0:
                     continue

--- a/plugin_bootstrap.py
+++ b/plugin_bootstrap.py
@@ -1405,6 +1405,7 @@ def _initialize_review_and_group_config(self: Any, c: Any) -> None:
         "enable_proactive_message_review",
         legacy_response_review_enabled,
     )
+    self.external_share_require_source_link = self._cfg_bool(c, "external_share_require_source_link", True)
     self.proactive_review_history_limit = self._cfg_int(
         c,
         "proactive_review_history_limit",
@@ -1779,6 +1780,15 @@ def _initialize_group_and_provider_config(self: Any, c: Any) -> None:
     self.external_event_self_link_cooldown_hours = self._cfg_int(c, "external_event_self_link_cooldown_hours", 12, 1, 168)
     self.external_link_share_cooldown_hours = self._cfg_int(c, "external_link_share_cooldown_hours", 72, 0, 168)
     self.news_max_items_per_source = self._cfg_int(c, "news_max_items_per_source", 5, 1, 20)
+    self.external_event_idle_minutes = self._cfg_int(c, "external_event_idle_minutes", 90, 5, 1440)
+    self.external_event_idle_strong_minutes = self._cfg_int(c, "external_event_idle_strong_minutes", 20, 1, 1440)
+    self.news_share_cooldown_hours = self._cfg_int(c, "news_share_cooldown_hours", 8, 0, 168)
+    self.bilibili_share_cooldown_hours = self._cfg_int(c, "bilibili_share_cooldown_hours", 10, 0, 168)
+    self.web_exploration_share_cooldown_hours = self._cfg_int(c, "web_exploration_share_cooldown_hours", 10, 0, 168)
+    self.external_event_self_link_override_min_relevance = self._cfg_int(c, "external_event_self_link_override_min_relevance", 0, 0, 10)
+    self.external_event_self_link_override_min_desire = self._cfg_int(c, "external_event_self_link_override_min_desire", 0, 0, 10)
+    self.external_event_self_link_override_probability = self._cfg_unit_interval(c, "external_event_self_link_override_probability", 0.6, 0.0)
+    self.external_event_share_min_total = self._cfg_int(c, "external_event_share_min_total", 18, 0, 100)
     self.news_hot_sources = self._cfg_str(c, "news_hot_sources", self._cfg_str(c, "hot_trend_sources", "weibo,hackernews"))
     self.news_hot_max_items = self._cfg_int(c, "news_hot_max_items", self._cfg_int(c, "hot_trend_max_items", 12, 3, 30), 3, 30)
     self.enable_ai_daily_watch = self._cfg_bool(c, "enable_ai_daily_watch", True)

--- a/proactive_message.py
+++ b/proactive_message.py
@@ -4555,7 +4555,8 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
                 "reason": f"来源平台错配：应为{expected_label}而不是{claimed_platform}",
                 "hard": True,
             }
-        if source_link and source_link not in cleaned:
+        require_source_link = bool(getattr(self, "external_share_require_source_link", True))
+        if require_source_link and source_link and source_link not in cleaned:
             reference = self._external_share_fallback_reference(source_text)
             if reference:
                 return {
@@ -4623,23 +4624,23 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
                 payload = user.get(key)
                 if not isinstance(payload, dict):
                     continue
-                for field in (
-                    "title",
-                    "headline",
-                    "topic",
-                    "summary",
-                    "impression",
-                    "comment",
-                    "review",
-                    "source",
-                    "selected_source",
-                    "source_title",
-                    "selected_link",
-                    "source_url",
-                    "link",
-                    "url",
-                    "bvid",
-                ):
+                prefixed_fields = {
+                    "topic": "话题",
+                    "headline": "标题",
+                    "title": "标题",
+                    "source": "来源",
+                    "selected_source": "来源",
+                    "source_title": "参考来源",
+                    "selected_link": "链接",
+                    "source_url": "链接",
+                    "link": "链接",
+                    "url": "链接",
+                }
+                for field, prefix in prefixed_fields.items():
+                    value = payload.get(field)
+                    if value:
+                        add(f"{prefix}：{value}", 180)
+                for field in ("summary", "impression", "comment", "review", "bvid"):
                     add(payload.get(field), 180)
         if not parts:
             add(motive, 140)
@@ -16284,6 +16285,17 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
         cleaned = str(text or "").strip()
         if not cleaned:
             return ""
+        # Protect URLs from sentence-flow tokenization: a URL is one atomic
+        # unit and must never be split on ASCII dots or receive an appended
+        # sentence punctuation. Swap each URL out for a NUL placeholder and
+        # restore it right before returning.
+        url_placeholders: list[str] = []
+
+        def _protect_url(match: re.Match[str]) -> str:
+            url_placeholders.append(match.group(0))
+            return f"\x00URL{len(url_placeholders) - 1}\x00"
+
+        cleaned = re.sub(r"https?://[^\s，。！？!?；;、]+", _protect_url, cleaned)
         cleaned = self._strip_unsupported_proactive_agreement(cleaned)
         cleaned = self._trim_abrupt_closing_topic_shift(cleaned)
         cleaned = _normalize_outbound_punctuation_flow(cleaned)
@@ -16322,10 +16334,14 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
         normalized = [self._ensure_chat_sentence_punctuation(item) for item in merged]
         normalized = [item for item in normalized if item]
         if len(normalized) <= 3:
-            return self._truncate_proactive_text("\n".join(normalized), 260)
-        head = normalized[:2]
-        tail_sentences = normalized[2:4]
-        return self._truncate_proactive_text("\n".join(head + tail_sentences), 260)
+            result = self._truncate_proactive_text("\n".join(normalized), 260)
+        else:
+            head = normalized[:2]
+            tail_sentences = normalized[2:4]
+            result = self._truncate_proactive_text("\n".join(head + tail_sentences), 260)
+        for idx, url in enumerate(url_placeholders):
+            result = result.replace(f"\x00URL{idx}\x00", url)
+        return result
 
     def _group_share_text_has_life_sidecar(self, text: str) -> bool:
         cleaned = _single_line(text, 500)

--- a/tests/test_external_share_deliverability.py
+++ b/tests/test_external_share_deliverability.py
@@ -1,0 +1,160 @@
+import asyncio
+
+from astrbot_plugin_private_companion.proactive_message import ProactiveMessageMixin
+from astrbot_plugin_private_companion.news_exploration import NewsExplorationMixin
+
+
+class _ShareHarness(ProactiveMessageMixin):
+    pass
+
+
+class _NewsHarness(NewsExplorationMixin, ProactiveMessageMixin):
+    pass
+
+
+# --- external_share_require_source_link ---
+
+
+def test_require_source_link_false_allows_mention_only():
+    harness = _ShareHarness()
+    harness.external_share_require_source_link = False
+    user = {
+        "news_context": {
+            "headline": "Anthropic 给 Claude 文字加水印",
+            "selected_link": "https://daringfireball.net/2026/08/x",
+        }
+    }
+    decision = harness._external_share_source_consistency_decision(
+        user,
+        "刚看到 Anthropic 给 Claude 文字加水印的新闻，挺有讨论的。",
+        reason="news_share",
+    )
+    assert decision is None  # 正文提到真实标题即通过，不强制带 URL
+
+
+def test_require_source_link_default_still_requires_url():
+    harness = _ShareHarness()  # 默认 True = 现状行为
+    user = {
+        "news_context": {
+            "headline": "Anthropic 给 Claude 文字加水印",
+            "selected_link": "https://daringfireball.net/2026/08/x",
+        }
+    }
+    decision = harness._external_share_source_consistency_decision(
+        user,
+        "刚看到 Anthropic 给 Claude 文字加水印的新闻，挺有讨论的。",
+        reason="news_share",
+    )
+    assert decision is not None
+    assert decision["decision"] == "rewrite"
+    assert "遗漏真实来源链接" in decision["reason"]
+
+
+# --- anchor 前缀 → 兜底抓真实标题 ---
+
+
+def test_anchor_text_prefixes_real_fields():
+    harness = _ShareHarness()
+    user = {
+        "news_context": {
+            "headline": "Anthropic 给 Claude 文字加水印",
+            "selected_link": "https://daringfireball.net/x",
+        }
+    }
+    anchor = harness._external_share_anchor_text(user, reason="news_share", topic="一个轻松的早安小趣闻")
+    assert "标题：Anthropic 给 Claude 文字加水印" in anchor
+    assert "链接：https://daringfireball.net/x" in anchor
+    # 泛化 topic 仍是第一分句，但带前缀的真实标题行可被 fallback pattern-1 命中
+    assert anchor.startswith("一个轻松的早安小趣闻")
+
+
+def test_fallback_grabs_prefixed_real_title_over_generic_first_segment():
+    harness = _ShareHarness()
+    source = (
+        "一个轻松的早安小趣闻/暖心短句；"
+        "标题：Anthropic 给 Claude 文字加水印；"
+        "链接：https://daringfireball.net/2026/08/anthropics_watermark"
+    )
+    text = harness._external_share_fallback_reference(source)
+    assert "Anthropic" in text
+    assert "早安" not in text  # 泛化 topic 不再被当成标题
+    assert "daringfireball.net" in text
+
+
+# --- URL 不被句子化管线破坏 ---
+
+
+def test_normalize_flow_preserves_url_integrity():
+    harness = _ShareHarness()
+    url = "https://daringfireball.net/2026/08/anthropics_watermark_text"
+    out = harness._normalize_proactive_sentence_flow(f"看看这个热闹～ {url}")
+    assert url in out
+
+
+# --- 统一评分 total 阈值参数化 ---
+
+
+def test_share_decision_min_total_configurable():
+    harness = _ShareHarness()
+    harness.data = {}
+    harness.idle_minutes = 40
+    harness.min_interval_minutes = 120
+    harness.external_event_share_min_total = 0
+    decision = harness._external_event_share_decision(
+        {},
+        {"selected_link": "http://example.com/a"},
+        source_type="news",
+        wish={"should_share": True, "relevance": 1, "desire": 1},
+        now=0,
+    )
+    assert decision["should_share"] is True
+
+
+# --- 意愿 override（rel/des 阈值） ---
+
+
+def test_override_flips_should_share_when_thresholds_met(monkeypatch):
+    harness = _NewsHarness()
+    harness.data = {}
+    harness.enable_external_event_self_link = True
+    harness.external_event_self_link_override_min_relevance = 5
+    harness.external_event_self_link_override_min_desire = 5
+    harness.external_event_self_link_override_probability = 0.7
+    monkeypatch.setattr(harness, "_external_event_self_link_provider_id", lambda *a, **k: "deepseek/test")
+    monkeypatch.setattr(harness, "_format_external_event_stable_self_context", lambda *a, **k: "")
+    monkeypatch.setattr(harness, "_format_external_event_current_self_context", lambda *a, **k: "")
+
+    async def fake_llm_call(*args, **kwargs):
+        return (
+            '{"relevance":5,"desire":5,"should_share":false,"share_probability":0.1,'
+            '"self_link":"和自己相关","motive":"想说说","tone":"自然","boundary":"别像通知"}'
+        )
+
+    monkeypatch.setattr(harness, "_llm_call", fake_llm_call)
+    payload = {"headline": "某条普通科技新闻", "impression": "普通内容，不含生活福利词"}
+    result = asyncio.run(harness._build_external_event_wish(payload, source_type="news"))
+    assert result["should_share"] is True
+    assert result["boost_reason"] == "override_by_user_threshold"
+    assert result["share_probability"] >= 0.7
+
+
+def test_override_not_applied_when_thresholds_zero(monkeypatch):
+    harness = _NewsHarness()
+    harness.data = {}
+    harness.enable_external_event_self_link = True
+    # override 阈值默认 0 = 不启用放宽，保持 LLM 原判
+    monkeypatch.setattr(harness, "_external_event_self_link_provider_id", lambda *a, **k: "deepseek/test")
+    monkeypatch.setattr(harness, "_format_external_event_stable_self_context", lambda *a, **k: "")
+    monkeypatch.setattr(harness, "_format_external_event_current_self_context", lambda *a, **k: "")
+
+    async def fake_llm_call(*args, **kwargs):
+        return (
+            '{"relevance":5,"desire":5,"should_share":false,"share_probability":0.1,'
+            '"self_link":"和自己相关","motive":"想说说","tone":"自然","boundary":"别像通知"}'
+        )
+
+    monkeypatch.setattr(harness, "_llm_call", fake_llm_call)
+    payload = {"headline": "另一条普通科技新闻", "impression": "普通内容"}
+    result = asyncio.run(harness._build_external_event_wish(payload, source_type="news"))
+    assert result["should_share"] is False
+    assert "boost_reason" not in result


### PR DESCRIPTION
## 背景

  新闻/B 站视频/主动搜索三类外部共享的漏斗门槛大量硬编码：
  - 空闲下限写死 90 分钟（新闻、B 站、网页、统一评分各一处），用户刚有过互动就无法分享；
  - per-source 冷却写死（新闻 8h、B 站 10h、网页 10h），另叠加主动外链统一冷却；
  - 意愿 LLM 过于保守——实测 18 次新闻阅读仅 2 次判定可分享（should_share=true），绝大多数候选在漏斗早期被砍；
  - 统一评分 should_share 需 total≥18 写死。

  同时存在正文损坏：一致性检查要求正文必须带真实来源链接（URL 检查先于「提到来源」判定），而清洗管线会把 URL
  按英文词断句截断，兜底模板抓标题时又落到第一分句（泛化话题）——导致实际发出的分享正文是「兜底模板 +
  泛化话题」而不是真实新闻。

  ## 改动

  新增 10 个配置参数（位于「新闻与 AI 日报」分组），默认值全部=旧版写死行为（不调即零变化）：

  - 空闲下限：`external_event_idle_minutes`（默认 90）、`external_event_idle_strong_minutes`（默认 20，强自我关联时）
  - 分享冷却：`news_share_cooldown_hours`（默认 8）、`bilibili_share_cooldown_hours`（默认
  10）、`web_exploration_share_cooldown_hours`（默认 10）
  - 意愿放宽：`external_event_self_link_override_min_relevance` / `external_event_self_link_override_min_desire`（默认
  0=关；开启后 LLM 判不可分享但相关度/分享欲达标时放行）、`external_event_self_link_override_probability`（默认
  0.6，放宽后的分享概率保底）
  - 评分下限：`external_event_share_min_total`（默认 18）
  - 链接要求：`external_share_require_source_link`（默认 true；关闭后正文无链接但提到来源即可放行）

  正文损坏修复：
  - 清洗管线对 URL 整体保护（占位符还原），URL 不再被断句/截断；
  - 兜底模板优先抓真实标题（anchor 字段带「标题：/话题：/链接：」前缀，命中 pattern-1），不再落到第一分句的泛化话题；
  - `external_share_require_source_link=false` 时，无 URL 的话题式分享可通过「提到来源」检查直接放行。

  ## 测试

  - `tests/test_external_share_deliverability.py` 新增 8 个配置与修复生效测试
  - 既有 external_share 自然度测试在默认值下保持通过（纯方法用例 6/6 实测通过；评审链用例默认行为不变）