### PR TITLE
fix(bridge): 修复在已加载 PyTorch 环境下动态反射触发的 RuntimeError 崩溃

### DIFF
--- a/event_dispatch.py
+++ b/event_dispatch.py
@@ -866,10 +866,17 @@ class EventDispatchMixin:
                     return False
 
         def identity_text(*values: Any) -> str:
+            # If the object belongs to the `torch` namespace, skip it directly to prevent triggering a C++ dynamic class instantiation assertion.
             for value in values:
-                text = str(value or "").strip()
-                if text:
-                    return text
+                val_type = type(value)
+                if getattr(val_type, "__module__", "").startswith("torch") or "_ClassNamespace" in str(val_type):
+                    continue
+                try:
+                    text = str(value or "").strip()
+                    if text:
+                        return text
+                except Exception:
+                    continue
             return ""
 
         sender_payload = raw.get("sender") if isinstance(raw.get("sender"), Mapping) else {}

--- a/external_bridge_resolver.py
+++ b/external_bridge_resolver.py
@@ -48,7 +48,14 @@ def _lifecycle_active(api: Any) -> bool:
 
 
 def _identity_segments(value: Any) -> set[str]:
-    text = str(value or "").strip().casefold().replace("\\", "/")
+    # If the object belongs to the `torch` namespace, skip it directly to prevent triggering a C++ dynamic class instantiation assertion.
+    val_type = type(value)
+    if getattr(val_type, "__module__", "").startswith("torch") or "_ClassNamespace" in str(val_type):
+        return set()
+    try:
+        text = str(value or "").strip().casefold().replace("\\", "/")
+    except Exception:
+        return set()
     if not text:
         return set()
     for separator in ("/", ":"):

--- a/memory_companion_adapter.py
+++ b/memory_companion_adapter.py
@@ -439,7 +439,14 @@ class MemoryCompanionAdapterMixin:
 
     @classmethod
     def _memory_companion_identity_matches(cls, value: Any) -> bool:
-        text = str(value or "").strip().lower()
+        # If the object belongs to the `torch` namespace, skip it directly to prevent triggering a C++ dynamic class instantiation assertion.
+        val_type = type(value)
+        if getattr(val_type, "__module__", "").startswith("torch") or "_ClassNamespace" in str(val_type):
+            return False
+        try:
+            text = str(value or "").strip().lower()
+        except Exception:
+            return False
         if not text:
             return False
         if text in cls._MEMORY_COMPANION_PLUGIN_ALIASES:

--- a/plugin_identity.py
+++ b/plugin_identity.py
@@ -13,8 +13,14 @@ _IDENTITY_SEPARATORS = re.compile(r"[.:/\\]+")
 
 
 def _identity_text(value: Any, *, limit: int = 240) -> str:
-    return " ".join(str(value or "").split())[:limit]
-
+    # If the object belongs to the `torch` namespace, skip it directly to prevent triggering a C++ dynamic class instantiation assertion.
+    val_type = type(value)
+    if getattr(val_type, "__module__", "").startswith("torch") or "_ClassNamespace" in str(val_type):
+        return ""
+    try:
+        return " ".join(str(value or "").split())[:limit]
+    except Exception:
+        return ""
 
 def _identity_segments(value: Any) -> tuple[str, ...]:
     text = _identity_text(value)


### PR DESCRIPTION
### 修复了什么

* **故障现象**：在已加载/导入 `torch` (PyTorch) 的运行环境中，访问 WebUI 扩展面板的「总览概览页」或「用户列表页」时会触发 500 报错，并在日志中抛出：
  `RuntimeError: Tried to instantiate class 'PLUGIN_NAME.__file__', but it does not exist! Ensure that it is registered via torch::class_`
* **影响范围**：受影响的模块包括外部桥接解析器、记忆适配器、事件分发及插件身份识别等 4 处涉及模块反射遍历的关键路径；在装有本地模型/多模态插件的 AstrBot 环境中会稳定复现。
* **实际根因**：在扫描已加载模块 (`sys.modules`) 匹配外部关联插件时，代码直接对模块属性 `value` 调用 `str(value)`。当遇到 PyTorch 的动态 C++ 类命名空间代理对象 (`torch._classes._ClassNamespace`) 时，Python 的 `_module_repr` 尝试查找其 `__file__` 属性，从而触发了 PyTorch 底层 C++ 绑定 (`torch._C._get_custom_class_python_wrapper`) 的自定义类实例化查找断言。由于该类未注册，导致直接抛出 `RuntimeError` 中断执行流程。

---

### 怎么修复

* **实现方式**：
  在 `event_dispatch.py`、`external_bridge_resolver.py`、`memory_companion_adapter.py` 和 `plugin_identity.py` 共 4 处身份与文本归一化函数中，增加针对 PyTorch 命名空间对象的防御性类型过滤：
  1. 通过 `getattr(val_type, "__module__", "").startswith("torch")` 及 `_ClassNamespace` 类型特征拦截 PyTorch 代理对象。
  2. 针对字符串转换操作增加 `try-except Exception` 全局异常兜底。
* **边界行为与兼容语义**：
  * 当遇到不可解析的 PyTorch 代理对象时，各函数安全返回空默认值（空字符串 `""`、空集合 `set()` 或 `False`），使外部桥接解析器判定为“未匹配到插件”，不影响原有扫描逻辑。
  * 对所有合法的字符串、模块名及文件路径，完全保持原有的分割、替换与匹配逻辑不变，无任何破坏性变更。

---

### 已经验证了什么

* [x] **实机功能验证**：在 Docker 容器环境（`AstrBot v4.26.5` + `Python 3.12` + `torch 2.x`）下验证：
  * WebUI 概览页（`/page/overview`）接口正常响应，卡片摘要与状态正常渲染。
  * 用户管理页（`/page/users`）各用户能力摘要（`_user_summary` / `_req036`）正常生成，不再触发 500 异常。
* [x] **静态检查**：确认 4 个文件的缩进、类型注解及语法无异常，无多余未暂存改动。
* [ ] **纯净环境对比（说明）**：未在完全脱离 `torch` 的独立虚拟环境中重复回测，但根据逻辑分析，在未导入 `torch` 时 `__module__` 检查不会被命中，逻辑与修改前完全等价。