### PR TITLE
fix: 修复上下文图片来源回流与重复识图

### DIFF
--- a/private_image.py
+++ b/private_image.py
@@ -3801,6 +3801,20 @@ class PrivateImageMixin:
                     add(source)
         return sources
 
+    def _context_image_source_is_resolvable(self, source: Any) -> bool:
+        """Return whether a context image source is directly resolvable."""
+
+        text = str(source or "").strip()
+        if not text:
+            return False
+        if re.match(r"^https?://", text, flags=re.I) or text.startswith(("data:", "base64://")):
+            return True
+        path = self._private_image_local_path_from_source(text)
+        try:
+            return path is not None and path.exists() and path.is_file()
+        except (OSError, ValueError):
+            return False
+
     def _replace_context_image_placeholder(self, value: Any, replacement: str, *, depth: int = 0) -> tuple[Any, bool]:
         if value is None or depth > 5:
             return value, False
@@ -3928,19 +3942,22 @@ class PrivateImageMixin:
                 items = getter(row)
             except Exception:
                 items = []
+        normalized_items = items if isinstance(items, list) else []
         sources: list[str] = []
-        for item in items if isinstance(items, list) else []:
+        for item in normalized_items:
             if not isinstance(item, dict):
                 continue
             source = str(item.get("source") or "").strip()
             tier = _single_line(item.get("tier"), 40)
             if source and tier not in {"placeholder", "platform_file"} and source not in sources:
                 sources.append(source)
-        if sources:
+        # Structured snapshots are authoritative. Falling back after filtering
+        # would reintroduce platform file IDs from the legacy ``images`` field.
+        if normalized_items:
             return sources[:5]
         for source in row.get("images") if isinstance(row.get("images"), list) else []:
             text = str(source or "").strip()
-            if text and text not in sources:
+            if text and self._context_image_source_is_resolvable(text) and text not in sources:
                 sources.append(text)
         return sources[:5]
 
@@ -4032,16 +4049,21 @@ class PrivateImageMixin:
         used_rows: set[str] = set()
         caption_cache: dict[tuple[str, ...], str] = {}
         changed = False
+        attempted = 0
         replaced = 0
         missed = 0
         updated_contexts = list(contexts)
         umo = str(getattr(event, "unified_msg_origin", "") or "")
 
         for index, item in enumerate(contexts):
-            if replaced >= max_items:
+            if attempted >= max_items:
                 break
             text = self._context_image_plain_text(item)
-            inline_sources = self._context_image_inline_sources(item)
+            inline_sources = [
+                source
+                for source in self._context_image_inline_sources(item)
+                if self._context_image_source_is_resolvable(source)
+            ]
             has_placeholder = self._context_image_has_placeholder(text)
             if not has_placeholder and not inline_sources:
                 continue
@@ -4054,10 +4076,14 @@ class PrivateImageMixin:
                 row = self._match_context_image_recall_row(text, rows, used_rows)
                 if row:
                     sources = self._context_image_sources_from_recall_row(row)
+                    unique = _single_line(row.get("message_id"), 120)
+                    if unique:
+                        used_rows.add(unique)
             if not sources:
                 missed += 1
                 continue
 
+            attempted += 1
             cache_key = tuple(sources)
             if cache_key not in caption_cache:
                 caption = await self._caption_context_image_sources(sources, umo=umo)
@@ -4076,10 +4102,6 @@ class PrivateImageMixin:
             updated_contexts[index] = updated_item
             changed = True
             replaced += 1
-            if row:
-                unique = _single_line(row.get("message_id"), 120)
-                if unique:
-                    used_rows.add(unique)
 
         if changed:
             try:

