### PR TITLE
fix: 修复无MemoryCompanion时群聊观测删除失败的问题

### DIFF
--- a/core_store.py
+++ b/core_store.py
@@ -474,6 +474,7 @@ class CoreStoreMixin:
             "group_llm_reply_blocks": {},
             "reaction_expression_group_states": {},
             "cache_metrics": {},
+            "_req041_memory_scope_state": {},
             "persona_lifecycle": {
                 "generation": 1,
                 "reset_at": 0,
@@ -569,6 +570,7 @@ class CoreStoreMixin:
         data.setdefault("group_llm_reply_blocks", {})
         data.setdefault("reaction_expression_group_states", {})
         data.setdefault("cache_metrics", {})
+        data.setdefault("_req041_memory_scope_state", {})
         lifecycle = data.setdefault("persona_lifecycle", {})
         if not isinstance(lifecycle, dict):
             lifecycle = {}

--- a/main.py
+++ b/main.py
@@ -4846,8 +4846,7 @@ class PrivateCompanionPlugin(
     ) -> dict[str, Any]:
         synchronizer = getattr(self, "req041_scoped_projection_sync", None)
         if synchronizer is None:
-            status = getattr(self, "req041_migration_status", None)
-            if isinstance(status, dict) and (status.get("required") or status.get("scoped_required")):
+            if self._req041_group_remote_cleanup_required():
                 return {"ok": False, "state": "degraded", "code": "scoped_group_erase_unavailable"}
             return {"ok": True, "state": "not_required", "code": "scoped_group_erase_not_required", "count": 0}
         raw_group = _single_line(group_id, 160)
@@ -4865,6 +4864,75 @@ class PrivateCompanionPlugin(
         return synchronizer.erase_group_scopes(
             context, operation_id=clean_operation, reason_code="group_reset",
         )
+
+    def _req041_memory_scope_was_bound(self) -> bool:
+        """Return whether this persona has ever had a remote scoped bridge bound."""
+        data = getattr(self, "data", None)
+        state = data.get("_req041_memory_scope_state") if isinstance(data, dict) else None
+        return isinstance(state, dict) and bool(state.get("ever_bound"))
+
+    def _req041_mark_memory_scope_bound(self) -> None:
+        """Persist remote-binding history so a later outage remains fail-closed."""
+        data = getattr(self, "data", None)
+        if not isinstance(data, dict):
+            return
+        state = data.get("_req041_memory_scope_state")
+        if not isinstance(state, dict):
+            state = {}
+            data["_req041_memory_scope_state"] = state
+        if state.get("ever_bound"):
+            return
+        state["ever_bound"] = True
+        state["bound_at"] = _now_ts()
+        scheduler = getattr(self, "_schedule_data_save", None)
+        if callable(scheduler):
+            try:
+                scheduler(delay=0.35)
+            except Exception:
+                pass
+
+    def _req041_group_remote_cleanup_required(self) -> bool:
+        """Decide whether deleting a group must wait for remote scope erasure.
+
+        A fresh runtime with no remote bridge has never published scoped records,
+        so local group cleanup is safe. Once a bridge was bound, an outage must
+        continue to fail closed because the remote side may retain group data.
+        Legacy migrations also remain fail-closed until their remote cleanup is
+        available.
+        """
+        status = getattr(self, "req041_migration_status", None)
+        if not isinstance(status, dict):
+            return False
+        if status.get("required"):
+            if (
+                str(status.get("code") or "").strip() == "memory_bridge_unavailable"
+                and not status.get("memory_bound")
+                and not self._req041_memory_scope_was_bound()
+            ):
+                coordinator = getattr(self, "req041_migration_coordinator", None)
+                status_getter = getattr(coordinator, "status", None)
+                if callable(status_getter):
+                    try:
+                        control = status_getter()
+                    except Exception:
+                        control = {}
+                    if isinstance(control, dict) and control.get("memory_version") == "not-detected":
+                        return False
+            return True
+        if not status.get("scoped_required"):
+            return False
+        if status.get("memory_bound") or self._req041_memory_scope_was_bound():
+            return True
+        coordinator = getattr(self, "req041_migration_coordinator", None)
+        status_getter = getattr(coordinator, "status", None)
+        if callable(status_getter):
+            try:
+                control = status_getter()
+            except Exception:
+                control = {}
+            if isinstance(control, dict) and control.get("source_schema_version") == "req041-fresh-v1":
+                return False
+        return True
 
     def _req041_erase_scoped_persona_data(
         self,
@@ -4990,8 +5058,20 @@ class PrivateCompanionPlugin(
                     synchronizer = getattr(self, "req041_scoped_projection_sync", None)
         if synchronizer is None:
             status = getattr(self, "req041_migration_status", None)
-            if isinstance(status, dict) and (status.get("required") or status.get("scoped_required")):
+            if self._req041_group_remote_cleanup_required():
+                logger.warning(
+                    "[PrivateCompanion] 群聊删除因远端分域不可用而保留: group=%s state=%s code=%s memory_bound=%s scoped_required=%s",
+                    clean_group,
+                    _single_line((status or {}).get("state"), 32),
+                    _single_line((status or {}).get("code"), 96),
+                    bool((status or {}).get("memory_bound")),
+                    bool((status or {}).get("scoped_required")),
+                )
                 return {"ok": False, "state": "degraded", "code": "scoped_group_erase_unavailable"}
+            logger.info(
+                "[PrivateCompanion] MemoryCompanion 从未绑定，群聊删除仅清理本地分域: group=%s",
+                clean_group,
+            )
             return {"ok": True, "state": "not_required", "code": "scoped_group_erase_not_required"}
 
         async with self._data_lock:
@@ -6056,6 +6136,7 @@ class PrivateCompanionPlugin(
                 "pending": 0, "completed": 0, "error_codes": [],
             }
             if remote.get("ok") and bridge is not None:
+                self._req041_mark_memory_scope_bound()
                 self.req041_scoped_projection_sync = ScopedProjectionSynchronizer(
                     read=lambda namespace, **kwargs: self._memory_companion_read_scoped_record(
                         bridge, namespace, **kwargs
@@ -6230,6 +6311,7 @@ class PrivateCompanionPlugin(
             "ok": False, "code": "namespace_scoped_api_not_bound", "scopes": []
         }
         if remote.get("ok") and bridge is not None:
+            self._req041_mark_memory_scope_bound()
             self.req041_scoped_projection_sync = ScopedProjectionSynchronizer(
                 read=lambda namespace, **kwargs: self._memory_companion_read_scoped_record(
                     bridge, namespace, **kwargs

--- a/tests/test_req041_group_reset_saga.py
+++ b/tests/test_req041_group_reset_saga.py
@@ -47,6 +47,10 @@ def _load_methods(*names: str) -> dict[str, Any]:
         "_now_ts": lambda: 100.0,
         "_set_into_config": set_config,
         "_single_line": lambda value, limit=240: " ".join(str(value or "").split())[:limit],
+        "logger": types.SimpleNamespace(
+            warning=lambda *_args, **_kwargs: None,
+            info=lambda *_args, **_kwargs: None,
+        ),
     }
     exec(compile(module, str(ROOT / "main.py"), "exec"), namespace)
     return {name: namespace[name] for name in names}
@@ -57,6 +61,8 @@ METHODS = _load_methods(
     "_req041_group_reset_sagas_locked",
     "_req041_finalize_group_reset_locked",
     "_req041_persist_archive_saga_locked",
+    "_req041_memory_scope_was_bound",
+    "_req041_group_remote_cleanup_required",
     "reset_group_scoped_data",
     "_req041_resume_confirmed_group_resets",
 )
@@ -122,6 +128,8 @@ class _Host:
     _req041_group_reset_sagas_locked = METHODS["_req041_group_reset_sagas_locked"]
     _req041_finalize_group_reset_locked = METHODS["_req041_finalize_group_reset_locked"]
     _req041_persist_archive_saga_locked = METHODS["_req041_persist_archive_saga_locked"]
+    _req041_memory_scope_was_bound = METHODS["_req041_memory_scope_was_bound"]
+    _req041_group_remote_cleanup_required = METHODS["_req041_group_remote_cleanup_required"]
     reset_group_scoped_data = METHODS["reset_group_scoped_data"]
     _req041_resume_confirmed_group_resets = METHODS["_req041_resume_confirmed_group_resets"]
 
@@ -212,6 +220,63 @@ class GroupResetSagaTests(unittest.TestCase):
         result = asyncio.run(host.reset_group_scoped_data("group-a"))
         self.assertTrue(result["ok"])
         self.assertEqual("not_required", result["state"])
+        self.assertIn("group-a", host.data["groups"])
+
+    def test_fresh_runtime_without_memory_bridge_allows_local_group_delete(self) -> None:
+        host = _Host()
+        host.req041_scoped_projection_sync = None
+        host.req041_migration_status = {
+            "required": False,
+            "scoped_required": True,
+            "state": "degraded",
+            "code": "memory_bridge_unavailable",
+        }
+        host.req041_migration_coordinator = types.SimpleNamespace(
+            status=lambda: {"source_schema_version": "req041-fresh-v1"}
+        )
+
+        result = asyncio.run(host.reset_group_scoped_data("group-a"))
+
+        self.assertTrue(result["ok"])
+        self.assertEqual("not_required", result["state"])
+        self.assertIn("group-a", host.data["groups"])
+
+    def test_existing_runtime_without_memory_bridge_allows_local_group_delete(self) -> None:
+        host = _Host()
+        host.req041_scoped_projection_sync = None
+        host.req041_migration_status = {
+            "required": True,
+            "state": "degraded",
+            "code": "memory_bridge_unavailable",
+        }
+        host.req041_migration_coordinator = types.SimpleNamespace(
+            status=lambda: {"source_schema_version": "companion-v6", "memory_version": "not-detected"}
+        )
+
+        result = asyncio.run(host.reset_group_scoped_data("group-a"))
+
+        self.assertTrue(result["ok"])
+        self.assertEqual("not_required", result["state"])
+        self.assertIn("group-a", host.data["groups"])
+
+    def test_fresh_runtime_that_had_memory_bound_still_fails_closed(self) -> None:
+        host = _Host()
+        host.req041_scoped_projection_sync = None
+        host.req041_migration_status = {
+            "required": False,
+            "scoped_required": True,
+            "state": "degraded",
+            "code": "memory_bridge_unavailable",
+        }
+        host.req041_migration_coordinator = types.SimpleNamespace(
+            status=lambda: {"source_schema_version": "req041-fresh-v1"}
+        )
+        host.data["_req041_memory_scope_state"] = {"ever_bound": True}
+
+        result = asyncio.run(host.reset_group_scoped_data("group-a"))
+
+        self.assertFalse(result["ok"])
+        self.assertEqual("scoped_group_erase_unavailable", result["code"])
         self.assertIn("group-a", host.data["groups"])
 
     def test_group_reset_waits_for_scoped_startup_binding(self) -> None:

--- a/tests/test_req041_migration_startup.py
+++ b/tests/test_req041_migration_startup.py
@@ -89,6 +89,7 @@ METHODS = _load_methods(
     "_req041_scoped_group_read_view",
     "_req041_replay_finished",
     "_req041_run_replay_batch",
+    "_req041_mark_memory_scope_bound",
     "_req041_initialize_fresh_scoped_runtime",
     "_req041_initialize_automatic_migration",
 )
@@ -109,6 +110,7 @@ class Harness:
     _req041_scoped_group_read_view = METHODS["_req041_scoped_group_read_view"]
     _req041_replay_finished = METHODS["_req041_replay_finished"]
     _req041_run_replay_batch = METHODS["_req041_run_replay_batch"]
+    _req041_mark_memory_scope_bound = METHODS["_req041_mark_memory_scope_bound"]
     _req041_initialize_fresh_scoped_runtime = METHODS["_req041_initialize_fresh_scoped_runtime"]
     _req041_initialize_automatic_migration = METHODS["_req041_initialize_automatic_migration"]
 
@@ -217,6 +219,7 @@ class MigrationStartupTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual("memory_bridge_unavailable", host.req041_migration_status["code"])
         self.assertTrue(host.req041_migration_status["scoped_required"])
         self.assertIsNone(getattr(host, "req041_scoped_projection_sync", None))
+        self.assertFalse((host.data.get("_req041_memory_scope_state") or {}).get("ever_bound", False))
         self.assertFalse((self.data_dir / "req041_backups").exists())
 
     async def test_new_install_first_exact_identity_reaches_new_read_through_outbox(self) -> None:
@@ -265,6 +268,7 @@ class MigrationStartupTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(host.req041_migration_coordinator.verify_backup())
         self.assertEqual("active", host.req041_migration_status["state"])
         self.assertTrue(host.req041_migration_status["memory_bound"])
+        self.assertTrue(host.data["_req041_memory_scope_state"]["ever_bound"])
         self.assertEqual(1, len(host.bind_calls))
         self.assertEqual(status["migration_epoch"], host.bind_calls[0]["migration_epoch"])
         self.assertEqual(status["policy_version"], host.bind_calls[0]["policy_version"])


### PR DESCRIPTION
## 问题

在未安装或未成功连接 MemoryCompanion 时，从陪伴面板删除群聊会失败：

```text
操作失败：scoped_group_erase_unavailable
```

例如仅使用 LivingMemory，或 REQ-041 处于 `memory_bridge_unavailable` 状态时，`/group/delete` 会在删除本地群聊资料之前被拦截。

## 原因

REQ-041 在 MemoryCompanion 不可用时会将运行状态标记为 `scoped_required=True`。群聊删除逻辑只要发现同步器不可用，就直接返回 `scoped_group_erase_unavailable`，没有区分：

- 从未绑定过远端 MemoryCompanion；
- 曾经绑定过远端记忆，但当前暂时不可用。

前一种情况下，远端没有由该插件发布的群分域数据，可以安全地执行本地清理。

## 修改内容

- 增加 `_req041_memory_scope_state`，持久化记录 MemoryCompanion 是否曾经成功绑定。
- 对全新运行环境或迁移控制库中 `memory_version=not-detected` 的情况，允许本地删除群聊资料、名单和表达学习范围。
- 对曾经绑定过远端记忆、或无法确认远端状态的情况，继续保持 fail-closed，避免远端数据残留。
- 为远端清理阻断和本地回退增加日志，便于排查。
- 增加群删除和迁移启动相关回归测试。

## 验证

已通过：

```text
uv run --no-project python -m unittest -q \
  tests.test_req041_group_reset_saga \
  tests.test_req041_migration_startup \
  tests.test_req041_memory_write_gate
```

结果：30 项测试通过。

另外通过了 Python 语法检查和 `git diff --check`。

## 兼容性说明

本修改不改变已经绑定 MemoryCompanion 时的远端删除流程。仅在确认远端从未绑定的情况下，允许删除本地群聊资料。