### PR TITLE
fix: 防止 TTS 发送泄漏历史媒体内部标记

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -611,13 +611,19 @@ _ESCAPED_HISTORY_MEDIA_MARKER_PATTERN = re.compile(
 )
 
 
-def _strip_history_media_markers(text: Any) -> str:
-    """Remove internal media metadata and legacy chat-like attachment notes."""
+def _has_history_media_marker(text: Any) -> bool:
+    """Return whether text contains raw, escaped, or mutated media metadata."""
     normalized = str(text or "")
-    had_marker = bool(
+    return bool(
         _HISTORY_MEDIA_MARKER_PATTERN.search(normalized)
         or _ESCAPED_HISTORY_MEDIA_MARKER_PATTERN.search(normalized)
     )
+
+
+def _strip_history_media_markers(text: Any) -> str:
+    """Remove internal media metadata and legacy chat-like attachment notes."""
+    normalized = str(text or "")
+    had_marker = _has_history_media_marker(normalized)
     normalized = _HISTORY_MEDIA_MARKER_PATTERN.sub("", normalized)
     normalized = _ESCAPED_HISTORY_MEDIA_MARKER_PATTERN.sub("", normalized)
     normalized = re.sub(

--- a/tests/test_tts_postprocess_tag_guard.py
+++ b/tests/test_tts_postprocess_tag_guard.py
@@ -5,7 +5,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from astrbot.api.message_components import At, Plain, Record, Reply
 from astrbot_plugin_private_companion.main import PrivateCompanionPlugin
@@ -525,6 +525,35 @@ class TtsPostprocessTagGuardTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(1, len(chain))
         self.assertEqual(spoken, chain[0].text)
+
+    async def test_tts_synthesis_failure_strips_history_media_marker_from_fallback(self):
+        harness = _TtsHarness()
+        harness.tts_generation_mode = "postprocess"
+        harness.tts_voice_language = "ja"
+        harness.tts_delivery_mode = "voice_and_text"
+        harness.tts_foreign_text_mode = "translation"
+        harness.tts_frequency_control_mode = "legacy"
+        harness._resolve_tts_synthesis_provider = lambda _event, provider: provider
+        harness._tts_provider_kind = lambda *_args, **_kwargs: "generic"
+        harness._tts_record_component = AsyncMock(return_value=None)
+        harness._tts_text_needs_language_conversion = lambda *_args, **_kwargs: False
+        spoken = "……あんたまで面白がらないでよ。"
+        visible = "……怎么你也跟着起哄。"
+        marker = '<pc_history_media records="1" />'
+
+        chain = await harness._process_tts_tags(
+            f"<tts>{spoken}</tts>\n{visible} {marker}",
+            object(),
+            provider_settings={},
+            config={},
+            fallback_plain=f"{visible} {marker}",
+        )
+
+        self.assertFalse(any(isinstance(component, Record) for component in chain))
+        self.assertEqual(
+            [visible],
+            [component.text for component in chain if isinstance(component, Plain)],
+        )
 
     async def test_provider_safety_refusal_plain_text_never_enters_auto_tts(self):
         harness = _TtsHarness()
@@ -1411,12 +1440,42 @@ class TtsPostprocessTagGuardTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual("对应正文", cleaned[1].text)
         self.assertNotIn("tts", cleaned[1].text.lower())
 
+    async def test_outbound_tts_chain_removes_history_marker_and_preserves_record(self):
+        harness = _TtsHarness()
+        record = Record(file="voice.wav")
+        marker = '<pc_history_media records="1" />'
+
+        cleaned = await harness._sanitize_outbound_tts_chain_without_event(
+            [record, Plain(f"可见正文 {marker}"), Plain(marker)],
+            umo="test-session",
+        )
+
+        self.assertEqual(2, len(cleaned))
+        self.assertIs(record, cleaned[0])
+        self.assertEqual("可见正文", cleaned[1].text)
+
     def test_visible_text_removes_known_emotion_cues_but_keeps_normal_brackets(self):
         harness = _TtsHarness()
 
         cleaned = harness._sanitize_tts_visible_text("[happy][affectionate][shy]今天很开心。[公告]明天见。")
 
         self.assertEqual("今天很开心。[公告]明天见。", cleaned)
+
+    def test_visible_text_removes_internal_history_media_marker(self):
+        harness = _TtsHarness()
+        markers = (
+            '<pc_history_media records="1" />',
+            '&lt;pc_history_media records="1" /&gt;',
+            '<pc_history_media_records="1" />',
+        )
+
+        for marker in markers:
+            with self.subTest(marker=marker):
+                self.assertEqual(
+                    "可见正文",
+                    harness._sanitize_tts_visible_text(f"可见正文 {marker}"),
+                )
+                self.assertEqual("", harness._sanitize_tts_visible_text(marker))
 
     async def test_global_probability_100_converts_plain_fast_tag_reply_without_legacy_auto_voice(self):
         harness = _TtsHarness()
@@ -1542,6 +1601,152 @@ class TtsPostprocessTagGuardTests(unittest.IsolatedAsyncioTestCase):
             ["普通第一段。", "普通第二段。"],
             [chunk[0].text for chunk in sent],
         )
+
+    async def test_tts_reply_remainder_drops_history_media_marker_before_direct_send(self):
+        harness = _TtsHarness()
+        harness._event_scope_key = lambda _event: "group:10001"
+        harness._scope_has_new_inbound_activity = lambda *_args, **_kwargs: True
+        marker = '<pc_history_media records="1" />'
+        sent: list[list[object]] = []
+
+        class Event:
+            unified_msg_origin = "default:GroupMessage:10001"
+
+            @staticmethod
+            def chain_result(chain):
+                return chain
+
+            async def send(self, chain):
+                sent.append(chain)
+
+        with patch(
+            "astrbot_plugin_private_companion.tts_enhancement.asyncio.sleep",
+            new=AsyncMock(),
+        ):
+            await harness._send_tts_chain_chunks_after_first(
+                Event(),
+                [
+                    [Plain(f"……不可爱，少在这学他们复读。 {marker}")],
+                    [Plain(marker)],
+                ],
+                started_at=1.0,
+            )
+
+        self.assertEqual(
+            ["……不可爱，少在这学他们复读。"],
+            [
+                "".join(
+                    component.text
+                    for component in chunk
+                    if isinstance(component, Plain)
+                )
+                for chunk in sent
+            ],
+        )
+        self.assertNotIn(
+            "pc_history_media",
+            "".join(
+                component.text
+                for chunk in sent
+                for component in chunk
+                if isinstance(component, Plain)
+            ),
+        )
+
+    async def test_tts_reply_remainder_drops_orphan_at_and_completes_review_case(self):
+        harness = _TtsHarness()
+        harness._update_daily_review_case = Mock()
+        at = At(qq="10001")
+        sent: list[list[object]] = []
+
+        class Event:
+            unified_msg_origin = "default:GroupMessage:10001"
+            _private_companion_daily_review_case_id = "case-1"
+
+            @staticmethod
+            def chain_result(chain):
+                return chain
+
+            async def send(self, chain):
+                sent.append(chain)
+
+        with patch(
+            "astrbot_plugin_private_companion.tts_enhancement.asyncio.sleep",
+            new=AsyncMock(),
+        ):
+            await harness._send_tts_chain_chunks_after_first(
+                Event(),
+                [[at, Plain('&lt;pc_history_media records="1" /&gt;')]],
+                started_at=1.0,
+            )
+
+        self.assertEqual([], sent)
+        harness._update_daily_review_case.assert_called_once_with(
+            "case-1",
+            outcome="delivered",
+            signals={
+                "segments_expected": 1,
+                "segments_sent": 1,
+                "visible_text_complete": True,
+            },
+        )
+
+    async def test_tts_reply_remainder_preserves_mixed_component_spacing(self):
+        harness = _TtsHarness()
+        at = At(qq="10001")
+        marker = '<pc_history_media records="1" />'
+        sent: list[list[object]] = []
+
+        class Event:
+            unified_msg_origin = "default:GroupMessage:10001"
+
+            @staticmethod
+            def chain_result(chain):
+                return chain
+
+            async def send(self, chain):
+                sent.append(chain)
+
+        with patch(
+            "astrbot_plugin_private_companion.tts_enhancement.asyncio.sleep",
+            new=AsyncMock(),
+        ):
+            await harness._send_tts_chain_chunks_after_first(
+                Event(),
+                [[at, Plain(f" 正文 {marker}")]],
+                started_at=1.0,
+            )
+
+        self.assertEqual(1, len(sent))
+        self.assertIs(at, sent[0][0])
+        self.assertEqual(" 正文", sent[0][1].text)
+
+    async def test_proactive_tts_remainder_drops_mutated_history_marker(self):
+        harness = _TtsHarness()
+        harness._send_chain_components = AsyncMock()
+
+        class Event:
+            unified_msg_origin = "default:FriendMessage:10001"
+            _private_companion_proactive_delivery_umo = "default:FriendMessage:10001"
+
+            @staticmethod
+            def chain_result(chain):
+                return chain
+
+            send = AsyncMock()
+
+        with patch(
+            "astrbot_plugin_private_companion.tts_enhancement.asyncio.sleep",
+            new=AsyncMock(),
+        ):
+            await harness._send_tts_chain_chunks_after_first(
+                Event(),
+                [[Plain('<pc_history_media_records="1" />')]],
+                started_at=1.0,
+            )
+
+        harness._send_chain_components.assert_not_awaited()
+        Event.send.assert_not_awaited()
 
     def test_segmented_tts_visible_text_keeps_transcript_marker(self):
         harness = _TtsHarness()

--- a/tts_enhancement.py
+++ b/tts_enhancement.py
@@ -28,7 +28,14 @@ from astrbot.core import file_token_service
 from astrbot.core.message.message_event_result import ResultContentType
 from astrbot.core.utils.astrbot_path import get_astrbot_data_path
 
-from .helpers import _normalize_outbound_punctuation_flow, _safe_int, _single_line, _strip_nonstandard_chat_control_tags
+from .helpers import (
+    _has_history_media_marker,
+    _normalize_outbound_punctuation_flow,
+    _safe_int,
+    _single_line,
+    _strip_history_media_markers,
+    _strip_nonstandard_chat_control_tags,
+)
 from .segmented_message import (
     component_kind,
     component_order_from_owner,
@@ -1117,7 +1124,8 @@ class TtsEnhancementMixin:
         return source
 
     def _sanitize_tts_visible_text(self, text: Any, *, max_chars: int = 800) -> str:
-        cleaned = self._strip_any_tts_markup(str(text or ""))
+        cleaned = _strip_history_media_markers(str(text or ""))
+        cleaned = self._strip_any_tts_markup(cleaned)
         cleaned = self._strip_visible_tts_emotion_cues(cleaned)
         cleaned = re.sub(TTS_TAG_PATTERN, "", cleaned).strip()
         cleaned = re.sub(r"(?m)^\s*[>＞]\s*", "", cleaned).strip()
@@ -3278,7 +3286,17 @@ TTS 朗读文本：
                 cleaned_chain.append(comp)
                 continue
             original = str(getattr(comp, "text", "") or "")
-            cleaned_control = _strip_nonstandard_chat_control_tags(original)
+            if _has_history_media_marker(original):
+                cleaned_history = _strip_history_media_markers(original)
+                if cleaned_history:
+                    leading_whitespace = original[: len(original) - len(original.lstrip())]
+                    trailing_whitespace = original[len(original.rstrip()) :]
+                    cleaned_control = f"{leading_whitespace}{cleaned_history}{trailing_whitespace}"
+                else:
+                    cleaned_control = ""
+            else:
+                cleaned_control = original
+            cleaned_control = _strip_nonstandard_chat_control_tags(cleaned_control)
             cleaned_control = self._strip_visible_tts_emotion_cues(cleaned_control)
             has_tts_markup = re.search(r"</?(?:pc[_-]?tts|t{2,}s)\b", cleaned_control, flags=re.IGNORECASE)
             if not has_tts_markup:
@@ -3295,7 +3313,7 @@ TTS 朗读文本：
                 cleaned_chain.append(Plain(fallback_text))
         if changed:
             logger.warning(
-                "[PrivateCompanion] 外发兜底清理残留 TTS 标签: umo=%s preview=%s",
+                "[PrivateCompanion] 外发兜底清理残留内部控制标记: umo=%s preview=%s",
                 _single_line(umo, 120) or "unknown",
                 _single_line(self._tts_chain_log_text(cleaned_chain), 160),
             )
@@ -3576,8 +3594,55 @@ TTS 朗读文本：
         expanded_chunks: list[list[Any]] = []
         for chunk in chunks:
             expanded_chunks.extend(self._tts_segment_plain_chunk_for_ordered_send(event, chunk))
+        outbound_umo = _single_line(
+            getattr(event, "unified_msg_origin", ""),
+            160,
+        ) or "unknown"
+        sanitized_chunks: list[list[Any]] = []
+        for chunk in expanded_chunks:
+            cleaned_chunk = await self._sanitize_outbound_tts_chain_without_event(
+                chunk,
+                umo=outbound_umo,
+            )
+            if not cleaned_chunk:
+                continue
+            has_visible_plain = any(
+                isinstance(component, Plain)
+                and bool(str(getattr(component, "text", "") or "").strip())
+                for component in cleaned_chunk
+            )
+            has_delivery_component = any(
+                not isinstance(component, Plain)
+                and component_kind(component) not in {"at", "reply"}
+                for component in cleaned_chunk
+            )
+            source_had_plain = any(isinstance(component, Plain) for component in chunk)
+            if source_had_plain and not has_visible_plain and not has_delivery_component:
+                logger.warning(
+                    "[PrivateCompanion] TTS 尾段清理后仅剩孤立上下文组件,已跳过: session=%s",
+                    outbound_umo,
+                )
+                continue
+            sanitized_chunks.append(cleaned_chunk)
+        expanded_chunks = sanitized_chunks
         case_id = _single_line(getattr(event, "_private_companion_daily_review_case_id", ""), 20)
         case_updater = getattr(self, "_update_daily_review_case", None)
+        if not expanded_chunks:
+            logger.info(
+                "[PrivateCompanion] TTS 尾段清理后无可发送内容: session=%s",
+                outbound_umo,
+            )
+            if case_id and callable(case_updater):
+                case_updater(
+                    case_id,
+                    outcome="delivered",
+                    signals={
+                        "segments_expected": 1,
+                        "segments_sent": 1,
+                        "visible_text_complete": True,
+                    },
+                )
+            return
         total_chunks = len(expanded_chunks) + 1
         sent_chunks = 1
         scope_getter = getattr(self, "_event_scope_key", None)


### PR DESCRIPTION
## 问题说明

插件会使用 `<pc_history_media ... />` 保存语音、图片等历史附件元数据。

当模型意外复述该标记，且 TTS 合成失败进入纯文本回退时，后台分段补发会绕过最终发送清理，导致该内部标记被作为独立消息发送到群聊。

## 修复内容

- 在 TTS 可见文本和合成失败回退文本进入分段前清理历史媒体标记。
- 在普通及主动 TTS 尾段实际发送前再次清理，覆盖绕过 decorating hooks 的直接发送路径。
- 丢弃纯标记尾段，以及清理后仅剩的孤立 `At`/`Reply` 组件。
- 保留 `Record` 等有效消息组件、组件顺序及正文必要的边缘空白。
- 尾段全部被清理时，将发送审计状态正确收束为已完成，避免长期停留在 `delivery_pending`。
- 支持原始、HTML 转义及模型变形后的历史媒体标记。

## 测试

- 新增 7 项回归测试，并覆盖 3 种标记形态。
- TTS 专项测试：`225 passed, 3 deselected, 36 subtests passed`。
- 相关发送链测试：`63 passed, 2 deselected, 15 subtests passed`。
- 当前分支可收集全量测试：`3570 passed, 80 failed, 2 skipped`。
- 干净 `main` 对照：`3563 passed, 80 failed, 2 skipped`。
- 两边的 80 项失败清单完全一致；当前分支仅增加了 7 项测试和 3 个子测试，没有新增失败。
- Python 语法检查及 `git diff --check` 通过。
- 人工验证：重启 AstrBot 后在实际环境复测通过，未再发送该内部标记。

本地可收集全量测试同样排除了 3 个因缺少兄弟插件仓库而无法收集的契约测试文件。