--- a/tests/test_context_image_caption_regressions.py
+++ b/tests/test_context_image_caption_regressions.py
@@ -1,0 +1,198 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from typing import Any
+
+from astrbot_plugin_private_companion.private_image import PrivateImageMixin
+
+
+class _ContextImageHarness(PrivateImageMixin):
+    def __init__(
+        self,
+        *,
+        rows: list[dict[str, Any]] | None = None,
+        max_items: int = 12,
+        caption_results: dict[tuple[str, ...], str] | None = None,
+    ) -> None:
+        self.enable_context_image_captioning = True
+        self.context_image_caption_max_items = max_items
+        self.rows = list(rows or [])
+        self.caption_calls: list[tuple[str, ...]] = []
+        self.caption_results = dict(caption_results or {})
+
+    @staticmethod
+    def _private_image_enhancement_enabled() -> bool:
+        return True
+
+    @staticmethod
+    def _recall_image_items_from_snapshot(row: dict[str, Any]) -> list[dict[str, str]]:
+        items = row.get("image_items")
+        return list(items) if isinstance(items, list) else []
+
+    def _context_image_recall_rows_for_event(self, _event: Any) -> list[dict[str, Any]]:
+        return list(self.rows)
+
+    async def _caption_context_image_sources(
+        self,
+        sources: list[str],
+        *,
+        umo: str = "",
+    ) -> str:
+        del umo
+        cache_key = tuple(sources)
+        self.caption_calls.append(cache_key)
+        return self.caption_results.get(cache_key, "")
+
+
+def _row(index: int, source: str) -> dict[str, Any]:
+    return {
+        "message_id": f"message-{index}",
+        "text": f"第 {index} 张 [图片]",
+        "image_items": [{"source": source, "tier": "url"}],
+        "images": [source],
+    }
+
+
+def _contexts(count: int) -> list[dict[str, str]]:
+    return [
+        {"role": "user", "content": f"第 {index} 张 [图片]"}
+        for index in range(1, count + 1)
+    ]
+
+
+class ContextImageSourceRegressionTests(unittest.TestCase):
+    def test_filtered_structured_platform_file_does_not_flow_back_from_legacy_images(self) -> None:
+        source = "5A9F2D800733CFC36AC147C5AC471FDB.jpg"
+        row = {
+            "image_items": [{"source": source, "tier": "platform_file"}],
+            "images": [source],
+        }
+        harness = _ContextImageHarness()
+
+        self.assertEqual([], harness._context_image_sources_from_recall_row(row))
+
+    def test_structured_local_and_url_sources_remain_eligible(self) -> None:
+        row = {
+            "image_items": [
+                {"source": "platform-file-id.jpg", "tier": "platform_file"},
+                {"source": "C:/AstrBot/cache/image.png", "tier": "local"},
+                {"source": "https://example.invalid/image.png", "tier": "url"},
+            ],
+            "images": ["platform-file-id.jpg", "legacy-alias.jpg"],
+        }
+        harness = _ContextImageHarness()
+
+        self.assertEqual(
+            ["C:/AstrBot/cache/image.png", "https://example.invalid/image.png"],
+            harness._context_image_sources_from_recall_row(row),
+        )
+
+    def test_legacy_images_keep_url_but_drop_nonexistent_bare_file_id(self) -> None:
+        image_url = "https://example.invalid/legacy.png"
+        with TemporaryDirectory() as temp_dir:
+            local_image = Path(temp_dir) / "cached.jpg"
+            local_image.write_bytes(b"cached image fixture")
+            row = {
+                "images": [
+                    image_url,
+                    str(local_image),
+                    "NONEXISTENT_PLATFORM_FILE_7E12CE450A5445A1.jpg",
+                ]
+            }
+            harness = _ContextImageHarness()
+
+            self.assertEqual(
+                [image_url, str(local_image)],
+                harness._context_image_sources_from_recall_row(row),
+            )
+
+
+class ContextImageAttemptRegressionTests(unittest.IsolatedAsyncioTestCase):
+    async def test_inline_image_segment_drops_bare_file_alias_when_url_is_available(self) -> None:
+        image_url = "https://example.invalid/current.png"
+        harness = _ContextImageHarness(max_items=2)
+        request = SimpleNamespace(
+            contexts=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "看看这张 [图片]"},
+                        {
+                            "type": "image",
+                            "data": {
+                                "url": image_url,
+                                "file": "5A9F2D800733CFC36AC147C5AC471FDB.jpg",
+                            },
+                        },
+                    ],
+                }
+            ]
+        )
+        event = SimpleNamespace(unified_msg_origin="default:GroupMessage:10001")
+
+        await harness._enrich_request_context_image_placeholders(event, request)
+
+        self.assertEqual([(image_url,)], harness.caption_calls)
+
+    async def test_max_items_caps_caption_attempts_even_when_every_caption_fails(self) -> None:
+        rows = [_row(index, f"https://example.invalid/image-{index}.png") for index in range(1, 5)]
+        harness = _ContextImageHarness(rows=rows, max_items=2)
+        request = SimpleNamespace(contexts=_contexts(4))
+        event = SimpleNamespace(unified_msg_origin="default:GroupMessage:10001")
+
+        result = await harness._enrich_request_context_image_placeholders(event, request)
+
+        self.assertEqual(
+            [
+                ("https://example.invalid/image-1.png",),
+                ("https://example.invalid/image-2.png",),
+            ],
+            harness.caption_calls,
+        )
+        self.assertEqual(0, result["replaced"])
+
+    async def test_same_failed_source_is_captioned_only_once_per_request(self) -> None:
+        shared_source = "https://example.invalid/shared.png"
+        rows = [_row(index, shared_source) for index in range(1, 5)]
+        harness = _ContextImageHarness(rows=rows, max_items=12)
+        request = SimpleNamespace(contexts=_contexts(4))
+        event = SimpleNamespace(unified_msg_origin="default:GroupMessage:10001")
+
+        result = await harness._enrich_request_context_image_placeholders(event, request)
+
+        self.assertEqual([(shared_source,)], harness.caption_calls)
+        self.assertEqual(0, result["replaced"])
+
+    async def test_failed_recall_row_is_not_reused_by_the_next_placeholder(self) -> None:
+        first_source = "https://example.invalid/first.png"
+        second_source = "https://example.invalid/second.png"
+        rows = [_row(1, first_source), _row(2, second_source)]
+        for row in rows:
+            row["text"] = "历史图片 [图片]"
+        harness = _ContextImageHarness(
+            rows=rows,
+            max_items=4,
+            caption_results={(second_source,): "第二张图片识别成功"},
+        )
+        request = SimpleNamespace(
+            contexts=[
+                {"role": "user", "content": "看看 [图片]"},
+                {"role": "user", "content": "看看 [图片]"},
+            ]
+        )
+        event = SimpleNamespace(unified_msg_origin="default:GroupMessage:10001")
+
+        result = await harness._enrich_request_context_image_placeholders(event, request)
+
+        self.assertEqual([(first_source,), (second_source,)], harness.caption_calls)
+        self.assertEqual(1, result["replaced"])
+        self.assertEqual("看看 [图片]", request.contexts[0]["content"])
+        self.assertIn("第二张图片识别成功", request.contexts[1]["content"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题说明

OneBot/NapCat 的图片消息可能同时包含图片 URL、本地缓存路径和平台文件 ID。

插件虽然会在结构化图片信息中排除无法直接读取的 `platform_file`，但旧版 `images` 字段的兼容回退可能再次加入该文件 ID。识图失败时，补全数量上限又只统计成功次数，并且图片记录只在识图成功后才标记为已使用，从而可能造成：

- 重复处理同一图片；
- 连续等待识图超时；
- 反复输出“本地图片源不可读”及超时警告；
- 前一张图片失败后无法正确继续处理下一张。

## 修改内容

- 过滤无法解析的裸平台文件 ID，同时保留有效 URL、Base64 和真实本地文件。
- 结构化图片信息存在时不再回退到旧字段，避免被过滤的来源重新进入识图流程。
- 将 `context_image_caption_max_items` 改为限制实际处理尝试次数，识图失败也会计入上限。
- 图片记录匹配后立即标记为已使用，失败时可以继续匹配下一张图片。
- 保留现有的失败缓存、SSRF 校验和本地路径安全检查。
- 不修改主聊天模型的原生多模态图片传递路径。

## 测试

新增 7 个回归测试，覆盖：

- `platform_file` 不从旧字段重新回流；
- 有效 URL 和本地图片仍可正常使用；
- URL 与裸文件 ID 同时存在时只使用有效 URL；
- 连续失败时补全数量上限仍然生效；
- 同一失败来源单轮只调用一次；
- 第一张图片失败后可以继续处理下一张。

验证结果：

- 图片相关测试：`42 passed`
- 完整测试对照：
  - 修复分支：`3609 passed`
  - 未修改基线：`3602 passed`
  - 两者均为相同的 `41 failed, 2 skipped`，未新增失败
- Python 编译检查通过
- `git diff --check` 通过
- AstrBot 重启后实机识图测试通过
