### PR TITLE
feat: preview recent image generation debug logs

### DIFF
--- a/page_api.py
+++ b/page_api.py
@@ -729,6 +729,7 @@ class PrivateCompanionPageApi(
             ("/reality-touch/update", self.update_reality_touch, ["POST"], "Private Companion Page update reality touch alarm"),
             ("/settings/swap_image_api", self.swap_image_api_settings, ["POST"], "Private Companion Page swap image API settings"),
             ("/extensions/image/status", self.get_image_extension_status, ["GET"], "Private Companion Page image extension status"),
+            ("/image/debug", self.get_image_debug, ["GET"], "Private Companion Page image generation debug trace"),
             ("/image_api/status", self.get_image_api_status, ["GET"], "Private Companion Page image API status"),
             ("/image_api/test", self.test_image_api_endpoint, ["POST"], "Private Companion Page test one image API endpoint"),
             ("/config/export", self.export_migration_config, ["GET"], "Private Companion Page export migration config"),
@@ -6561,6 +6562,447 @@ class PrivateCompanionPageApi(
             "timeout_seconds": self._int(endpoint.get("timeout_seconds"), 180, 20, 600),
         }
 
+    def _legacy_recent_photo_generation_debug(self, *, event_limit: int = 240) -> dict[str, Any]:
+        """读取生图 trace 的最近事件，供生图父面板按需展开查看。
+
+        文件内容已经由生图运行时统一按 JSONL 写入并执行默认脱敏。页面只返回最近
+        的一段事件，避免把历史日志或无界请求体一次性送到浏览器。
+        """
+        data_dir = str(getattr(self.plugin, "data_dir", "") or "").strip()
+        root = Path(data_dir) if data_dir else None
+        if root is None:
+            return {
+                "enabled": False,
+                "available": False,
+                "path": "",
+                "latest": {},
+                "traces": [],
+                "events": [],
+            }
+        candidates = [root / "photo_generation_trace.txt"]
+        candidates.extend(sorted(root.glob("photo_generation_trace.*.txt")))
+        debug_root = root / "photo_debug"
+        candidates.append(debug_root / "generation.jsonl")
+        candidates.extend(sorted(debug_root.glob("generation.*.jsonl")))
+        paths = [item for item in candidates if item.is_file()]
+        if not paths:
+            return {
+                "enabled": False,
+                "available": False,
+                "path": str(root / "photo_generation_trace.txt"),
+                "latest": {},
+                "traces": [],
+                "events": [],
+            }
+        events: list[dict[str, Any]] = []
+        try:
+            per_file_limit = max(1, min(1000, int(event_limit) * 4))
+            for path in paths:
+                lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+                for line in lines[-per_file_limit:]:
+                    try:
+                        value = json.loads(line)
+                    except (TypeError, ValueError, json.JSONDecodeError):
+                        continue
+                    if isinstance(value, dict) and (value.get("trace") or value.get("trace_id")):
+                        if not value.get("trace"):
+                            value["trace"] = value.get("trace_id")
+                        value["source_file"] = path.name
+                        events.append(value)
+        except (OSError, UnicodeError):
+            return {
+                "enabled": True,
+                "available": False,
+                "path": str(paths[0]),
+                "latest": {},
+                "traces": [],
+                "events": [],
+            }
+        events.sort(key=lambda item: (
+            self._photo_debug_event_timestamp(item),
+            self._photo_debug_event_sequence(item),
+        ))
+        events = events[-max(1, min(240, int(event_limit))):]
+        trace_rows: dict[str, dict[str, Any]] = {}
+        for event in events:
+            trace_id = self._single_line(event.get("trace"), 80)
+            if not trace_id:
+                continue
+            row = trace_rows.pop(trace_id, None)
+            if row is None:
+                row = {
+                    "trace": trace_id,
+                    "started_at": event.get("time") or event.get("ts"),
+                    "last_at": event.get("time") or event.get("ts"),
+                    "stage": "",
+                    "status": "",
+                    "event_count": 0,
+                }
+            row["last_at"] = event.get("time") or event.get("ts")
+            row["stage"] = self._single_line(event.get("stage"), 80)
+            row["status"] = self._single_line(event.get("status"), 30)
+            row["event_count"] = self._int(row.get("event_count"), 0) + 1
+            trace_rows[trace_id] = row
+        traces = list(trace_rows.values())[-24:]
+        latest_trace = events[-1].get("trace") if events else ""
+        latest = next((row for row in reversed(events) if row.get("trace") == latest_trace), {}) if latest_trace else {}
+        return {
+            "enabled": True,
+            "available": bool(events),
+            "path": str(paths[0]),
+            "sources": [str(item) for item in paths],
+            "latest": latest,
+            "traces": traces,
+            "events": events,
+        }
+
+    def _image_debug_data_roots(self) -> list[Path]:
+        """Resolve the image extension's actual debug roots for this owner."""
+        roots: list[str] = []
+        getter = getattr(self.plugin, "_image_companion_api", None)
+        try:
+            api = getter() if callable(getter) else None
+            resolver = getattr(api, "debug_data_dirs", None)
+            if callable(resolver):
+                values = resolver(self.plugin)
+                if isinstance(values, (list, tuple)):
+                    roots.extend(str(item or "").strip() for item in values)
+        except Exception:
+            pass
+        fallback = str(getattr(self.plugin, "data_dir", "") or "").strip()
+        if fallback:
+            roots.append(fallback)
+        result: list[Path] = []
+        seen: set[str] = set()
+        for raw in roots:
+            if not raw:
+                continue
+            try:
+                root = Path(raw).expanduser().resolve(strict=False)
+            except (OSError, RuntimeError, ValueError):
+                continue
+            key = str(root).casefold()
+            if key not in seen:
+                seen.add(key)
+                result.append(root)
+        return result
+
+    @staticmethod
+    def _read_debug_lines(path: Path, *, tail_lines: int | None = None) -> list[str]:
+        """Read a bounded tail for collapsed status requests."""
+        if tail_lines is None:
+            return path.read_text(encoding="utf-8", errors="replace").splitlines()
+        limit = max(1, min(4096, int(tail_lines)))
+        with path.open("rb") as handle:
+            handle.seek(0, 2)
+            end = handle.tell()
+            maximum = min(end, 1024 * 1024)
+            size = min(maximum, max(64 * 1024, limit * 2048))
+            offset = end - size
+            starts_on_boundary = offset == 0
+            while offset > 0 and not starts_on_boundary and size < maximum:
+                handle.seek(offset - 1)
+                starts_on_boundary = handle.read(1) == b"\n"
+                if starts_on_boundary:
+                    break
+                size = min(maximum, size * 2)
+                offset = end - size
+                if offset == 0:
+                    starts_on_boundary = True
+                    break
+            if offset > 0 and not starts_on_boundary:
+                handle.seek(offset - 1)
+                starts_on_boundary = handle.read(1) == b"\n"
+            handle.seek(offset)
+            content = handle.read(size)
+        if not starts_on_boundary:
+            # The hard cap cut through an oversized line. Do not hand a
+            # malformed partial record to the JSON parser; later full lines
+            # are still returned when present.
+            newline = content.find(b"\n")
+            content = content[newline + 1:] if newline >= 0 else b""
+        return content.decode("utf-8", "replace").splitlines()[-limit:]
+
+    @staticmethod
+    def _attach_debug_payload_contents(
+        events: list[dict[str, Any]],
+        roots: list[Path],
+        *,
+        max_total_bytes: int = 2 * 1024 * 1024,
+        max_payload_bytes: int = 512 * 1024,
+    ) -> None:
+        """Attach captured sidecar bodies for the explicitly expanded view.
+
+        Payload paths are recorder-generated relative paths. Resolve them only
+        below each known ``photo_debug`` directory and reject symlinks so a
+        forged log line cannot turn the page API into an arbitrary file reader.
+        """
+        remaining = max(0, int(max_total_bytes))
+        if remaining <= 0:
+            return
+        for event in events:
+            if remaining <= 0 or not isinstance(event, dict):
+                break
+            data = event.get("data")
+            payloads = data.get("payloads") if isinstance(data, dict) else None
+            if not isinstance(payloads, dict):
+                continue
+            for metadata in payloads.values():
+                if remaining <= 0 or not isinstance(metadata, dict):
+                    continue
+                relative = str(metadata.get("path") or "").strip()
+                if not relative or not bool(metadata.get("captured")):
+                    continue
+                for root in roots:
+                    debug_root = root / "photo_debug"
+                    candidate = debug_root / relative
+                    try:
+                        if candidate.is_symlink():
+                            continue
+                        resolved_root = debug_root.resolve(strict=False)
+                        resolved = candidate.resolve(strict=True)
+                        if resolved == resolved_root or resolved_root not in resolved.parents:
+                            continue
+                        if not resolved.is_file():
+                            continue
+                        size = resolved.stat().st_size
+                        if size > min(max_payload_bytes, remaining):
+                            metadata["content_truncated"] = True
+                            metadata["content_limit"] = min(max_payload_bytes, remaining)
+                            break
+                        raw = resolved.read_bytes()
+                    except (OSError, RuntimeError, ValueError):
+                        continue
+                    remaining -= len(raw)
+                    encoding = str(metadata.get("encoding") or "utf-8").lower()
+                    if encoding in {"base64", "binary"} or str(metadata.get("mime_type") or "").startswith("image/"):
+                        metadata["content_base64"] = base64.b64encode(raw).decode("ascii")
+                    else:
+                        metadata["content"] = raw.decode("utf-8", "replace")
+                    break
+
+    @staticmethod
+    def _photo_debug_event_timestamp(value: Mapping[str, Any]) -> float:
+        try:
+            timestamp = float(value.get("ts") or 0)
+        except (TypeError, ValueError, OverflowError):
+            return 0.0
+        return timestamp if math.isfinite(timestamp) and timestamp > 0 else 0.0
+
+    @staticmethod
+    def _photo_debug_event_sequence(value: Mapping[str, Any]) -> int:
+        """Parse an event sequence without letting malformed logs abort reads."""
+        try:
+            raw = value.get("seq")
+            if raw in (None, ""):
+                return 0
+            return int(raw)
+        except (TypeError, ValueError, OverflowError):
+            return 0
+
+    @staticmethod
+    def _photo_debug_event_fingerprint(value: Mapping[str, Any]) -> str:
+        """Return the source-independent portion of a generation event.
+
+        Legacy TXT and unified JSONL records deliberately differ in envelope
+        fields such as sequence, timestamp and severity. The bridge writes
+        both records for one operation, so use only the shared semantic fields
+        to find those pairs. Optional route metadata remains included when it
+        is present, preventing unrelated engine events from being coalesced.
+        """
+        fingerprint: dict[str, Any] = {
+            "stage": str(value.get("stage") or ""),
+            "status": str(value.get("status") or ""),
+            "context": value.get("context"),
+            "data": value.get("data"),
+        }
+        for key in (
+            "operation",
+            "workflow",
+            "backend",
+            "route",
+            "attempt",
+            "error_code",
+            "failure_stage",
+        ):
+            item = value.get(key)
+            if item not in (None, ""):
+                fingerprint[key] = item
+        return hashlib.sha256(
+            json.dumps(
+                fingerprint,
+                ensure_ascii=False,
+                sort_keys=True,
+                default=str,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest()
+
+    def _recent_photo_generation_debug(
+        self,
+        *,
+        event_limit: int = 240,
+        trace_id: str = "",
+        summary_only: bool = False,
+    ) -> dict[str, Any]:
+        """Read generation events from the resolved data roots.
+
+        The collapsed status endpoint reads only file tails and returns a
+        summary. Full events are read only after the user opens the detail.
+        """
+        roots = self._image_debug_data_roots()
+        if not roots:
+            return {"enabled": False, "available": False, "path": "", "latest": {}, "traces": [], "events": []}
+        candidates: list[tuple[Path, str, int]] = []
+        for root in roots:
+            paths = [root / "photo_generation_trace.txt"]
+            paths.extend(sorted(root.glob("photo_generation_trace.*.txt")))
+            debug_root = root / "photo_debug"
+            paths.append(debug_root / "generation.jsonl")
+            paths.extend(sorted(debug_root.glob("generation.*.jsonl")))
+            for path in paths:
+                try:
+                    resolved = path.resolve(strict=True)
+                    if path.is_symlink() or not resolved.is_file():
+                        continue
+                    if root not in resolved.parents:
+                        continue
+                    logical = str(resolved.relative_to(root)).replace("\\", "/")
+                    candidates.append((resolved, logical, 2 if logical.startswith("photo_debug/generation") else 1))
+                except (OSError, RuntimeError, ValueError):
+                    continue
+        unique: dict[str, tuple[Path, str, int]] = {
+            str(path).casefold(): (path, logical, rank)
+            for path, logical, rank in candidates
+        }
+        paths = list(unique.values())
+        if not paths:
+            return {"enabled": False, "available": False, "path": "", "latest": {}, "traces": [], "events": []}
+        requested_trace = self._single_line(trace_id, 80)
+        # Preserve same-source repetitions: retries and fallbacks can visit
+        # the same stage more than once. Only combine the paired records that
+        # the migration bridge writes to the legacy and unified log formats.
+        records: list[tuple[int, dict[str, Any]]] = []
+        records_by_event_id: dict[tuple[str, str], int] = {}
+        records_by_fingerprint: dict[tuple[str, str], list[int]] = {}
+        try:
+            for path, logical, rank in paths:
+                for line in self._read_debug_lines(path, tail_lines=256 if summary_only else None):
+                    try:
+                        value = json.loads(line)
+                    except (TypeError, ValueError, json.JSONDecodeError):
+                        continue
+                    if not isinstance(value, dict):
+                        continue
+                    trace = self._single_line(value.get("trace") or value.get("trace_id"), 80)
+                    if not trace or (requested_trace and trace != requested_trace):
+                        continue
+                    value["trace"] = trace
+                    value["source_file"] = logical
+                    event_id = self._single_line(value.get("event_id"), 120)
+                    seq = self._photo_debug_event_sequence(value)
+                    if event_id:
+                        event_key = (trace, event_id)
+                        existing_index = records_by_event_id.get(event_key)
+                        if existing_index is not None:
+                            existing_rank, _existing = records[existing_index]
+                            if rank >= existing_rank:
+                                records[existing_index] = (rank, value)
+                            continue
+
+                    fingerprint = self._photo_debug_event_fingerprint(value)
+                    pair_key = (trace, fingerprint)
+                    timestamp = self._photo_debug_event_timestamp(value)
+                    bridge_index: int | None = None
+                    bridge_distance: tuple[int, float] | None = None
+                    for candidate_index in records_by_fingerprint.get(pair_key, []):
+                        candidate_rank, candidate = records[candidate_index]
+                        if candidate_rank == rank:
+                            continue
+                        candidate_seq = self._photo_debug_event_sequence(candidate)
+                        candidate_timestamp = self._photo_debug_event_timestamp(candidate)
+                        # A bridge normally keeps the sequence aligned. A
+                        # short timestamp window covers migration paths with
+                        # independent counters while preserving older repeats.
+                        same_seq = bool(seq and candidate_seq and seq == candidate_seq)
+                        close_in_time = bool(
+                            timestamp
+                            and candidate_timestamp
+                            and abs(timestamp - candidate_timestamp) <= 1.0
+                        )
+                        if not same_seq and not close_in_time:
+                            continue
+                        distance = (0 if same_seq else 1, abs(timestamp - candidate_timestamp))
+                        if bridge_distance is None or distance < bridge_distance:
+                            bridge_index = candidate_index
+                            bridge_distance = distance
+                    if bridge_index is not None:
+                        existing_rank, _existing = records[bridge_index]
+                        if rank >= existing_rank:
+                            records[bridge_index] = (rank, value)
+                        if event_id:
+                            records_by_event_id[(trace, event_id)] = bridge_index
+                        continue
+
+                    record_index = len(records)
+                    records.append((rank, value))
+                    if event_id:
+                        records_by_event_id[(trace, event_id)] = record_index
+                    records_by_fingerprint.setdefault(pair_key, []).append(record_index)
+        except (OSError, UnicodeError):
+            return {"enabled": True, "available": False, "path": paths[0][1], "latest": {}, "traces": [], "events": []}
+        # New JSONL events win when the same legacy event was dual-written,
+        # while older unique legacy events remain available for a complete
+        # trace across a migration boundary.
+        events = [value for _rank, value in records]
+        events.sort(key=lambda item: (
+            self._photo_debug_event_timestamp(item),
+            self._photo_debug_event_sequence(item),
+        ))
+        limit = max(1, min(1000, int(event_limit)))
+        events = events[-limit:]
+        trace_rows: dict[str, dict[str, Any]] = {}
+        for event in events:
+            trace = self._single_line(event.get("trace"), 80)
+            row = trace_rows.pop(trace, None)
+            if row is None:
+                row = {
+                    "trace": trace,
+                    "started_at": event.get("time") or event.get("ts"),
+                    "last_at": event.get("time") or event.get("ts"),
+                    "stage": "",
+                    "status": "",
+                    "event_count": 0,
+                }
+            row["last_at"] = event.get("time") or event.get("ts")
+            row["stage"] = self._single_line(event.get("stage"), 80)
+            row["status"] = self._single_line(event.get("status"), 30)
+            row["event_count"] = self._int(row.get("event_count"), 0) + 1
+            # Reinsert on every event so insertion order reflects each Trace's
+            # most recent event rather than its first appearance.
+            trace_rows[trace] = row
+        traces = list(trace_rows.values())[-24:]
+        latest = events[-1] if events else {}
+        if summary_only:
+            latest = {
+                key: latest.get(key)
+                for key in (
+                    "trace", "trace_id", "request_id", "seq", "time", "ts", "elapsed_ms",
+                    "stage", "status", "severity", "backend", "workflow", "route", "attempt",
+                    "error_code", "failure_stage",
+                )
+                if key in latest
+            }
+        return {
+            "enabled": True,
+            "available": bool(events),
+            "path": paths[0][1],
+            "sources": [logical for _path, logical, _rank in paths],
+            "latest": latest,
+            "traces": traces,
+            "events": [] if summary_only else events,
+        }
+
     async def get_image_extension_status(self) -> dict[str, Any]:
         """Expose the split image runtime through the companion-owned page."""
         getter = getattr(self.plugin, "_image_companion_api", None)
@@ -6615,7 +7057,45 @@ class PrivateCompanionPageApi(
         status.setdefault("installed", True)
         status.setdefault("available", bool(status.get("enabled")))
         status.setdefault("state", "managed")
+        debug_summary = self._recent_photo_generation_debug(
+            event_limit=240,
+            summary_only=True,
+        )
+        status["photo_debug"] = debug_summary
         return self._ok(status)
+
+    async def get_image_debug(self) -> dict[str, Any]:
+        """Return full recent image debug events only when the panel expands them."""
+        try:
+            limit = self._int(request.args.get("limit"), 240, 1, 1000)
+            trace_id = self._single_line(request.args.get("trace"), 80)
+            payload = self._recent_photo_generation_debug(
+                event_limit=limit,
+                trace_id=trace_id,
+            )
+            if trace_id:
+                summary = self._recent_photo_generation_debug(
+                    event_limit=240,
+                    summary_only=True,
+                )
+                # Keep the recent trace chooser intact after loading one
+                # selected trace; only the event body is trace-scoped.
+                payload["traces"] = summary.get("traces", [])
+                payload["latest"] = payload["events"][-1] if payload["events"] else {}
+            if isinstance(payload.get("events"), list):
+                self._attach_debug_payload_contents(
+                    payload["events"],
+                    self._image_debug_data_roots(),
+                )
+            payload["requested_trace"] = trace_id
+            return self._ok(payload)
+        except Exception as exc:
+            logger.warning(
+                "[PrivateCompanionPage] 读取生图 debug 失败: %s",
+                self._single_line(exc, 180),
+                exc_info=True,
+            )
+            return self._exception_error("读取生图 debug 失败")
 
     async def get_image_api_status(self) -> dict[str, Any]:
         try:

--- a/pages/companion-panel/app.css
+++ b/pages/companion-panel/app.css
@@ -460,6 +460,92 @@
   .reaction-asset-card { transition: none; }
 }
 
+.image-runtime-debug {
+  margin-top: 18px;
+  border-top: 1px solid var(--line, rgba(120, 130, 150, .2));
+  padding-top: 16px;
+}
+
+.image-runtime-debug-latest {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+  margin: 10px 0;
+}
+
+.image-runtime-debug-latest > div {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  padding: 10px 12px;
+  border: 1px solid var(--line, rgba(120, 130, 150, .2));
+  border-radius: 6px;
+}
+
+.image-runtime-debug-latest span {
+  color: var(--muted, #78808d);
+  font-size: .78rem;
+}
+
+.image-runtime-debug-latest b {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.image-runtime-debug-details {
+  margin-top: 10px;
+  border: 1px solid var(--line, rgba(120, 130, 150, .2));
+  border-radius: 6px;
+  padding: 10px 12px;
+}
+
+.image-runtime-debug-details summary {
+  cursor: pointer;
+  color: var(--accent, #5b6ee1);
+  font-weight: 600;
+}
+
+.image-runtime-debug-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.image-runtime-debug-controls select {
+  min-width: 240px;
+  max-width: 100%;
+}
+
+.image-runtime-debug-log {
+  max-height: 520px;
+  overflow: auto;
+  margin: 12px 0 0;
+  padding: 12px;
+  background: rgba(20, 24, 32, .06);
+  border-radius: 4px;
+  font: 12px/1.55 ui-monospace, SFMono-Regular, Consolas, monospace;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+@media (max-width: 760px) {
+  .image-runtime-debug-latest {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .image-runtime-debug-controls {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .image-runtime-debug-controls select {
+    min-width: 0;
+    width: 100%;
+  }
+}
+
 /* Reaction library v2: image-first catalog with visible analysis state. */
 .reaction-library-workspace {
   gap: 12px;

--- a/pages/companion-panel/app.js
+++ b/pages/companion-panel/app.js
@@ -159,6 +159,8 @@ const state = {
   imageApiStatus: null,
   imageExtensionStatus: null,
   imageExtensionError: "",
+  imageDebugTrace: "",
+  imageDebugExpanded: false,
   imageApiEndpointTestResults: {},
   proactiveCandidateFilter: "all",
   imageCacheItems: [],
@@ -6991,6 +6993,7 @@ function renderImageRuntimeStatus() {
   setText("imageRuntimeBackend", latest.backend || "-");
   setText("imageRuntimeResult", latest.success === true ? "成功" : latest.success === false ? "失败" : "-");
   setText("imageRuntimeNote", latest.note || "-");
+  renderImageRuntimeDebug(value);
 
   const engine = document.getElementById("imageRuntimeEngine");
   if (!engine) return;
@@ -7012,6 +7015,77 @@ function renderImageRuntimeStatus() {
   engine.innerHTML = entries.length
     ? entries.map(([key, item]) => `<div><dt>${escapeHtml(labelMap[key] || key)}</dt><dd>${escapeHtml(String(item))}</dd></div>`).join("")
     : '<div><dt>诊断</dt><dd>暂无统一引擎摘要</dd></div>';
+}
+
+function renderImageRuntimeDebug(value = state.imageExtensionStatus || {}) {
+  const debug = value?.photo_debug && typeof value.photo_debug === "object"
+    ? value.photo_debug
+    : {};
+  const badge = document.getElementById("imageRuntimeDebugBadge");
+  const hint = document.getElementById("imageRuntimeDebugHint");
+  const latestTarget = document.getElementById("imageRuntimeDebugLatest");
+  const details = document.getElementById("imageRuntimeDebugDetails");
+  const select = document.getElementById("imageRuntimeDebugTraceSelect");
+  const log = document.getElementById("imageRuntimeDebugLog");
+  const events = Array.isArray(debug.events) ? debug.events : [];
+  const traces = Array.isArray(debug.traces) ? debug.traces : [];
+  const latest = debug.latest && typeof debug.latest === "object" ? debug.latest : {};
+  const debugConfig = value?.debug && typeof value.debug === "object" ? value.debug : {};
+  if (badge) {
+    badge.textContent = debugConfig.sensitive
+      ? "含敏感信息"
+      : debug.available ? "已记录" : debug.enabled ? "暂无记录" : "未启用";
+    badge.dataset.tone = debugConfig.sensitive ? "error" : debug.available ? "ready" : debug.enabled ? "warn" : "idle";
+  }
+  if (hint) {
+    hint.textContent = debugConfig.sensitive
+      ? "当前为 full_with_secrets，展开日志前请确认访问环境安全"
+      : debug.available
+      ? `最近一次摘要已就绪（${traces.length} 个 Trace），展开后按 Trace 查看完整链路`
+      : debug.enabled ? "调试文件已启用，等待下一次生图" : "调试日志未启用";
+  }
+  if (latestTarget) {
+    if (!debug.available) {
+      latestTarget.innerHTML = '<span class="muted">暂无生图调试记录</span>';
+    } else {
+      const trace = String(latest.trace || "");
+      const stage = String(latest.stage || "-");
+      const status = String(latest.status || "-");
+      const time = String(latest.time || latest.ts || "-");
+      latestTarget.innerHTML = `
+        <div><span>Trace</span><b>${escapeHtml(trace || "-")}</b></div>
+        <div><span>最后阶段</span><b>${escapeHtml(stage)}</b></div>
+        <div><span>状态</span><b>${escapeHtml(status)}</b></div>
+        <div><span>时间</span><b>${escapeHtml(time)}</b></div>`;
+    }
+  }
+  if (!select || !log || !details) return;
+  const selected = state.imageDebugTrace || String(latest.trace || traces.at(-1)?.trace || "");
+  if (select.dataset.optionsKey !== traces.map((item) => item.trace).join("|")) {
+    select.innerHTML = traces.length
+      ? traces.slice().reverse().map((item) => {
+        const trace = String(item.trace || "");
+        const label = `${trace} · ${item.stage || "-"} · ${item.status || "-"}`;
+        return `<option value="${escapeHtml(trace)}">${escapeHtml(label)}</option>`;
+      }).join("")
+      : '<option value="">暂无 Trace</option>';
+    select.dataset.optionsKey = traces.map((item) => item.trace).join("|");
+  }
+  if (selected && traces.some((item) => String(item.trace) === selected)) {
+    state.imageDebugTrace = selected;
+    select.value = selected;
+  } else if (select.options.length) {
+    state.imageDebugTrace = select.value;
+  }
+  if (!details.open) {
+    log.textContent = "展开后加载完整事件";
+    return;
+  }
+  state.imageDebugExpanded = true;
+  const selectedEvents = events.filter((event) => String(event.trace || "") === state.imageDebugTrace);
+  log.textContent = selectedEvents.length
+    ? selectedEvents.map((event) => JSON.stringify(event, null, 2)).join("\n\n")
+    : "该 Trace 暂无事件";
 }
 
 function renderQzonePanel() {
@@ -7195,6 +7269,27 @@ async function loadImageExtensionStatus(force = false) {
     if (state.activeTab === "image") renderImageRuntimeStatus();
   }
   return state.imageExtensionStatus;
+}
+
+async function loadImageDebug(trace = "") {
+  const params = new URLSearchParams({ limit: "240" });
+  if (trace) params.set("trace", trace);
+  const payload = await fetchJson(`/image/debug?${params.toString()}`);
+  if (state.imageExtensionStatus && payload && typeof payload === "object") {
+    const summary = state.imageExtensionStatus.photo_debug && typeof state.imageExtensionStatus.photo_debug === "object"
+      ? state.imageExtensionStatus.photo_debug
+      : {};
+    // Keep the collapsed card anchored to the latest generation. The expanded
+    // endpoint may be scoped to an older Trace and only owns its event body.
+    state.imageExtensionStatus.photo_debug = {
+      ...summary,
+      ...payload,
+      latest: summary.latest && typeof summary.latest === "object" ? summary.latest : payload.latest,
+      traces: Array.isArray(payload.traces) ? payload.traces : summary.traces,
+    };
+  }
+  renderImageRuntimeDebug(state.imageExtensionStatus || {});
+  return payload;
 }
 
 async function loadRoleplayPersonas(force = false) {
@@ -36381,6 +36476,28 @@ document.getElementById("imageRuntimeRefreshBtn")?.addEventListener("click", asy
 
 document.getElementById("imageRuntimeConfigBtn")?.addEventListener("click", () => {
   openModelConfigSection("image");
+});
+
+document.getElementById("imageRuntimeDebugDetails")?.addEventListener("toggle", (event) => {
+  state.imageDebugExpanded = Boolean(event.currentTarget.open);
+  if (state.imageDebugExpanded) {
+    const trace = state.imageDebugTrace || state.imageExtensionStatus?.photo_debug?.latest?.trace || "";
+    loadImageDebug(trace).catch((error) => {
+      const log = document.getElementById("imageRuntimeDebugLog");
+      if (log) log.textContent = `读取 debug 失败：${error?.message || "未知错误"}`;
+    });
+  } else {
+    renderImageRuntimeDebug(state.imageExtensionStatus || {});
+  }
+});
+
+document.getElementById("imageRuntimeDebugTraceSelect")?.addEventListener("change", (event) => {
+  state.imageDebugTrace = String(event.currentTarget.value || "");
+  if (state.imageDebugExpanded) {
+    loadImageDebug(state.imageDebugTrace).catch(() => {});
+  } else {
+    renderImageRuntimeDebug(state.imageExtensionStatus || {});
+  }
 });
 
 document.addEventListener("click", (event) => {

--- a/pages/companion-panel/index.html
+++ b/pages/companion-panel/index.html
@@ -1825,6 +1825,26 @@ QQ空间 = 公开札记
             <dl id="imageRuntimeEngine" class="image-runtime-list"></dl>
           </section>
         </div>
+        <section class="image-runtime-debug" aria-labelledby="imageRuntimeDebugTitle">
+          <div class="section-head compact">
+            <div>
+              <h3 id="imageRuntimeDebugTitle">最近生图调试</h3>
+              <span id="imageRuntimeDebugHint" class="muted">默认只显示最近一次结果</span>
+            </div>
+            <span id="imageRuntimeDebugBadge" class="module-badge">未启用</span>
+          </div>
+          <div id="imageRuntimeDebugLatest" class="image-runtime-debug-latest">
+            <span class="muted">暂无生图调试记录</span>
+          </div>
+          <details id="imageRuntimeDebugDetails" class="image-runtime-debug-details">
+            <summary>打开下拉菜单查看完整 debug 日志</summary>
+            <div class="image-runtime-debug-controls">
+              <label for="imageRuntimeDebugTraceSelect">Trace</label>
+              <select id="imageRuntimeDebugTraceSelect" aria-label="选择生图调试 Trace"></select>
+            </div>
+            <pre id="imageRuntimeDebugLog" class="image-runtime-debug-log" aria-live="polite">展开后加载完整事件</pre>
+          </details>
+        </section>
       </section>
 
       <section class="panel" id="panel-models">

--- a/pages/陪伴面板/app.css
+++ b/pages/陪伴面板/app.css
@@ -460,6 +460,92 @@
   .reaction-asset-card { transition: none; }
 }
 
+.image-runtime-debug {
+  margin-top: 18px;
+  border-top: 1px solid var(--line, rgba(120, 130, 150, .2));
+  padding-top: 16px;
+}
+
+.image-runtime-debug-latest {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+  margin: 10px 0;
+}
+
+.image-runtime-debug-latest > div {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  padding: 10px 12px;
+  border: 1px solid var(--line, rgba(120, 130, 150, .2));
+  border-radius: 6px;
+}
+
+.image-runtime-debug-latest span {
+  color: var(--muted, #78808d);
+  font-size: .78rem;
+}
+
+.image-runtime-debug-latest b {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.image-runtime-debug-details {
+  margin-top: 10px;
+  border: 1px solid var(--line, rgba(120, 130, 150, .2));
+  border-radius: 6px;
+  padding: 10px 12px;
+}
+
+.image-runtime-debug-details summary {
+  cursor: pointer;
+  color: var(--accent, #5b6ee1);
+  font-weight: 600;
+}
+
+.image-runtime-debug-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.image-runtime-debug-controls select {
+  min-width: 240px;
+  max-width: 100%;
+}
+
+.image-runtime-debug-log {
+  max-height: 520px;
+  overflow: auto;
+  margin: 12px 0 0;
+  padding: 12px;
+  background: rgba(20, 24, 32, .06);
+  border-radius: 4px;
+  font: 12px/1.55 ui-monospace, SFMono-Regular, Consolas, monospace;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+@media (max-width: 760px) {
+  .image-runtime-debug-latest {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .image-runtime-debug-controls {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .image-runtime-debug-controls select {
+    min-width: 0;
+    width: 100%;
+  }
+}
+
 /* Reaction library v2: image-first catalog with visible analysis state. */
 .reaction-library-workspace {
   gap: 12px;

--- a/pages/陪伴面板/app.js
+++ b/pages/陪伴面板/app.js
@@ -159,6 +159,8 @@ const state = {
   imageApiStatus: null,
   imageExtensionStatus: null,
   imageExtensionError: "",
+  imageDebugTrace: "",
+  imageDebugExpanded: false,
   imageApiEndpointTestResults: {},
   proactiveCandidateFilter: "all",
   imageCacheItems: [],
@@ -6991,6 +6993,7 @@ function renderImageRuntimeStatus() {
   setText("imageRuntimeBackend", latest.backend || "-");
   setText("imageRuntimeResult", latest.success === true ? "成功" : latest.success === false ? "失败" : "-");
   setText("imageRuntimeNote", latest.note || "-");
+  renderImageRuntimeDebug(value);
 
   const engine = document.getElementById("imageRuntimeEngine");
   if (!engine) return;
@@ -7012,6 +7015,77 @@ function renderImageRuntimeStatus() {
   engine.innerHTML = entries.length
     ? entries.map(([key, item]) => `<div><dt>${escapeHtml(labelMap[key] || key)}</dt><dd>${escapeHtml(String(item))}</dd></div>`).join("")
     : '<div><dt>诊断</dt><dd>暂无统一引擎摘要</dd></div>';
+}
+
+function renderImageRuntimeDebug(value = state.imageExtensionStatus || {}) {
+  const debug = value?.photo_debug && typeof value.photo_debug === "object"
+    ? value.photo_debug
+    : {};
+  const badge = document.getElementById("imageRuntimeDebugBadge");
+  const hint = document.getElementById("imageRuntimeDebugHint");
+  const latestTarget = document.getElementById("imageRuntimeDebugLatest");
+  const details = document.getElementById("imageRuntimeDebugDetails");
+  const select = document.getElementById("imageRuntimeDebugTraceSelect");
+  const log = document.getElementById("imageRuntimeDebugLog");
+  const events = Array.isArray(debug.events) ? debug.events : [];
+  const traces = Array.isArray(debug.traces) ? debug.traces : [];
+  const latest = debug.latest && typeof debug.latest === "object" ? debug.latest : {};
+  const debugConfig = value?.debug && typeof value.debug === "object" ? value.debug : {};
+  if (badge) {
+    badge.textContent = debugConfig.sensitive
+      ? "含敏感信息"
+      : debug.available ? "已记录" : debug.enabled ? "暂无记录" : "未启用";
+    badge.dataset.tone = debugConfig.sensitive ? "error" : debug.available ? "ready" : debug.enabled ? "warn" : "idle";
+  }
+  if (hint) {
+    hint.textContent = debugConfig.sensitive
+      ? "当前为 full_with_secrets，展开日志前请确认访问环境安全"
+      : debug.available
+      ? `最近一次摘要已就绪（${traces.length} 个 Trace），展开后按 Trace 查看完整链路`
+      : debug.enabled ? "调试文件已启用，等待下一次生图" : "调试日志未启用";
+  }
+  if (latestTarget) {
+    if (!debug.available) {
+      latestTarget.innerHTML = '<span class="muted">暂无生图调试记录</span>';
+    } else {
+      const trace = String(latest.trace || "");
+      const stage = String(latest.stage || "-");
+      const status = String(latest.status || "-");
+      const time = String(latest.time || latest.ts || "-");
+      latestTarget.innerHTML = `
+        <div><span>Trace</span><b>${escapeHtml(trace || "-")}</b></div>
+        <div><span>最后阶段</span><b>${escapeHtml(stage)}</b></div>
+        <div><span>状态</span><b>${escapeHtml(status)}</b></div>
+        <div><span>时间</span><b>${escapeHtml(time)}</b></div>`;
+    }
+  }
+  if (!select || !log || !details) return;
+  const selected = state.imageDebugTrace || String(latest.trace || traces.at(-1)?.trace || "");
+  if (select.dataset.optionsKey !== traces.map((item) => item.trace).join("|")) {
+    select.innerHTML = traces.length
+      ? traces.slice().reverse().map((item) => {
+        const trace = String(item.trace || "");
+        const label = `${trace} · ${item.stage || "-"} · ${item.status || "-"}`;
+        return `<option value="${escapeHtml(trace)}">${escapeHtml(label)}</option>`;
+      }).join("")
+      : '<option value="">暂无 Trace</option>';
+    select.dataset.optionsKey = traces.map((item) => item.trace).join("|");
+  }
+  if (selected && traces.some((item) => String(item.trace) === selected)) {
+    state.imageDebugTrace = selected;
+    select.value = selected;
+  } else if (select.options.length) {
+    state.imageDebugTrace = select.value;
+  }
+  if (!details.open) {
+    log.textContent = "展开后加载完整事件";
+    return;
+  }
+  state.imageDebugExpanded = true;
+  const selectedEvents = events.filter((event) => String(event.trace || "") === state.imageDebugTrace);
+  log.textContent = selectedEvents.length
+    ? selectedEvents.map((event) => JSON.stringify(event, null, 2)).join("\n\n")
+    : "该 Trace 暂无事件";
 }
 
 function renderQzonePanel() {
@@ -7195,6 +7269,27 @@ async function loadImageExtensionStatus(force = false) {
     if (state.activeTab === "image") renderImageRuntimeStatus();
   }
   return state.imageExtensionStatus;
+}
+
+async function loadImageDebug(trace = "") {
+  const params = new URLSearchParams({ limit: "240" });
+  if (trace) params.set("trace", trace);
+  const payload = await fetchJson(`/image/debug?${params.toString()}`);
+  if (state.imageExtensionStatus && payload && typeof payload === "object") {
+    const summary = state.imageExtensionStatus.photo_debug && typeof state.imageExtensionStatus.photo_debug === "object"
+      ? state.imageExtensionStatus.photo_debug
+      : {};
+    // Keep the collapsed card anchored to the latest generation. The expanded
+    // endpoint may be scoped to an older Trace and only owns its event body.
+    state.imageExtensionStatus.photo_debug = {
+      ...summary,
+      ...payload,
+      latest: summary.latest && typeof summary.latest === "object" ? summary.latest : payload.latest,
+      traces: Array.isArray(payload.traces) ? payload.traces : summary.traces,
+    };
+  }
+  renderImageRuntimeDebug(state.imageExtensionStatus || {});
+  return payload;
 }
 
 async function loadRoleplayPersonas(force = false) {
@@ -36381,6 +36476,28 @@ document.getElementById("imageRuntimeRefreshBtn")?.addEventListener("click", asy
 
 document.getElementById("imageRuntimeConfigBtn")?.addEventListener("click", () => {
   openModelConfigSection("image");
+});
+
+document.getElementById("imageRuntimeDebugDetails")?.addEventListener("toggle", (event) => {
+  state.imageDebugExpanded = Boolean(event.currentTarget.open);
+  if (state.imageDebugExpanded) {
+    const trace = state.imageDebugTrace || state.imageExtensionStatus?.photo_debug?.latest?.trace || "";
+    loadImageDebug(trace).catch((error) => {
+      const log = document.getElementById("imageRuntimeDebugLog");
+      if (log) log.textContent = `读取 debug 失败：${error?.message || "未知错误"}`;
+    });
+  } else {
+    renderImageRuntimeDebug(state.imageExtensionStatus || {});
+  }
+});
+
+document.getElementById("imageRuntimeDebugTraceSelect")?.addEventListener("change", (event) => {
+  state.imageDebugTrace = String(event.currentTarget.value || "");
+  if (state.imageDebugExpanded) {
+    loadImageDebug(state.imageDebugTrace).catch(() => {});
+  } else {
+    renderImageRuntimeDebug(state.imageExtensionStatus || {});
+  }
 });
 
 document.addEventListener("click", (event) => {

--- a/pages/陪伴面板/index.html
+++ b/pages/陪伴面板/index.html
@@ -1825,6 +1825,26 @@ QQ空间 = 公开札记
             <dl id="imageRuntimeEngine" class="image-runtime-list"></dl>
           </section>
         </div>
+        <section class="image-runtime-debug" aria-labelledby="imageRuntimeDebugTitle">
+          <div class="section-head compact">
+            <div>
+              <h3 id="imageRuntimeDebugTitle">最近生图调试</h3>
+              <span id="imageRuntimeDebugHint" class="muted">默认只显示最近一次结果</span>
+            </div>
+            <span id="imageRuntimeDebugBadge" class="module-badge">未启用</span>
+          </div>
+          <div id="imageRuntimeDebugLatest" class="image-runtime-debug-latest">
+            <span class="muted">暂无生图调试记录</span>
+          </div>
+          <details id="imageRuntimeDebugDetails" class="image-runtime-debug-details">
+            <summary>打开下拉菜单查看完整 debug 日志</summary>
+            <div class="image-runtime-debug-controls">
+              <label for="imageRuntimeDebugTraceSelect">Trace</label>
+              <select id="imageRuntimeDebugTraceSelect" aria-label="选择生图调试 Trace"></select>
+            </div>
+            <pre id="imageRuntimeDebugLog" class="image-runtime-debug-log" aria-live="polite">展开后加载完整事件</pre>
+          </details>
+        </section>
       </section>
 
       <section class="panel" id="panel-models">

--- a/tests/test_image_debug_page_api.py
+++ b/tests/test_image_debug_page_api.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import math
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+
+class _Logger:
+    def __getattr__(self, _name: str):
+        return lambda *_args, **_kwargs: None
+
+
+def _runtime_stubs() -> dict[str, types.ModuleType]:
+    astrbot = types.ModuleType("astrbot")
+    astrbot.__path__ = []
+    api = types.ModuleType("astrbot.api")
+    api.__path__ = []
+    api_event = types.ModuleType("astrbot.api.event")
+    core = types.ModuleType("astrbot.core")
+    core.__path__ = []
+    utils = types.ModuleType("astrbot.core.utils")
+    utils.__path__ = []
+    astrbot_path = types.ModuleType("astrbot.core.utils.astrbot_path")
+    quart = types.ModuleType("quart")
+
+    api.logger = _Logger()
+    api_event.MessageChain = list
+    astrbot_path.get_astrbot_data_path = tempfile.gettempdir
+    quart.request = SimpleNamespace(args={})
+
+    async def send_file(*_args, **_kwargs):
+        return None
+
+    quart.send_file = send_file
+    astrbot.api = api
+    astrbot.core = core
+    api.event = api_event
+    core.utils = utils
+    utils.astrbot_path = astrbot_path
+    return {
+        "astrbot": astrbot,
+        "astrbot.api": api,
+        "astrbot.api.event": api_event,
+        "astrbot.core": core,
+        "astrbot.core.utils": utils,
+        "astrbot.core.utils.astrbot_path": astrbot_path,
+        "quart": quart,
+    }
+
+
+with mock.patch.dict(sys.modules, _runtime_stubs()):
+    package_name = "astrbot_plugin_private_companion"
+    if package_name not in sys.modules:
+        package = types.ModuleType(package_name)
+        package.__path__ = [str(Path(__file__).resolve().parents[1])]
+        package.__package__ = package_name
+        sys.modules[package_name] = package
+    from astrbot_plugin_private_companion.page_api import PrivateCompanionPageApi
+    PAGE_API_MODULE = sys.modules["astrbot_plugin_private_companion.page_api"]
+
+
+class _ImageApi:
+    def __init__(self, data_dir: Path) -> None:
+        self.data_dir = data_dir
+
+    def status(self) -> dict[str, object]:
+        return {
+            "installed": True,
+            "enabled": True,
+            "available": True,
+            "state": "managed",
+            "debug": {"enabled": True, "capture_mode": "redacted", "sensitive": False},
+        }
+
+    def debug_data_dirs(self, _owner: object) -> list[str]:
+        return [str(self.data_dir)]
+
+
+class _Plugin:
+    def __init__(self, data_dir: Path) -> None:
+        self.data_dir = str(data_dir)
+        self._api = _ImageApi(data_dir)
+
+    def _image_companion_api(self) -> _ImageApi:
+        return self._api
+
+
+def _event(
+    *,
+    trace: str,
+    seq: int,
+    ts: float,
+    stage: str = "backend_submit",
+    status: str = "ok",
+    source: str = "legacy",
+) -> dict[str, object]:
+    event: dict[str, object] = {
+        "schema_version": 1,
+        "trace": trace,
+        "seq": seq,
+        "ts": ts,
+        "time": "2026-08-20T12:00:00+00:00",
+        "elapsed_ms": 12,
+        "stage": stage,
+        "status": status,
+        "context": {"session": "FriendMessage:10001"},
+        "data": {"prompt": "a quiet room"},
+    }
+    if source == "unified":
+        event.pop("trace")
+        event["trace_id"] = trace
+        event["request_id"] = trace
+        event["event_id"] = f"event-{trace}-{seq}"
+        event["severity"] = "info"
+        event.update(
+            {
+                "operation": "",
+                "workflow": "",
+                "backend": "",
+                "route": "",
+                "attempt": None,
+                "error_code": "",
+                "failure_stage": "",
+            }
+        )
+    return event
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(json.dumps(row, ensure_ascii=False) for row in rows) + "\n",
+        encoding="utf-8",
+    )
+
+
+class ImageDebugPageApiTests(unittest.TestCase):
+    def _api(self, data_dir: Path) -> PrivateCompanionPageApi:
+        return PrivateCompanionPageApi(_Plugin(data_dir))
+
+    def test_status_returns_only_latest_summary_without_event_payloads(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            _write_jsonl(
+                root / "photo_debug" / "generation.jsonl",
+                [_event(trace="trace-latest", seq=1, ts=1001.0, source="unified")],
+            )
+            result = asyncio.run(self._api(root).get_image_extension_status())
+
+        debug = result["data"]["photo_debug"]
+        self.assertEqual(debug["events"], [])
+        self.assertEqual(debug["latest"]["trace"], "trace-latest")
+        self.assertNotIn("data", debug["latest"])
+        self.assertNotIn(str(root), repr(debug))
+
+    def test_expanded_trace_returns_full_selected_events_and_all_trace_options(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            _write_jsonl(
+                root / "photo_debug" / "generation.jsonl",
+                [
+                    _event(trace="trace-first", seq=1, ts=1000.0, source="unified"),
+                    _event(trace="trace-latest", seq=1, ts=1001.0, source="unified"),
+                ],
+            )
+            api = self._api(root)
+            request_stub = SimpleNamespace(args={"trace": "trace-first", "limit": "240"})
+            with mock.patch.object(PAGE_API_MODULE, "request", request_stub):
+                result = asyncio.run(api.get_image_debug())
+
+        payload = result["data"]
+        self.assertEqual(payload["requested_trace"], "trace-first")
+        self.assertEqual([item["trace"] for item in payload["events"]], ["trace-first"])
+        self.assertEqual({item["trace"] for item in payload["traces"]}, {"trace-first", "trace-latest"})
+        self.assertEqual(payload["events"][0]["data"]["prompt"], "a quiet room")
+
+    def test_expanded_trace_includes_safe_payload_sidecar_contents(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            sidecar = root / "photo_debug" / "traces" / "trace-payload" / "payloads" / "request_1.json"
+            sidecar.parent.mkdir(parents=True, exist_ok=True)
+            sidecar.write_text('{"prompt":"full body","api_key":"secret"}', encoding="utf-8")
+            row = _event(trace="trace-payload", seq=1, ts=1000.0, source="unified")
+            row["data"] = {
+                "payloads": {
+                    "request": {
+                        "captured": True,
+                        "path": "traces/trace-payload/payloads/request_1.json",
+                        "mime_type": "application/json",
+                        "encoding": "utf-8",
+                    }
+                }
+            }
+            _write_jsonl(root / "photo_debug" / "generation.jsonl", [row])
+            request_stub = SimpleNamespace(args={"trace": "trace-payload", "limit": "240"})
+            with mock.patch.object(PAGE_API_MODULE, "request", request_stub):
+                result = asyncio.run(self._api(root).get_image_debug())
+
+        metadata = result["data"]["events"][0]["data"]["payloads"]["request"]
+        self.assertIn('"prompt":"full body"', metadata["content"])
+        self.assertIn('"api_key":"secret"', metadata["content"])
+
+    def test_dual_written_events_are_coalesced_even_with_independent_sequences(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            _write_jsonl(
+                root / "photo_generation_trace.txt",
+                [_event(trace="trace-a", seq=4, ts=1000.00)],
+            )
+            _write_jsonl(
+                root / "photo_debug" / "generation.jsonl",
+                [_event(trace="trace-a", seq=99, ts=1000.35, source="unified")],
+            )
+            payload = self._api(root)._recent_photo_generation_debug()
+
+        self.assertEqual(len(payload["events"]), 1)
+        self.assertEqual(payload["events"][0]["source_file"], "photo_debug/generation.jsonl")
+
+    def test_same_source_repeated_stage_is_retained(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            _write_jsonl(
+                root / "photo_generation_trace.txt",
+                [
+                    _event(trace="trace-a", seq=1, ts=1000.0),
+                    _event(trace="trace-a", seq=2, ts=1000.1),
+                ],
+            )
+            payload = self._api(root)._recent_photo_generation_debug()
+
+        self.assertEqual(len(payload["events"]), 2)
+        self.assertEqual(payload["traces"][0]["event_count"], 2)
+
+    def test_tail_reader_handles_utf8_long_line_and_empty_file(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            empty = root / "empty.jsonl"
+            empty.write_bytes(b"")
+            long_line = root / "long.jsonl"
+            long_line.write_text(json.dumps({"text": "生图" * 25000}, ensure_ascii=False) + "\n", encoding="utf-8")
+
+            self.assertEqual(PrivateCompanionPageApi._read_debug_lines(empty, tail_lines=8), [])
+            lines = PrivateCompanionPageApi._read_debug_lines(long_line, tail_lines=1)
+
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(json.loads(lines[0])["text"][:2], "生图")
+
+    def test_symbolic_link_debug_file_is_not_read(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            outside = root.parent / f"image-debug-outside-{os.getpid()}.jsonl"
+            _write_jsonl(outside, [_event(trace="trace-outside", seq=1, ts=1000.0)])
+            link = root / "photo_debug" / "generation.jsonl"
+            link.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                os.symlink(outside, link)
+            except OSError:
+                self.skipTest("当前环境不允许创建符号链接")
+            try:
+                payload = self._api(root)._recent_photo_generation_debug()
+            finally:
+                outside.unlink(missing_ok=True)
+
+        self.assertFalse(payload["available"])
+        self.assertEqual(payload["events"], [])
+
+    def test_timestamp_rejects_non_finite_values(self) -> None:
+        self.assertEqual(PrivateCompanionPageApi._photo_debug_event_timestamp({"ts": "bad"}), 0.0)
+        self.assertEqual(PrivateCompanionPageApi._photo_debug_event_timestamp({"ts": math.inf}), 0.0)
+
+    def test_malformed_timestamp_and_sequence_do_not_break_debug_reads(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            malformed = _event(trace="trace-bad", seq=1, ts=1000.0)
+            malformed["ts"] = "not-a-number"
+            malformed["seq"] = "bad"
+            valid = _event(trace="trace-good", seq=2, ts=1001.0)
+            _write_jsonl(root / "photo_debug" / "generation.jsonl", [malformed, valid])
+
+            payload = self._api(root)._recent_photo_generation_debug()
+
+        self.assertEqual([item["trace"] for item in payload["events"]], ["trace-bad", "trace-good"])
+        self.assertEqual(PrivateCompanionPageApi._photo_debug_event_sequence({"seq": "bad"}), 0)
+        self.assertEqual(PrivateCompanionPageApi._photo_debug_event_sequence({"seq": float("nan")}), 0)
+
+    def test_trace_options_keep_latest_trace_after_last_event_sorting(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            rows = [
+                _event(trace=f"trace-{index}", seq=1, ts=1000.0 + index)
+                for index in range(25)
+            ]
+            # This Trace first appeared early but finished after all newer
+            # Trace IDs, so it must remain in the 24-item chooser.
+            rows.append(_event(trace="trace-0", seq=2, ts=2000.0, stage="completed", status="completed"))
+            _write_jsonl(root / "photo_debug" / "generation.jsonl", rows)
+
+            payload = self._api(root)._recent_photo_generation_debug()
+
+        trace_ids = [item["trace"] for item in payload["traces"]]
+        self.assertEqual(payload["latest"]["trace"], "trace-0")
+        self.assertIn("trace-0", trace_ids)
+        self.assertEqual(len(trace_ids), 24)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an image debug API for recent trace summaries, full event streams and payload sidecars
- keep the image parent panel compact by showing only the latest generation summary by default
- load the complete debug trace only after expanding the details dropdown
- mirror the UI in both companion-panel and 陪伴面板 copies

## Verification
- python -m unittest tests.test_image_debug_page_api (10 tests, 1 skipped)
- Python/JavaScript syntax checks and git diff --check passed

## Related
- Image runtime/debug tracing PR: https://github.com/menglimi/astrbot_plugin_image_companion/pull/4