### PR TITLE
完善高频路径增量持久化与 SQLite tombstone 保护

### DIFF
--- a/atrelay.py
+++ b/atrelay.py
@@ -1298,7 +1298,7 @@ class AtRelayMixin:
                 target = self._atrelay_receipt_label_for_user(target_user, sender_display_name)
                 await self._send_atrelay_receipt_to_source(task, f"{target}回复了，但说不方便转回来。")
                 await self.context.send_message(event.unified_msg_origin, MessageChain([Plain("好，那我不转回去。")]))
-            self._save_data_sync()
+            self._save_data_sync(sections={"pending_atrelay_receipts"})
             try:
                 event.stop_event()
             except Exception:
@@ -1310,7 +1310,7 @@ class AtRelayMixin:
             task["status"] = "waiting_confirm"
             task["pending_reply_text"] = cleaned
             task["target_name"] = self._atrelay_receipt_label_for_user(target_user, sender_display_name)
-            self._save_data_sync()
+            self._save_data_sync(sections={"pending_atrelay_receipts"})
             source_name = _single_line(task.get("source_name"), 30) or "对方"
             await self.context.send_message(
                 event.unified_msg_origin,
@@ -1325,7 +1325,7 @@ class AtRelayMixin:
         task["target_name"] = self._atrelay_receipt_label_for_user(target_user, sender_display_name)
         report = self._format_atrelay_receipt_report(task, cleaned)
         await self._send_atrelay_receipt_to_source(task, report)
-        self._save_data_sync()
+        self._save_data_sync(sections={"pending_atrelay_receipts"})
         try:
             event.stop_event()
         except Exception:
@@ -1374,7 +1374,7 @@ class AtRelayMixin:
         async with self._data_lock:
             due = self._pop_due_atrelay_tasks_for_sender(group_id, sender_id)
             if due:
-                self._save_data_sync()
+                self._save_data_sync(sections={"groups"})
         if not due:
             return
         platform = str(getattr(event, "unified_msg_origin", "") or "").split(":")[0] or self.target_platform or "aiocqhttp"
@@ -1397,7 +1397,7 @@ class AtRelayMixin:
                     source_user=_single_line(task.get("source_user"), 40),
                     source_name=_single_line(task.get("source_name"), 80),
                 )
-                self._save_data_sync()
+                self._save_data_sync(sections={"groups", "recent_atrelay_contexts", "atrelay_send_log"})
             except Exception as exc:
                 logger.warning("[PrivateCompanion] 延迟转述发送失败: group=%s user=%s err=%s", group_id, sender_id, _single_line(exc, 160))
 

--- a/balance_awareness.py
+++ b/balance_awareness.py
@@ -610,7 +610,7 @@ class BalanceAwarenessMixin:
                 )
                 schedule_save = getattr(self, "_schedule_data_save", None)
                 if callable(schedule_save):
-                    schedule_save(delay=0.5)
+                    schedule_save(sections={"balance_awareness"}, delay=0.5)
                 if auto_unsupported:
                     logger.warning(
                         "[PrivateCompanion] 当前 Provider 不支持余额查询,已延长探测间隔: "
@@ -673,7 +673,10 @@ class BalanceAwarenessMixin:
                 state["last_recovered_at"] = now
             schedule_save = getattr(self, "_schedule_data_save", None)
             if callable(schedule_save):
-                schedule_save(delay=0.5)
+                sections = {"balance_awareness"}
+                if offered > 0:
+                    sections.add("users")
+                schedule_save(sections=sections, delay=0.5)
             if offered:
                 logger.info(
                     "[PrivateCompanion] 余额偏低事件已进入主动候选链: tier=%s targets=%s",

--- a/body_monitor_integration.py
+++ b/body_monitor_integration.py
@@ -150,10 +150,15 @@ class BodyMonitorIntegration:
         state.setdefault("generation", 0)
         return state
 
-    def _save(self) -> None:
+    def _save(self, *, include_candidates: bool = False) -> None:
         save = getattr(self._host, "_save_data_sync", None)
         if callable(save):
-            save()
+            sections = {STATE_KEY}
+            if include_candidates:
+                # Offering a candidate mutates both the owner profile and the
+                # shared review pool in addition to this integration cursor.
+                sections.update({"users", "proactive_candidate_pool"})
+            save(sections=sections)
 
     @asynccontextmanager
     async def _host_data_locked(self):
@@ -213,7 +218,7 @@ class BodyMonitorIntegration:
                     state["status"] = "initializing" if enabled else "disabled"
                     state["last_error"] = ""
                 if changed:
-                    self._save()
+                    self._save(include_candidates=not enabled)
         else:
             state = self._state()
             previous = bool(state.get("enabled_last"))
@@ -228,7 +233,7 @@ class BodyMonitorIntegration:
                 state["status"] = "initializing" if enabled else "disabled"
                 state["last_error"] = ""
             if changed:
-                self._save()
+                self._save(include_candidates=not enabled)
         return self.status_view()
 
     async def poll(self) -> dict[str, Any]:
@@ -334,7 +339,7 @@ class BodyMonitorIntegration:
                     state["last_error"] = ""
                     state["has_more"] = bool(feed.get("has_more"))
                     state["last_batch"] = batch
-                    self._save()
+                    self._save(include_candidates=True)
             except Exception as exc:
                 if int(self._state().get("generation") or 0) != request_generation:
                     return self.status_view()

--- a/command_handlers.py
+++ b/command_handlers.py
@@ -133,7 +133,7 @@ class CommandHandlersMixin:
             data["weather_alert_awareness"] = {}
             saver = getattr(self, "_save_data_sync", None)
             if callable(saver):
-                saver(sections=None, deleted_sections={"daily_weather"})
+                saver(sections=set(), deleted_sections={"daily_weather"})
 
         data_lock = getattr(self, "_data_lock", None)
         if isinstance(data_lock, asyncio.Lock):
@@ -2086,7 +2086,7 @@ class CommandHandlersMixin:
         if not proposals:
             if key in store:
                 store.pop(key, None)
-                self._save_data_sync()
+                self._save_data_sync(sections={"manual_diagnosis_pending_config"})
             return ""
         token = uuid.uuid4().hex[:6]
         store[key] = {
@@ -2095,7 +2095,7 @@ class CommandHandlersMixin:
             "question": _single_line(question, 260),
             "changes": proposals,
         }
-        self._save_data_sync()
+        self._save_data_sync(sections={"manual_diagnosis_pending_config"})
         return token
 
     def _companion_manual_recent_context_store(self) -> dict[str, Any]:
@@ -2238,7 +2238,7 @@ class CommandHandlersMixin:
             self._schedule_data_save(sections={"manual_diagnosis_recent_context"})
         except Exception:
             try:
-                self._save_data_sync()
+                self._save_data_sync(sections={"manual_diagnosis_recent_context"})
             except Exception:
                 pass
 
@@ -2474,7 +2474,7 @@ class CommandHandlersMixin:
             return None
         if _now_ts() - _safe_float(pending.get("ts"), 0.0, 0.0) > 1800:
             store.pop(key, None)
-            self._save_data_sync()
+            self._save_data_sync(sections={"manual_diagnosis_pending_config"})
             return None
         return pending
 
@@ -2559,7 +2559,7 @@ class CommandHandlersMixin:
                 f"；{_single_line(item.get('reason'), 120) or '按答疑建议调整'}"
             )
         self._companion_manual_pending_store().pop(self._companion_manual_pending_key(event), None)
-        self._save_data_sync()
+        self._save_data_sync(sections={"runtime_settings", "manual_diagnosis_pending_config"})
         if applied <= 0:
             return "没有成功应用的配置项。"
         lines.append("已保存到插件配置；如果 AstrBot 配置对象不支持同步保存，日志里会提示。")
@@ -2570,7 +2570,7 @@ class CommandHandlersMixin:
         key = self._companion_manual_pending_key(event)
         existed = key in store
         store.pop(key, None)
-        self._save_data_sync()
+        self._save_data_sync(sections={"manual_diagnosis_pending_config"})
         return "已取消刚才的答疑配置建议。" if existed else "当前没有待确认的答疑配置建议。"
 
     def _companion_manual_parse_setting_text(self, text: str) -> tuple[str, str]:
@@ -2616,7 +2616,7 @@ class CommandHandlersMixin:
         if not ok:
             return error
         self._companion_manual_pending_store().pop(self._companion_manual_pending_key(event), None)
-        self._save_data_sync()
+        self._save_data_sync(sections={"runtime_settings", "manual_diagnosis_pending_config"})
         if self._companion_manual_values_equal(old, new):
             return (
                 "配置没有变化：\n"
@@ -5371,7 +5371,7 @@ class CommandHandlersMixin:
                         user_id=user_id,
                         scope=photo_scope,
                     )
-                self._save_data_sync()
+                self._save_data_sync(sections={"users", "photo_generation_scope_attempts"})
         if not image_path:
             await self._reply(
                 event,
@@ -5684,7 +5684,7 @@ class CommandHandlersMixin:
                         user_id=user_id,
                         scope=photo_scope,
                     )
-                self._save_data_sync()
+                self._save_data_sync(sections={"users", "photo_generation_scope_attempts"})
         if not image_path:
             await self._reply(
                 event,
@@ -5812,7 +5812,7 @@ class CommandHandlersMixin:
                         operator_id=operator_id,
                         reason="group_command",
                     )
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"group_llm_reply_blocks"})
                     ts_text = self._format_timestamp_elapsed(_safe_float(item.get("updated_at"), 0.0, 0.0)) if item else "刚刚"
                     response = (
                         "已关闭本群所有 LLM 回复。\n"
@@ -5827,7 +5827,7 @@ class CommandHandlersMixin:
                         operator_id=operator_id,
                         reason="group_command",
                     )
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"group_llm_reply_blocks"})
                     response = "已恢复本群 LLM 回复。"
                 else:
                     item = self._group_llm_reply_block_item(group_id)
@@ -5861,11 +5861,11 @@ class CommandHandlersMixin:
             group = self._get_group(group_id)
             if action in {"开启", "启用", "打开"}:
                 group["enabled"] = True
-                self._save_data_sync()
+                self._save_data_sync(sections={"groups"})
                 response = "群聊陪伴观察已开启。"
             elif action in {"关闭", "停用", "关掉"}:
                 group["enabled"] = False
-                self._save_data_sync()
+                self._save_data_sync(sections={"groups"})
                 response = "群聊陪伴观察已关闭。"
             elif action in {"黑话", "梗", "词"}:
                 slang = group.get("slang_terms") if isinstance(group.get("slang_terms"), list) else []

--- a/command_handlers.py
+++ b/command_handlers.py
@@ -133,7 +133,7 @@ class CommandHandlersMixin:
             data["weather_alert_awareness"] = {}
             saver = getattr(self, "_save_data_sync", None)
             if callable(saver):
-                saver()
+                saver(sections=None, deleted_sections={"daily_weather"})
 
         data_lock = getattr(self, "_data_lock", None)
         if isinstance(data_lock, asyncio.Lock):
@@ -2235,7 +2235,7 @@ class CommandHandlersMixin:
         }
         self._companion_manual_recent_context_store()
         try:
-            self._schedule_data_save()
+            self._schedule_data_save(sections={"manual_diagnosis_recent_context"})
         except Exception:
             try:
                 self._save_data_sync()

--- a/core_store.py
+++ b/core_store.py
@@ -25,6 +25,7 @@ import unicodedata
 import uuid
 import zoneinfo
 from collections.abc import Collection
+from contextvars import ContextVar
 from copy import deepcopy
 from datetime import date, datetime, timedelta
 from email.utils import parsedate_to_datetime
@@ -275,11 +276,303 @@ _PLATFORM_DISPLAY_NAMES = {
     "discord": "Discord",
 }
 
+# Durable top-level sections are intentionally explicit.  Save requests may
+# only name sections registered here; legacy roots that exist only in a live
+# snapshot are handled by explicit full-scope migration/reset paths.
+_DURABLE_SECTION_NAMES = frozenset(
+    {
+        "version",
+        "users",
+        "private_user_alias_merge_backups",
+        "groups",
+        "daily_plan",
+        "daily_plan_history",
+        "agenda_version",
+        "agenda_contract_version",
+        "observed_activities",
+        "place_cognitive_maps",
+        "reality_touch_outputs",
+        "window_snapshots",
+        "agenda_reconciliation_history",
+        "daily_state",
+        "daily_weather",
+        "state_conditions",
+        "state_generated_day",
+        "body_cycle_state",
+        "body_cycle_strategy_mode",
+        "bot_diaries",
+        "dream_fragments",
+        "daily_dream",
+        "diary_generated_day",
+        "daily_diary_deleted_days",
+        "daily_diary_delete_revision",
+        "daily_diary_failed_day",
+        "daily_diary_failed_at",
+        "daily_diary_last_error",
+        "daily_diary_postprocess_error",
+        "daily_outfit_photo",
+        "daily_outfit_history",
+        "dialogue_outfit_override",
+        "recent_photo_generations",
+        "recent_photo_continuity",
+        "daily_story_plan",
+        "daily_story_plan_history",
+        "bot_personal_outbox",
+        "skill_growth",
+        "detail_enhanced_day",
+        "detail_enhanced_segments",
+        "detail_enhanced_history",
+        "schedule_adjustments",
+        "yesterday_conversation_summary",
+        "can_do",
+        "important_dates",
+        "qq_presence_state",
+        "token_usage",
+        "bilibili_integration",
+        "news_integration",
+        "web_exploration",
+        "qzone_integration",
+        "jm_cosmos_integration",
+        "bookshelf_items",
+        "bookshelf_secret",
+        "bookshelf_store_revision",
+        "memo_notes",
+        "creative_projects",
+        "creative_memory_pool",
+        "proactive_candidate_pool",
+        "proactive_runtime",
+        "proactive_review_runtime",
+        "proactive_audit_log",
+        "passive_no_reply_records",
+        "external_proactive_abilities",
+        "external_event_pool",
+        "external_event_self_link_cache",
+        "expression_learning_runtime",
+        "expression_voice_profile",
+        "extension_migration_notice_preferences",
+        "boundary_feedback_reports",
+        "boundary_feedback_vent_history",
+        "worldbook_entries",
+        "worldbook_member_profiles",
+        "worldbook_group_profiles",
+        "worldbook_deleted_member_ids",
+        "worldbook_deleted_group_ids",
+        "photo_reference_assets",
+        "worldbook_import_state",
+        "runtime_settings",
+        "manual_diagnosis_pending_config",
+        "manual_diagnosis_recent_context",
+        "atrelay_send_log",
+        "inbound_debounce_stats",
+        "smart_message_debounce",
+        "group_llm_reply_blocks",
+        "reaction_expression_group_states",
+        "cache_metrics",
+        "persona_lifecycle",
+        "balance_awareness",
+        "qweather_location",
+        "weather_alerts",
+        "weather_alert_awareness",
+        "body_monitor_integration",
+        "environment_change_awareness",
+        "personal_goal_state",
+        "personal_goals",
+        "food_menu",
+        "hunger_window_attempts",
+        "last_food_state_feedback_at",
+        "last_food_state_feedback_text",
+        "live_stream_companion",
+        "pending_atrelay_receipts",
+        "pending_atrelay_requests",
+        "personality_iteration_auto_tune",
+        "private_image_vision_cache",
+        "private_image_visual_provider_state",
+        "proactive_only_temp_unlocks",
+        "photo_generation_scope_attempts",
+        "photo_reference_feedback",
+        "reality_touch",
+        "recent_atrelay_contexts",
+        "recent_prompt_injection_events",
+        "recent_prompt_injections",
+        "social_fact_sanitized_at",
+        "screen_diary_context",
+        "self_meal_log",
+        "setup_guide_completed_at",
+        "setup_guide_completed_version",
+        "troubleshooting_suppressed_warning_types",
+        "web_search_runtime",
+        "daily_review_reports",
+        "daily_review_active_guidance",
+        "daily_review_last_attempt",
+        "daily_review_completed_day",
+        "daily_review_case_audit",
+        "troubleshooting_test_results",
+        "req036_capability_migration",
+        "unified_person",
+        # Derived maintenance markers are persisted with their source section.
+        "proactive_candidate_repeat_sanitized_at",
+        "_req041_expression_promotion_operations",
+        "_req041_group_reset_sagas",
+        "_req041_private_memory",
+        "_req041_persona_expression_profile",
+        "_req041_persona_reset_saga",
+    }
+)
+
+_FULL_SAVE_SCOPES = frozenset(
+    {
+        "startup_migration",
+        "startup_maintenance",
+        "explicit_reset",
+        "shutdown_flush",
+        "admin_import_export",
+    }
+)
+
+_EVENT_DATA_SAVE_BATCH: ContextVar[dict[str, Any] | None] = ContextVar(
+    "private_companion_event_data_save_batch",
+    default=None,
+)
+_EVENT_DATA_SAVE_BATCH_ATTR = "_private_companion_event_data_save_batch"
+
 
 
 
 class CoreStoreMixin:
     """配置、数据存储、用户/群组基础访问"""
+
+    def _begin_event_data_save_batch(self, event: Any) -> tuple[Any, dict[str, Any]] | None:
+        """Begin or resume one persistence batch for a managed message event."""
+        current = _EVENT_DATA_SAVE_BATCH.get()
+        if (
+            isinstance(current, dict)
+            and current.get("owner") is self
+            and not bool(current.get("closed"))
+        ):
+            return None
+
+        # Message filters run in separate persona contexts. Keep the batch on
+        # the event so an early guard and the final handler can share it.
+        event_batch = getattr(event, _EVENT_DATA_SAVE_BATCH_ATTR, None)
+        if (
+            isinstance(event_batch, dict)
+            and event_batch.get("owner") is self
+            and not bool(event_batch.get("closed"))
+        ):
+            token = _EVENT_DATA_SAVE_BATCH.set(event_batch)
+            return token, event_batch
+
+        sections: set[str] = set()
+        deleted_sections: set[str] = set()
+        batch = {
+            "owner": self,
+            "event": event,
+            "sections": sections,
+            "deleted_sections": deleted_sections,
+            "delay": 1.5,
+            "closed": False,
+        }
+        try:
+            setattr(event, _EVENT_DATA_SAVE_BATCH_ATTR, batch)
+            setattr(event, "_private_companion_pending_save_sections", sections)
+        except Exception:
+            pass
+        token = _EVENT_DATA_SAVE_BATCH.set(batch)
+        return token, batch
+
+    def _suspend_event_data_save_batch(
+        self,
+        handle: tuple[Any, dict[str, Any]] | None,
+    ) -> None:
+        """Detach the current task from an open event batch without flushing it."""
+        if handle is None:
+            return
+        token, batch = handle
+        if bool(batch.get("closed")):
+            return
+        try:
+            _EVENT_DATA_SAVE_BATCH.reset(token)
+        except (LookupError, RuntimeError, ValueError):
+            # A defensive fallback for handlers that changed the context
+            # before returning; the event-owned batch remains authoritative.
+            if _EVENT_DATA_SAVE_BATCH.get() is batch:
+                _EVENT_DATA_SAVE_BATCH.set(None)
+
+    def _collect_event_data_save_request(
+        self,
+        *,
+        sections: set[str] | None,
+        deleted_sections: set[str],
+        full_scope: str | None,
+        delay: float,
+    ) -> bool:
+        """Merge an incremental request into the active message-event batch."""
+        batch = _EVENT_DATA_SAVE_BATCH.get()
+        if (
+            not isinstance(batch, dict)
+            or batch.get("owner") is not self
+            or bool(batch.get("closed"))
+            or full_scope is not None
+            or sections is None
+        ):
+            return False
+        changed = batch["sections"]
+        deleted = batch["deleted_sections"]
+        for section in sections:
+            deleted.discard(section)
+            changed.add(section)
+        for section in deleted_sections:
+            changed.discard(section)
+            deleted.add(section)
+        batch["delay"] = min(float(batch.get("delay", 1.5)), max(0.0, float(delay)))
+        return True
+
+    def _finish_event_data_save_batch(
+        self,
+        handle: tuple[Any, dict[str, Any]] | None,
+    ) -> None:
+        """Close an event batch and submit its final section union once."""
+        if handle is None:
+            return
+        token, batch = handle
+        if bool(batch.get("closed")):
+            return
+        # Child tasks inherit ContextVar values. Mark this shared batch closed
+        # before resetting the parent context so later child writes cannot be
+        # absorbed into a request that has already been submitted.
+        batch["closed"] = True
+        if _EVENT_DATA_SAVE_BATCH.get() is batch:
+            try:
+                _EVENT_DATA_SAVE_BATCH.reset(token)
+            except (LookupError, RuntimeError, ValueError):
+                _EVENT_DATA_SAVE_BATCH.set(None)
+            if _EVENT_DATA_SAVE_BATCH.get() is batch:
+                _EVENT_DATA_SAVE_BATCH.set(None)
+        else:
+            try:
+                _EVENT_DATA_SAVE_BATCH.reset(token)
+            except (LookupError, RuntimeError, ValueError):
+                pass
+        self._close_event_data_save_batch(batch)
+
+    def _close_event_data_save_batch(self, batch: dict[str, Any]) -> None:
+        """Remove event markers and submit the captured section union."""
+        event = batch.get("event")
+        try:
+            if getattr(event, _EVENT_DATA_SAVE_BATCH_ATTR, None) is batch:
+                delattr(event, _EVENT_DATA_SAVE_BATCH_ATTR)
+            delattr(event, "_private_companion_pending_save_sections")
+        except Exception:
+            pass
+        sections = set(batch.get("sections") or ())
+        deleted_sections = set(batch.get("deleted_sections") or ())
+        if not sections and not deleted_sections:
+            return
+        self._schedule_data_save(
+            sections=sections,
+            deleted_sections=deleted_sections,
+            delay=float(batch.get("delay", 1.5)),
+        )
 
     @staticmethod
     def _backup_store_switch_target(backend: str, path: Path) -> Path | None:
@@ -544,15 +837,18 @@ class CoreStoreMixin:
             "daily_plan": {},
             "daily_plan_history": [],
             "agenda_version": 1,
+            "agenda_contract_version": 0,
             "observed_activities": [],
             "place_cognitive_maps": {},
             "reality_touch_outputs": {},
             "window_snapshots": [],
             "agenda_reconciliation_history": [],
             "daily_state": {},
+            "daily_weather": {},
             "state_conditions": [],
             "state_generated_day": "",
             "body_cycle_state": {},
+            "body_cycle_strategy_mode": "",
             "bot_diaries": [],
             "dream_fragments": [],
             "daily_dream": {},
@@ -565,6 +861,7 @@ class CoreStoreMixin:
             "daily_diary_postprocess_error": "",
             "daily_outfit_photo": {},
             "daily_outfit_history": [],
+            "dialogue_outfit_override": {},
             "recent_photo_generations": [],
             "recent_photo_continuity": {},
             "daily_story_plan": {},
@@ -592,6 +889,12 @@ class CoreStoreMixin:
             "creative_projects": [],
             "creative_memory_pool": [],
             "proactive_candidate_pool": [],
+            "proactive_runtime": {},
+            "proactive_review_runtime": {},
+            "proactive_audit_log": [],
+            "passive_no_reply_records": {},
+            "external_event_pool": [],
+            "external_event_self_link_cache": {},
             "external_proactive_abilities": {},
             "boundary_feedback_reports": [],
             "boundary_feedback_vent_history": [],
@@ -602,7 +905,10 @@ class CoreStoreMixin:
             "photo_reference_assets": [],
             "worldbook_import_state": {},
             "runtime_settings": {},
+            "manual_diagnosis_pending_config": {},
+            "manual_diagnosis_recent_context": {},
             "inbound_debounce_stats": {},
+            "smart_message_debounce": {},
             "group_llm_reply_blocks": {},
             "reaction_expression_group_states": {},
             "cache_metrics": {},
@@ -625,7 +931,47 @@ class CoreStoreMixin:
             "daily_review_last_attempt": {},
             "daily_review_completed_day": "",
             "daily_review_case_audit": [],
+            "troubleshooting_test_results": {},
+            "troubleshooting_suppressed_warning_types": [],
+            "expression_learning_runtime": {},
+            "expression_voice_profile": {},
+            "extension_migration_notice_preferences": {},
+            "hunger_window_attempts": {},
+            "last_food_state_feedback_at": 0,
+            "last_food_state_feedback_text": "",
+            "live_stream_companion": {},
+            "pending_atrelay_receipts": [],
+            "pending_atrelay_requests": {},
+            "personality_iteration_auto_tune": {},
+            "private_image_vision_cache": {},
+            "private_image_visual_provider_state": {},
+            "proactive_only_temp_unlocks": {},
+            "photo_generation_scope_attempts": {},
+            "photo_reference_feedback": [],
+            "reality_touch": {},
+            "recent_atrelay_contexts": [],
+            "recent_prompt_injection_events": [],
+            "recent_prompt_injections": {},
+            "social_fact_sanitized_at": "",
+            "screen_diary_context": {},
+            "self_meal_log": [],
+            "setup_guide_completed_at": "",
+            "setup_guide_completed_version": "",
+            "web_search_runtime": {},
             "unified_person": empty_person_store(),
+            "req036_capability_migration": {},
+            "_req041_expression_promotion_operations": {},
+            "_req041_group_reset_sagas": {},
+            "_req041_private_memory": {
+                "schema": "req041.person_private_memory.v1",
+                "records": {},
+            },
+            "_req041_persona_expression_profile": {},
+            "_req041_persona_reset_saga": {},
+            "atrelay_send_log": [],
+            "worldbook_deleted_member_ids": [],
+            "worldbook_deleted_group_ids": [],
+            "proactive_candidate_repeat_sanitized_at": "",
         }
 
     @staticmethod
@@ -637,15 +983,18 @@ class CoreStoreMixin:
         data.setdefault("daily_plan", {})
         data.setdefault("daily_plan_history", [])
         data.setdefault("agenda_version", 1)
+        data.setdefault("agenda_contract_version", 0)
         data.setdefault("observed_activities", [])
         data.setdefault("place_cognitive_maps", {})
         data.setdefault("reality_touch_outputs", {})
         data.setdefault("window_snapshots", [])
         data.setdefault("agenda_reconciliation_history", [])
         data.setdefault("daily_state", {})
+        data.setdefault("daily_weather", {})
         data.setdefault("state_conditions", [])
         data.setdefault("state_generated_day", "")
         data.setdefault("body_cycle_state", {})
+        data.setdefault("body_cycle_strategy_mode", "")
         data.setdefault("bot_diaries", [])
         data.setdefault("dream_fragments", [])
         data.setdefault("daily_dream", {})
@@ -658,6 +1007,7 @@ class CoreStoreMixin:
         data.setdefault("daily_diary_postprocess_error", "")
         data.setdefault("daily_outfit_photo", {})
         data.setdefault("daily_outfit_history", [])
+        data.setdefault("dialogue_outfit_override", {})
         data.setdefault("recent_photo_generations", [])
         data.setdefault("recent_photo_continuity", {})
         data.setdefault("daily_story_plan", {})
@@ -685,6 +1035,12 @@ class CoreStoreMixin:
         data.setdefault("creative_projects", [])
         data.setdefault("creative_memory_pool", [])
         data.setdefault("proactive_candidate_pool", [])
+        data.setdefault("proactive_runtime", {})
+        data.setdefault("proactive_review_runtime", {})
+        data.setdefault("proactive_audit_log", [])
+        data.setdefault("passive_no_reply_records", {})
+        data.setdefault("external_event_pool", [])
+        data.setdefault("external_event_self_link_cache", {})
         data.setdefault("external_proactive_abilities", {})
         data.setdefault("boundary_feedback_reports", [])
         data.setdefault("boundary_feedback_vent_history", [])
@@ -696,8 +1052,11 @@ class CoreStoreMixin:
         data.setdefault("worldbook_deleted_group_ids", [])
         data.setdefault("worldbook_import_state", {})
         data.setdefault("runtime_settings", {})
+        data.setdefault("manual_diagnosis_pending_config", {})
+        data.setdefault("manual_diagnosis_recent_context", {})
         data.setdefault("atrelay_send_log", [])
         data.setdefault("inbound_debounce_stats", {})
+        data.setdefault("smart_message_debounce", {})
         data.setdefault("group_llm_reply_blocks", {})
         data.setdefault("reaction_expression_group_states", {})
         data.setdefault("cache_metrics", {})
@@ -722,6 +1081,43 @@ class CoreStoreMixin:
         data.setdefault("daily_review_last_attempt", {})
         data.setdefault("daily_review_completed_day", "")
         data.setdefault("daily_review_case_audit", [])
+        data.setdefault("troubleshooting_test_results", {})
+        data.setdefault("troubleshooting_suppressed_warning_types", [])
+        data.setdefault("expression_learning_runtime", {})
+        data.setdefault("expression_voice_profile", {})
+        data.setdefault("extension_migration_notice_preferences", {})
+        data.setdefault("hunger_window_attempts", {})
+        data.setdefault("last_food_state_feedback_at", 0)
+        data.setdefault("last_food_state_feedback_text", "")
+        data.setdefault("live_stream_companion", {})
+        data.setdefault("pending_atrelay_receipts", [])
+        data.setdefault("pending_atrelay_requests", {})
+        data.setdefault("personality_iteration_auto_tune", {})
+        data.setdefault("private_image_vision_cache", {})
+        data.setdefault("private_image_visual_provider_state", {})
+        data.setdefault("proactive_only_temp_unlocks", {})
+        data.setdefault("photo_generation_scope_attempts", {})
+        data.setdefault("photo_reference_feedback", [])
+        data.setdefault("reality_touch", {})
+        data.setdefault("recent_atrelay_contexts", [])
+        data.setdefault("recent_prompt_injection_events", [])
+        data.setdefault("recent_prompt_injections", {})
+        data.setdefault("social_fact_sanitized_at", "")
+        data.setdefault("screen_diary_context", {})
+        data.setdefault("self_meal_log", [])
+        data.setdefault("setup_guide_completed_at", "")
+        data.setdefault("setup_guide_completed_version", "")
+        data.setdefault("web_search_runtime", {})
+        data.setdefault("req036_capability_migration", {})
+        data.setdefault("_req041_expression_promotion_operations", {})
+        data.setdefault("_req041_group_reset_sagas", {})
+        data.setdefault(
+            "_req041_private_memory",
+            {"schema": "req041.person_private_memory.v1", "records": {}},
+        )
+        data.setdefault("_req041_persona_expression_profile", {})
+        data.setdefault("_req041_persona_reset_saga", {})
+        data.setdefault("proactive_candidate_repeat_sanitized_at", "")
         ensure_person_store(data)
         # Legacy profiles retain their effective durable permissions once.
         # Creation paths below install a separate default-closed state for new
@@ -1209,7 +1605,18 @@ class CoreStoreMixin:
         *,
         sections: Collection[str] | None = None,
         deleted_sections: Collection[str] = (),
+        full_scope: str | None = None,
     ):
+        sections, deleted_sections, full_scope = self._validate_save_request(
+            sections, deleted_sections, full_scope
+        )
+        if self._collect_event_data_save_request(
+            sections=sections,
+            deleted_sections=deleted_sections,
+            full_scope=full_scope,
+            delay=0.35,
+        ):
+            return
         scoped_scheduler = getattr(self, "_req041_schedule_scoped_sync", None)
         if callable(scoped_scheduler):
             scoped_scheduler()
@@ -1228,10 +1635,14 @@ class CoreStoreMixin:
                 pending_full = bool(
                     self._persona_data_save_full_revision.get(active_persona, 0)
                 )
+                pending_full_scope = str(
+                    self._persona_data_save_full_scope.get(active_persona, "") or ""
+                )
                 if self._mark_persona_data_dirty(
                     active_persona,
                     sections=sections,
                     deleted_sections=deleted_sections,
+                    full_scope=full_scope,
                 ):
                     batch = self._capture_persona_data_save_batch(active_persona)
                     result = self._write_persona_data_save_batch_sync(
@@ -1251,11 +1662,13 @@ class CoreStoreMixin:
                             active_persona,
                             sections=None if pending_full else set(pending_dirty),
                             deleted_sections=set(pending_deleted),
+                            full_scope=pending_full_scope if pending_full else None,
                         )
                 return
             self._schedule_data_save(
                 sections=sections,
                 deleted_sections=deleted_sections,
+                full_scope=full_scope,
                 delay=0.35,
             )
             return
@@ -1265,11 +1678,13 @@ class CoreStoreMixin:
             self._save_data_now_sync(
                 sections=sections,
                 deleted_sections=deleted_sections,
+                full_scope=full_scope,
             )
             return
         self._schedule_data_save(
             sections=sections,
             deleted_sections=deleted_sections,
+            full_scope=full_scope,
             delay=0.35,
         )
 
@@ -1278,14 +1693,20 @@ class CoreStoreMixin:
         *,
         sections: Collection[str] | None = None,
         deleted_sections: Collection[str] = (),
+        full_scope: str | None = None,
     ) -> None:
+        sections, deleted_sections, full_scope = self._validate_save_request(
+            sections, deleted_sections, full_scope
+        )
         self._ensure_default_save_state()
         pending_dirty = dict(self._data_save_dirty)
         pending_deleted = dict(self._data_save_deleted)
         pending_full = bool(self._data_save_full_revision)
+        pending_full_scope = str(getattr(self, "_data_save_full_scope", "") or "")
         if not self._mark_default_data_dirty(
             sections=sections,
             deleted_sections=deleted_sections,
+            full_scope=full_scope,
         ):
             return
         batch = self._capture_default_data_save_batch()
@@ -1300,6 +1721,7 @@ class CoreStoreMixin:
             self._mark_default_data_dirty(
                 sections=None if pending_full else set(pending_dirty),
                 deleted_sections=set(pending_deleted),
+                full_scope=pending_full_scope if pending_full else None,
             )
 
     def _write_data_snapshot_sync(
@@ -1426,6 +1848,43 @@ class CoreStoreMixin:
             values = (values,)
         return {str(value).strip() for value in values if str(value).strip()}
 
+    @classmethod
+    def _validate_save_request(
+        cls,
+        sections: Collection[str] | None,
+        deleted_sections: Collection[str],
+        full_scope: str | None,
+    ) -> tuple[set[str] | None, set[str], str | None]:
+        """Validate the explicit section or full-save contract."""
+        normalized_sections = cls._save_section_names(sections)
+        normalized_deleted = cls._save_section_names(deleted_sections) or set()
+        normalized_scope = str(full_scope or "").strip() or None
+        if normalized_scope is not None and normalized_scope not in _FULL_SAVE_SCOPES:
+            raise ValueError(f"unknown full save scope: {normalized_scope}")
+        if normalized_sections is None:
+            if normalized_scope is None:
+                raise ValueError(
+                    "sections must be explicit unless an allowlisted full_scope is provided"
+                )
+            if normalized_deleted:
+                raise ValueError("full_scope cannot be combined with deleted_sections")
+        elif normalized_scope is not None:
+            raise ValueError("sections and full_scope are mutually exclusive")
+        unknown = (
+            (normalized_sections or set()) | normalized_deleted
+        ) - _DURABLE_SECTION_NAMES
+        if unknown:
+            raise ValueError(
+                "unknown durable sections: " + ", ".join(sorted(unknown))
+            )
+        overlap = (normalized_sections or set()) & normalized_deleted
+        if overlap:
+            raise ValueError(
+                "changed and deleted sections must be disjoint: "
+                + ", ".join(sorted(overlap))
+            )
+        return normalized_sections, normalized_deleted, normalized_scope
+
     def _save_is_stopping(self) -> bool:
         stop_event = getattr(self, "_stop_event", None)
         return bool(
@@ -1484,6 +1943,8 @@ class CoreStoreMixin:
             self._data_save_section_revisions = {}
         if not isinstance(getattr(self, "_data_save_full_revision", None), int):
             self._data_save_full_revision = 0
+        if not isinstance(getattr(self, "_data_save_full_scope", None), str):
+            self._data_save_full_scope = ""
         if not isinstance(getattr(self, "_data_save_revision", None), int):
             seed = 1
             manager = getattr(self, "store_manager", None)
@@ -1506,6 +1967,7 @@ class CoreStoreMixin:
                 self._data_save_section_revisions[str(section)] = revision
             self._data_save_full_revision = revision
             self._data_save_full_since = now
+            self._data_save_full_scope = "startup_maintenance"
 
     def _refresh_data_save_revision_from_manager(self) -> int:
         manager = getattr(self, "store_manager", None)
@@ -1528,6 +1990,7 @@ class CoreStoreMixin:
             "_persona_data_save_deleted",
             "_persona_data_save_dirty_since",
             "_persona_data_save_full_revision",
+            "_persona_data_save_full_scope",
             "_persona_data_save_revision",
             "_persona_data_save_section_revisions",
         ):
@@ -1539,6 +2002,8 @@ class CoreStoreMixin:
             self._persona_data_save_write_generation = {}
         if not isinstance(getattr(self, "_persona_data_save_tasks", None), dict):
             self._persona_data_save_tasks = {}
+        if not isinstance(getattr(self, "_persona_data_save_full_scope", None), dict):
+            self._persona_data_save_full_scope = {}
         for persona_id in legacy_personas:
             if persona_id in self._persona_data_save_dirty or persona_id in self._persona_data_save_deleted:
                 continue
@@ -1554,6 +2019,7 @@ class CoreStoreMixin:
                 since[str(section)] = now
                 section_revisions[str(section)] = revision
             self._persona_data_save_full_revision[str(persona_id)] = revision
+            self._persona_data_save_full_scope[str(persona_id)] = "startup_maintenance"
 
     def _next_data_save_revision(self, persona_id: str = "") -> int:
         if persona_id:
@@ -1591,10 +2057,12 @@ class CoreStoreMixin:
         *,
         sections: Collection[str] | None,
         deleted_sections: Collection[str],
+        full_scope: str | None = None,
     ) -> bool:
         self._ensure_default_save_state()
-        changed = self._save_section_names(sections)
-        deleted = self._save_section_names(deleted_sections) or set()
+        changed, deleted, full_scope = self._validate_save_request(
+            sections, deleted_sections, full_scope
+        )
         full = changed is None
         if changed is None:
             changed = {str(name) for name in self.data}
@@ -1618,6 +2086,7 @@ class CoreStoreMixin:
         if full:
             self._data_save_full_revision = revision
             self._data_save_full_since = now
+            self._data_save_full_scope = str(full_scope)
         return True
 
     def _mark_persona_data_dirty(
@@ -1626,11 +2095,13 @@ class CoreStoreMixin:
         *,
         sections: Collection[str] | None,
         deleted_sections: Collection[str],
+        full_scope: str | None = None,
     ) -> bool:
         self._ensure_persona_save_state()
         live_data = self._persona_data_for_save(persona_id)
-        changed = self._save_section_names(sections)
-        deleted = self._save_section_names(deleted_sections) or set()
+        changed, deleted, full_scope = self._validate_save_request(
+            sections, deleted_sections, full_scope
+        )
         full = changed is None
         if changed is None:
             changed = {str(name) for name in live_data}
@@ -1657,6 +2128,7 @@ class CoreStoreMixin:
             section_revisions[section] = revision
         if full:
             self._persona_data_save_full_revision[persona_id] = revision
+            self._persona_data_save_full_scope[persona_id] = str(full_scope)
         return True
 
     def _default_data_save_is_dirty(self) -> bool:
@@ -1744,7 +2216,17 @@ class CoreStoreMixin:
         manager = getattr(self, "store_manager", None)
         manager_backend = str(getattr(manager, "backend_name", "") or "").lower()
         full_compatibility_save = bool(self._data_save_full_revision)
-        full_replacement = bool(force_full and full_compatibility_save)
+        full_scope = str(getattr(self, "_data_save_full_scope", "") or "").strip()
+        # A full-scope request marks every live section dirty, but SQLite can
+        # still persist that capture incrementally.  Shutdown is the only
+        # general path that forces a compatibility full snapshot so removed
+        # roots are reconciled without inferring deletes during ordinary
+        # writes.  An explicit reset is also a complete replacement by
+        # definition and must become durable before returning.
+        full_replacement = bool(
+            full_compatibility_save
+            and (force_full or full_scope == "explicit_reset")
+        )
         incremental = bool(
             manager_backend == "sqlite"
             and callable(getattr(manager, "save_sections", None))
@@ -2134,6 +2616,7 @@ class CoreStoreMixin:
         if complete and self._data_save_full_revision == batch["full_revision"]:
             self._data_save_full_revision = 0
             self._data_save_full_since = 0.0
+            self._data_save_full_scope = ""
         if not batch["incremental"]:
             self._refresh_data_save_revision_from_manager()
             self._rebase_default_pending_revisions()
@@ -2187,6 +2670,7 @@ class CoreStoreMixin:
         )
         if complete and self._persona_data_save_full_revision.get(persona_id, 0) == batch["full_revision"]:
             self._persona_data_save_full_revision.pop(persona_id, None)
+            self._persona_data_save_full_scope.pop(persona_id, None)
         if result["control_changed"]:
             self._log_store_control_cleanup("delayed_persona_save", result["control_changed"])
         if not self._persona_data_save_dirty.get(persona_id):
@@ -2305,11 +2789,13 @@ class CoreStoreMixin:
         *,
         sections: Collection[str] | None = None,
         deleted_sections: Collection[str] = (),
+        full_scope: str | None = None,
     ) -> None:
         if not self._mark_persona_data_dirty(
             persona_id,
             sections=sections,
             deleted_sections=deleted_sections,
+            full_scope=full_scope,
         ):
             return
         self._start_persona_data_save_writer(persona_id, delay)
@@ -2320,10 +2806,12 @@ class CoreStoreMixin:
         *,
         sections: Collection[str] | None = None,
         deleted_sections: Collection[str] = (),
+        full_scope: str | None = None,
     ) -> None:
         if not self._mark_default_data_dirty(
             sections=sections,
             deleted_sections=deleted_sections,
+            full_scope=full_scope,
         ):
             return
         self._start_default_data_save_writer(delay)
@@ -2333,8 +2821,19 @@ class CoreStoreMixin:
         *,
         sections: Collection[str] | None = None,
         deleted_sections: Collection[str] = (),
+        full_scope: str | None = None,
         delay: float = 1.5,
     ) -> None:
+        sections, deleted_sections, full_scope = self._validate_save_request(
+            sections, deleted_sections, full_scope
+        )
+        if self._collect_event_data_save_request(
+            sections=sections,
+            deleted_sections=deleted_sections,
+            full_scope=full_scope,
+            delay=delay,
+        ):
+            return
         scoped_scheduler = getattr(self, "_req041_schedule_scoped_sync", None)
         if callable(scoped_scheduler):
             scoped_scheduler()
@@ -2346,12 +2845,14 @@ class CoreStoreMixin:
                 delay,
                 sections=sections,
                 deleted_sections=deleted_sections,
+                full_scope=full_scope,
             )
             return
         self._schedule_default_data_save(
             delay,
             sections=sections,
             deleted_sections=deleted_sections,
+            full_scope=full_scope,
         )
 
     def _clear_default_data_save_dirty(self, through_revision: int | None = None) -> None:
@@ -2364,6 +2865,7 @@ class CoreStoreMixin:
         if through_revision is None or self._data_save_full_revision <= through_revision:
             self._data_save_full_revision = 0
             self._data_save_full_since = 0.0
+            self._data_save_full_scope = ""
 
     def _clear_persona_data_save_dirty(
         self,
@@ -2382,6 +2884,7 @@ class CoreStoreMixin:
         full_revision = int(self._persona_data_save_full_revision.get(persona_id, 0) or 0)
         if through_revision is None or full_revision <= through_revision:
             self._persona_data_save_full_revision.pop(persona_id, None)
+            self._persona_data_save_full_scope.pop(persona_id, None)
         if not self._persona_data_save_dirty_since.get(persona_id):
             self._persona_data_save_dirty_since.pop(persona_id, None)
 
@@ -2429,8 +2932,8 @@ class CoreStoreMixin:
                 self._sync_configured_targets()
             self._clear_default_data_save_dirty()
             await asyncio.to_thread(
-                self._write_data_snapshot_sync,
-                deepcopy(self.data),
+                self._save_data_now_sync,
+                full_scope="explicit_reset",
             )
 
     async def _rebuild_today_after_reset(
@@ -2440,7 +2943,9 @@ class CoreStoreMixin:
         plan = await self._generate_daily_plan()
         async with self._data_lock:
             self.data["daily_plan"] = plan
-            self._save_data_sync()
+            self._save_data_sync(
+                sections={"daily_state", "daily_plan"},
+            )
 
         diary = None
         if self.enable_daily_diary:
@@ -2467,7 +2972,15 @@ class CoreStoreMixin:
                 story_plan = diary.get("story_plan") if isinstance(diary, dict) else None
                 if isinstance(story_plan, dict):
                     self.data["daily_story_plan"] = story_plan
-                self._save_data_sync()
+                self._save_data_sync(
+                    sections={
+                        "bot_diaries",
+                        "diary_generated_day",
+                        "dream_fragments",
+                        "daily_diary_postprocess_error",
+                        "daily_story_plan",
+                    },
+                )
             outfit_generator = getattr(self, "_ensure_daily_outfit_photo", None)
             if callable(outfit_generator):
                 try:

--- a/core_store.py
+++ b/core_store.py
@@ -10,6 +10,7 @@ import gc
 import hashlib
 import html
 import importlib
+import inspect
 import json
 import math
 import os
@@ -1217,8 +1218,40 @@ class CoreStoreMixin:
             try:
                 asyncio.get_running_loop()
             except RuntimeError:
-                snapshot = deepcopy(self.data)
-                self._write_persona_data_snapshot_sync(active_persona, snapshot)
+                self._ensure_persona_save_state()
+                pending_dirty = dict(
+                    self._persona_data_save_dirty.get(active_persona, {})
+                )
+                pending_deleted = dict(
+                    self._persona_data_save_deleted.get(active_persona, {})
+                )
+                pending_full = bool(
+                    self._persona_data_save_full_revision.get(active_persona, 0)
+                )
+                if self._mark_persona_data_dirty(
+                    active_persona,
+                    sections=sections,
+                    deleted_sections=deleted_sections,
+                ):
+                    batch = self._capture_persona_data_save_batch(active_persona)
+                    result = self._write_persona_data_save_batch_sync(
+                        active_persona,
+                        batch,
+                        advance_generation=True,
+                    )
+                    self._finish_persona_data_save_batch(
+                        active_persona,
+                        batch,
+                        result,
+                    )
+                    if not result.get("superseded") and (
+                        pending_dirty or pending_deleted or pending_full
+                    ):
+                        self._mark_persona_data_dirty(
+                            active_persona,
+                            sections=None if pending_full else set(pending_dirty),
+                            deleted_sections=set(pending_deleted),
+                        )
                 return
             self._schedule_data_save(
                 sections=sections,
@@ -1229,7 +1262,10 @@ class CoreStoreMixin:
         try:
             asyncio.get_running_loop()
         except RuntimeError:
-            self._save_data_now_sync(deleted_sections=deleted_sections)
+            self._save_data_now_sync(
+                sections=sections,
+                deleted_sections=deleted_sections,
+            )
             return
         self._schedule_data_save(
             sections=sections,
@@ -1240,52 +1276,40 @@ class CoreStoreMixin:
     def _save_data_now_sync(
         self,
         *,
+        sections: Collection[str] | None = None,
         deleted_sections: Collection[str] = (),
     ) -> None:
-        changed = self._sanitize_store_control_tags_inplace(self.data)
-        repeat_changed = self._sanitize_proactive_candidate_repeat_counts_inplace(self.data)
-        compacted = self._compact_store_history_inplace(self.data)
-        if changed:
-            self._log_store_control_cleanup("immediate_save", changed)
-        if repeat_changed:
-            logger.warning("[PrivateCompanion] 保存数据前压缩主动候选重复计数: items=%s", repeat_changed)
-        if compacted:
-            logger.info("[PrivateCompanion] 保存前压缩历史存储: %s", compacted)
-        manager = getattr(self, "store_manager", None)
-        if manager is not None:
-            manager_backend = str(getattr(manager, "backend_name", "") or "").lower()
-            save_sections = getattr(manager, "save_sections", None)
-            if manager_backend == "sqlite" and callable(save_sections):
-                self._ensure_default_save_state()
-                revision = self._next_data_save_revision()
-                deleted = self._save_section_names(deleted_sections) or set()
-                changed_sections = {
-                    str(section): (revision, deepcopy(value))
-                    for section, value in self.data.items()
-                    if str(section) not in deleted
-                }
-                with self._data_save_io_lock():
-                    confirmed = save_sections(
-                        changed_sections,
-                        {section: revision for section in deleted},
-                    )
-                    if any(
-                        int(confirmed.get(section, -1)) < revision
-                        for section in changed_sections
-                    ):
-                        raise RuntimeError(
-                            "SQLite synchronous section save did not confirm all sections"
-                        )
-                    self._refresh_data_save_revision_from_manager()
-                    self._clear_default_data_save_dirty()
-                    self._advance_data_save_write_generation()
-                return
-            with self._data_save_io_lock():
-                manager.save_store(self.data)
-                self._refresh_data_save_revision_from_manager()
-                self._advance_data_save_write_generation()
+        self._ensure_default_save_state()
+        pending_dirty = dict(self._data_save_dirty)
+        pending_deleted = dict(self._data_save_deleted)
+        pending_full = bool(self._data_save_full_revision)
+        if not self._mark_default_data_dirty(
+            sections=sections,
+            deleted_sections=deleted_sections,
+        ):
             return
-        if not self.data.get("worldbook_entries") and os.path.exists(self.data_file):
+        batch = self._capture_default_data_save_batch()
+        result = self._write_default_data_save_batch_sync(
+            batch,
+            advance_generation=True,
+        )
+        self._finish_default_data_save_batch(batch, result)
+        if not result.get("superseded") and (
+            pending_dirty or pending_deleted or pending_full
+        ):
+            self._mark_default_data_dirty(
+                sections=None if pending_full else set(pending_dirty),
+                deleted_sections=set(pending_deleted),
+            )
+
+    def _write_data_snapshot_sync(
+        self,
+        data: dict[str, Any],
+        *,
+        advance_generation: bool = True,
+    ) -> int:
+        manager = getattr(self, "store_manager", None)
+        if manager is None and not data.get("worldbook_entries") and os.path.exists(self.data_file):
             try:
                 with open(self.data_file, "r", encoding="utf-8") as f:
                     existing = json.load(f)
@@ -1296,28 +1320,45 @@ class CoreStoreMixin:
                         "worldbook_group_profiles",
                         "worldbook_import_state",
                     ):
-                        self.data[key] = existing.get(key, self.data.get(key))
+                        data[key] = existing.get(key, data.get(key))
             except Exception:
                 pass
-        with self._data_save_io_lock():
-            self._atomic_write_data_file_sync(self.data)
-            self._advance_data_save_write_generation()
-
-    def _write_data_snapshot_sync(self, data: dict[str, Any]) -> int:
         changed = self._sanitize_store_control_tags_inplace(data)
         self._sanitize_proactive_candidate_repeat_counts_inplace(data)
         self._compact_store_history_inplace(data)
-        manager = getattr(self, "store_manager", None)
         if manager is not None:
             with self._data_save_io_lock():
                 manager.save_snapshot(data)
                 self._refresh_data_save_revision_from_manager()
-                self._advance_data_save_write_generation()
+                if advance_generation:
+                    self._advance_data_save_write_generation()
             return changed
         with self._data_save_io_lock():
             self._atomic_write_data_file_sync(data)
-            self._advance_data_save_write_generation()
+            if advance_generation:
+                self._advance_data_save_write_generation()
         return changed
+
+    def _invoke_data_snapshot_writer_sync(
+        self,
+        snapshot: dict[str, Any],
+        *,
+        advance_generation: bool,
+    ) -> int:
+        """Invoke an overridable snapshot writer with legacy signature support."""
+        writer = self._write_data_snapshot_sync
+        try:
+            parameters = inspect.signature(writer).parameters.values()
+            accepts_generation = any(
+                parameter.name == "advance_generation"
+                or parameter.kind is inspect.Parameter.VAR_KEYWORD
+                for parameter in parameters
+            )
+        except (TypeError, ValueError):
+            accepts_generation = False
+        if accepts_generation:
+            return writer(snapshot, advance_generation=advance_generation)
+        return writer(snapshot)
 
     def _atomic_write_data_file_sync(self, data: dict[str, Any]) -> None:
         base = self.data_file
@@ -1801,7 +1842,12 @@ class CoreStoreMixin:
         }
         return prepared, control_changed, repeat_changed, compacted, cleaned_sections
 
-    def _write_default_data_save_batch_sync(self, batch: dict[str, Any]) -> dict[str, Any]:
+    def _write_default_data_save_batch_sync(
+        self,
+        batch: dict[str, Any],
+        *,
+        advance_generation: bool = False,
+    ) -> dict[str, Any]:
         if batch["incremental"] and batch["missing_revisions"]:
             missing = ", ".join(sorted(batch["missing_revisions"]))
             raise RuntimeError(
@@ -1837,6 +1883,8 @@ class CoreStoreMixin:
                         },
                         batch["deleted_revisions"],
                     )
+                    if advance_generation:
+                        self._advance_data_save_write_generation()
         else:
             snapshot = batch["full_snapshot"]
             for section, value in prepared.items():
@@ -1884,6 +1932,8 @@ class CoreStoreMixin:
                         confirmed = {
                             section: persisted_revision for section in expected_revisions
                         }
+                        if advance_generation:
+                            self._advance_data_save_write_generation()
             else:
                 with self._data_save_io_lock():
                     if batch["write_generation"] != self._current_data_save_write_generation():
@@ -1893,8 +1943,13 @@ class CoreStoreMixin:
                     else:
                         # Keep the compatibility path behind the overridable
                         # snapshot writer used by JSON/test harnesses.
-                        self._write_data_snapshot_sync(snapshot)
+                        self._invoke_data_snapshot_writer_sync(
+                            snapshot,
+                            advance_generation=False,
+                        )
                     if not superseded:
+                        if advance_generation:
+                            self._advance_data_save_write_generation()
                         confirmed = dict(expected_revisions)
         return {
             "confirmed": dict(confirmed or {}),
@@ -1911,6 +1966,8 @@ class CoreStoreMixin:
         self,
         persona_id: str,
         batch: dict[str, Any],
+        *,
+        advance_generation: bool = False,
     ) -> dict[str, Any]:
         prepared, control_changed, repeat_changed, compacted, cleaned_sections = self._prepare_dirty_save_payloads_sync(
             batch["payloads"],
@@ -1942,6 +1999,8 @@ class CoreStoreMixin:
                 superseded = True
             else:
                 saver(persona_id, snapshot)
+                if advance_generation:
+                    self._advance_data_save_write_generation(persona_id)
                 confirmed = dict(changed_revisions)
                 confirmed.update(batch["deleted_revisions"])
                 confirmed.update(batch["missing_revisions"])

--- a/core_store.py
+++ b/core_store.py
@@ -16,12 +16,14 @@ import os
 import random
 import re
 import shutil
+import sqlite3
 import sys
 import threading
 import time
 import unicodedata
 import uuid
 import zoneinfo
+from collections.abc import Collection
 from copy import deepcopy
 from datetime import date, datetime, timedelta
 from email.utils import parsedate_to_datetime
@@ -278,6 +280,48 @@ _PLATFORM_DISPLAY_NAMES = {
 class CoreStoreMixin:
     """配置、数据存储、用户/群组基础访问"""
 
+    @staticmethod
+    def _backup_store_switch_target(backend: str, path: Path) -> Path | None:
+        if not path.exists():
+            return None
+        suffix = f".before-switch-{datetime.now().strftime('%Y%m%dT%H%M%S%f')}-{uuid.uuid4().hex[:12]}.bak"
+        backup_path = path.with_name(path.name + suffix)
+        if backend == "sqlite":
+            source = sqlite3.connect(str(path), timeout=15.0)
+            destination = sqlite3.connect(str(backup_path), timeout=15.0)
+            try:
+                source.backup(destination)
+                destination.commit()
+            finally:
+                destination.close()
+                source.close()
+        else:
+            shutil.copy2(path, backup_path)
+        return backup_path
+
+    @staticmethod
+    def _restore_store_switch_target(
+        backend: str,
+        path: Path,
+        backup_path: Path | None,
+    ) -> None:
+        for sidecar in (Path(str(path) + "-wal"), Path(str(path) + "-shm")):
+            sidecar.unlink(missing_ok=True)
+        if backup_path is None:
+            path.unlink(missing_ok=True)
+            return
+        if backend == "sqlite":
+            source = sqlite3.connect(str(backup_path), timeout=15.0)
+            destination = sqlite3.connect(str(path), timeout=15.0)
+            try:
+                source.backup(destination)
+                destination.commit()
+            finally:
+                destination.close()
+                source.close()
+        else:
+            shutil.copy2(backup_path, path)
+
     def _rebuild_store_manager(self, *, reload_data: bool = False) -> None:
         backend = str(getattr(self, "storage_backend", "json") or "json").strip().lower() or "json"
         if backend not in {"json", "sqlite"}:
@@ -305,17 +349,104 @@ class CoreStoreMixin:
                     invalid_reason,
                     default_sqlite_path,
                 )
+        previous_effective_path = str(
+            getattr(self, "storage_sqlite_effective_path", "") or ""
+        )
+        previous_manager = getattr(self, "store_manager", None)
+        previous_data = deepcopy(getattr(self, "data", {})) if reload_data else None
+        previous_manager_backend = str(
+            getattr(previous_manager, "backend_name", "") or ""
+        ).lower()
+        previous_manager_sqlite_path = str(
+            getattr(previous_manager, "sqlite_path", "") or ""
+        )
+        previous_configured_backend = str(
+            getattr(
+                self,
+                "_storage_backend_applied",
+                previous_manager_backend or "json",
+            )
+        )
+        if hasattr(self, "_storage_sqlite_path_applied"):
+            previous_configured_sqlite_path = str(
+                getattr(self, "_storage_sqlite_path_applied", "") or ""
+            )
+        else:
+            previous_configured_sqlite_path = (
+                ""
+                if previous_manager_sqlite_path
+                and Path(previous_manager_sqlite_path).resolve()
+                == Path(default_sqlite_path).resolve()
+                else previous_manager_sqlite_path
+            )
+        same_store = bool(
+            reload_data
+            and previous_manager is not None
+            and previous_manager_backend == backend
+            and (
+                backend != "sqlite"
+                or Path(previous_manager_sqlite_path).resolve()
+                == Path(sqlite_path).resolve()
+            )
+        )
+        target_path = Path(sqlite_path if backend == "sqlite" else self.data_file)
+        target_backup: Path | None = None
+        target_write_started = False
+        try:
+            next_manager = StoreManager(
+                backend_name=backend,
+                data_file=self.data_file,
+                sqlite_path=sqlite_path,
+                ensure_defaults=self._ensure_store_defaults,
+                new_store=self._new_store,
+            )
+            if reload_data and not same_store and isinstance(previous_data, dict):
+                # A backend change must carry the current authority forward before
+                # reading the target, otherwise switching away from SQLite falls
+                # back to an obsolete JSON mirror.
+                target_backup = self._backup_store_switch_target(backend, target_path)
+                target_write_started = True
+                with self._data_save_io_lock():
+                    with next_manager._store_lock:
+                        next_manager.backend.save_store(deepcopy(previous_data))
+                    self._advance_data_save_write_generation()
+                loaded = next_manager.backend.load_store()
+                if not isinstance(loaded, dict):
+                    raise RuntimeError("Storage switch target returned a non-object store")
+            elif reload_data:
+                loaded = next_manager.load_initial_store()
+            else:
+                loaded = None
+        except Exception:
+            if target_write_started:
+                try:
+                    self._restore_store_switch_target(
+                        backend,
+                        target_path,
+                        target_backup,
+                    )
+                except Exception as restore_exc:
+                    logger.error(
+                        "[PrivateCompanion] Failed to restore storage switch target: %s",
+                        _single_line(restore_exc, 200),
+                    )
+            if reload_data and previous_manager is not None:
+                self.storage_backend = previous_configured_backend
+                self.storage_sqlite_path = previous_configured_sqlite_path
+                self.storage_sqlite_effective_path = previous_effective_path
+                self.store_manager = previous_manager
+                if isinstance(previous_data, dict):
+                    self.data = previous_data
+            raise
+
         self.storage_backend = backend
         self.storage_sqlite_effective_path = sqlite_path
-        self.store_manager = StoreManager(
-            backend_name=backend,
-            data_file=self.data_file,
-            sqlite_path=sqlite_path,
-            ensure_defaults=self._ensure_store_defaults,
-            new_store=self._new_store,
-        )
-        if reload_data:
-            self.data = self.store_manager.load_initial_store()
+        self._storage_backend_applied = backend
+        self._storage_sqlite_path_applied = configured_sqlite_path
+        self.store_manager = next_manager
+        if reload_data and isinstance(loaded, dict):
+            self.data = loaded
+            self._refresh_data_save_revision_from_manager()
 
     async def _save_config_if_possible(self) -> bool:
         for method_name in ("save_config", "save", "save_conf"):
@@ -930,11 +1061,99 @@ class CoreStoreMixin:
             logger.warning("[PrivateCompanion] 已根据本地书页和删除记录校准夹层书库: changed=%s", recovered)
         return recovered
 
+    def _persist_startup_maintenance_sync(
+        self,
+        manager: Any,
+        before: dict[str, Any],
+        data: dict[str, Any],
+        persisted_tombstones: dict[str, int] | None = None,
+    ) -> None:
+        tombstones = {
+            str(section): int(revision)
+            for section, revision in (persisted_tombstones or {}).items()
+        }
+        for section in tombstones:
+            data.pop(section, None)
+        changed_sections = {
+            str(section)
+            for section, value in data.items()
+            if section not in before or before[section] != value
+        }
+        deleted_sections = {str(section) for section in before if section not in data}
+        bookshelf_sections = {
+            "bookshelf_items",
+            "bookshelf_secret",
+            "bookshelf_store_revision",
+            "jm_cosmos_integration",
+        }
+        bookshelf_tombstones = bookshelf_sections & set(tombstones)
+        if bookshelf_sections & (changed_sections | deleted_sections):
+            changed_sections.difference_update(bookshelf_tombstones)
+            deleted_sections.update(bookshelf_tombstones)
+        if not changed_sections and not deleted_sections:
+            return
+
+        incremental = bool(
+            str(getattr(manager, "backend_name", "") or "").lower() == "sqlite"
+            and callable(getattr(manager, "save_sections", None))
+            and callable(getattr(manager, "next_revision", None))
+        )
+        if not incremental:
+            manager.save_store(data)
+            self._refresh_data_save_revision_from_manager()
+            return
+
+        self._expand_bookshelf_save_sections(
+            data,
+            changed_sections,
+            deleted_sections,
+            tombstones,
+        )
+        revision = manager.next_revision()
+        if isinstance(revision, bool) or not isinstance(revision, int) or revision < 1:
+            raise RuntimeError("SQLite startup maintenance returned an invalid revision")
+        confirmed = manager.save_sections(
+            {
+                section: (revision, deepcopy(data[section]))
+                for section in changed_sections
+            },
+            {section: revision for section in deleted_sections},
+        )
+        expected = changed_sections | deleted_sections
+        unconfirmed = sorted(
+            section
+            for section in expected
+            if int(confirmed.get(section, -1)) < revision
+        )
+        if unconfirmed:
+            raise RuntimeError(
+                "SQLite startup maintenance did not confirm sections: "
+                + ", ".join(unconfirmed)
+            )
+        self._refresh_data_save_revision_from_manager()
+
     def _load_data_sync(self) -> dict[str, Any]:
         manager = getattr(self, "store_manager", None)
         if manager is not None:
             try:
                 data = manager.load_initial_store()
+                manager_backend = str(
+                    getattr(manager, "backend_name", "") or ""
+                ).lower()
+                persisted_bookshelf_tombstones: dict[str, int] = {}
+                deleted_revisions = getattr(manager, "deleted_section_revisions", None)
+                if manager_backend == "sqlite" and callable(deleted_revisions):
+                    persisted_bookshelf_tombstones = dict(
+                        deleted_revisions(
+                            {
+                                "bookshelf_items",
+                                "bookshelf_secret",
+                                "bookshelf_store_revision",
+                                "jm_cosmos_integration",
+                            }
+                        )
+                    )
+                before_maintenance = deepcopy(data)
                 changed = self._sanitize_store_control_tags_inplace(data)
                 repeat_changed = self._sanitize_proactive_candidate_repeat_counts_inplace(data)
                 compacted = self._compact_store_history_inplace(data)
@@ -945,13 +1164,12 @@ class CoreStoreMixin:
                     logger.warning("[PrivateCompanion] 启动读取数据时压缩主动候选重复计数: items=%s", repeat_changed)
                 if compacted:
                     logger.info("[PrivateCompanion] 启动读取数据时压缩历史存储: %s", compacted)
-                if bookshelf_recovered:
-                    manager.save_store(data)
-                    if getattr(self, "storage_backend", "json") == "sqlite":
-                        try:
-                            manager.export_current_to_json(data)
-                        except Exception as exc:
-                            logger.debug("[PrivateCompanion] 夹层恢复后的 JSON 镜像写出失败: %s", _single_line(exc, 160))
+                self._persist_startup_maintenance_sync(
+                    manager,
+                    before_maintenance,
+                    data,
+                    persisted_bookshelf_tombstones,
+                )
                 return data
             except Exception as exc:
                 logger.error(
@@ -985,7 +1203,12 @@ class CoreStoreMixin:
             )
             raise
 
-    def _save_data_sync(self):
+    def _save_data_sync(
+        self,
+        *,
+        sections: Collection[str] | None = None,
+        deleted_sections: Collection[str] = (),
+    ):
         scoped_scheduler = getattr(self, "_req041_schedule_scoped_sync", None)
         if callable(scoped_scheduler):
             scoped_scheduler()
@@ -997,33 +1220,70 @@ class CoreStoreMixin:
                 snapshot = deepcopy(self.data)
                 self._write_persona_data_snapshot_sync(active_persona, snapshot)
                 return
-            self._schedule_data_save(delay=0.35)
+            self._schedule_data_save(
+                sections=sections,
+                deleted_sections=deleted_sections,
+                delay=0.35,
+            )
             return
-        compacted = self._compact_store_history_inplace(self.data)
-        if compacted:
-            logger.info("[PrivateCompanion] 保存前压缩历史存储: %s", compacted)
         try:
             asyncio.get_running_loop()
         except RuntimeError:
-            self._save_data_now_sync()
+            self._save_data_now_sync(deleted_sections=deleted_sections)
             return
-        self._schedule_data_save(delay=0.35)
+        self._schedule_data_save(
+            sections=sections,
+            deleted_sections=deleted_sections,
+            delay=0.35,
+        )
 
-    def _save_data_now_sync(self) -> None:
+    def _save_data_now_sync(
+        self,
+        *,
+        deleted_sections: Collection[str] = (),
+    ) -> None:
         changed = self._sanitize_store_control_tags_inplace(self.data)
         repeat_changed = self._sanitize_proactive_candidate_repeat_counts_inplace(self.data)
+        compacted = self._compact_store_history_inplace(self.data)
         if changed:
             self._log_store_control_cleanup("immediate_save", changed)
         if repeat_changed:
             logger.warning("[PrivateCompanion] 保存数据前压缩主动候选重复计数: items=%s", repeat_changed)
+        if compacted:
+            logger.info("[PrivateCompanion] 保存前压缩历史存储: %s", compacted)
         manager = getattr(self, "store_manager", None)
         if manager is not None:
-            manager.save_store(self.data)
-            if getattr(self, "storage_backend", "json") == "sqlite":
-                try:
-                    manager.export_current_to_json(self.data)
-                except Exception as exc:
-                    logger.debug("[PrivateCompanion] SQLite 镜像 JSON 写出失败: %s", _single_line(exc, 160))
+            manager_backend = str(getattr(manager, "backend_name", "") or "").lower()
+            save_sections = getattr(manager, "save_sections", None)
+            if manager_backend == "sqlite" and callable(save_sections):
+                self._ensure_default_save_state()
+                revision = self._next_data_save_revision()
+                deleted = self._save_section_names(deleted_sections) or set()
+                changed_sections = {
+                    str(section): (revision, deepcopy(value))
+                    for section, value in self.data.items()
+                    if str(section) not in deleted
+                }
+                with self._data_save_io_lock():
+                    confirmed = save_sections(
+                        changed_sections,
+                        {section: revision for section in deleted},
+                    )
+                    if any(
+                        int(confirmed.get(section, -1)) < revision
+                        for section in changed_sections
+                    ):
+                        raise RuntimeError(
+                            "SQLite synchronous section save did not confirm all sections"
+                        )
+                    self._refresh_data_save_revision_from_manager()
+                    self._clear_default_data_save_dirty()
+                    self._advance_data_save_write_generation()
+                return
+            with self._data_save_io_lock():
+                manager.save_store(self.data)
+                self._refresh_data_save_revision_from_manager()
+                self._advance_data_save_write_generation()
             return
         if not self.data.get("worldbook_entries") and os.path.exists(self.data_file):
             try:
@@ -1039,21 +1299,24 @@ class CoreStoreMixin:
                         self.data[key] = existing.get(key, self.data.get(key))
             except Exception:
                 pass
-        self._atomic_write_data_file_sync(self.data)
+        with self._data_save_io_lock():
+            self._atomic_write_data_file_sync(self.data)
+            self._advance_data_save_write_generation()
 
     def _write_data_snapshot_sync(self, data: dict[str, Any]) -> int:
         changed = self._sanitize_store_control_tags_inplace(data)
+        self._sanitize_proactive_candidate_repeat_counts_inplace(data)
         self._compact_store_history_inplace(data)
         manager = getattr(self, "store_manager", None)
         if manager is not None:
-            manager.save_snapshot(data)
-            if getattr(self, "storage_backend", "json") == "sqlite":
-                try:
-                    manager.export_current_to_json(data)
-                except Exception as exc:
-                    logger.debug("[PrivateCompanion] SQLite 快照镜像 JSON 写出失败: %s", _single_line(exc, 160))
+            with self._data_save_io_lock():
+                manager.save_snapshot(data)
+                self._refresh_data_save_revision_from_manager()
+                self._advance_data_save_write_generation()
             return changed
-        self._atomic_write_data_file_sync(data)
+        with self._data_save_io_lock():
+            self._atomic_write_data_file_sync(data)
+            self._advance_data_save_write_generation()
         return changed
 
     def _atomic_write_data_file_sync(self, data: dict[str, Any]) -> None:
@@ -1104,166 +1367,978 @@ class CoreStoreMixin:
 
     def _write_persona_data_snapshot_sync(self, persona_id: str, data: dict[str, Any]) -> int:
         changed = self._sanitize_store_control_tags_inplace(data)
+        self._sanitize_proactive_candidate_repeat_counts_inplace(data)
         self._compact_store_history_inplace(data)
         saver = getattr(self, "_save_persona_profile_sync", None)
         if not callable(saver):
             raise RuntimeError("persona profile saver is unavailable")
-        saver(persona_id, data)
+        with self._data_save_io_lock(persona_id):
+            saver(persona_id, data)
+            self._advance_data_save_write_generation(persona_id)
         return changed
 
-    def _schedule_persona_data_save(self, persona_id: str, delay: float) -> None:
-        dirty = getattr(self, "_persona_data_save_dirty", None)
-        if not isinstance(dirty, set):
-            dirty = set()
-            self._persona_data_save_dirty = dirty
-        tasks = getattr(self, "_persona_data_save_tasks", None)
-        if not isinstance(tasks, dict):
-            tasks = {}
-            self._persona_data_save_tasks = tasks
-        dirty.add(persona_id)
+    @staticmethod
+    def _save_section_names(values: Collection[str] | None) -> set[str] | None:
+        if values is None:
+            return None
+        if isinstance(values, str):
+            values = (values,)
+        return {str(value).strip() for value in values if str(value).strip()}
+
+    def _save_is_stopping(self) -> bool:
         stop_event = getattr(self, "_stop_event", None)
-        if stop_event is not None and callable(getattr(stop_event, "is_set", None)) and stop_event.is_set():
+        return bool(
+            stop_event is not None
+            and callable(getattr(stop_event, "is_set", None))
+            and stop_event.is_set()
+        )
+
+    def _data_save_io_lock(self, persona_id: str = "") -> threading.RLock:
+        if not persona_id:
+            lock = getattr(self, "_data_save_io_lock_instance", None)
+            if lock is None:
+                lock = threading.RLock()
+                self._data_save_io_lock_instance = lock
+            return lock
+        locks = getattr(self, "_persona_data_save_io_locks", None)
+        if not isinstance(locks, dict):
+            locks = {}
+            self._persona_data_save_io_locks = locks
+        lock = locks.get(persona_id)
+        if lock is None:
+            lock = threading.RLock()
+            locks[persona_id] = lock
+        return lock
+
+    def _current_data_save_write_generation(self, persona_id: str = "") -> int:
+        if persona_id:
+            generations = getattr(self, "_persona_data_save_write_generation", None)
+            if not isinstance(generations, dict):
+                generations = {}
+                self._persona_data_save_write_generation = generations
+            return max(0, int(generations.get(persona_id, 0) or 0))
+        generation = getattr(self, "_data_save_write_generation", 0)
+        if not isinstance(generation, int) or isinstance(generation, bool):
+            generation = 0
+            self._data_save_write_generation = generation
+        return max(0, generation)
+
+    def _advance_data_save_write_generation(self, persona_id: str = "") -> int:
+        generation = self._current_data_save_write_generation(persona_id) + 1
+        if persona_id:
+            self._persona_data_save_write_generation[persona_id] = generation
+        else:
+            self._data_save_write_generation = generation
+        return generation
+
+    def _ensure_default_save_state(self) -> None:
+        legacy_dirty = getattr(self, "_data_save_dirty", None) is True
+        if not isinstance(getattr(self, "_data_save_dirty", None), dict):
+            self._data_save_dirty = {}
+        if not isinstance(getattr(self, "_data_save_deleted", None), dict):
+            self._data_save_deleted = {}
+        if not isinstance(getattr(self, "_data_save_dirty_since", None), dict):
+            self._data_save_dirty_since = {}
+        if not isinstance(getattr(self, "_data_save_section_revisions", None), dict):
+            self._data_save_section_revisions = {}
+        if not isinstance(getattr(self, "_data_save_full_revision", None), int):
+            self._data_save_full_revision = 0
+        if not isinstance(getattr(self, "_data_save_revision", None), int):
+            seed = 1
+            manager = getattr(self, "store_manager", None)
+            next_revision = getattr(manager, "next_revision", None)
+            if callable(next_revision):
+                try:
+                    seed = max(1, int(next_revision()))
+                except Exception:
+                    seed = 1
+            self._data_save_revision = seed - 1
+        if not isinstance(getattr(self, "_data_save_write_generation", None), int):
+            self._data_save_write_generation = 0
+        if legacy_dirty and not self._data_save_dirty and not self._data_save_deleted:
+            revision = self._next_data_save_revision()
+            now = time.monotonic()
+            live_data = getattr(self, "data", {})
+            for section in live_data if isinstance(live_data, dict) else ():
+                self._data_save_dirty[str(section)] = revision
+                self._data_save_dirty_since[str(section)] = now
+                self._data_save_section_revisions[str(section)] = revision
+            self._data_save_full_revision = revision
+            self._data_save_full_since = now
+
+    def _refresh_data_save_revision_from_manager(self) -> int:
+        manager = getattr(self, "store_manager", None)
+        next_revision = getattr(manager, "next_revision", None)
+        if not callable(next_revision):
+            return max(0, int(getattr(self, "_data_save_revision", 0) or 0))
+        try:
+            persisted = max(0, int(next_revision()) - 1)
+        except Exception:
+            return max(0, int(getattr(self, "_data_save_revision", 0) or 0))
+        current = max(0, int(getattr(self, "_data_save_revision", 0) or 0))
+        self._data_save_revision = max(current, persisted)
+        return self._data_save_revision
+
+    def _ensure_persona_save_state(self) -> None:
+        legacy_dirty = getattr(self, "_persona_data_save_dirty", None)
+        legacy_personas = set(legacy_dirty) if isinstance(legacy_dirty, set) else set()
+        for name in (
+            "_persona_data_save_dirty",
+            "_persona_data_save_deleted",
+            "_persona_data_save_dirty_since",
+            "_persona_data_save_full_revision",
+            "_persona_data_save_revision",
+            "_persona_data_save_section_revisions",
+        ):
+            if not isinstance(getattr(self, name, None), dict):
+                setattr(self, name, {})
+        if not isinstance(
+            getattr(self, "_persona_data_save_write_generation", None), dict
+        ):
+            self._persona_data_save_write_generation = {}
+        if not isinstance(getattr(self, "_persona_data_save_tasks", None), dict):
+            self._persona_data_save_tasks = {}
+        for persona_id in legacy_personas:
+            if persona_id in self._persona_data_save_dirty or persona_id in self._persona_data_save_deleted:
+                continue
+            revision = max(1, int(self._persona_data_save_revision.get(persona_id, 0) or 0) + 1)
+            self._persona_data_save_revision[persona_id] = revision
+            profile = self._persona_data_for_save(str(persona_id))
+            dirty = self._persona_data_save_dirty.setdefault(str(persona_id), {})
+            since = self._persona_data_save_dirty_since.setdefault(str(persona_id), {})
+            section_revisions = self._persona_data_save_section_revisions.setdefault(str(persona_id), {})
+            now = time.monotonic()
+            for section in profile if isinstance(profile, dict) else ():
+                dirty[str(section)] = revision
+                since[str(section)] = now
+                section_revisions[str(section)] = revision
+            self._persona_data_save_full_revision[str(persona_id)] = revision
+
+    def _next_data_save_revision(self, persona_id: str = "") -> int:
+        if persona_id:
+            self._ensure_persona_save_state()
+            current = max(0, int(self._persona_data_save_revision.get(persona_id, 0) or 0))
+            revision = current + 1
+            self._persona_data_save_revision[persona_id] = revision
+            return revision
+        self._ensure_default_save_state()
+        revision = max(0, int(self._data_save_revision or 0)) + 1
+        self._data_save_revision = revision
+        return revision
+
+    @staticmethod
+    def _expand_bookshelf_save_sections(
+        live_data: dict[str, Any],
+        changed: set[str],
+        deleted: set[str],
+        already_deleted: dict[str, int],
+    ) -> None:
+        bookshelf_sections = {
+            "bookshelf_items",
+            "bookshelf_secret",
+            "bookshelf_store_revision",
+            "jm_cosmos_integration",
+        }
+        if not (bookshelf_sections & (changed | deleted)):
             return
-        task = tasks.get(persona_id)
-        if isinstance(task, asyncio.Task) and not task.done():
+        for section in bookshelf_sections:
+            if section in live_data and section not in deleted and section not in already_deleted:
+                changed.add(section)
+
+    def _mark_default_data_dirty(
+        self,
+        *,
+        sections: Collection[str] | None,
+        deleted_sections: Collection[str],
+    ) -> bool:
+        self._ensure_default_save_state()
+        changed = self._save_section_names(sections)
+        deleted = self._save_section_names(deleted_sections) or set()
+        full = changed is None
+        if changed is None:
+            changed = {str(name) for name in self.data}
+        if changed & deleted:
+            raise ValueError("changed and deleted sections must be disjoint")
+        if not changed and not deleted and not full:
+            return False
+        self._expand_bookshelf_save_sections(self.data, changed, deleted, self._data_save_deleted)
+        revision = self._next_data_save_revision()
+        now = time.monotonic()
+        for section in changed:
+            self._data_save_dirty[section] = revision
+            self._data_save_deleted.pop(section, None)
+            self._data_save_dirty_since.setdefault(section, now)
+            self._data_save_section_revisions[section] = revision
+        for section in deleted:
+            self._data_save_deleted[section] = revision
+            self._data_save_dirty.pop(section, None)
+            self._data_save_dirty_since.setdefault(section, now)
+            self._data_save_section_revisions[section] = revision
+        if full:
+            self._data_save_full_revision = revision
+            self._data_save_full_since = now
+        return True
+
+    def _mark_persona_data_dirty(
+        self,
+        persona_id: str,
+        *,
+        sections: Collection[str] | None,
+        deleted_sections: Collection[str],
+    ) -> bool:
+        self._ensure_persona_save_state()
+        live_data = self._persona_data_for_save(persona_id)
+        changed = self._save_section_names(sections)
+        deleted = self._save_section_names(deleted_sections) or set()
+        full = changed is None
+        if changed is None:
+            changed = {str(name) for name in live_data}
+        if changed & deleted:
+            raise ValueError("changed and deleted sections must be disjoint")
+        if not changed and not deleted and not full:
+            return False
+        dirty = self._persona_data_save_dirty.setdefault(persona_id, {})
+        removed = self._persona_data_save_deleted.setdefault(persona_id, {})
+        dirty_since = self._persona_data_save_dirty_since.setdefault(persona_id, {})
+        section_revisions = self._persona_data_save_section_revisions.setdefault(persona_id, {})
+        self._expand_bookshelf_save_sections(live_data, changed, deleted, removed)
+        revision = self._next_data_save_revision(persona_id)
+        now = time.monotonic()
+        for section in changed:
+            dirty[section] = revision
+            removed.pop(section, None)
+            dirty_since.setdefault(section, now)
+            section_revisions[section] = revision
+        for section in deleted:
+            removed[section] = revision
+            dirty.pop(section, None)
+            dirty_since.setdefault(section, now)
+            section_revisions[section] = revision
+        if full:
+            self._persona_data_save_full_revision[persona_id] = revision
+        return True
+
+    def _default_data_save_is_dirty(self) -> bool:
+        dirty = getattr(self, "_data_save_dirty", None)
+        if not isinstance(dirty, dict):
+            return bool(dirty)
+        return bool(
+            dirty
+            or getattr(self, "_data_save_deleted", {})
+            or getattr(self, "_data_save_full_revision", 0)
+        )
+
+    def _persona_data_save_is_dirty(self, persona_id: str) -> bool:
+        self._ensure_persona_save_state()
+        return bool(
+            self._persona_data_save_dirty.get(persona_id)
+            or self._persona_data_save_deleted.get(persona_id)
+            or self._persona_data_save_full_revision.get(persona_id, 0)
+        )
+
+    def _dirty_persona_ids(self) -> set[str]:
+        self._ensure_persona_save_state()
+        return {
+            str(persona_id)
+            for source in (
+                self._persona_data_save_dirty,
+                self._persona_data_save_deleted,
+                self._persona_data_save_full_revision,
+            )
+            for persona_id, value in source.items()
+            if value
+        }
+
+    def _capture_data_save_batch(
+        self,
+        live_data: dict[str, Any],
+        dirty: dict[str, int],
+        deleted: dict[str, int],
+        full_revision: int,
+        section_revisions: dict[str, int],
+        *,
+        full_snapshot: bool,
+    ) -> dict[str, Any]:
+        captured_revisions = dict(dirty)
+        captured_deleted = dict(deleted)
+        payloads = {
+            section: deepcopy(live_data[section])
+            for section in captured_revisions
+            if section in live_data and section not in captured_deleted
+        }
+        missing = {
+            section: revision
+            for section, revision in captured_revisions.items()
+            if section not in live_data and section not in captured_deleted
+        }
+        readonly_context: dict[str, Any] = {}
+        dependency_revisions: dict[str, int] = {}
+        if "proactive_candidate_pool" in payloads and "users" not in payloads:
+            users = live_data.get("users")
+            if isinstance(users, dict):
+                readonly_context["users"] = deepcopy(users)
+                dependency_revisions["users"] = int(section_revisions.get("users", 0) or 0)
+        return {
+            "changed_revisions": {
+                section: revision
+                for section, revision in captured_revisions.items()
+                if section in payloads
+            },
+            "deleted_revisions": captured_deleted,
+            "missing_revisions": missing,
+            "payloads": payloads,
+            "readonly_context": readonly_context,
+            "dependency_revisions": dependency_revisions,
+            "full_revision": int(full_revision or 0),
+            "full_snapshot": deepcopy(live_data) if full_snapshot else None,
+        }
+
+    def _capture_default_data_save_batch(
+        self,
+        *,
+        force_full: bool = False,
+    ) -> dict[str, Any]:
+        self._ensure_default_save_state()
+        write_generation = self._current_data_save_write_generation()
+        manager = getattr(self, "store_manager", None)
+        manager_backend = str(getattr(manager, "backend_name", "") or "").lower()
+        full_compatibility_save = bool(self._data_save_full_revision)
+        full_replacement = bool(force_full and full_compatibility_save)
+        incremental = bool(
+            manager_backend == "sqlite"
+            and callable(getattr(manager, "save_sections", None))
+            and not full_replacement
+        )
+        batch = self._capture_data_save_batch(
+            self.data,
+            self._data_save_dirty,
+            self._data_save_deleted,
+            self._data_save_full_revision,
+            self._data_save_section_revisions,
+            full_snapshot=not incremental,
+        )
+        batch["incremental"] = incremental
+        batch["full_replacement"] = full_replacement
+        batch["preserve_tombstones"] = full_replacement
+        batch["write_generation"] = write_generation
+        return batch
+
+    async def _flush_default_data_save_on_terminate(self) -> None:
+        """Drain SQLite default-store revisions without replacing persisted tombstones."""
+        manager = getattr(self, "store_manager", None)
+        if not (
+            str(getattr(manager, "backend_name", "") or "").lower() == "sqlite"
+            and callable(getattr(manager, "save_sections", None))
+        ):
             return
 
-        async def _runner() -> None:
-            should_retry = False
+        current = asyncio.current_task()
+        task = getattr(self, "_data_save_task", None)
+        if isinstance(task, asyncio.Task) and not task.done() and task is not current:
             try:
-                while persona_id in dirty:
-                    dirty.discard(persona_id)
-                    await asyncio.sleep(max(0.0, float(delay)))
-                    live_data = self._persona_data_for_save(persona_id)
-                    snapshot = deepcopy(live_data)
-                    try:
-                        snapshot_changed = await asyncio.to_thread(
-                            self._write_persona_data_snapshot_sync,
-                            persona_id,
-                            snapshot,
-                        )
-                    finally:
-                        # Do not keep a full store copy alive while waiting for the
-                        # next coalesced write; this matters for large persona stores.
-                        snapshot = None
-                    if snapshot_changed:
-                        live_changed = self._sanitize_store_control_tags_inplace(live_data)
-                        if live_changed:
-                            dirty.add(persona_id)
-                            self._log_store_control_cleanup(
-                                "delayed_persona_save_live_sync",
-                                live_changed,
-                            )
+                await asyncio.shield(task)
             except asyncio.CancelledError:
-                raise
+                # A cancelled scheduled writer leaves its revisions dirty for this
+                # final pass to retry.
+                pass
             except Exception as exc:
-                dirty.add(persona_id)
-                should_retry = True
-                logger.warning(
-                    "[PrivateCompanion] 延迟保存人格数据失败: persona=%s error=%s",
-                    persona_id,
+                logger.debug(
+                    "[PrivateCompanion] Waiting for the default incremental writer "
+                    "during shutdown failed: %s",
                     _single_line(exc, 160),
                 )
-            finally:
-                tasks.pop(persona_id, None)
-                stop_event = getattr(self, "_stop_event", None)
-                stopping = bool(
-                    stop_event is not None
-                    and callable(getattr(stop_event, "is_set", None))
-                    and stop_event.is_set()
-                )
-                if not stopping and persona_id in dirty:
-                    retry_delay = (
-                        max(3.0, min(30.0, float(delay) * 2.0 if delay else 3.0))
-                        if should_retry
-                        else max(0.0, float(delay))
+
+        self._ensure_default_save_state()
+        while self._default_data_save_is_dirty():
+            # ``sections=None`` is the compatibility full-replacement path.
+            # Preserve that meaning during shutdown so a section removed from
+            # the live store is removed by the full snapshot, while ordinary
+            # partial batches still require explicit tombstones.
+            batch = self._capture_default_data_save_batch(force_full=True)
+            result = await asyncio.to_thread(
+                self._write_default_data_save_batch_sync,
+                batch,
+            )
+            self._finish_default_data_save_batch(batch, result)
+            if self._default_data_save_is_dirty():
+                await asyncio.sleep(0)
+
+    def _capture_persona_data_save_batch(self, persona_id: str) -> dict[str, Any]:
+        self._ensure_persona_save_state()
+        write_generation = self._current_data_save_write_generation(persona_id)
+        batch = self._capture_data_save_batch(
+            self._persona_data_for_save(persona_id),
+            self._persona_data_save_dirty.setdefault(persona_id, {}),
+            self._persona_data_save_deleted.setdefault(persona_id, {}),
+            int(self._persona_data_save_full_revision.get(persona_id, 0) or 0),
+            self._persona_data_save_section_revisions.setdefault(persona_id, {}),
+            full_snapshot=True,
+        )
+        batch["write_generation"] = write_generation
+        return batch
+
+    def _prepare_dirty_save_payloads_sync(
+        self,
+        payloads: dict[str, Any],
+        readonly_context: dict[str, Any],
+    ) -> tuple[dict[str, Any], int, int, dict[str, int], set[str]]:
+        prepared = payloads
+        original_payloads = deepcopy(payloads)
+        control_changed = self._sanitize_store_control_tags_inplace(prepared)
+        repeat_changed = self._sanitize_proactive_candidate_repeat_counts_inplace(prepared)
+        readonly_names: set[str] = set()
+        for section, value in readonly_context.items():
+            if section not in prepared:
+                prepared[section] = value
+                readonly_names.add(section)
+        compacted = self._compact_store_history_inplace(prepared)
+        for section in readonly_names:
+            prepared.pop(section, None)
+        cleaned_sections = {
+            section
+            for section, value in prepared.items()
+            if section not in original_payloads or original_payloads[section] != value
+        }
+        return prepared, control_changed, repeat_changed, compacted, cleaned_sections
+
+    def _write_default_data_save_batch_sync(self, batch: dict[str, Any]) -> dict[str, Any]:
+        if batch["incremental"] and batch["missing_revisions"]:
+            missing = ", ".join(sorted(batch["missing_revisions"]))
+            raise RuntimeError(
+                "SQLite incremental save found missing dirty sections without "
+                f"explicit tombstones: {missing}"
+            )
+        prepared, control_changed, repeat_changed, compacted, cleaned_sections = self._prepare_dirty_save_payloads_sync(
+            batch["payloads"],
+            batch["readonly_context"],
+        )
+        changed_revisions = dict(batch["changed_revisions"])
+        if (
+            "proactive_candidate_repeat_sanitized_at" in prepared
+            and "proactive_candidate_repeat_sanitized_at" not in changed_revisions
+            and "proactive_candidate_pool" in changed_revisions
+        ):
+            changed_revisions["proactive_candidate_repeat_sanitized_at"] = changed_revisions[
+                "proactive_candidate_pool"
+            ]
+        manager = getattr(self, "store_manager", None)
+        confirmed: dict[str, int] = {}
+        superseded = False
+        if batch["incremental"]:
+            with self._data_save_io_lock():
+                if batch["write_generation"] != self._current_data_save_write_generation():
+                    superseded = True
+                else:
+                    confirmed = manager.save_sections(
+                        {
+                            section: (revision, prepared[section])
+                            for section, revision in changed_revisions.items()
+                            if section in prepared
+                        },
+                        batch["deleted_revisions"],
                     )
-                    try:
-                        self._schedule_persona_data_save(persona_id, retry_delay)
-                    except Exception as retry_exc:
-                        logger.warning(
-                            "[PrivateCompanion] 延迟保存人格数据重试调度失败: persona=%s error=%s",
-                            persona_id,
-                            _single_line(retry_exc, 160),
+        else:
+            snapshot = batch["full_snapshot"]
+            for section, value in prepared.items():
+                snapshot[section] = value
+            for section in batch["deleted_revisions"]:
+                snapshot.pop(section, None)
+            # SQLite full replacement assigns one backend revision to the whole
+            # snapshot.  Raise that baseline to the newest revision captured in
+            # this batch so its confirmation never trails the payload it stores.
+            sqlite_snapshot = (
+                manager is not None
+                and str(getattr(manager, "backend_name", "") or "").lower()
+                == "sqlite"
+            )
+            expected_revisions = {
+                **changed_revisions,
+                **batch["deleted_revisions"],
+                **batch["missing_revisions"],
+            }
+            if sqlite_snapshot:
+                minimum_revision = max(
+                    int(batch["full_revision"] or 0),
+                    *(int(revision) for revision in expected_revisions.values()),
+                )
+                with self._data_save_io_lock():
+                    if batch["write_generation"] != self._current_data_save_write_generation():
+                        superseded = True
+                    else:
+                        persisted_revision = manager.save_snapshot(
+                            snapshot,
+                            minimum_revision=max(1, minimum_revision),
+                            deleted_sections=batch["deleted_revisions"],
+                            preserve_tombstones=bool(
+                                batch.get("preserve_tombstones", False)
+                            ),
                         )
+                        if (
+                            isinstance(persisted_revision, bool)
+                            or not isinstance(persisted_revision, int)
+                            or persisted_revision < minimum_revision
+                        ):
+                            raise RuntimeError(
+                                "SQLite full snapshot did not confirm its minimum revision"
+                            )
+                        confirmed = {
+                            section: persisted_revision for section in expected_revisions
+                        }
+            else:
+                with self._data_save_io_lock():
+                    if batch["write_generation"] != self._current_data_save_write_generation():
+                        superseded = True
+                    elif manager is not None:
+                        manager.save_snapshot(snapshot)
+                    else:
+                        # Keep the compatibility path behind the overridable
+                        # snapshot writer used by JSON/test harnesses.
+                        self._write_data_snapshot_sync(snapshot)
+                    if not superseded:
+                        confirmed = dict(expected_revisions)
+        return {
+            "confirmed": dict(confirmed or {}),
+            "superseded": superseded,
+            "prepared": prepared,
+            "changed_revisions": changed_revisions,
+            "control_changed": control_changed,
+            "repeat_changed": repeat_changed,
+            "compacted": compacted,
+            "cleaned_sections": cleaned_sections,
+        }
 
-        try:
-            tasks[persona_id] = asyncio.create_task(_runner())
-        except RuntimeError:
-            snapshot = deepcopy(self._persona_data_for_save(persona_id))
-            self._write_persona_data_snapshot_sync(persona_id, snapshot)
-            dirty.discard(persona_id)
+    def _write_persona_data_save_batch_sync(
+        self,
+        persona_id: str,
+        batch: dict[str, Any],
+    ) -> dict[str, Any]:
+        prepared, control_changed, repeat_changed, compacted, cleaned_sections = self._prepare_dirty_save_payloads_sync(
+            batch["payloads"],
+            batch["readonly_context"],
+        )
+        changed_revisions = dict(batch["changed_revisions"])
+        if (
+            "proactive_candidate_repeat_sanitized_at" in prepared
+            and "proactive_candidate_repeat_sanitized_at" not in changed_revisions
+            and "proactive_candidate_pool" in changed_revisions
+        ):
+            changed_revisions["proactive_candidate_repeat_sanitized_at"] = changed_revisions[
+                "proactive_candidate_pool"
+            ]
+        snapshot = batch["full_snapshot"]
+        for section, value in prepared.items():
+            snapshot[section] = value
+        for section in batch["deleted_revisions"]:
+            snapshot.pop(section, None)
+        saver = getattr(self, "_save_persona_profile_sync", None)
+        if not callable(saver):
+            raise RuntimeError("persona profile saver is unavailable")
+        superseded = False
+        confirmed: dict[str, int] = {}
+        with self._data_save_io_lock(persona_id):
+            if batch["write_generation"] != self._current_data_save_write_generation(
+                persona_id
+            ):
+                superseded = True
+            else:
+                saver(persona_id, snapshot)
+                confirmed = dict(changed_revisions)
+                confirmed.update(batch["deleted_revisions"])
+                confirmed.update(batch["missing_revisions"])
+        return {
+            "confirmed": confirmed,
+            "superseded": superseded,
+            "prepared": prepared,
+            "changed_revisions": changed_revisions,
+            "control_changed": control_changed,
+            "repeat_changed": repeat_changed,
+            "compacted": compacted,
+            "cleaned_sections": cleaned_sections,
+        }
 
-    def _schedule_default_data_save(self, delay: float) -> None:
-        self._data_save_dirty = True
-        stop_event = getattr(self, "_stop_event", None)
-        if stop_event is not None and callable(getattr(stop_event, "is_set", None)) and stop_event.is_set():
+    @classmethod
+    def _apply_cleaned_store_value_inplace(cls, target: Any, source: Any) -> bool:
+        if isinstance(target, dict) and isinstance(source, dict):
+            for key in tuple(target):
+                if key not in source:
+                    target.pop(key, None)
+            for key, value in source.items():
+                if key in target and cls._apply_cleaned_store_value_inplace(target[key], value):
+                    continue
+                target[key] = deepcopy(value)
+            return True
+        if isinstance(target, list) and isinstance(source, list):
+            target[:] = deepcopy(source)
+            return True
+        return target == source
+
+    def _apply_prepared_save_section(
+        self,
+        live_data: dict[str, Any],
+        section: str,
+        value: Any,
+    ) -> None:
+        if section in live_data and self._apply_cleaned_store_value_inplace(live_data[section], value):
+            return
+        live_data[section] = deepcopy(value)
+
+    def _finish_data_save_batch(
+        self,
+        live_data: dict[str, Any],
+        batch: dict[str, Any],
+        result: dict[str, Any],
+        dirty: dict[str, int],
+        deleted: dict[str, int],
+        dirty_since: dict[str, float],
+        section_revisions: dict[str, int],
+        *,
+        persona_id: str = "",
+    ) -> bool:
+        confirmed = result["confirmed"]
+        prepared = result["prepared"]
+        expected = {
+            **batch["changed_revisions"],
+            **batch["deleted_revisions"],
+            **batch["missing_revisions"],
+        }
+        derived = "proactive_candidate_repeat_sanitized_at"
+        derived_revision = result["changed_revisions"].get(derived)
+        if derived_revision is not None and derived not in batch["changed_revisions"]:
+            expected[derived] = derived_revision
+        dependency_stale = False
+        if (
+            "proactive_candidate_pool" in batch["changed_revisions"]
+            and "proactive_candidate_pool" in result["cleaned_sections"]
+        ):
+            dependency_stale = any(
+                int(section_revisions.get(section, 0) or 0) != int(revision or 0)
+                for section, revision in batch["dependency_revisions"].items()
+            )
+            if dependency_stale and dirty.get("proactive_candidate_pool") == batch["changed_revisions"].get(
+                "proactive_candidate_pool"
+            ):
+                revision = self._next_data_save_revision(persona_id)
+                dirty["proactive_candidate_pool"] = revision
+                section_revisions["proactive_candidate_pool"] = revision
+        for section, revision in batch["changed_revisions"].items():
+            if dirty.get(section) != revision or int(confirmed.get(section, -1)) < revision:
+                continue
+            if (
+                section == "proactive_candidate_pool"
+                and derived_revision is not None
+                and int(confirmed.get(derived, -1)) < derived_revision
+            ):
+                continue
+            if section == "proactive_candidate_pool" and dependency_stale:
+                continue
+            if section in prepared and section in result["cleaned_sections"]:
+                self._apply_prepared_save_section(live_data, section, prepared[section])
+            dirty.pop(section, None)
+            dirty_since.pop(section, None)
+        for section, revision in batch["deleted_revisions"].items():
+            if deleted.get(section) == revision and int(confirmed.get(section, -1)) >= revision:
+                deleted.pop(section, None)
+                dirty_since.pop(section, None)
+        for section, revision in batch["missing_revisions"].items():
+            if (
+                dirty.get(section) == revision
+                and int(confirmed.get(section, -1)) >= revision
+            ):
+                dirty.pop(section, None)
+                dirty_since.pop(section, None)
+        if derived in prepared and derived not in batch["changed_revisions"]:
+            source_revision = batch["changed_revisions"].get("proactive_candidate_pool")
+            if (
+                source_revision is not None
+                and not dependency_stale
+                and dirty.get("proactive_candidate_pool") in {None, source_revision}
+                and int(confirmed.get(derived, -1)) >= source_revision
+                and int(section_revisions.get(derived, 0) or 0) <= source_revision
+            ):
+                self._apply_prepared_save_section(live_data, derived, prepared[derived])
+                section_revisions[derived] = source_revision
+        complete = all(int(confirmed.get(section, -1)) >= revision for section, revision in expected.items())
+        return complete and not dependency_stale
+
+    def _finish_default_data_save_batch(self, batch: dict[str, Any], result: dict[str, Any]) -> None:
+        if result.get("superseded"):
+            return
+        complete = self._finish_data_save_batch(
+            self.data,
+            batch,
+            result,
+            self._data_save_dirty,
+            self._data_save_deleted,
+            self._data_save_dirty_since,
+            self._data_save_section_revisions,
+        )
+        if complete and self._data_save_full_revision == batch["full_revision"]:
+            self._data_save_full_revision = 0
+            self._data_save_full_since = 0.0
+        if not batch["incremental"]:
+            self._refresh_data_save_revision_from_manager()
+            self._rebase_default_pending_revisions()
+        if result["control_changed"]:
+            self._log_store_control_cleanup("delayed_save", result["control_changed"])
+
+    def _rebase_default_pending_revisions(self) -> None:
+        """Move mutations made during a full write above its persisted revision."""
+        self._ensure_default_save_state()
+        floor = int(self._data_save_revision or 0)
+        pending_revisions = sorted(
+            {
+                int(revision)
+                for source in (self._data_save_dirty, self._data_save_deleted)
+                for revision in source.values()
+                if int(revision) <= floor
+            }
+            | (
+                {int(self._data_save_full_revision)}
+                if 0 < int(self._data_save_full_revision or 0) <= floor
+                else set()
+            )
+        )
+        for previous in pending_revisions:
+            revision = self._next_data_save_revision()
+            for source in (self._data_save_dirty, self._data_save_deleted):
+                for section, current in tuple(source.items()):
+                    if current == previous:
+                        source[section] = revision
+                        self._data_save_section_revisions[section] = revision
+            if self._data_save_full_revision == previous:
+                self._data_save_full_revision = revision
+
+    def _finish_persona_data_save_batch(
+        self,
+        persona_id: str,
+        batch: dict[str, Any],
+        result: dict[str, Any],
+    ) -> None:
+        if result.get("superseded"):
+            return
+        complete = self._finish_data_save_batch(
+            self._persona_data_for_save(persona_id),
+            batch,
+            result,
+            self._persona_data_save_dirty.setdefault(persona_id, {}),
+            self._persona_data_save_deleted.setdefault(persona_id, {}),
+            self._persona_data_save_dirty_since.setdefault(persona_id, {}),
+            self._persona_data_save_section_revisions.setdefault(persona_id, {}),
+            persona_id=persona_id,
+        )
+        if complete and self._persona_data_save_full_revision.get(persona_id, 0) == batch["full_revision"]:
+            self._persona_data_save_full_revision.pop(persona_id, None)
+        if result["control_changed"]:
+            self._log_store_control_cleanup("delayed_persona_save", result["control_changed"])
+        if not self._persona_data_save_dirty.get(persona_id):
+            self._persona_data_save_dirty.pop(persona_id, None)
+        if not self._persona_data_save_deleted.get(persona_id):
+            self._persona_data_save_deleted.pop(persona_id, None)
+        if not self._persona_data_save_dirty_since.get(persona_id):
+            self._persona_data_save_dirty_since.pop(persona_id, None)
+
+    def _bounded_data_save_delay(self, delay: float) -> float:
+        maximum = max(0.01, float(getattr(self, "_data_save_max_delay_seconds", 2.0) or 2.0))
+        return max(0.0, min(maximum, float(delay)))
+
+    def _retry_data_save_delay(self, failures: int) -> float:
+        base = max(0.0, float(getattr(self, "_data_save_retry_base_seconds", 1.0) or 1.0))
+        maximum = max(base, float(getattr(self, "_data_save_retry_max_seconds", 30.0) or 30.0))
+        return min(maximum, base * (2 ** max(0, failures - 1)))
+
+    def _start_default_data_save_writer(self, delay: float) -> None:
+        if self._save_is_stopping():
             return
         task = getattr(self, "_data_save_task", None)
         if isinstance(task, asyncio.Task) and not task.done():
             return
 
         async def _runner() -> None:
-            should_retry = False
+            failures = 0
             try:
-                while bool(getattr(self, "_data_save_dirty", False)):
-                    self._data_save_dirty = False
-                    await asyncio.sleep(max(0.0, float(delay)))
-                    snapshot = deepcopy(self.data)
+                await asyncio.sleep(self._bounded_data_save_delay(delay))
+                while self._default_data_save_is_dirty() and not self._save_is_stopping():
+                    batch = self._capture_default_data_save_batch()
                     try:
-                        snapshot_changed = await asyncio.to_thread(self._write_data_snapshot_sync, snapshot)
-                    finally:
-                        # A dirty burst can schedule another iteration immediately.
-                        # Release the previous full copy before that iteration starts.
-                        snapshot = None
-                    if snapshot_changed:
-                        live_changed = self._sanitize_store_control_tags_inplace(self.data)
-                        if live_changed:
-                            self._data_save_dirty = True
-                            self._log_store_control_cleanup("delayed_save_live_sync", live_changed)
-            except asyncio.CancelledError:
-                raise
-            except Exception as exc:
-                self._data_save_dirty = True
-                should_retry = True
-                logger.warning("[PrivateCompanion] 延迟保存数据失败: %s", exc)
+                        result = await asyncio.to_thread(self._write_default_data_save_batch_sync, batch)
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as exc:
+                        failures += 1
+                        logger.warning(
+                            "[PrivateCompanion] Delayed data save failed: %s",
+                            _single_line(exc, 160),
+                        )
+                        if self._save_is_stopping():
+                            break
+                        await asyncio.sleep(self._retry_data_save_delay(failures))
+                        continue
+                    failures = 0
+                    self._finish_default_data_save_batch(batch, result)
+                    if self._default_data_save_is_dirty():
+                        await asyncio.sleep(0)
             finally:
-                self._data_save_task = None
-                stop_event = getattr(self, "_stop_event", None)
-                stopping = bool(
-                    stop_event is not None
-                    and callable(getattr(stop_event, "is_set", None))
-                    and stop_event.is_set()
-                )
-                if not stopping and bool(getattr(self, "_data_save_dirty", False)):
-                    retry_delay = (
-                        max(3.0, min(30.0, float(delay) * 2.0 if delay else 3.0))
-                        if should_retry
-                        else max(0.0, float(delay))
-                    )
-                    try:
-                        self._schedule_default_data_save(delay=retry_delay)
-                    except Exception as retry_exc:
-                        logger.warning("[PrivateCompanion] 延迟保存重试调度失败: %s", retry_exc)
+                current = asyncio.current_task()
+                if getattr(self, "_data_save_task", None) is current:
+                    self._data_save_task = None
 
         try:
             self._data_save_task = asyncio.create_task(_runner())
         except RuntimeError:
-            self._save_data_sync()
+            snapshot = deepcopy(self.data)
+            self._write_data_snapshot_sync(snapshot)
+            self._clear_default_data_save_dirty()
 
-    def _schedule_data_save(self, delay: float = 1.5) -> None:
+    def _start_persona_data_save_writer(self, persona_id: str, delay: float) -> None:
+        self._ensure_persona_save_state()
+        if self._save_is_stopping():
+            return
+        task = self._persona_data_save_tasks.get(persona_id)
+        if isinstance(task, asyncio.Task) and not task.done():
+            return
+
+        async def _runner() -> None:
+            failures = 0
+            try:
+                await asyncio.sleep(self._bounded_data_save_delay(delay))
+                while self._persona_data_save_is_dirty(persona_id) and not self._save_is_stopping():
+                    batch = self._capture_persona_data_save_batch(persona_id)
+                    try:
+                        result = await asyncio.to_thread(
+                            self._write_persona_data_save_batch_sync,
+                            persona_id,
+                            batch,
+                        )
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as exc:
+                        failures += 1
+                        logger.warning(
+                            "[PrivateCompanion] Delayed persona data save failed: "
+                            "persona=%s error=%s",
+                            persona_id,
+                            _single_line(exc, 160),
+                        )
+                        if self._save_is_stopping():
+                            break
+                        await asyncio.sleep(self._retry_data_save_delay(failures))
+                        continue
+                    failures = 0
+                    self._finish_persona_data_save_batch(persona_id, batch, result)
+                    if self._persona_data_save_is_dirty(persona_id):
+                        await asyncio.sleep(0)
+            finally:
+                current = asyncio.current_task()
+                if self._persona_data_save_tasks.get(persona_id) is current:
+                    self._persona_data_save_tasks.pop(persona_id, None)
+
+        try:
+            self._persona_data_save_tasks[persona_id] = asyncio.create_task(_runner())
+        except RuntimeError:
+            snapshot = deepcopy(self._persona_data_for_save(persona_id))
+            self._write_persona_data_snapshot_sync(persona_id, snapshot)
+            self._clear_persona_data_save_dirty(persona_id)
+
+    def _schedule_persona_data_save(
+        self,
+        persona_id: str,
+        delay: float = 1.5,
+        *,
+        sections: Collection[str] | None = None,
+        deleted_sections: Collection[str] = (),
+    ) -> None:
+        if not self._mark_persona_data_dirty(
+            persona_id,
+            sections=sections,
+            deleted_sections=deleted_sections,
+        ):
+            return
+        self._start_persona_data_save_writer(persona_id, delay)
+
+    def _schedule_default_data_save(
+        self,
+        delay: float = 1.5,
+        *,
+        sections: Collection[str] | None = None,
+        deleted_sections: Collection[str] = (),
+    ) -> None:
+        if not self._mark_default_data_dirty(
+            sections=sections,
+            deleted_sections=deleted_sections,
+        ):
+            return
+        self._start_default_data_save_writer(delay)
+
+    def _schedule_data_save(
+        self,
+        *,
+        sections: Collection[str] | None = None,
+        deleted_sections: Collection[str] = (),
+        delay: float = 1.5,
+    ) -> None:
         scoped_scheduler = getattr(self, "_req041_schedule_scoped_sync", None)
         if callable(scoped_scheduler):
             scoped_scheduler()
         active_getter = getattr(self, "_active_persona_scope", None)
         persona_id = str(active_getter() if callable(active_getter) else "").strip()
         if bool(getattr(self, "enable_multi_persona_mode", False)) and persona_id:
-            self._schedule_persona_data_save(persona_id, delay)
+            self._schedule_persona_data_save(
+                persona_id,
+                delay,
+                sections=sections,
+                deleted_sections=deleted_sections,
+            )
             return
-        self._schedule_default_data_save(delay)
+        self._schedule_default_data_save(
+            delay,
+            sections=sections,
+            deleted_sections=deleted_sections,
+        )
+
+    def _clear_default_data_save_dirty(self, through_revision: int | None = None) -> None:
+        self._ensure_default_save_state()
+        for source in (self._data_save_dirty, self._data_save_deleted):
+            for section, revision in tuple(source.items()):
+                if through_revision is None or revision <= through_revision:
+                    source.pop(section, None)
+                    self._data_save_dirty_since.pop(section, None)
+        if through_revision is None or self._data_save_full_revision <= through_revision:
+            self._data_save_full_revision = 0
+            self._data_save_full_since = 0.0
+
+    def _clear_persona_data_save_dirty(
+        self,
+        persona_id: str,
+        through_revision: int | None = None,
+    ) -> None:
+        self._ensure_persona_save_state()
+        for source in (self._persona_data_save_dirty, self._persona_data_save_deleted):
+            values = source.get(persona_id, {})
+            for section, revision in tuple(values.items()):
+                if through_revision is None or revision <= through_revision:
+                    values.pop(section, None)
+                    self._persona_data_save_dirty_since.get(persona_id, {}).pop(section, None)
+            if not values:
+                source.pop(persona_id, None)
+        full_revision = int(self._persona_data_save_full_revision.get(persona_id, 0) or 0)
+        if through_revision is None or full_revision <= through_revision:
+            self._persona_data_save_full_revision.pop(persona_id, None)
+        if not self._persona_data_save_dirty_since.get(persona_id):
+            self._persona_data_save_dirty_since.pop(persona_id, None)
+
+    def _clear_scheduled_data_save_dirty(
+        self,
+        *,
+        persona_id: str = "",
+        through_revision: int | None = None,
+    ) -> None:
+        if persona_id:
+            self._clear_persona_data_save_dirty(persona_id, through_revision)
+        else:
+            self._clear_default_data_save_dirty(through_revision)
 
     async def _flush_scheduled_data_save(self) -> None:
-        """Wait until all coalesced writes, including writes queued while waiting, finish."""
+        """Wait until default and persona writers drain all revisions visible while flushing."""
         while True:
             pending: list[asyncio.Task] = []
             task = getattr(self, "_data_save_task", None)
@@ -1279,29 +2354,25 @@ class CoreStoreMixin:
             if pending:
                 await asyncio.gather(*(asyncio.shield(item) for item in pending))
                 continue
-            legacy_dirty = bool(getattr(self, "_data_save_dirty", False))
-            persona_dirty = set(getattr(self, "_persona_data_save_dirty", set()) or set())
-            if legacy_dirty or persona_dirty:
-                stop_event = getattr(self, "_stop_event", None)
-                if (
-                    stop_event is not None
-                    and callable(getattr(stop_event, "is_set", None))
-                    and stop_event.is_set()
-                ):
-                    return
-                for persona_id in persona_dirty:
-                    self._schedule_persona_data_save(persona_id, 0.0)
-                if legacy_dirty:
-                    self._schedule_default_data_save(delay=0.0)
-                continue
-            return
+            if not self._default_data_save_is_dirty() and not self._dirty_persona_ids():
+                return
+            if self._save_is_stopping():
+                return
+            for persona_id in self._dirty_persona_ids():
+                self._start_persona_data_save_writer(persona_id, 0.0)
+            if self._default_data_save_is_dirty():
+                self._start_default_data_save_writer(0.0)
 
     async def _reset_plugin_store(self) -> None:
         async with self._data_lock:
             self.data = self._new_store()
             if self.default_enable_configured_targets:
                 self._sync_configured_targets()
-            self._save_data_sync()
+            self._clear_default_data_save_dirty()
+            await asyncio.to_thread(
+                self._write_data_snapshot_sync,
+                deepcopy(self.data),
+            )
 
     async def _rebuild_today_after_reset(
         self,
@@ -2630,7 +3701,7 @@ class CoreStoreMixin:
                 pending_points = 0
             if str(role).strip().lower() != "owner" and pending_points > 0:
                 if score_migration.get("changed"):
-                    self._schedule_data_save()
+                    self._schedule_data_save(sections={"users"})
                 return {
                     "changed": False,
                     "code": "relationship_violation_recovery_pending",
@@ -2693,7 +3764,7 @@ class CoreStoreMixin:
                     _single_line(exc, 160),
                 )
         if result.get("changed") or score_migration.get("changed"):
-            self._schedule_data_save()
+            self._schedule_data_save(sections={"users"})
         return result
 
     def _get_user(self, user_id: str) -> dict[str, Any]:
@@ -2759,7 +3830,7 @@ class CoreStoreMixin:
         if not user.get("style"):
             user["style"] = self.default_style
         if relationship_changed or alias_migration_changed:
-            self._schedule_data_save()
+            self._schedule_data_save(sections={"users"})
         return user
 
     def _auto_profile_platform_set(self) -> set[str]:
@@ -2886,7 +3957,7 @@ class CoreStoreMixin:
         user["last_seen"] = max(_safe_float(user.get("last_seen"), 0), created_at)
         user["last_activity_at"] = max(_safe_float(user.get("last_activity_at"), 0), created_at)
         self._note_private_user_umo(canonical_user_id, user, getattr(event, "unified_msg_origin", ""))
-        self._schedule_data_save()
+        self._schedule_data_save(sections={"users"})
         return user, True
 
     def _latest_user_activity_ts(self, user: dict[str, Any] | None) -> float:

--- a/creative.py
+++ b/creative.py
@@ -1154,7 +1154,7 @@ class CreativeMixin:
                 importance=5,
             )
             self.data["creative_projects"] = projects
-            self._save_data_sync()
+            self._save_data_sync(sections={"creative_projects"})
             return {"success": True, "project_id": project_id, "edit_type": normalized_type}
 
     async def _rebuild_creative_memory_from_project(self, project_id: str) -> dict[str, Any]:
@@ -1215,7 +1215,7 @@ class CreativeMixin:
                     ["人工修订"], importance=5,
                 )
             self.data["creative_projects"] = projects
-            self._save_data_sync()
+            self._save_data_sync(sections={"creative_projects"})
             return {"success": True, "project_id": project_id, "memory_count": len(pool)}
 
     # ============================================================
@@ -1424,7 +1424,7 @@ class CreativeMixin:
             projects.append(project)
             del projects[:-20]
             self.data["creative_projects"] = projects
-            self._save_data_sync()
+            self._save_data_sync(sections={"creative_projects"})
         logger.info("[PrivateCompanion] 新增创作项目: %s / %s", project.get("work_type"), project.get("title"))
         return True
 
@@ -1804,7 +1804,7 @@ class CreativeMixin:
                         project["cover_generation_status"] = "unavailable"
                         project["cover_generation_error"] = "当前没有可用的生图后端"
                         project["cover_generation_next_retry_at"] = _now_ts() + 3600
-                        self._save_data_sync()
+                        self._save_data_sync(sections={"creative_projects"})
                         return dict(project)
                 return None
 
@@ -1838,7 +1838,7 @@ class CreativeMixin:
                         project["cover_generation_status"] = "ready"
                         project["cover_generation_error"] = "旧封面等待人物参考图可用后再升级"
                         project["cover_generation_next_retry_at"] = _now_ts() + 3 * 3600
-                        self._save_data_sync()
+                        self._save_data_sync(sections={"creative_projects"})
                         return dict(project)
                 return None
             prompt_text = self._creative_cover_prompt(
@@ -1859,7 +1859,7 @@ class CreativeMixin:
                 project["cover_generation_attempts"] = attempt_number
                 project["cover_generation_attempted_at"] = _now_ts()
                 project["cover_generation_error"] = ""
-                self._save_data_sync()
+                self._save_data_sync(sections={"creative_projects"})
 
             backend, generated_path, note = await generator(
                 workflow_kind="portrait" if reference_image_path else "text2img",
@@ -1900,7 +1900,7 @@ class CreativeMixin:
                     project["cover_generation_error"] = _single_line(note, 220) or "生图失败"
                     project["cover_generation_next_retry_at"] = now + min(24, max(3, attempt_number * 3)) * 3600
                     logger.info("[PrivateCompanion] 创作封面未生成: project=%s attempt=%s error=%s", project_id, attempt_number, _single_line(note, 180))
-                self._save_data_sync()
+                self._save_data_sync(sections={"creative_projects"})
                 return dict(project)
 
     async def _maybe_advance_creative_projects(self) -> None:
@@ -2000,7 +2000,7 @@ class CreativeMixin:
             if self._maybe_schedule_creative_share():
                 changed = True
             if changed:
-                self._save_data_sync()
+                self._save_data_sync(sections={"creative_projects"})
         if creative_record_payload is not None:
             recorder = getattr(self, "_memory_companion_record_creative_progress", None)
             if callable(recorder):

--- a/daily_review.py
+++ b/daily_review.py
@@ -299,7 +299,7 @@ class DailyReviewMixin:
         audit[:] = [entry for entry in audit if isinstance(entry, dict) and _safe_float(entry.get("ts"), 0.0) >= cutoff][-160:]
         scheduler = getattr(self, "_schedule_data_save", None)
         if callable(scheduler):
-            scheduler()
+            scheduler(sections={"daily_review_case_audit"})
         return str(item["id"])
 
     def _update_daily_review_case(self, case_id: str, **changes: Any) -> None:
@@ -327,7 +327,7 @@ class DailyReviewMixin:
             item["updated_ts"] = time.time()
             scheduler = getattr(self, "_schedule_data_save", None)
             if callable(scheduler):
-                scheduler()
+                scheduler(sections={"daily_review_case_audit"})
             return
 
     def _record_daily_review_outbound_case(self, event: Any, chain: list[Any]) -> str:

--- a/daily_review.py
+++ b/daily_review.py
@@ -1299,7 +1299,7 @@ class DailyReviewMixin:
                         "attempted_at": time.time(),
                         "error": error,
                     }
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"daily_review_last_attempt"})
                 if force:
                     raise RuntimeError(error)
                 return None
@@ -1312,7 +1312,7 @@ class DailyReviewMixin:
                     "attempted_at": time.time(),
                     "error": "",
                 }
-                self._save_data_sync()
+                self._save_data_sync(sections={"daily_review_last_attempt"})
             try:
                 raw = await self._llm_call(
                     self._daily_review_prompt(snapshot),
@@ -1344,7 +1344,7 @@ class DailyReviewMixin:
                         "attempted_at": time.time(),
                         "error": safe_error,
                     }
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"daily_review_last_attempt"})
                 if force:
                     raise
                 logger.warning("[PrivateCompanion] 每日终盘巡视失败，将在冷却后重试: %s", safe_error)
@@ -1368,7 +1368,7 @@ class DailyReviewMixin:
                     "attempted_at": report["generated_at"],
                     "error": "",
                 }
-                self._save_data_sync()
+                self._save_data_sync(sections={"daily_review_reports", "daily_review_active_guidance", "daily_review_last_attempt", "daily_review_completed_day"})
             logger.info(
                 "[PrivateCompanion] 每日终盘巡视完成: date=%s score=%s findings=%s guidance=%s",
                 date_key,

--- a/daily_state.py
+++ b/daily_state.py
@@ -907,7 +907,7 @@ class DailyStateMixin(DailyStateTickMixin):
             for meal_entry in meal_entries:
                 await self._memory_companion_record_self_meal(meal_entry)
             if meal_entries:
-                self._schedule_data_save()
+                self._schedule_data_save(sections={"self_meal_log"})
             await self._apply_detail_presence_status(segment, detail)
         return last_detail
 
@@ -3361,13 +3361,13 @@ class DailyStateMixin(DailyStateTickMixin):
                     return state
                 async with self._data_lock:
                     before = json.dumps(self.data.get("daily_state", {}), ensure_ascii=False, sort_keys=True, default=str)
-                    self._cleanup_expired_conditions()
+                    deleted_sections = self._cleanup_expired_conditions()
                     self._ensure_time_based_hunger_condition()
                     state = self._compose_state_from_conditions(weather)
                     after = json.dumps(state, ensure_ascii=False, sort_keys=True, default=str)
-                    if before != after:
+                    if before != after or deleted_sections:
                         self.data["daily_state"] = state
-                        self._save_data_sync()
+                        self._save_data_sync(deleted_sections=deleted_sections)
                     return state
             cached_weather = self.data.get("daily_weather", {})
             weather = cached_weather if isinstance(cached_weather, dict) and cached_weather.get("date") == today else {
@@ -3398,11 +3398,11 @@ class DailyStateMixin(DailyStateTickMixin):
 
             needs_generation = force or self.data.get("state_generated_day") != today
             if not needs_generation:
-                self._cleanup_expired_conditions()
+                deleted_sections = self._cleanup_expired_conditions()
                 self._ensure_time_based_hunger_condition()
                 state = self._compose_state_from_conditions(weather)
                 self.data["daily_state"] = state
-                self._save_data_sync()
+                self._save_data_sync(deleted_sections=deleted_sections)
                 return state
 
         generation_day = _today_key()
@@ -3413,10 +3413,11 @@ class DailyStateMixin(DailyStateTickMixin):
         )
 
         async with self._data_lock:
+            deleted_sections: set[str] = set()
             if not force and self.data.get("state_generated_day") == generation_day:
-                self._cleanup_expired_conditions()
+                deleted_sections = self._cleanup_expired_conditions()
             else:
-                self._cleanup_expired_conditions()
+                deleted_sections = self._cleanup_expired_conditions()
                 if force:
                     self.data["state_conditions"] = []
                 dream_pick = deferred_updates.get("dream_pick")
@@ -3442,7 +3443,7 @@ class DailyStateMixin(DailyStateTickMixin):
             self._ensure_time_based_hunger_condition()
             state = self._compose_state_from_conditions(weather)
             self.data["daily_state"] = state
-            self._save_data_sync()
+            self._save_data_sync(deleted_sections=deleted_sections)
             return state
 
     async def _generate_state_conditions(
@@ -4783,11 +4784,17 @@ class DailyStateMixin(DailyStateTickMixin):
             state["last_observation"] = self._environment_weather_observation(current)
             state["initialized"] = True
             if not initialized:
-                self._schedule_data_save(delay=0.5)
+                self._schedule_data_save(
+                    sections={"environment_change_awareness", "daily_weather"},
+                    delay=0.5,
+                )
                 return
             change = self._detect_environment_weather_change(previous, current)
             if not change:
-                self._schedule_data_save(delay=0.5)
+                self._schedule_data_save(
+                    sections={"environment_change_awareness", "daily_weather"},
+                    delay=0.5,
+                )
                 return
             fingerprint = _single_line(change.get("fingerprint"), 160)
             cooldown_minutes = max(
@@ -4810,7 +4817,10 @@ class DailyStateMixin(DailyStateTickMixin):
             # 形同虚设（实测 30-40 分钟就 offer 一条）。score>=90 的极端变化保留逃生口。
             too_soon = now - last_prompted_at < cooldown_minutes * 60 and _safe_int(change.get("score"), 0) < 90
             if recently_repeated or too_soon:
-                self._schedule_data_save(delay=0.5)
+                self._schedule_data_save(
+                    sections={"environment_change_awareness", "daily_weather"},
+                    delay=0.5,
+                )
                 return
             offered = 0
             async with self._data_lock:
@@ -9081,12 +9091,13 @@ class DailyStateMixin(DailyStateTickMixin):
         )
         return kept
 
-    def _cleanup_expired_conditions(self):
+    def _cleanup_expired_conditions(self) -> set[str]:
         now = _now_ts()
+        had_body_cycle_state = "body_cycle_state" in self.data
         conditions = self.data.setdefault("state_conditions", [])
         if not isinstance(conditions, list):
             self.data["state_conditions"] = []
-            return
+            return set()
         profile = self._persona_state_profile()
         if not profile.get("allow_cycle", False):
             before_count = len(conditions)
@@ -9129,6 +9140,9 @@ class DailyStateMixin(DailyStateTickMixin):
         active = self._reconcile_advanced_cycle_condition(active, now)
         active = self._prune_active_hunger_conditions(active, now)
         self.data["state_conditions"] = active
+        return {
+            "body_cycle_state"
+        } if had_body_cycle_state and "body_cycle_state" not in self.data else set()
 
     def _prune_active_hunger_conditions(self, conditions: list[dict[str, Any]], now: float) -> list[dict[str, Any]]:
         hunger_items = [

--- a/daily_state.py
+++ b/daily_state.py
@@ -5858,7 +5858,7 @@ class DailyStateMixin(DailyStateTickMixin):
             saver = getattr(self, "_save_data_sync", None)
             if callable(saver):
                 try:
-                    saver()
+                    saver(sections={"qweather_location"})
                 except Exception as exc:
                     logger.debug("[PrivateCompanion] 保存和风天气地点缓存失败: %s", _single_line(exc, 160))
 
@@ -6496,7 +6496,7 @@ class DailyStateMixin(DailyStateTickMixin):
             saver = getattr(self, "_save_data_sync", None)
             if callable(saver):
                 try:
-                    saver()
+                    saver(sections={"weather_alerts"})
                 except Exception as exc:
                     logger.debug("[PrivateCompanion] 保存天气预警缓存失败: %s", _single_line(exc, 160))
         return result
@@ -7019,7 +7019,13 @@ class DailyStateMixin(DailyStateTickMixin):
             state["last_offered_count"] = offered
             saver = getattr(self, "_save_data_sync", None)
             if callable(saver):
-                saver()
+                saver(
+                    sections={
+                        "weather_alert_awareness",
+                        "users",
+                        "proactive_candidate_pool",
+                    }
+                )
             return deepcopy(result)
 
     @classmethod

--- a/daily_state.py
+++ b/daily_state.py
@@ -527,7 +527,15 @@ class DailyStateMixin(DailyStateTickMixin):
                 if plan_changed:
                     self._refresh_daily_state_location_from_plan(plan=current_plan)
                 if plan_changed or detail_day_changed:
-                    self._save_data_sync()
+                    self._save_data_sync(
+                        sections={
+                            "daily_plan",
+                            "daily_state",
+                            "detail_enhanced_day",
+                            "detail_enhanced_segments",
+                            "daily_story_plan",
+                        }
+                    )
                 source = _single_line(current_plan.get("source"), 40).lower()
                 retry_after = _safe_float(current_plan.get("retry_after"), 0.0)
                 fallback_retry_due = source.startswith("fallback") and (
@@ -544,7 +552,15 @@ class DailyStateMixin(DailyStateTickMixin):
                 if plan_changed:
                     self._refresh_daily_state_location_from_plan(plan=current_plan)
                 if plan_changed or detail_day_changed:
-                    self._save_data_sync()
+                    self._save_data_sync(
+                        sections={
+                            "daily_plan",
+                            "daily_state",
+                            "detail_enhanced_day",
+                            "detail_enhanced_segments",
+                            "daily_story_plan",
+                        }
+                    )
                 return current_plan
             if not force and not known_users:
                 return current_plan if current_plan.get("date") == today else None
@@ -554,7 +570,15 @@ class DailyStateMixin(DailyStateTickMixin):
                     if plan_changed:
                         self._refresh_daily_state_location_from_plan(plan=current_plan)
                     if plan_changed or detail_day_changed:
-                        self._save_data_sync()
+                        self._save_data_sync(
+                            sections={
+                                "daily_plan",
+                                "daily_state",
+                                "detail_enhanced_day",
+                                "detail_enhanced_segments",
+                                "daily_story_plan",
+                            }
+                        )
                     return current_plan
                 return None
 
@@ -563,7 +587,15 @@ class DailyStateMixin(DailyStateTickMixin):
             self.data["daily_plan"] = plan
             self._sync_detail_enhancement_day_locked(plan.get("date"), reset=True)
             self._refresh_daily_state_location_from_plan(plan=plan)
-            self._save_data_sync()
+            self._save_data_sync(
+                sections={
+                    "daily_plan",
+                    "daily_state",
+                    "detail_enhanced_day",
+                    "detail_enhanced_segments",
+                    "daily_story_plan",
+                }
+            )
         outfit_generator = getattr(self, "_ensure_daily_outfit_photo", None)
         if callable(outfit_generator):
             try:
@@ -619,7 +651,13 @@ class DailyStateMixin(DailyStateTickMixin):
                 self.data["daily_diary_failed_day"] = request_day
                 self.data["daily_diary_failed_at"] = _now_ts()
                 self.data["daily_diary_last_error"] = _single_line(exc, 180)
-                self._save_data_sync()
+                self._save_data_sync(
+                    sections={
+                        "daily_diary_failed_day",
+                        "daily_diary_failed_at",
+                        "daily_diary_last_error",
+                    }
+                )
             if force:
                 raise
             logger.warning(
@@ -745,7 +783,19 @@ class DailyStateMixin(DailyStateTickMixin):
             story_plan = diary.get("story_plan") if isinstance(diary, dict) else None
             if isinstance(story_plan, dict):
                 self.data["daily_story_plan"] = story_plan
-            self._save_data_sync()
+            self._save_data_sync(
+                sections={
+                    "bot_diaries",
+                    "diary_generated_day",
+                    "daily_diary_deleted_days",
+                    "daily_diary_failed_day",
+                    "daily_diary_failed_at",
+                    "daily_diary_last_error",
+                    "daily_diary_postprocess_error",
+                    "dream_fragments",
+                    "daily_story_plan",
+                }
+            )
         diary_recorder = getattr(self, "_memory_companion_record_daily_diary", None)
         if callable(diary_recorder):
             try:
@@ -782,7 +832,9 @@ class DailyStateMixin(DailyStateTickMixin):
             segments = self._collect_due_detail_segments(plan, enhanced, force=force)
             if not segments:
                 if sanitized_existing:
-                    self._save_data_sync()
+                    self._save_data_sync(
+                        sections={"detail_enhanced_segments", "daily_story_plan"}
+                    )
                 return None
             for segment in segments:
                 generation_id = uuid.uuid4().hex
@@ -793,7 +845,7 @@ class DailyStateMixin(DailyStateTickMixin):
                     "started_ts": _now_ts(),
                     "generation_id": generation_id,
                 }
-            self._save_data_sync()
+            self._save_data_sync(sections={"detail_enhanced_segments"})
 
         last_detail = None
         for segment in segments:
@@ -830,7 +882,7 @@ class DailyStateMixin(DailyStateTickMixin):
                             "interaction_updates": [],
                             "coverage_repair_done": bool(segment.get("_coverage_repair")),
                         }
-                        self._save_data_sync()
+                        self._save_data_sync(sections={"detail_enhanced_segments"})
                     else:
                         retry_after = ""
                 if failure_is_current:
@@ -902,7 +954,18 @@ class DailyStateMixin(DailyStateTickMixin):
                     segment=segment,
                 )
                 self._reschedule_users_for_new_detail_events(segment)
-                self._save_data_sync()
+                self._save_data_sync(
+                    sections={
+                        "daily_plan",
+                        "daily_state",
+                        "detail_enhanced_segments",
+                        "detail_enhanced_history",
+                        "daily_story_plan",
+                        "daily_story_plan_history",
+                        "users",
+                        "self_meal_log",
+                    }
+                )
                 last_detail = detail
             for meal_entry in meal_entries:
                 await self._memory_companion_record_self_meal(meal_entry)
@@ -1381,7 +1444,16 @@ class DailyStateMixin(DailyStateTickMixin):
             enhanced[key] = cancelled
             story = self._rebuild_story_plan_from_detail_snapshots(str(plan.get("date") or _today_key()))
             self._remember_detail_enhancement_history(str(plan.get("date") or _today_key()), enhanced, story)
-            self._save_data_sync()
+            self._save_data_sync(
+                sections={
+                    "daily_plan",
+                    "detail_enhanced_day",
+                    "detail_enhanced_segments",
+                    "detail_enhanced_history",
+                    "daily_story_plan",
+                    "daily_story_plan_history",
+                }
+            )
             return True, f"已取消：{label}"
 
     async def _regenerate_daily_plan_segment_by_selector(
@@ -1453,7 +1525,9 @@ class DailyStateMixin(DailyStateTickMixin):
                     "regenerated": True,
                     "generation_id": generation_id,
                 }
-                self._save_data_sync()
+                self._save_data_sync(
+                    sections={"daily_plan", "detail_enhanced_day", "detail_enhanced_segments"}
+                )
 
             detail = await generator(self, segment, plan, state)
             if not isinstance(detail, dict) or not isinstance(detail.get("today_events"), list) or not detail.get("today_events"):
@@ -1495,7 +1569,17 @@ class DailyStateMixin(DailyStateTickMixin):
                     detail=detail,
                     segment=segment,
                 )
-                self._save_data_sync()
+                self._save_data_sync(
+                    sections={
+                        "daily_plan",
+                        "daily_state",
+                        "detail_enhanced_day",
+                        "detail_enhanced_segments",
+                        "detail_enhanced_history",
+                        "daily_story_plan",
+                        "daily_story_plan_history",
+                    }
+                )
                 label = self._schedule_segment_label(segment)
             return True, f"已重新细化：{label}", detail
         except Exception as exc:
@@ -1522,7 +1606,9 @@ class DailyStateMixin(DailyStateTickMixin):
                                 live_item[field] = value
                             else:
                                 live_item.pop(field, None)
-                    self._save_data_sync()
+                    self._save_data_sync(
+                        sections={"daily_plan", "detail_enhanced_segments"}
+                    )
             return False, _single_line(exc, 180) or "局部重生成失败。", {}
 
     def _detail_generation_is_current(self, segment: dict[str, Any], generation_id: str) -> bool:
@@ -1944,7 +2030,7 @@ class DailyStateMixin(DailyStateTickMixin):
                 state["detail_key"] = key
                 state["date"] = _today_key()
                 state["plan_date"] = str(self.data.get("detail_enhanced_day") or "")
-                self._save_data_sync()
+                self._save_data_sync(sections={"qq_presence_state"})
                 return
             ok, note = await self._set_qq_online_presence("online")
             state["detail_key"] = key
@@ -1957,7 +2043,7 @@ class DailyStateMixin(DailyStateTickMixin):
             state["ok"] = bool(ok)
             state["note"] = _single_line(note, 120)
             state["managed_by_plugin"] = True
-            self._save_data_sync()
+            self._save_data_sync(sections={"qq_presence_state"})
             return
         if mode in {"custom", "自定义", "自定义状态"}:
             ok, note = await self._set_qq_custom_presence(custom_text)
@@ -1978,7 +2064,7 @@ class DailyStateMixin(DailyStateTickMixin):
         state["ok"] = bool(ok)
         state["note"] = _single_line(note, 120)
         state["managed_by_plugin"] = True
-        self._save_data_sync()
+        self._save_data_sync(sections={"qq_presence_state"})
 
     async def _ensure_current_detail_presence_status(self) -> None:
         plan = self.data.get("daily_plan", {})
@@ -1993,7 +2079,7 @@ class DailyStateMixin(DailyStateTickMixin):
         snapshot = enhanced.get(str(segment.get("key") or ""))
         if not isinstance(snapshot, dict) or snapshot.get("status") != "done":
             if self._refresh_daily_state_location_from_plan(plan=plan, segment=segment):
-                self._save_data_sync()
+                self._save_data_sync(sections={"daily_state"})
             if self.enable_qq_presence_sync:
                 # Clear a previous plugin-managed segment status while the
                 # new segment is still being generated. The completed detail
@@ -2001,7 +2087,7 @@ class DailyStateMixin(DailyStateTickMixin):
                 await self._apply_detail_presence_status(segment, {})
             return
         if self._refresh_daily_state_location_from_plan(plan=plan, detail=snapshot, segment=segment):
-            self._save_data_sync()
+            self._save_data_sync(sections={"daily_state"})
         if not self.enable_qq_presence_sync:
             return
         await self._apply_detail_presence_status(segment, snapshot)
@@ -3361,13 +3447,21 @@ class DailyStateMixin(DailyStateTickMixin):
                     return state
                 async with self._data_lock:
                     before = json.dumps(self.data.get("daily_state", {}), ensure_ascii=False, sort_keys=True, default=str)
-                    deleted_sections = self._cleanup_expired_conditions()
+                    deleted_sections = self._cleanup_expired_conditions() or set()
                     self._ensure_time_based_hunger_condition()
                     state = self._compose_state_from_conditions(weather)
                     after = json.dumps(state, ensure_ascii=False, sort_keys=True, default=str)
                     if before != after or deleted_sections:
                         self.data["daily_state"] = state
-                        self._save_data_sync(deleted_sections=deleted_sections)
+                        save_sections = {
+                            "daily_state",
+                            "state_conditions",
+                            "body_cycle_state",
+                        } - set(deleted_sections)
+                        self._save_data_sync(
+                            sections=save_sections,
+                            deleted_sections=deleted_sections,
+                        )
                     return state
             cached_weather = self.data.get("daily_weather", {})
             weather = cached_weather if isinstance(cached_weather, dict) and cached_weather.get("date") == today else {
@@ -3393,16 +3487,25 @@ class DailyStateMixin(DailyStateTickMixin):
                 state["date"] = today
                 state["weather"] = self._weather_summary_text(weather)
                 self.data["daily_state"] = state
-                self._save_data_sync()
+                self._save_data_sync(sections={"daily_state"})
                 return state
 
             needs_generation = force or self.data.get("state_generated_day") != today
             if not needs_generation:
-                deleted_sections = self._cleanup_expired_conditions()
+                deleted_sections = self._cleanup_expired_conditions() or set()
                 self._ensure_time_based_hunger_condition()
                 state = self._compose_state_from_conditions(weather)
                 self.data["daily_state"] = state
-                self._save_data_sync(deleted_sections=deleted_sections)
+                save_sections = {
+                    "daily_state",
+                    "state_conditions",
+                    "body_cycle_state",
+                    "hunger_window_attempts",
+                } - set(deleted_sections)
+                self._save_data_sync(
+                    sections=save_sections,
+                    deleted_sections=deleted_sections,
+                )
                 return state
 
         generation_day = _today_key()
@@ -3415,9 +3518,9 @@ class DailyStateMixin(DailyStateTickMixin):
         async with self._data_lock:
             deleted_sections: set[str] = set()
             if not force and self.data.get("state_generated_day") == generation_day:
-                deleted_sections = self._cleanup_expired_conditions()
+                deleted_sections = self._cleanup_expired_conditions() or set()
             else:
-                deleted_sections = self._cleanup_expired_conditions()
+                deleted_sections = self._cleanup_expired_conditions() or set()
                 if force:
                     self.data["state_conditions"] = []
                 dream_pick = deferred_updates.get("dream_pick")
@@ -3443,7 +3546,18 @@ class DailyStateMixin(DailyStateTickMixin):
             self._ensure_time_based_hunger_condition()
             state = self._compose_state_from_conditions(weather)
             self.data["daily_state"] = state
-            self._save_data_sync(deleted_sections=deleted_sections)
+            save_sections = {
+                "daily_state",
+                "state_conditions",
+                "state_generated_day",
+                "daily_dream",
+                "body_cycle_state",
+                "hunger_window_attempts",
+            } - set(deleted_sections)
+            self._save_data_sync(
+                sections=save_sections,
+                deleted_sections=deleted_sections,
+            )
             return state
 
     async def _generate_state_conditions(
@@ -4494,7 +4608,7 @@ class DailyStateMixin(DailyStateTickMixin):
             )
             state = self._compose_state_from_conditions(self.data.get("daily_weather", {}))
             self.data["daily_state"] = state
-            self._save_data_sync()
+            self._save_data_sync(sections={"daily_state", "state_conditions"})
         return True, f"已增添状态：{label}（约持续 {duration_hours} 小时）"
 
     def _recent_diary_tags(self) -> set[str]:
@@ -4832,7 +4946,14 @@ class DailyStateMixin(DailyStateTickMixin):
                     state["last_prompted_at"] = now
                     state["last_prompted_users"] = offered
                     recent_fingerprints[fingerprint] = now
-                self._save_data_sync()
+                self._save_data_sync(
+                    sections={
+                        "environment_change_awareness",
+                        "daily_weather",
+                        "users",
+                        "proactive_candidate_pool",
+                    }
+                )
             if offered:
                 logger.info(
                     "[PrivateCompanion] 环境突变已进入即时主动候选: kind=%s targets=%s topic=%s",
@@ -4911,7 +5032,7 @@ class DailyStateMixin(DailyStateTickMixin):
         }
         async with self._data_lock:
             self.data["daily_weather"] = weather
-            self._save_data_sync()
+            self._save_data_sync(sections={"daily_weather"})
         return weather
 
     @staticmethod
@@ -5115,7 +5236,7 @@ class DailyStateMixin(DailyStateTickMixin):
             payload = self._load_yesterday_screen_diary_context(yesterday)
         async with self._data_lock:
             self.data["screen_diary_context"] = payload
-            self._save_data_sync()
+            self._save_data_sync(sections={"screen_diary_context"})
         return payload
 
     def _load_yesterday_screen_diary_context(self, target_date: date) -> dict[str, Any]:
@@ -8210,7 +8331,7 @@ class DailyStateMixin(DailyStateTickMixin):
         if changed:
             state["updated_ts"] = now
             self.data["food_menu"] = state
-            self._save_data_sync()
+            self._save_data_sync(sections={"food_menu"})
 
     def _food_menu_candidates_for_prompt(self, text: str, *, limit: int = 3, user: dict[str, Any] | None = None) -> list[dict[str, Any]]:
         profile = self._food_menu_query_profile(text, user=user)
@@ -8986,7 +9107,9 @@ class DailyStateMixin(DailyStateTickMixin):
                     changed = True
             if changed:
                 self.data["memo_notes"] = notes[-200:]
-                self._save_data_sync()
+                self._save_data_sync(
+                    sections={"memo_notes", "users", "proactive_candidate_pool"}
+                )
 
     def _synchronize_body_cycle_strategy(self, conditions: list[Any], now: float) -> list[Any]:
         advanced_enabled = self._advanced_cycle_enabled()
@@ -9932,7 +10055,7 @@ class DailyStateMixin(DailyStateTickMixin):
             summary = await self._summarize_yesterday_conversation_for_schedule(raw_text)
         async with self._data_lock:
             self.data["yesterday_conversation_summary"] = summary
-            self._save_data_sync()
+            self._save_data_sync(sections={"yesterday_conversation_summary"})
         return summary
 
     async def _collect_yesterday_conversation_text(self) -> str:
@@ -11838,7 +11961,7 @@ class DailyStateMixin(DailyStateTickMixin):
         state["location_source"] = "dialogue_override"
         state["location_updated_at"] = self._environment_now().strftime("%H:%M")
         state["location_override_ts"] = _now_ts()
-        self._save_data_sync()
+        self._save_data_sync(sections={"daily_state"})
 
     def _current_detail_model_location(self) -> str:
         segment = self._current_detail_segment_for_update()
@@ -12992,20 +13115,20 @@ class DailyStateMixin(DailyStateTickMixin):
             if not force and now_ts - _safe_float(state.get("last_check_ts"), 0) < 20 * 60:
                 if profile_changed:
                     state["updated_ts"] = now_ts
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"skill_growth"})
                 return
             state["last_check_ts"] = now_ts
             plan = self.data.get("daily_plan", {})
             if not isinstance(plan, dict):
                 if profile_changed:
                     state["updated_ts"] = now_ts
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"skill_growth"})
                 return
             items = plan.get("items") if isinstance(plan.get("items"), list) else plan.get("schedule")
             if not isinstance(items, list):
                 if profile_changed:
                     state["updated_ts"] = now_ts
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"skill_growth"})
                 return
             day_key = _single_line(plan.get("date"), 20) or _today_key()
             processed = state.get("processed_schedule_keys") if isinstance(state.get("processed_schedule_keys"), list) else []
@@ -13056,7 +13179,7 @@ class DailyStateMixin(DailyStateTickMixin):
                 del processed[:-120]
             if changed:
                 state["updated_ts"] = now_ts
-                self._save_data_sync()
+                self._save_data_sync(sections={"skill_growth"})
 
     @staticmethod
     def _personal_goal_status(value: Any) -> str:
@@ -13301,7 +13424,14 @@ class DailyStateMixin(DailyStateTickMixin):
                     changed = True
             if changed:
                 state["updated_at"] = now
-                self._save_data_sync()
+                self._save_data_sync(
+                    sections={
+                        "personal_goal_state",
+                        "personal_goals",
+                        "users",
+                        "proactive_candidate_pool",
+                    }
+                )
 
     def _format_skill_growth_for_prompt(self, limit: int = 8) -> str:
         if not self.enable_skill_growth_simulation:
@@ -14274,7 +14404,7 @@ class DailyStateMixin(DailyStateTickMixin):
                     current["job_id"] = metadata["job_id"]
                     current["cron_job_id"] = metadata["job_id"]
                 self._clear_llm_timer_internal_plan_fields(current_user)
-                self._save_data_sync()
+                self._save_data_sync(sections={"users"})
         logger.info(
             "[PrivateCompanion] 官方临时预约开始执行: user=%s timer=%s job=%s",
             user_id,
@@ -14320,7 +14450,7 @@ class DailyStateMixin(DailyStateTickMixin):
                 current["status"] = "delivered" if succeeded else "delivery_failed"
                 current["delivery_at"] = _now_ts()
                 current["delivery_error"] = "" if succeeded else "send_message_to_user 未确认发送成功"
-                self._save_data_sync()
+                self._save_data_sync(sections={"users"})
         return True
 
     async def _complete_official_llm_timer_event(self, event: Any) -> bool:
@@ -14347,7 +14477,7 @@ class DailyStateMixin(DailyStateTickMixin):
                 else:
                     return False
                 current["completed_at"] = _now_ts()
-                self._save_data_sync()
+                self._save_data_sync(sections={"users"})
         return True
 
     def _expire_stale_official_llm_timers_locked(self, *, now: float | None = None) -> int:
@@ -14490,7 +14620,7 @@ class DailyStateMixin(DailyStateTickMixin):
                         "status": "cancel_skipped",
                         "error": "没有可取消的对话临时预约",
                     }
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users"})
                     return False
 
             runtime_supported, runtime_status = await self._official_llm_timer_job_runtime(existing_job_id)
@@ -14512,7 +14642,7 @@ class DailyStateMixin(DailyStateTickMixin):
                         current["cancel_status"] = "not_found"
                         current["cancel_error"] = "官方任务已结束或不存在，无法确认取消"
                     current.pop("cancel_requested_at", None)
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users"})
                 return False
 
             async with self._data_lock:
@@ -14527,7 +14657,7 @@ class DailyStateMixin(DailyStateTickMixin):
                 current["cancel_origin"] = source_origin
                 current["cancel_topic"] = _single_line(payload.get("topic") or "取消临时约定", 60)
                 current["cancel_source_text"] = _single_line(source_text, 140)
-                self._save_data_sync()
+                self._save_data_sync(sections={"users"})
 
             ok, error = await self._delete_official_llm_timer_job(existing_job_id)
             async with self._data_lock:
@@ -14552,7 +14682,7 @@ class DailyStateMixin(DailyStateTickMixin):
                     restored["cancel_failed_at"] = _now_ts()
                     restored.pop("cancel_requested_at", None)
                     user["llm_timer_event"] = restored
-                self._save_data_sync()
+                self._save_data_sync(sections={"users"})
             logger.info(
                 "[PrivateCompanion] 对话临时预约取消%s: user=%s job=%s error=%s",
                 "完成" if ok else "失败",
@@ -14714,7 +14844,7 @@ class DailyStateMixin(DailyStateTickMixin):
             user = self._get_user(user_id)
             if not self._user_enabled_for_proactive(user_id, user):
                 self._clear_pending_proactive_plan(user)
-                self._save_data_sync()
+                self._save_data_sync(sections={"users"})
                 return
             reason = _single_line(payload.get("reason"), 40) or self._infer_timer_reason(
                 scheduled_ts,
@@ -14828,7 +14958,7 @@ class DailyStateMixin(DailyStateTickMixin):
             user_snapshot = dict(user)
             user["llm_timer_event"] = deepcopy(timer_event)
             self._clear_llm_timer_internal_plan_fields(user)
-            self._save_data_sync()
+            self._save_data_sync(sections={"users"})
 
         previous_running_job_id = ""
         if replaced_job_id:
@@ -14865,7 +14995,7 @@ class DailyStateMixin(DailyStateTickMixin):
                         timer_event["error"] = error or "官方定时计划登记失败"
                         timer_event.pop("operation_id", None)
                         user["llm_timer_event"] = timer_event
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users"})
             logger.warning(
                 "[PrivateCompanion] LLM 临时预约登记失败,已保留原任务: user=%s old_job=%s error=%s",
                 user_id,
@@ -14884,7 +15014,7 @@ class DailyStateMixin(DailyStateTickMixin):
             )
             if reservation_current:
                 current["candidate_job_id"] = job_id
-                self._save_data_sync()
+                self._save_data_sync(sections={"users"})
         if not reservation_current:
             await self._delete_official_llm_timer_job(job_id)
             logger.warning(
@@ -14919,7 +15049,7 @@ class DailyStateMixin(DailyStateTickMixin):
                             current["candidate_job_id"] = job_id
                             current["replace_error"] = replace_error or "旧官方任务删除失败"
                             current["rollback_error"] = rollback_error or "新官方任务回滚失败"
-                        self._save_data_sync()
+                        self._save_data_sync(sections={"users"})
                 logger.warning(
                     "[PrivateCompanion] LLM 临时预约替换失败,新任务回滚%s: user=%s old_job=%s new_job=%s error=%s rollback_error=%s",
                     "完成" if rollback_ok else "失败",
@@ -14950,7 +15080,7 @@ class DailyStateMixin(DailyStateTickMixin):
                 timer_event.pop("operation_id", None)
                 user["llm_timer_event"] = timer_event
                 self._clear_llm_timer_internal_plan_fields(user)
-                self._save_data_sync()
+                self._save_data_sync(sections={"users"})
         if not reservation_current:
             await self._delete_official_llm_timer_job(job_id)
             return
@@ -17658,7 +17788,7 @@ class DailyStateMixin(DailyStateTickMixin):
                 runtime["last_tick_error"] = ""
             stale_timer_count = self._expire_stale_official_llm_timers_locked()
             if stale_timer_count:
-                self._save_data_sync()
+                self._save_data_sync(sections={"users"})
             if self._proactive_generation_disabled():
                 changed = False
                 users_root = self.data.get("users") if isinstance(self.data.get("users"), dict) else {}
@@ -17681,13 +17811,22 @@ class DailyStateMixin(DailyStateTickMixin):
                     runtime["generation_disabled_reason"] = "max_daily_messages=0"
                     runtime["last_tick_finished_at"] = _now_ts()
                 if changed:
-                    self._save_data_sync()
+                    self._save_data_sync(
+                        sections={"users", "proactive_candidate_pool", "proactive_runtime"}
+                    )
                 return
             if isinstance(runtime, dict):
                 runtime["generation_disabled"] = False
                 runtime["generation_disabled_reason"] = ""
             if self._maybe_schedule_bilibili_video_share():
-                self._save_data_sync()
+                self._save_data_sync(
+                    sections={
+                        "users",
+                        "proactive_candidate_pool",
+                        "external_event_pool",
+                        "external_event_self_link_cache",
+                    }
+                )
             users = list(self.data.get("users", {}).items())
 
         for user_id, user in users:

--- a/daily_state_tick.py
+++ b/daily_state_tick.py
@@ -131,7 +131,10 @@ class DailyStateTickMixin:
                         self._restore_troubleshooting_proactive_plan(current_for_clear)
                     else:
                         self._clear_pending_proactive_plan(current_for_clear)
-                    self._save_data_sync()
+                    save_sections = {"users"}
+                    if self._is_troubleshooting_proactive_plan(user):
+                        save_sections.add("troubleshooting_test_results")
+                    self._save_data_sync(sections=save_sections)
             return
         now = _now_ts()
         due_timer_id = self._due_internal_llm_timer_id(user, now=now)
@@ -140,7 +143,7 @@ class DailyStateTickMixin:
         if not should_send:
             async with self._data_lock:
                 if self._sync_live_user_proactive_schedule(user_id, user):
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users"})
         if not should_send:
             if not is_troubleshooting_for_send and _safe_float(user.get("next_proactive_at"), 0) <= now:
                 guard_reason = _single_line(reason, 120)
@@ -153,7 +156,7 @@ class DailyStateTickMixin:
                         )
                         if handled:
                             self._sync_live_user_proactive_schedule(user_id, current_for_quiet)
-                            self._save_data_sync()
+                            self._save_data_sync(sections={"users"})
                             logger.info(
                                 "[PrivateCompanion] 免打扰主动任务已一次性改期: user=%s next=%s note=%s",
                                 user_id,
@@ -183,7 +186,7 @@ class DailyStateTickMixin:
                             user["planned_proactive_origin_key"] = current_for_guard.get("planned_proactive_origin_key", "")
                             user["planned_proactive_freshness"] = current_for_guard.get("planned_proactive_freshness", "")
                             user["planned_proactive_delivery_state"] = current_for_guard.get("planned_proactive_delivery_state", "")
-                            self._save_data_sync()
+                            self._save_data_sync(sections={"users"})
                             logger.info(
                                 "[PrivateCompanion] 主动发送检查未通过且无未来调度,已兜底延后: user=%s reason=%s delay=%ss",
                                 user_id,
@@ -202,7 +205,7 @@ class DailyStateTickMixin:
                         error=reason,
                     )
                     self._restore_troubleshooting_proactive_plan(current_for_failed_check)
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users", "troubleshooting_test_results"})
             self._debug_tick_skip(user_id, reason)
             return
 
@@ -241,7 +244,7 @@ class DailyStateTickMixin:
                                 delay_minutes=(60, 150),
                                 block_current=False,
                             )
-                            self._save_data_sync()
+                            self._save_data_sync(sections={"users", "proactive_candidate_pool"})
                             self._debug_tick_skip(user_id, note, prefix="延后")
                             return
                         if changed:
@@ -256,7 +259,7 @@ class DailyStateTickMixin:
                                 _single_line(model_judgement.get("reason"), 120),
                             )
                         user = dict(current_for_model)
-                        self._save_data_sync()
+                        self._save_data_sync(sections={"users", "proactive_candidate_pool"})
                     elif model_decision == "defer":
                         note = "模型人格判定延后: " + _single_line(model_judgement.get("reason"), 120)
                         delay = _safe_int(model_judgement.get("delay_minutes"), 90, 20, 360)
@@ -270,7 +273,7 @@ class DailyStateTickMixin:
                         )
                         if not replaced and _safe_float(current_for_model.get("next_proactive_at"), 0) <= 0:
                             self._schedule_next_proactive(current_for_model, now=_now_ts(), delay_hours=(1.5, 4.0))
-                        self._save_data_sync()
+                        self._save_data_sync(sections={"users", "proactive_candidate_pool"})
                         self._debug_tick_skip(user_id, note, prefix="延后")
                         return
                     elif model_decision == "drop":
@@ -279,7 +282,7 @@ class DailyStateTickMixin:
                         self._mark_planned_candidate_status(current_for_model, "blocked", note)
                         self._clear_pending_proactive_plan(current_for_model)
                         self._schedule_next_proactive(current_for_model, now=_now_ts(), delay_hours=(2.0, 6.0))
-                        self._save_data_sync()
+                        self._save_data_sync(sections={"users", "proactive_candidate_pool"})
                         self._debug_tick_skip(user_id, note, prefix="取消")
                         return
             else:
@@ -289,7 +292,7 @@ class DailyStateTickMixin:
                     judged_signature = _single_line(model_judgement.get("signature"), 80) or current_signature
                     if current_signature == judged_signature:
                         self._cache_proactive_model_judgement(current_for_model_cache, model_judgement, now=_now_ts())
-                        self._save_data_sync()
+                        self._save_data_sync(sections={"users"})
 
         async with self._data_lock:
             current_for_mark = self._get_user(user_id)
@@ -314,7 +317,10 @@ class DailyStateTickMixin:
                     self._restore_troubleshooting_proactive_plan(current_for_mark)
                 else:
                     self._clear_pending_proactive_plan(current_for_mark)
-                self._save_data_sync()
+                save_sections = {"users"}
+                if is_troubleshooting_for_send:
+                    save_sections.add("troubleshooting_test_results")
+                self._save_data_sync(sections=save_sections)
                 self._debug_tick_skip(user_id, "私聊对象未启用")
                 return
             self._recover_stale_proactive_sending(current_for_mark)
@@ -329,7 +335,10 @@ class DailyStateTickMixin:
                         error="已有主动发送正在进行",
                     )
                     self._restore_troubleshooting_proactive_plan(current_for_mark)
-                    self._save_data_sync()
+                    save_sections = {"users"}
+                    if is_troubleshooting_for_send:
+                        save_sections.add("troubleshooting_test_results")
+                    self._save_data_sync(sections=save_sections)
                 self._debug_tick_skip(user_id, "主动发送仍在进行中")
                 return
             current_reason = normalize_legacy_tag_text(current_for_mark.get("planned_proactive_reason"))
@@ -369,7 +378,7 @@ class DailyStateTickMixin:
                 self._clear_pending_proactive_plan(current_for_mark)
                 current_for_mark["planned_meal_care_context"] = {}
                 self._schedule_next_proactive(current_for_mark, now=_now_ts())
-                self._save_data_sync()
+                self._save_data_sync(sections={"users", "proactive_candidate_pool"})
                 self._debug_tick_skip(user_id, "近期已经聊过饮食，本次饭点关心或补问进入共享冷却", prefix="取消")
                 return
             if (
@@ -383,7 +392,7 @@ class DailyStateTickMixin:
                 self._clear_pending_proactive_plan(current_for_mark)
                 current_for_mark["planned_meal_care_context"] = {}
                 self._schedule_next_proactive(current_for_mark, now=_now_ts())
-                self._save_data_sync()
+                self._save_data_sync(sections={"users", "proactive_candidate_pool"})
                 self._debug_tick_skip(user_id, "早餐关心等待用户回应早安", prefix="取消")
                 return
             if (
@@ -395,7 +404,7 @@ class DailyStateTickMixin:
                 if isinstance(suppressed_greetings, list) and current_reason in suppressed_greetings:
                     self._mark_planned_candidate_status(current_for_mark, "blocked", "用户在该问候窗口内已经活跃过")
                     self._clear_pending_proactive_plan(current_for_mark)
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users", "proactive_candidate_pool"})
                     self._debug_tick_skip(user_id, "问候窗口已被用户互动占掉", prefix="取消")
                     return
                 recent_user_at = self._latest_user_activity_ts(current_for_mark)
@@ -410,7 +419,7 @@ class DailyStateTickMixin:
                         self._clear_pending_proactive_plan(current_for_mark)
                     else:
                         self._reschedule_greeting_within_window(current_for_mark, current_reason, now=_now_ts())
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users", "proactive_candidate_pool"})
                     self._debug_tick_skip(user_id, "用户刚自然来聊,已取消或延后问候主动")
                     return
             recent_chat_guard_reason = self._route_recent_chat_guard_reason(
@@ -426,7 +435,7 @@ class DailyStateTickMixin:
                     now=_now_ts(),
                     note=recent_chat_guard_reason,
                 )
-                self._save_data_sync()
+                self._save_data_sync(sections={"users", "proactive_candidate_pool"})
                 logger.info(
                     "[PrivateCompanion] 刚聊完,延后本轮普通主动: user=%s reason=%s planned=%s/%s",
                     user_id,
@@ -461,7 +470,7 @@ class DailyStateTickMixin:
                     action=str(current_for_mark.get("planned_proactive_action") or "message"),
                     reason=normalize_legacy_tag_text(current_for_mark.get("planned_proactive_reason")) or "check_in",
                 )
-            self._save_data_sync()
+            self._save_data_sync(sections={"users", "troubleshooting_test_results"})
 
         planned_action_for_send = str(user.get("planned_proactive_action") or "message")
         planned_motive_for_send = _single_line(user.get("planned_proactive_motive"), 140)
@@ -500,7 +509,7 @@ class DailyStateTickMixin:
                     self._clear_pending_proactive_plan(current_for_duplicate_cooldown)
                     self._update_proactive_audit(audit_id, status="cancelled", note=f"活动分享去重冷却中: {note}")
                     self._schedule_next_proactive(current_for_duplicate_cooldown, now=_now_ts(), delay_hours=(2.0, 5.0))
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users", "proactive_candidate_pool", "proactive_audit_log"})
                 logger.info(
                     "[PrivateCompanion] 活动分享去重冷却中,跳过本轮主动: user=%s remain=%.0fs note=%s",
                     user_id,
@@ -527,7 +536,7 @@ class DailyStateTickMixin:
                         "accepted",
                         "photo_text 后端不可用,已降级为普通主动消息",
                     )
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users", "proactive_candidate_pool"})
         load_defer_note = self._photo_text_load_defer_note(planned_action_for_send, force_refresh=True)
         if load_defer_note:
             async with self._data_lock:
@@ -536,7 +545,7 @@ class DailyStateTickMixin:
                 current_for_defer["proactive_sending"] = False
                 current_for_defer["proactive_sending_started_at"] = 0
                 self._update_proactive_audit(audit_id, status="deferred", note=load_defer_note)
-                self._save_data_sync()
+                self._save_data_sync(sections={"users", "proactive_candidate_pool", "proactive_audit_log"})
             self._debug_tick_skip(user_id, load_defer_note, prefix="延后")
             return
         group_share_block_reason = ""
@@ -553,7 +562,7 @@ class DailyStateTickMixin:
                     self._clear_pending_proactive_plan(current_for_group_check)
                     current_for_group_check["group_share_context"] = {}
                     self._update_proactive_audit(audit_id, status="cancelled", note=group_share_block_reason)
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users", "proactive_candidate_pool", "proactive_audit_log"})
             if group_share_block_reason:
                 logger.info(
                     "[PrivateCompanion] 群聊分享主动发送前复核取消: user=%s reason=%s",
@@ -610,7 +619,7 @@ class DailyStateTickMixin:
                         current_after_render_failure["next_proactive_at"] = 0
                         self._schedule_next_proactive(current_after_render_failure, now=_now_ts(), delay_hours=(1, 3))
                     self._update_proactive_audit(audit_id, status="failed", note=f"生成失败: {_single_line(e, 140)}")
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users", "proactive_audit_log", "troubleshooting_test_results"})
                 return
         render_failure_stage = _single_line(user.pop("_proactive_render_failure_stage", ""), 240)
         if is_troubleshooting_for_send:
@@ -634,7 +643,7 @@ class DailyStateTickMixin:
                     reason=reason or "check_in",
                     extra_count=len(extra_components),
                 )
-                self._save_data_sync()
+                self._save_data_sync(sections={"users", "troubleshooting_test_results"})
         review_candidate_text = text
         if not review_candidate_text and (image_path or extra_components):
             if image_path:
@@ -686,7 +695,7 @@ class DailyStateTickMixin:
                             "last_error": _single_line(exc, 160),
                             "updated_at": _now_ts(),
                         }
-                        self._save_data_sync()
+                        self._save_data_sync(sections={"users"})
                     if failure_count >= 3:
                         review_strength_getter = getattr(self, "_proactive_review_strength", None)
                         review_strength = review_strength_getter() if callable(review_strength_getter) else str(getattr(self, "proactive_review_strength", "lenient") or "lenient")
@@ -745,7 +754,7 @@ class DailyStateTickMixin:
                         review_decision.get("review_fallback_reason") or review_decision.get("reason"),
                         180,
                     )
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"proactive_review_runtime"})
                 if release_count == 10 or release_count % 10 == 0:
                     logger.warning(
                         "[PrivateCompanion] 主动复核模型已连续放行 %s 条原文，请检查 RESPONSE_REVIEW_PROVIDER_ID",
@@ -766,7 +775,7 @@ class DailyStateTickMixin:
                     if isinstance(review_runtime, dict) and _safe_int(review_runtime.get("consecutive_fallback_releases"), 0) > 0:
                         review_runtime["consecutive_fallback_releases"] = 0
                         review_runtime["last_recovered_at"] = _now_ts()
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users", "proactive_review_runtime"})
             if decision == "defer":
                 delay_minutes = max(
                     5,
@@ -839,7 +848,7 @@ class DailyStateTickMixin:
                         note=note,
                         text=text or review_candidate_text,
                     )
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users", "proactive_candidate_pool", "proactive_audit_log"})
                 logger.info(
                     "[PrivateCompanion] 主动消息发送前复核%s: user=%s delay=%s reason=%s",
                     "作废过期候选" if stale_candidate else "延后",
@@ -902,7 +911,9 @@ class DailyStateTickMixin:
                                 reason=reason or "check_in",
                                 extra_count=len(extra_components),
                             )
-                        self._save_data_sync()
+                        self._save_data_sync(
+                            sections={"users", "proactive_audit_log", "troubleshooting_test_results"}
+                        )
             elif decision == "drop":
                 note = _single_line(review_decision.get("reason"), 120) or "proactive final content gate dropped the candidate"
                 async with self._data_lock:
@@ -929,7 +940,14 @@ class DailyStateTickMixin:
                         self._clear_pending_proactive_plan(current_for_review)
                         self._schedule_next_proactive(current_for_review, now=_now_ts(), delay_hours=(1.5, 4.0))
                     self._update_proactive_audit(audit_id, status="cancelled", note=note, text=text or review_candidate_text)
-                    self._save_data_sync()
+                    self._save_data_sync(
+                        sections={
+                            "users",
+                            "proactive_candidate_pool",
+                            "proactive_audit_log",
+                            "troubleshooting_test_results",
+                        }
+                    )
                 logger.info("[PrivateCompanion] Proactive final content gate dropped: user=%s reason=%s text=%s", user_id, note, _single_line(text, 120))
                 self._debug_tick_skip(user_id, note, prefix="dropped")
                 return
@@ -981,7 +999,14 @@ class DailyStateTickMixin:
                             self._schedule_next_proactive(current_for_outbound_guard, now=_now_ts(), delay_hours=(1.5, 4.0))
                     self._update_proactive_audit(audit_id, status="cancelled", note=note, text=text)
                     self._clear_pending_proactive_send_retry(current_for_outbound_guard)
-                    self._save_data_sync()
+                    self._save_data_sync(
+                        sections={
+                            "users",
+                            "proactive_candidate_pool",
+                            "proactive_audit_log",
+                            "troubleshooting_test_results",
+                        }
+                    )
                 logger.warning(
                     "[PrivateCompanion] 主动消息发送前统一校验拦截: user=%s reason=%s text=%s",
                     user_id,
@@ -1027,7 +1052,7 @@ class DailyStateTickMixin:
                 self._clear_pending_proactive_send_retry(current_for_meta_leak)
                 self._clear_pending_proactive_plan(current_for_meta_leak)
                 self._schedule_next_proactive(current_for_meta_leak, now=_now_ts(), delay_hours=(1.5, 4.0))
-                self._save_data_sync()
+                self._save_data_sync(sections={"users", "proactive_candidate_pool", "proactive_audit_log"})
             logger.warning(
                 "[PrivateCompanion] 主动消息发送前硬拦截元叙述泄漏: user=%s text=%s",
                 user_id,
@@ -1079,7 +1104,9 @@ class DailyStateTickMixin:
                         audit_note = f"{audit_note}；已移除候选碎片 {len(removed_can_do)} 条"
                     self._update_proactive_audit(audit_id, status="cancelled", note=audit_note)
                     self._schedule_next_proactive(current_for_dedupe, now=_now_ts(), delay_hours=(2.0, 5.0))
-                    self._save_data_sync()
+                    self._save_data_sync(
+                        sections={"users", "proactive_candidate_pool", "proactive_audit_log", "can_do"}
+                    )
             if duplicate_note:
                 logger.info(
                     "[PrivateCompanion] 取消重复活动分享: user=%s duplicate=%s",
@@ -1129,7 +1156,14 @@ class DailyStateTickMixin:
                     self._clear_pending_proactive_plan(current_for_time_guard)
                     self._schedule_next_proactive(current_for_time_guard, now=_now_ts(), delay_hours=(1.5, 4.0))
                 self._update_proactive_audit(audit_id, status="cancelled", note=time_mismatch_reason)
-                self._save_data_sync()
+                self._save_data_sync(
+                    sections={
+                        "users",
+                        "proactive_candidate_pool",
+                        "proactive_audit_log",
+                        "troubleshooting_test_results",
+                    }
+                )
             self._debug_tick_skip(user_id, "主动消息时间不一致", prefix="取消")
             return
         if not is_troubleshooting_for_send and (effective_action_for_send or planned_action_for_send or "message") == "message":
@@ -1165,7 +1199,7 @@ class DailyStateTickMixin:
                     self._clear_pending_proactive_plan(current_for_similarity_guard)
                     self._schedule_next_proactive(current_for_similarity_guard, now=_now_ts(), delay_hours=(0.5, 1.5))
                     self._update_proactive_audit(audit_id, status="cancelled", note=similar_note, text=text)
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users", "proactive_candidate_pool", "proactive_audit_log"})
             if similar_note:
                 logger.info(
                     "[PrivateCompanion] 主动消息正文近似重复,已取消: user=%s reason=%s text=%s",
@@ -1194,7 +1228,7 @@ class DailyStateTickMixin:
                     self._clear_pending_proactive_plan(current_for_greeting_text)
                     self._schedule_next_proactive(current_for_greeting_text, now=_now_ts(), delay_hours=(2.0, 5.0))
                     self._update_proactive_audit(audit_id, status="cancelled", note=textual_greeting_note, text=text)
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users", "proactive_candidate_pool", "proactive_audit_log"})
             if textual_greeting_note:
                 logger.info(
                     "[PrivateCompanion] 主动消息正文命中重复问候,已取消: user=%s reason=%s text=%s",
@@ -1220,7 +1254,7 @@ class DailyStateTickMixin:
                     reason=reason or "check_in",
                     extra_count=len(extra_components),
                 )
-                self._save_data_sync()
+                self._save_data_sync(sections={"users", "troubleshooting_test_results"})
         async with self._data_lock:
             current_after_render = self._get_user(user_id)
             has_new_user_message = (
@@ -1253,7 +1287,7 @@ class DailyStateTickMixin:
                         reason=reason or "check_in",
                         extra_count=len(extra_components),
                     )
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users", "troubleshooting_test_results"})
             elif not bool(route_options_for_send.get("cancel_if_new_inbound", True)):
                 logger.info(
                     "[PrivateCompanion] 生成期间收到新消息，但 %s 路线保留独立投递: user=%s",
@@ -1271,7 +1305,7 @@ class DailyStateTickMixin:
                     current_for_clear["proactive_sending"] = False
                     current_for_clear["proactive_sending_started_at"] = 0
                     self._update_proactive_audit(audit_id, status="cancelled", note="用户在生成期间发来新消息,已取消本次主动")
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users", "proactive_audit_log"})
                 return
         delivery_freshness_reason = ""
         if not is_troubleshooting_for_send:
@@ -1290,7 +1324,7 @@ class DailyStateTickMixin:
                     self._clear_pending_proactive_plan(current_for_freshness)
                     self._schedule_next_proactive(current_for_freshness, now=_now_ts(), delay_hours=(1.5, 4.0))
                     self._update_proactive_audit(audit_id, status="cancelled", note=delivery_freshness_reason)
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users", "proactive_candidate_pool", "proactive_audit_log"})
         if delivery_freshness_reason:
             logger.info(
                 "[PrivateCompanion] 主动候选在生成期间失效,已取消发送: user=%s reason=%s",
@@ -1303,7 +1337,7 @@ class DailyStateTickMixin:
             async with self._data_lock:
                 current_disabled = self._get_user(str(user_id))
                 if self._suspend_user_proactive_generation(current_disabled):
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users"})
             return
         async with self._data_lock:
             current_for_recent_chat = self._get_user(user_id)
@@ -1338,7 +1372,14 @@ class DailyStateTickMixin:
                         note=recent_chat_guard_reason,
                     )
                 self._update_proactive_audit(audit_id, status="deferred", note=recent_chat_guard_reason)
-                self._save_data_sync()
+                self._save_data_sync(
+                    sections={
+                        "users",
+                        "proactive_candidate_pool",
+                        "proactive_audit_log",
+                        "troubleshooting_test_results",
+                    }
+                )
         if recent_chat_guard_reason:
             logger.info(
                 "[PrivateCompanion] 发送前发现刚聊完,延后普通主动: user=%s reason=%s",
@@ -1378,7 +1419,14 @@ class DailyStateTickMixin:
                     self._clear_pending_proactive_plan(current)
                     self._schedule_next_proactive(current, now=_now_ts(), delay_hours=(2, 8))
                 self._update_proactive_audit(audit_id, status="dropped", note=note, text=text)
-                self._save_data_sync()
+                self._save_data_sync(
+                    sections={
+                        "users",
+                        "proactive_candidate_pool",
+                        "proactive_audit_log",
+                        "troubleshooting_test_results",
+                    }
+                )
             self._debug_tick_skip(user_id, note, prefix="放弃")
             return
         if not text and not image_path and not extra_components:
@@ -1410,7 +1458,14 @@ class DailyStateTickMixin:
                     if not materialized:
                         self._schedule_next_proactive(current, now=_now_ts(), delay_hours=(0.33, 1.0))
                 self._update_proactive_audit(audit_id, status="dropped", note=empty_note)
-                self._save_data_sync()
+                self._save_data_sync(
+                    sections={
+                        "users",
+                        "proactive_candidate_pool",
+                        "proactive_audit_log",
+                        "troubleshooting_test_results",
+                    }
+                )
             self._debug_tick_skip(user_id, empty_note, prefix="放弃")
             return
         try:
@@ -1507,7 +1562,14 @@ class DailyStateTickMixin:
                         note=cancel_note,
                         text=text,
                     )
-                    self._save_data_sync()
+                    self._save_data_sync(
+                        sections={
+                            "users",
+                            "proactive_candidate_pool",
+                            "proactive_audit_log",
+                            "troubleshooting_test_results",
+                        }
+                    )
                 self._debug_tick_skip(user_id, cancel_note, prefix="取消")
                 return
             delivery_complete = bool(getattr(delivered, "complete", True))
@@ -1587,7 +1649,7 @@ class DailyStateTickMixin:
                             sent_at=sent_at,
                             delivery_umo=send_umo_for_send,
                         )
-                self._save_data_sync()
+                self._save_data_sync(sections={"users"})
             if not is_troubleshooting_for_send and reason == "creative_share":
                 # Keep a per-user anchor before history archival so an immediate reply has context.
                 self._remember_recent_creative_share_snapshot(
@@ -1612,7 +1674,7 @@ class DailyStateTickMixin:
                         reason=reason or "check_in",
                         extra_count=len(extra_components),
                     )
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users", "troubleshooting_test_results"})
             logger.info(
                 "[PrivateCompanion] 主动发送完成: user=%s reason=%s action=%s complete=%s",
                 user_id,
@@ -1659,7 +1721,7 @@ class DailyStateTickMixin:
                         reason=reason or "check_in",
                         extra_count=len(extra_components),
                     )
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users", "troubleshooting_test_results"})
         except Exception as e:
             formatter = getattr(self, "_format_send_exception", None)
             error_text = formatter(e) if callable(formatter) else (_single_line(str(e), 180) or repr(e))
@@ -1714,14 +1776,21 @@ class DailyStateTickMixin:
                     note=f"发送失败: {_single_line(error_text, 140)}",
                     diagnostic_detail=diagnostic_detail,
                 )
-                self._save_data_sync()
+                self._save_data_sync(
+                    sections={
+                        "users",
+                        "proactive_candidate_pool",
+                        "proactive_audit_log",
+                        "troubleshooting_test_results",
+                    }
+                )
             return
         finally:
             async with self._data_lock:
                 current_for_clear = self._get_user(user_id)
                 current_for_clear["proactive_sending"] = False
                 current_for_clear["proactive_sending_started_at"] = 0
-                self._save_data_sync()
+                self._save_data_sync(sections={"users"})
 
         memory_companion_proactive_payload: dict[str, Any] = {}
         async with self._data_lock:
@@ -1897,7 +1966,7 @@ class DailyStateTickMixin:
                     extra_count=len(extra_components),
                 )
                 self._restore_troubleshooting_proactive_plan(current)
-                self._save_data_sync()
+                self._save_data_sync(sections={"users", "troubleshooting_test_results"})
                 return
             self._note_proactive_daypart_sent(current, current["last_sent"])
             opener_mode = planned_opener_mode_for_send
@@ -2121,7 +2190,15 @@ class DailyStateTickMixin:
                     schedule_now = _now_ts()
                     next_delay = self._friend_proactive_spread_delay_hours(current, now=schedule_now)
                     self._schedule_next_proactive(current, now=schedule_now, delay_hours=next_delay)
-            self._save_data_sync()
+            self._save_data_sync(
+                sections={
+                    "users",
+                    "proactive_candidate_pool",
+                    "proactive_audit_log",
+                    "proactive_runtime",
+                    "troubleshooting_test_results",
+                }
+            )
             current_snapshot = dict(current)
             if not simulation_active and visible_text:
                 memory_companion_proactive_payload = {

--- a/event_dispatch.py
+++ b/event_dispatch.py
@@ -10,6 +10,7 @@ import gc
 import hashlib
 import html
 import importlib
+import inspect
 import json
 import math
 import os
@@ -1636,7 +1637,10 @@ class EventDispatchMixin:
                 sender_label=sender_label,
             )
         try:
-            self._schedule_data_save(delay=2.0)
+            self._schedule_data_save(
+                sections={"recent_prompt_injections", "recent_prompt_injection_events"},
+                delay=2.0,
+            )
         except Exception:
             pass
 
@@ -3707,12 +3711,12 @@ class EventDispatchMixin:
         messages: list[str],
         previous_decision: str = "",
         note: str = "",
-    ) -> None:
+    ) -> bool:
         if not self._smart_message_debounce_enabled():
-            return
+            return False
         cleaned = [_single_line(item, 160) for item in messages if _single_line(item, 160)]
         if not cleaned:
-            return
+            return False
         store = self._smart_message_debounce_store()
         examples = store.setdefault("examples", [])
         if not isinstance(examples, list):
@@ -3720,7 +3724,7 @@ class EventDispatchMixin:
             store["examples"] = examples
         signature = hashlib.sha1("\n".join([kind, scope, sender_id, *cleaned]).encode("utf-8", errors="ignore")).hexdigest()
         if any(isinstance(item, dict) and item.get("sig") == signature for item in examples[-20:]):
-            return
+            return False
         examples.append(
             {
                 "sig": signature,
@@ -3751,6 +3755,7 @@ class EventDispatchMixin:
             source=kind,
             message_count=len(cleaned),
         )
+        return True
 
     def _remember_smart_message_debounce_decision(
         self,
@@ -3764,7 +3769,10 @@ class EventDispatchMixin:
     ) -> None:
         if not self._smart_message_debounce_enabled():
             return
-        store = self._smart_message_debounce_store()
+        data = getattr(self, "data", None)
+        store = data.get("smart_message_debounce") if isinstance(data, dict) else None
+        if not isinstance(store, dict):
+            return
         last = store.setdefault("last_decisions", {})
         if not isinstance(last, dict):
             last = {}
@@ -3790,22 +3798,25 @@ class EventDispatchMixin:
         sender_id: str,
         text: str,
         now: float | None = None,
-    ) -> None:
+    ) -> bool:
         if not self._smart_message_debounce_enabled():
-            return
-        store = self._smart_message_debounce_store()
+            return False
+        data = getattr(self, "data", None)
+        store = data.get("smart_message_debounce") if isinstance(data, dict) else None
+        if not isinstance(store, dict):
+            return False
         last = store.get("last_decisions") if isinstance(store.get("last_decisions"), dict) else {}
         key = self._semantic_buffer_key(scope, sender_id)
         previous = last.get(key) if isinstance(last, dict) else None
         if not isinstance(previous, dict):
-            return
+            return False
         if str(previous.get("decision") or "") != "complete":
-            return
+            return False
         now = now or _now_ts()
         window = max(1.0, _safe_float(getattr(self, "smart_message_debounce_learning_window_seconds", 8.0), 8.0, 1.0))
         if now - _safe_float(previous.get("ts"), 0) > window:
-            return
-        self._record_smart_message_debounce_example(
+            return False
+        return self._record_smart_message_debounce_example(
             kind="false_complete",
             scope=scope,
             sender_id=sender_id,
@@ -4007,6 +4018,10 @@ class EventDispatchMixin:
         wait = max(0.0, min(15.0, _safe_float(getattr(self, "smart_message_debounce_wait_seconds", 3.0), 3.0, 0.0)))
         if wait <= 0:
             return 0.0
+        # Fast-rule decisions also need a durable section before they record
+        # ``last_decisions``; otherwise the first decision after startup can
+        # be lost because the log path initializes the store only afterward.
+        self._smart_message_debounce_store()
         buffers = getattr(self, "_semantic_message_buffers", None)
         existing = buffers.get(key) if isinstance(buffers, dict) else None
         if isinstance(existing, dict):

--- a/event_dispatch.py
+++ b/event_dispatch.py
@@ -4654,7 +4654,7 @@ Bot 近期回复：
             if refreshed:
                 active = self._group_active_conversation(group)
                 expires_in = max(0.0, _safe_float(active.get("expires_at"), 0) - _now_ts())
-                self._save_data_sync()
+                self._save_data_sync(sections={"groups"})
         if refreshed:
             logger.info(
                 "[PrivateCompanion] Bot 回复已确认发送，群聊续接窗口从实际回复时间重新计时: group=%s sender=%s window=%.1fs",
@@ -4702,7 +4702,7 @@ Bot 近期回复：
                 text=text,
                 contextual_followup=bool(getattr(event, "private_companion_group_contextual_followup", False)),
             )
-            self._save_data_sync()
+            self._save_data_sync(sections={"groups"})
 
     def _extract_group_id_from_event(self, event: AstrMessageEvent) -> str:
         umo = str(getattr(event, "unified_msg_origin", "") or "")

--- a/final_response_persistence.py
+++ b/final_response_persistence.py
@@ -17,7 +17,13 @@ from astrbot.core.provider.entities import LLMResponse
 from astrbot.core.star.star import star_map
 from astrbot.core.star.star_handler import EventType, star_handlers_registry
 
-from .helpers import _format_history_media_marker, _now_ts, _safe_float, _single_line
+from .helpers import (
+    _format_history_media_marker,
+    _now_ts,
+    _safe_float,
+    _single_line,
+    _strip_internal_message_blocks,
+)
 
 
 _DELIVERY_TASK_LABELS = frozenset({"segmented_llm_remainder"})
@@ -924,18 +930,64 @@ class FinalResponsePersistenceMixin:
             )
             return False
 
-    async def _record_confirmed_private_bot_continuity(
+    def _confirmed_delivery_cache_key(
+        self,
+        event: Any,
+        delivery_id: str,
+    ) -> str:
+        persona_getter = getattr(self, "_active_persona_scope", None)
+        try:
+            persona_id = str(persona_getter() if callable(persona_getter) else "")
+        except Exception:
+            persona_id = ""
+        umo = str(getattr(event, "unified_msg_origin", "") or "")
+        return "\0".join((persona_id, umo, str(delivery_id or "")))
+
+    def _claim_confirmed_delivery_locked(
+        self,
+        event: Any,
+        delivery_id: str,
+    ) -> bool:
+        """Claim one delivery id while the caller holds the data lock."""
+        cache = getattr(self, "_private_companion_final_delivery_ids", None)
+        if not isinstance(cache, dict):
+            cache = {}
+            self._private_companion_final_delivery_ids = cache
+        key = self._confirmed_delivery_cache_key(event, delivery_id)
+        if key in cache:
+            return False
+        cache[key] = _now_ts()
+        if len(cache) > 512:
+            for stale_key, _ in sorted(cache.items(), key=lambda item: item[1])[:-384]:
+                cache.pop(stale_key, None)
+        return True
+
+    def _release_confirmed_delivery_claim(
+        self,
+        event: Any,
+        delivery_id: str,
+    ) -> None:
+        cache = getattr(self, "_private_companion_final_delivery_ids", None)
+        if isinstance(cache, dict):
+            cache.pop(self._confirmed_delivery_cache_key(event, delivery_id), None)
+
+    def _record_confirmed_private_bot_state_locked(
         self,
         event: Any,
         *,
         response_text: str,
-    ) -> bool:
+        now: float,
+    ) -> set[str]:
+        visible_text = _single_line(
+            _strip_internal_message_blocks(response_text),
+            500,
+        )
+        if not visible_text:
+            return set()
         recorder = getattr(self, "_record_confirmed_bot_continuity", None)
-        if not callable(recorder) or not response_text:
-            return False
         try:
             if not bool(getattr(event, "is_private_chat", lambda: False)()):
-                return False
+                return set()
             resolver = getattr(self, "_private_user_id_for_event", None)
             user_id = (
                 resolver(event)
@@ -943,43 +995,236 @@ class FinalResponsePersistenceMixin:
                 else self._canonical_private_user_id(str(event.get_sender_id()))
             )
         except Exception:
-            return False
+            return set()
+        users = (
+            self.data.get("users", {})
+            if isinstance(getattr(self, "data", None), dict)
+            else {}
+        )
+        user = users.get(user_id) if isinstance(users, dict) else None
+        if not isinstance(user, dict):
+            return set()
 
-        def record() -> bool:
-            users = self.data.get("users", {}) if isinstance(getattr(self, "data", None), dict) else {}
-            user = users.get(user_id) if isinstance(users, dict) else None
-            if not isinstance(user, dict):
-                return False
-            changed = bool(recorder(user, response_text, now=_now_ts()))
-            reunion_observed_at = _safe_float(
-                getattr(event, "_private_companion_reunion_observed_at", 0),
-                0,
+        user["last_companion_message"] = visible_text
+        user["last_companion_message_at"] = now
+        screen_scheduler = getattr(self, "_maybe_schedule_goodnight_screen_check", None)
+        if callable(screen_scheduler):
+            screen_scheduler(user, visible_text, now=now)
+
+        updated_sections = {"users"}
+        expression_rule_details = getattr(
+            event,
+            "private_companion_expression_rule_details",
+            None,
+        )
+        semantic_rules = getattr(
+            event,
+            "private_companion_semantic_expression_rules",
+            None,
+        )
+        expression_context = getattr(
+            event,
+            "private_companion_semantic_expression_context",
+            None,
+        )
+        usage_recorder = getattr(self, "_record_expression_rule_injection", None)
+        if callable(usage_recorder) and (
+            isinstance(expression_rule_details, dict)
+            or (isinstance(semantic_rules, list) and semantic_rules)
+        ):
+            usage = usage_recorder(
+                user,
+                expression_rule_details
+                if isinstance(expression_rule_details, dict)
+                else {},
+                visible_text,
+                semantic_rules=semantic_rules if isinstance(semantic_rules, list) else [],
+                context=expression_context
+                if isinstance(expression_context, dict)
+                else {"channel": "private"},
             )
-            if reunion_observed_at > _safe_float(user.get("last_reunion_ack_at"), 0):
-                user["last_reunion_ack_at"] = reunion_observed_at
-                changed = True
-            return changed
+            if isinstance(usage, dict):
+                updated_sections.update(usage.get("updated_sections") or ())
+
+        topic_recorder = getattr(self, "_remember_passive_reply_topic", None)
+        if callable(topic_recorder):
+            topic_recorder(
+                user,
+                visible_text,
+                _single_line(user.get("last_user_message"), 260),
+            )
+        if callable(recorder):
+            recorder(user, visible_text, now=now)
+        reunion_observed_at = _safe_float(
+            getattr(event, "_private_companion_reunion_observed_at", 0),
+            0,
+        )
+        if reunion_observed_at > _safe_float(user.get("last_reunion_ack_at"), 0):
+            user["last_reunion_ack_at"] = reunion_observed_at
+        return updated_sections
+
+    def _record_confirmed_group_bot_state_locked(
+        self,
+        event: Any,
+        *,
+        response_text: str,
+        now: float,
+    ) -> set[str]:
+        visible_text = _single_line(
+            _strip_internal_message_blocks(response_text),
+            500,
+        )
+        if not visible_text:
+            return set()
+        try:
+            if bool(getattr(event, "is_private_chat", lambda: False)()):
+                return set()
+        except Exception:
+            pass
+        group_id_getter = getattr(self, "_extract_group_id_from_event", None)
+        group_id = _single_line(
+            group_id_getter(event) if callable(group_id_getter) else "",
+            80,
+        )
+        if not group_id:
+            return set()
+        feature_checker = getattr(self, "_feature_enabled_or_temp_unlocked", None)
+        if callable(feature_checker) and not feature_checker("enable_group_companion"):
+            return set()
+        group_getter = getattr(self, "_get_group", None)
+        if not callable(group_getter):
+            return set()
+        group = group_getter(group_id)
+        if not isinstance(group, dict):
+            return set()
+
+        updated_sections: set[str] = set()
+        semantic_rules = getattr(
+            event,
+            "private_companion_semantic_expression_rules",
+            None,
+        )
+        expression_context = getattr(
+            event,
+            "private_companion_semantic_expression_context",
+            None,
+        )
+        usage_recorder = getattr(self, "_record_expression_rule_injection", None)
+        if (
+            callable(usage_recorder)
+            and isinstance(semantic_rules, list)
+            and semantic_rules
+        ):
+            usage = usage_recorder(
+                group,
+                {},
+                visible_text,
+                semantic_rules=semantic_rules,
+                context=expression_context
+                if isinstance(expression_context, dict)
+                else {"channel": "group"},
+            )
+            if isinstance(usage, dict) and usage:
+                updated_sections.update(usage.get("updated_sections") or ("groups",))
+                try:
+                    setattr(
+                        event,
+                        "private_companion_group_semantic_usage_recorded",
+                        True,
+                    )
+                except Exception:
+                    pass
+
+        try:
+            sender_id = str(event.get_sender_id())
+        except Exception:
+            sender_id = ""
+        scene = getattr(event, "private_companion_group_scene", None)
+        talking_to_bot = (
+            isinstance(scene, dict) and str(scene.get("talking_to") or "") == "bot"
+        )
+        active_getter = getattr(self, "_group_active_conversation", None)
+        active = active_getter(group) if callable(active_getter) else {}
+        if talking_to_bot or (
+            isinstance(active, dict)
+            and str(active.get("sender_id") or "") == str(sender_id or "")
+        ):
+            active["last_bot_reply"] = visible_text
+            active["last_bot_reply_ts"] = now
+            recent_bot = group.setdefault("recent_bot_replies", [])
+            if not isinstance(recent_bot, list):
+                recent_bot = []
+                group["recent_bot_replies"] = recent_bot
+            recent_bot.append(
+                {
+                    "ts": now,
+                    "sender_id": sender_id,
+                    "text": visible_text,
+                    "talking_to_bot": talking_to_bot,
+                }
+            )
+            del recent_bot[:-20]
+            trimmer = getattr(self, "_group_air_guard_trim_bot_replies", None)
+            if callable(trimmer):
+                trimmer(group)
+            if talking_to_bot:
+                refresher = getattr(
+                    self,
+                    "_refresh_group_bot_conversation_after_reply",
+                    None,
+                )
+                if callable(refresher):
+                    refresher(group, sender_id, now=now)
+            updated_sections.add("groups")
+        return updated_sections
+
+    async def _record_confirmed_outbound_state(
+        self,
+        event: Any,
+        *,
+        response_text: str,
+        delivery_id: str,
+    ) -> tuple[bool, set[str]]:
+        """Commit all local continuity for one confirmed delivery exactly once."""
+        if not response_text:
+            return False, set()
+
+        def record() -> tuple[bool, set[str]]:
+            if not self._claim_confirmed_delivery_locked(event, delivery_id):
+                return True, set()
+            try:
+                now = _now_ts()
+                private_sections = self._record_confirmed_private_bot_state_locked(
+                    event,
+                    response_text=response_text,
+                    now=now,
+                )
+                group_sections = self._record_confirmed_group_bot_state_locked(
+                    event,
+                    response_text=response_text,
+                    now=now,
+                )
+                sections = private_sections | group_sections
+                if sections:
+                    self._save_data_sync(sections=sections)
+                return False, sections
+            except Exception:
+                self._release_confirmed_delivery_claim(event, delivery_id)
+                raise
 
         lock = getattr(self, "_data_lock", None)
         try:
             if lock is not None and hasattr(lock, "__aenter__"):
                 async with lock:
-                    changed = record()
-                    if changed:
-                        self._save_data_sync()
+                    return record()
             else:
-                changed = record()
-                if changed:
-                    scheduler = getattr(self, "_schedule_data_save", None)
-                    if callable(scheduler):
-                        scheduler(sections={"users"})
-            return changed
+                return record()
         except Exception as exc:
             logger.debug(
-                "[PrivateCompanion] Bot 连续性状态记录失败: %s",
+                "[PrivateCompanion] Confirmed delivery state commit failed: %s",
                 _single_line(exc, 120),
             )
-            return False
+            return False, set()
 
     async def _finalize_passive_delivered_response(
         self,
@@ -1014,10 +1259,20 @@ class FinalResponsePersistenceMixin:
         if not response_text:
             return False
 
-        await self._record_confirmed_private_bot_continuity(
+        delivery_id = str(
+            getattr(event, "_private_companion_delivery_id", "")
+            or self._event_message_id(event)
+            or f"passive:{id(event)}"
+        )
+        setattr(event, "_private_companion_delivery_id", delivery_id)
+        duplicate, local_sections = await self._record_confirmed_outbound_state(
             event,
             response_text=response_text,
+            delivery_id=delivery_id,
         )
+        if duplicate:
+            setattr(event, "_private_companion_delivery_persisted", True)
+            return True
 
         official_written = self._stage_delivered_assistant_for_official_history(
             event=event,
@@ -1028,11 +1283,6 @@ class FinalResponsePersistenceMixin:
                 event=event,
                 assistant_response=response_text,
             )
-        delivery_id = str(
-            getattr(event, "_private_companion_delivery_id", "")
-            or self._event_message_id(event)
-            or f"passive:{id(event)}"
-        )
         memory_written = await self._record_final_assistant_in_livingmemory(
             umo=str(getattr(event, "unified_msg_origin", "") or ""),
             assistant_response=response_text,
@@ -1050,6 +1300,11 @@ class FinalResponsePersistenceMixin:
                     delivery_id=delivery_id,
                 )
             )
-        if official_written or memory_written or memory_companion_written:
-            setattr(event, "_private_companion_delivery_persisted", True)
-        return official_written or memory_written or memory_companion_written
+        persisted = bool(
+            local_sections
+            or official_written
+            or memory_written
+            or memory_companion_written
+        )
+        setattr(event, "_private_companion_delivery_persisted", True)
+        return persisted

--- a/final_response_persistence.py
+++ b/final_response_persistence.py
@@ -972,7 +972,7 @@ class FinalResponsePersistenceMixin:
                 if changed:
                     scheduler = getattr(self, "_schedule_data_save", None)
                     if callable(scheduler):
-                        scheduler()
+                        scheduler(sections={"users"})
             return changed
         except Exception as exc:
             logger.debug(

--- a/game_integration.py
+++ b/game_integration.py
@@ -1039,7 +1039,7 @@ class GameIntegrationMixin:
                     user["game_afterglow"] = deepcopy(previous)
                     persisted = True
                     try:
-                        self._save_data_sync()
+                        self._save_data_sync(sections={"users"})
                     except Exception as exc:
                         persisted = False
                         logger.warning("[PrivateCompanion] 游戏旧事件回执保存失败: %s", self._game_clean_text(exc, 120))
@@ -1073,7 +1073,7 @@ class GameIntegrationMixin:
                     user["game_afterglow"] = deepcopy(current)
                     persisted = True
                     try:
-                        self._save_data_sync()
+                        self._save_data_sync(sections={"users"})
                     except Exception:
                         persisted = False
                     return self._game_public_result(current, stale=True, persisted=persisted)
@@ -1174,7 +1174,7 @@ class GameIntegrationMixin:
                 user["game_afterglow"] = deepcopy(updated)
                 persisted = True
                 try:
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users"})
                 except Exception as exc:
                     persisted = False
                     logger.warning("[PrivateCompanion] 游戏余韵保存失败: %s", self._game_clean_text(exc, 120))

--- a/group_member_safety.py
+++ b/group_member_safety.py
@@ -615,7 +615,7 @@ class GroupMemberSafetyMixin:
                     blocked_now = True
                     if events and isinstance(events[-1], dict) and _safe_float(events[-1].get("ts"), 0.0) == now:
                         events[-1]["blocked"] = True
-            self._save_data_sync()
+            self._save_data_sync(sections={"groups"})
         if counted:
             setattr(event, "_private_companion_member_safety_counted", True)
         return {

--- a/group_observation.py
+++ b/group_observation.py
@@ -658,7 +658,7 @@ class GroupObservationMixin:
         async with self._data_lock:
             group = self._get_group(group_id)
             self._apply_group_role_member_list(group, raw_members, self_id=self_id, now=now)
-            self._save_data_sync()
+            self._save_data_sync(sections={"groups"})
         return True
 
     def _group_injection_guard_threshold(self) -> int:
@@ -3982,7 +3982,7 @@ class GroupObservationMixin:
             current["last_expression_rule_attempt_at"] = now
             current["last_expression_rule_batch_key"] = batch_key
             current["last_expression_rule_candidate_count"] = max(0, int(candidate_count))
-            self._save_data_sync()
+            self._save_data_sync(sections={"groups", "expression_learning_runtime"})
         return True
 
     async def _maybe_refresh_group_episode(self, group_id: str, group: dict[str, Any]) -> None:
@@ -4127,7 +4127,10 @@ class GroupObservationMixin:
             current["group_episode_retry_after"] = 0
             current["group_episode_last_error"] = ""
             current["group_episode_running_at"] = 0
-            self._save_data_sync()
+            save_sections = {"groups"}
+            if expression_rules:
+                save_sections.add("expression_voice_profile")
+            self._save_data_sync(sections=save_sections)
 
     async def _maybe_refresh_group_slang_meanings(self, group_id: str, group: dict[str, Any]) -> None:
         if not self.enable_group_slang_meanings:
@@ -4278,7 +4281,7 @@ class GroupObservationMixin:
             current["group_slang_running_at"] = 0
             if removed_uncertain:
                 logger.info("[PrivateCompanion] 已清理低置信度群黑话释义: group=%s removed=%s", group_id, removed_uncertain)
-            self._save_data_sync()
+            self._save_data_sync(sections={"groups"})
 
     async def _try_acquire_group_background_task(
         self,
@@ -4301,7 +4304,7 @@ class GroupObservationMixin:
             if running_at > 0 and now - running_at < 10 * 60:
                 return False
             current[running_key] = now
-            self._save_data_sync()
+            self._save_data_sync(sections={"groups"})
         return True
 
     async def _mark_group_background_retry(self, group_id: str, task: str, now: float, error: Any) -> None:
@@ -4316,7 +4319,7 @@ class GroupObservationMixin:
                 current[retry_key] = 0
                 current[error_key] = ""
                 current[running_key] = 0
-                self._save_data_sync()
+                self._save_data_sync(sections={"groups"})
             logger.debug(
                 "[PrivateCompanion] 群黑话释义 JSON 解析失败,已跳过本轮刷新: group=%s",
                 group_id,
@@ -4332,7 +4335,7 @@ class GroupObservationMixin:
             current[retry_key] = now + delay
             current[error_key] = error_text
             current[running_key] = 0
-            self._save_data_sync()
+            self._save_data_sync(sections={"groups"})
         logger.warning(
             "[PrivateCompanion] 群聊后台整理失败,已进入短冷却避免重复请求: group=%s task=%s retry=%ss error=%s",
             group_id,
@@ -4424,7 +4427,7 @@ class GroupObservationMixin:
                         web_state["cursor"] = 0
                     web_state["last_error"] = error_text
                     web_state["updated_at"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-                self._save_data_sync()
+                self._save_data_sync(sections={"groups"})
             logger.info(
                 "[PrivateCompanion] 群黑话联网参考单词搜索失败并冷却: group=%s term=%s error=%s",
                 group_id,
@@ -4462,7 +4465,7 @@ class GroupObservationMixin:
                 except ValueError:
                     web_state["cursor"] = 0
                 web_state["updated_at"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-            self._save_data_sync()
+            self._save_data_sync(sections={"groups"})
         if lines:
             logger.info("[PrivateCompanion] 群黑话联网参考已收集: group=%s term=%s", group_id, term)
         return "\n".join(lines)[:1800]

--- a/llm_tool_actions.py
+++ b/llm_tool_actions.py
@@ -2931,7 +2931,7 @@ class LlmToolActionsMixin:
                 previous_notes = raw_notes
                 self.data["memo_notes"] = updated_notes
                 try:
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"memo_notes"})
                 except Exception:
                     self.data["memo_notes"] = previous_notes
                     raise
@@ -3023,7 +3023,7 @@ class LlmToolActionsMixin:
             if changed:
                 saver = getattr(self, "_save_data_sync", None)
                 if callable(saver):
-                    saver()
+                    saver(sections={"users", "photo_generation_scope_attempts"})
             return changed
 
         data_lock = getattr(self, "_data_lock", None)
@@ -5125,7 +5125,10 @@ class LlmToolActionsMixin:
                 pass
         saver = getattr(self, "_save_data_sync", None)
         if callable(saver):
-            saver()
+            saver(
+                sections=sections
+                or {"users", "reaction_expression_group_states"}
+            )
 
     @staticmethod
     def _is_reaction_embedding_provider(provider: Any) -> bool:
@@ -6881,7 +6884,7 @@ class LlmToolActionsMixin:
                         reason="reaction_library_image",
                         subject_owner="unknown",
                     )
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users"})
 
         if sent:
             self._mark_reaction_asset_used(lookup.get("image_id"), event=event)
@@ -8223,7 +8226,7 @@ class LlmToolActionsMixin:
                 ]
             if self.enable_worldbook_member_recognition:
                 async with self._data_lock:
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"worldbook_member_profiles"})
             return json.dumps({"status": "success", "group_id": target_group, "count": len(formatted), "members": formatted[:80]}, ensure_ascii=False)
         except Exception as exc:
             return json.dumps({"status": "error", "message": f"查询群成员失败: {_single_line(exc, 120)}"}, ensure_ascii=False)
@@ -8659,7 +8662,7 @@ class LlmToolActionsMixin:
             )
             return f"发送失败：{_single_line(error, 180)}"
         self._note_atrelay_send("group", target_group, text, at_qq or at_user, event=event)
-        self._save_data_sync()
+        self._save_data_sync(sections={"recent_atrelay_contexts", "atrelay_send_log"})
         logger.info(
             "[PrivateCompanion] 跨群转述发送完成: group=%s at=%s umo=%s",
             target_group,
@@ -8731,7 +8734,7 @@ class LlmToolActionsMixin:
                 confirm_before_report=confirm_before_report,
                 expire_hours=receipt_expire_hours,
             )
-        self._save_data_sync()
+        self._save_data_sync(sections={"pending_atrelay_receipts", "recent_atrelay_contexts", "atrelay_send_log"})
         logger.info(
             "[PrivateCompanion] 私聊转述发送完成: user=%s umo=%s",
             target_user,
@@ -8862,5 +8865,5 @@ class LlmToolActionsMixin:
                 }
             )
             del tasks[:-30]
-            self._save_data_sync()
+            self._save_data_sync(sections={"groups"})
         return f"已挂起：等 {target_name} 在群 {target_group} 出现时转述"

--- a/llm_tool_actions.py
+++ b/llm_tool_actions.py
@@ -4961,7 +4961,11 @@ class LlmToolActionsMixin:
                         return bool(authorization["authorized"])
                     state = ensure_reaction_expression_state(user)
                     reaction_expression_scope_state(state, scope_key)["last_offer_at"] = now
-                    self._persist_reaction_expression_state()
+                    self._persist_reaction_expression_state(
+                        sections={"reaction_expression_group_states"}
+                        if scope == "group"
+                        else {"users"}
+                    )
             self._note_reaction_expression_runtime(offers=1, last_reason="offered")
         self._note_reaction_expression_runtime(
             trigger_mode=authorization.get("trigger_mode"),
@@ -5107,11 +5111,15 @@ class LlmToolActionsMixin:
             )
         runtime["last_at"] = _now_ts()
 
-    def _persist_reaction_expression_state(self) -> None:
+    def _persist_reaction_expression_state(
+        self,
+        *,
+        sections: set[str] | None = None,
+    ) -> None:
         scheduler = getattr(self, "_schedule_data_save", None)
         if callable(scheduler):
             try:
-                scheduler()
+                scheduler(sections=sections)
                 return
             except Exception:
                 pass
@@ -5763,7 +5771,11 @@ class LlmToolActionsMixin:
                     now=now,
                     candidate_limit=candidate_limit,
                 )
-                self._persist_reaction_expression_state()
+                self._persist_reaction_expression_state(
+                    sections={"reaction_expression_group_states"}
+                    if scope == "group"
+                    else {"users"}
+                )
                 return json.dumps(
                     self._reaction_expression_skip_result(
                         reason,
@@ -5857,7 +5869,11 @@ class LlmToolActionsMixin:
                     cache_hit=lookup_cache_hit,
                     latency_ms=lookup_latency_ms,
                 )
-                self._persist_reaction_expression_state()
+                self._persist_reaction_expression_state(
+                    sections={"reaction_expression_group_states"}
+                    if scope == "group"
+                    else {"users"}
+                )
             return json.dumps(
                 self._reaction_expression_skip_result(
                     reason,
@@ -5939,7 +5955,11 @@ class LlmToolActionsMixin:
                     cache_hit=lookup_cache_hit,
                     latency_ms=lookup_latency_ms,
                 )
-                self._persist_reaction_expression_state()
+                self._persist_reaction_expression_state(
+                    sections={"reaction_expression_group_states"}
+                    if scope == "group"
+                    else {"users"}
+                )
                 return json.dumps(
                     self._reaction_expression_skip_result(
                         final_reason,
@@ -5978,7 +5998,11 @@ class LlmToolActionsMixin:
                     cache_hit=lookup_cache_hit,
                     latency_ms=lookup_latency_ms,
                 )
-                self._persist_reaction_expression_state()
+                self._persist_reaction_expression_state(
+                    sections={"reaction_expression_group_states"}
+                    if scope == "group"
+                    else {"users"}
+                )
                 return json.dumps(
                     self._reaction_expression_skip_result(
                         "duplicate_image",
@@ -6163,7 +6187,11 @@ class LlmToolActionsMixin:
                     cache_hit=lookup_cache_hit,
                     latency_ms=lookup_latency_ms,
                 )
-                self._persist_reaction_expression_state()
+                self._persist_reaction_expression_state(
+                    sections={"reaction_expression_group_states"}
+                    if scope == "group"
+                    else {"users"}
+                )
             return json.dumps(
                 self._reaction_expression_skip_result(
                     delivery_reason,
@@ -6223,7 +6251,11 @@ class LlmToolActionsMixin:
                     reason="reaction_expression_experiment",
                     subject_owner="unknown",
                 )
-            self._persist_reaction_expression_state()
+            self._persist_reaction_expression_state(
+                sections={"reaction_expression_group_states"}
+                if scope == "group"
+                else {"users"}
+            )
 
         self._note_reaction_expression_runtime(sent=1, last_reason="delivered")
         self._mark_reaction_asset_used(image_id, event=event)
@@ -6401,7 +6433,11 @@ class LlmToolActionsMixin:
                     cache_hit=cache_hit,
                     latency_ms=latency_ms,
                 )
-            self._persist_reaction_expression_state()
+            self._persist_reaction_expression_state(
+                sections={"reaction_expression_group_states"}
+                if scope == "group"
+                else {"users"}
+            )
 
         if sent:
             self._note_reaction_expression_runtime(sent=1, last_reason="delivered")

--- a/main.py
+++ b/main.py
@@ -263,7 +263,11 @@ from .chronotype import ChronotypeMixin
 from .memory_companion_adapter import MemoryCompanionAdapterMixin
 from .p5_attestation import P5AttestationError, REASON_CODES as P5_ATTESTATION_REASON_CODES
 from .p5_source_observer import evaluate_source
-from .message_pipeline import handle_group_message, handle_private_message
+from .message_pipeline import (
+    event_data_save_boundary,
+    handle_group_message,
+    handle_private_message,
+)
 from .tool_history_sanitizer import sanitize_history_image_blocks, sanitize_openai_tool_history
 from .forward_message import ForwardMessageMixin
 from .private_image import PrivateImageMixin
@@ -1099,7 +1103,7 @@ class PrivateCompanionExtensionAPI:
             profile["pending_observations"] = ordinary_pending + historical_pending
             if staged:
                 profile["last_pending_observation_at"] = time.time()
-                plugin._save_data_sync()
+                plugin._save_data_sync(sections={"worldbook_member_profiles"})
         return {"staged": staged, "batch_id": normalized_batch_id}
 
     async def rebind_historical_relationship_observations(
@@ -1299,7 +1303,7 @@ class PrivateCompanionExtensionAPI:
             profiles[normalized_old_user_id] = source_profile
             profiles[normalized_user_id] = target_profile
             try:
-                plugin._save_data_sync()
+                plugin._save_data_sync(sections={"worldbook_member_profiles"})
             except Exception:
                 profiles[normalized_old_user_id] = original_source
                 if target_had_entry:
@@ -1358,7 +1362,7 @@ class PrivateCompanionExtensionAPI:
                 removed += len(pending) - len(kept)
                 profile["pending_observations"] = kept
             if removed:
-                plugin._save_data_sync()
+                plugin._save_data_sync(sections={"worldbook_member_profiles"})
         return {"removed": removed, "batch_id": normalized_batch_id}
 
 _LUNAR_MONTH_NAMES = [
@@ -2132,7 +2136,9 @@ class PrivateCompanionPlugin(
                             "state": "confirmed",
                             "created_at": _now_ts(),
                         }
-                        self._req041_persist_archive_saga_locked()
+                        self._req041_persist_archive_saga_locked(
+                            sections={"_req041_persona_reset_saga"},
+                        )
                 scoped_reset = self._req041_erase_scoped_persona_data(
                     pid, operation_id=clean_operation,
                 )
@@ -4975,7 +4981,9 @@ class PrivateCompanionPlugin(
                     "created_at": _now_ts(),
                 }
                 sagas[clean_operation] = saga
-                self._req041_persist_archive_saga_locked()
+                self._req041_persist_archive_saga_locked(
+                    sections={"_req041_group_reset_sagas"},
+                )
             else:
                 clean_operation = _single_line(saga.get("operation_id"), 120)
                 if (
@@ -5008,7 +5016,13 @@ class PrivateCompanionPlugin(
                 "namespace_count": int(remote.get("namespace_count") or 0),
             }
             saga["local_result"] = deepcopy(local)
-            self._req041_persist_archive_saga_locked()
+            self._req041_persist_archive_saga_locked(
+                sections={
+                    "groups",
+                    "expression_voice_profile",
+                    "_req041_group_reset_sagas",
+                },
+            )
 
         config_saved = await self._save_config_if_possible()
         if not config_saved:
@@ -5023,6 +5037,7 @@ class PrivateCompanionPlugin(
                 self.data.pop("_req041_group_reset_sagas", None)
                 deleted_sections.add("_req041_group_reset_sagas")
             self._req041_persist_archive_saga_locked(
+                sections={"_req041_group_reset_sagas"},
                 deleted_sections=deleted_sections,
             )
         return {
@@ -5101,14 +5116,67 @@ class PrivateCompanionPlugin(
     def _req041_persist_archive_saga_locked(
         self,
         *,
+        sections: Collection[str] | None = None,
         deleted_sections: Collection[str] = (),
+        full_scope: str | None = None,
     ) -> None:
         """Durably persist a destructive saga before any cross-store write."""
+        normalized_scope = str(full_scope or "").strip() or None
+        normalized_deleted = {
+            str(section).strip()
+            for section in deleted_sections
+            if str(section).strip()
+        }
+        normalized_sections = {
+            str(section).strip()
+            for section in (sections or ())
+            if str(section).strip()
+        }
+        if normalized_scope is None and sections is None:
+            raise ValueError(
+                "archive saga sections must be explicit unless full_scope is provided"
+            )
+        if normalized_scope is not None:
+            if normalized_scope != "admin_import_export":
+                raise ValueError(
+                    "archive saga full_scope must be admin_import_export"
+                )
+            if sections is not None or normalized_deleted:
+                raise ValueError(
+                    "archive saga full_scope cannot be combined with sections"
+                )
+        else:
+            # The live mapping is authoritative when an internal caller names a
+            # section in both sets. Present values are upserts; absent values are
+            # tombstones. Never pass an overlapping request to the writer.
+            for section in normalized_sections & normalized_deleted:
+                if section in self.data:
+                    normalized_deleted.discard(section)
+                else:
+                    normalized_sections.discard(section)
+        if not normalized_sections and not normalized_deleted:
+            if normalized_scope is None:
+                return
+        validator = getattr(self, "_validate_save_request", None)
+        if callable(validator):
+            validator(
+                None if normalized_scope is not None else normalized_sections,
+                normalized_deleted,
+                normalized_scope,
+            )
         active_persona = str(self._active_persona_scope() or "")
         if bool(getattr(self, "enable_multi_persona_mode", False)) and active_persona:
+            # Destructive sagas must be durable before touching another store;
+            # the persona profile backend exposes only an immediate snapshot API.
             self._write_persona_data_snapshot_sync(active_persona, deepcopy(self.data))
             return
-        self._save_data_now_sync(deleted_sections=deleted_sections)
+        if normalized_scope is not None:
+            self._save_data_now_sync(full_scope="admin_import_export")
+        else:
+            self._save_data_now_sync(
+                sections=normalized_sections,
+                deleted_sections=normalized_deleted,
+            )
 
     async def archive_unified_person(
         self,
@@ -5133,12 +5201,20 @@ class PrivateCompanionPlugin(
             )
             if not prepared.get("ok"):
                 return prepared
-            self._req041_persist_archive_saga_locked()
+            self._req041_persist_archive_saga_locked(
+                sections={"unified_person"},
+            )
             if prepared.get("code") == "person_archived":
                 subjects = registry.archived_identity_subjects(clean_person)
                 removed = self._req041_erase_person_private_auxiliary_locked(clean_person, subjects)
                 if sum(removed.values()) > 0:
-                    self._req041_persist_archive_saga_locked()
+                    self._req041_persist_archive_saga_locked(
+                        sections={
+                            name
+                            for name, count in removed.items()
+                            if int(count or 0) > 0
+                        },
+                    )
                 return prepared
             if dry_run:
                 return prepared
@@ -5153,7 +5229,9 @@ class PrivateCompanionPlugin(
             )
             if not confirmed.get("ok"):
                 return confirmed
-            self._req041_persist_archive_saga_locked()
+            self._req041_persist_archive_saga_locked(
+                sections={"unified_person"},
+            )
             context = self._req041_scoped_private_context_for_person(clean_person)
             synchronizer = getattr(self, "req041_scoped_projection_sync", None)
             relationship_store = getattr(self, "req041_relationship_store", None)
@@ -5228,7 +5306,16 @@ class PrivateCompanionPlugin(
                 rollback = getattr(coordinator, "rollback_identity", None)
                 if callable(rollback):
                     rollback(clean_person, reason_code="person_archived")
-                self._req041_persist_archive_saga_locked()
+                self._req041_persist_archive_saga_locked(
+                    sections={
+                        "unified_person",
+                        *(
+                            name
+                            for name, count in auxiliary_counts.items()
+                            if int(count or 0) > 0
+                        ),
+                    },
+                )
             return result
 
     async def _req041_resume_confirmed_person_archives(self) -> dict[str, Any]:
@@ -5254,7 +5341,11 @@ class PrivateCompanionPlugin(
         }
 
     def _req041_purge_legacy_person_locked(
-        self, person_id: str, subjects: list[str]
+        self,
+        person_id: str,
+        subjects: list[str],
+        *,
+        changed_sections: set[str] | None = None,
     ) -> dict[str, int]:
         """Remove only exact identity-owned legacy nodes; never fuzzy-search text."""
         clean_person = _single_line(person_id, 80)
@@ -5282,7 +5373,7 @@ class PrivateCompanionPlugin(
             if isinstance(value, dict):
                 for key in list(value):
                     item = value[key]
-                    if str(key) in subject_set or owned(item):
+                    if str(key) == clean_person or str(key) in subject_set or owned(item):
                         value.pop(key, None)
                         counts["mapping_entries"] += 1
                         counts["records"] += 1
@@ -5303,7 +5394,11 @@ class PrivateCompanionPlugin(
         for key in list(self.data):
             if key == "unified_person":
                 continue
-            self.data[key] = scrub(self.data[key])
+            before = deepcopy(self.data[key])
+            scrubbed = scrub(self.data[key])
+            self.data[key] = scrubbed
+            if changed_sections is not None and before != scrubbed:
+                changed_sections.add(str(key))
         return counts
 
     async def purge_unified_person(
@@ -5328,7 +5423,9 @@ class PrivateCompanionPlugin(
             )
             if not prepared.get("ok"):
                 return prepared
-            self._req041_persist_archive_saga_locked()
+            self._req041_persist_archive_saga_locked(
+                sections={"unified_person"},
+            )
             if prepared.get("code") == "person_purged":
                 return prepared
             if dry_run:
@@ -5344,7 +5441,9 @@ class PrivateCompanionPlugin(
             )
             if not confirmed.get("ok"):
                 return confirmed
-            self._req041_persist_archive_saga_locked()
+            self._req041_persist_archive_saga_locked(
+                sections={"unified_person"},
+            )
             subjects = registry.archived_identity_subjects(clean_person)
             if int(prepared.get("detached_identity_count") or 0) > 0 and not subjects:
                 return {
@@ -5371,7 +5470,12 @@ class PrivateCompanionPlugin(
                     "person_id": clean_person, "operation_id": clean_operation, "changed": False,
                 }
             auxiliary_counts = self._req041_erase_person_private_auxiliary_locked(clean_person, subjects)
-            legacy_counts = self._req041_purge_legacy_person_locked(clean_person, subjects)
+            legacy_changed_sections: set[str] = set()
+            legacy_counts = self._req041_purge_legacy_person_locked(
+                clean_person,
+                subjects,
+                changed_sections=legacy_changed_sections,
+            )
             result = registry.finalize_person_purge(
                 clean_person, clean_operation, confirmation_token, outbox_receipt,
                 actor_id=actor_id, reason_code=reason_code,
@@ -5379,7 +5483,22 @@ class PrivateCompanionPlugin(
             if result.get("changed"):
                 result["legacy_removed_record_count"] = int(legacy_counts.get("records") or 0)
                 result["auxiliary_removed_record_count"] = sum(auxiliary_counts.values())
-                self._req041_persist_archive_saga_locked()
+                if legacy_changed_sections:
+                    # Legacy identity records may live under unregistered roots.
+                    # This administrator-confirmed purge is therefore an explicit
+                    # full-store repair boundary rather than an implicit fallback.
+                    self._req041_persist_archive_saga_locked(
+                        full_scope="admin_import_export",
+                    )
+                else:
+                    self._req041_persist_archive_saga_locked(
+                        sections={"unified_person"}
+                        | {
+                            name
+                            for name, count in auxiliary_counts.items()
+                            if int(count or 0) > 0
+                        },
+                    )
             return result
 
     async def _req041_resume_confirmed_person_purges(self) -> dict[str, Any]:
@@ -6255,7 +6374,10 @@ class PrivateCompanionPlugin(
         needs_startup_save = False
         agenda_before = bool(getattr(self, "_agenda_migration_dirty", False))
         self._agenda_prepare_store()
-        if getattr(self, "_agenda_migration_dirty", False) and not agenda_before:
+        agenda_migration_changed = bool(
+            getattr(self, "_agenda_migration_dirty", False) and not agenda_before
+        )
+        if agenda_migration_changed:
             needs_startup_save = True
         async with self._data_lock:
             changed = False
@@ -6284,10 +6406,19 @@ class PrivateCompanionPlugin(
             if changed:
                 needs_startup_save = True
         if needs_startup_save:
-            # Startup maintenance can reconcile several legacy sections; retain
-            # the explicit full-save compatibility path until its mutation set
-            # is proven stable across all migration and recovery branches.
-            self._schedule_data_save(sections=None, delay=0.5)
+            # Initialization may combine an agenda schema migration with legacy
+            # user repair and recovery across several durable roots. Keep this
+            # one-time boundary explicit and distinguish migration from upkeep.
+            if agenda_migration_changed:
+                self._schedule_data_save(
+                    full_scope="startup_migration",
+                    delay=0.5,
+                )
+            else:
+                self._schedule_data_save(
+                    full_scope="startup_maintenance",
+                    delay=0.5,
+                )
         self._create_startup_background_task(
             "req041_automatic_migration",
             self._req041_initialize_automatic_migration,
@@ -6576,7 +6707,9 @@ class PrivateCompanionPlugin(
                 await self._nai_image_maintenance()
             async with self._data_lock:
                 if self._run_startup_data_maintenance_locked():
-                    self._save_data_sync()
+                    # This one-time pass can scrub legacy records across several
+                    # roots, so it intentionally uses the startup maintenance scope.
+                    self._save_data_sync(full_scope="startup_maintenance")
             elapsed_ms = int((time.perf_counter() - started) * 1000)
             if elapsed_ms > 1200:
                 logger.info("[PrivateCompanion] 启动后台维护完成: elapsed=%sms", elapsed_ms)
@@ -7704,7 +7837,6 @@ class PrivateCompanionPlugin(
         candidate = getattr(event, "_private_companion_outbound_text_candidate", None)
         if isinstance(candidate, dict):
             self._confirm_outbound_text_candidate(candidate)
-        await self._refresh_group_conversation_after_confirmed_send(event)
 
     @filter.after_message_sent(priority=9000)
     @_multi_persona_event_context
@@ -9095,53 +9227,10 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
     @_multi_persona_event_context
     async def remember_group_bot_reply_context_before_send(self, event: AstrMessageEvent, *args, **kwargs):
         """记录群聊 Bot 实际候选回复，供下一轮连续对话判断使用。"""
-        if self is None or not self.enabled:
-            return
-        if self._proactive_only_blocks_passive_event(event, "enable_group_companion"):
-            return
-        if not self._feature_enabled_or_temp_unlocked("enable_group_companion"):
-            return
-        group_id = self._extract_group_id_from_event(event)
-        if not group_id:
-            return
-        result = event.get_result()
-        chain = list(getattr(result, "chain", []) or []) if result is not None else []
-        if not chain:
-            return
-        reply_text = self._chain_text_for_forbidden_recall(chain, limit=500)
-        reply_text = _single_line(_strip_internal_message_blocks(reply_text), 260)
-        if not reply_text:
-            return
-        try:
-            sender_id = str(event.get_sender_id())
-        except Exception:
-            sender_id = ""
-        scene = getattr(event, "private_companion_group_scene", None)
-        talking_to_bot = isinstance(scene, dict) and str(scene.get("talking_to") or "") == "bot"
-        async with self._data_lock:
-            group = self._get_group(group_id)
-            active = self._group_active_conversation(group)
-            if not talking_to_bot and str(active.get("sender_id") or "") != str(sender_id or ""):
-                return
-            active["last_bot_reply"] = reply_text
-            active["last_bot_reply_ts"] = _now_ts()
-            recent_bot = group.setdefault("recent_bot_replies", [])
-            if not isinstance(recent_bot, list):
-                recent_bot = []
-                group["recent_bot_replies"] = recent_bot
-            recent_bot.append(
-                {
-                    "ts": _now_ts(),
-                    "sender_id": sender_id,
-                    "text": reply_text,
-                    "talking_to_bot": bool(talking_to_bot),
-                }
-            )
-            del recent_bot[:-20]
-            trimmer = getattr(self, "_group_air_guard_trim_bot_replies", None)
-            if callable(trimmer):
-                trimmer(group)
-            self._save_data_sync()
+        # Group continuity is committed only by the confirmed-delivery
+        # finalizer. This decorating hook must remain a pure read/transform
+        # stage because the adapter can reject the outgoing result afterwards.
+        return
 
     def _plain_result_body_text(self, chain: list[Any]) -> str:
         """Return text when a result contains only an optional quote and plain body."""
@@ -13347,7 +13436,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             },
             "reason": _single_line(reason, 120),
         }
-        self._save_data_sync()
+        self._save_data_sync(sections={"pending_atrelay_requests"})
         logger.info(
             "[PrivateCompanion] 转述请求等待补群: user=%s target=%s text=%s reason=%s",
             uid,
@@ -13456,7 +13545,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         except Exception:
             result = {"status": "error", "message": _single_line(result_raw, 240)}
         pending.pop(uid, None)
-        self._save_data_sync()
+        self._save_data_sync(sections={"pending_atrelay_requests"})
         logger.info(
             "[PrivateCompanion] 已用补充群名续发转述: user=%s group=%s status=%s target=%s",
             uid,
@@ -14522,13 +14611,13 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             removed = keys & target_keys
             keys.difference_update(target_keys)
             self._set_proactive_only_unlock_store(keys)
-            self._save_data_sync()
+            self._save_data_sync(sections={"proactive_only_temp_unlocks"})
             if not removed:
                 return "对应临时放行项本来就没有开启。"
             return "已取消临时放行：\n" + "\n".join(f"- {self._proactive_only_unlock_label(item)}" for item in sorted(removed))
         keys.update(target_keys)
         self._set_proactive_only_unlock_store(keys)
-        self._save_data_sync()
+        self._save_data_sync(sections={"proactive_only_temp_unlocks"})
         return "已临时放行：\n" + "\n".join(f"- {self._proactive_only_unlock_label(item)}" for item in sorted(target_keys))
 
     def _proactive_only_blocks_passive_event(self, event: AstrMessageEvent | None, feature: str = "") -> bool:
@@ -15916,29 +16005,13 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         completion = _single_line(getattr(resp, "completion_text", ""), 500)
         if not completion:
             return
-        group_id = _single_line(
-            getattr(event, "private_companion_semantic_expression_group_id", "")
-            or self._extract_group_id_from_event(event),
-            80,
-        )
-        if not group_id:
-            return
-        context = getattr(event, "private_companion_semantic_expression_context", None)
-        async with self._data_lock:
-            group = self._get_group(group_id)
-            usage = self._record_expression_rule_injection(
-                group,
-                {},
-                completion,
-                semantic_rules=semantic_rules,
-                context=context if isinstance(context, dict) else {"channel": "group"},
-            )
-            if usage:
-                try:
-                    setattr(event, "private_companion_group_semantic_usage_recorded", True)
-                except Exception:
-                    pass
-                self._save_data_sync()
+        # Rule usage is committed by the confirmed-delivery finalizer. Keep this
+        # hook read-only so an LLM response that is later dropped cannot mutate
+        # durable expression-learning state.
+        try:
+            setattr(event, "private_companion_group_semantic_usage_pending", True)
+        except Exception:
+            pass
 
     @filter.on_llm_response()
     @_multi_persona_event_context
@@ -16070,7 +16143,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                         current["postprocess_stats"] = stats
                     stats["smart_silence"] = _safe_int(stats.get("smart_silence"), 0, 0) + 1
                     stats["last_smart_silence_at"] = self._environment_now().strftime("%Y-%m-%d %H:%M")
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users"})
                 logger.info(
                     "[PrivateCompanion] 智能沉默已取消本轮私聊回复: user=%s reason=%s inbound=%s reply=%s",
                     user_id,
@@ -16107,7 +16180,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                         current["postprocess_stats"] = stats
                     stats["duplicate_dropped"] = _safe_int(stats.get("duplicate_dropped"), 0, 0) + 1
                     stats["last_duplicate_dropped_at"] = self._environment_now().strftime("%Y-%m-%d %H:%M")
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users"})
                 logger.info(
                     "[PrivateCompanion] 回复复核已取消重复私聊回复: user=%s inbound=%s reply=%s",
                     user_id,
@@ -16135,7 +16208,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                         current["postprocess_stats"] = stats
                     stats["rewritten"] = _safe_int(stats.get("rewritten"), 0, 0) + 1
                     stats["last_rewritten_at"] = self._environment_now().strftime("%Y-%m-%d %H:%M")
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users"})
 
             async with self._data_lock:
                 live_user_for_duplicate = self._get_user(user_id)
@@ -16154,7 +16227,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                         current["postprocess_stats"] = stats
                     stats["duplicate_dropped"] = _safe_int(stats.get("duplicate_dropped"), 0, 0) + 1
                     stats["last_duplicate_dropped_at"] = self._environment_now().strftime("%Y-%m-%d %H:%M")
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users"})
                 logger.info(
                     "[PrivateCompanion] 发送前去重已取消重复私聊回复: user=%s reason=%s inbound=%s reply=%s",
                     user_id,
@@ -16173,52 +16246,6 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                 release_now = True
                 return
 
-            async with self._data_lock:
-                current = self._get_user(user_id)
-                visible_reply_text = _single_line(_strip_internal_message_blocks(working_text), 500)
-                current["last_companion_message"] = visible_reply_text
-                current["last_companion_message_at"] = _now_ts()
-                self._maybe_schedule_goodnight_screen_check(
-                    current,
-                    visible_reply_text,
-                    now=current["last_companion_message_at"],
-                )
-                expression_rule_details = getattr(
-                    event,
-                    "private_companion_expression_rule_details",
-                    None,
-                )
-                semantic_expression_rules = getattr(
-                    event,
-                    "private_companion_semantic_expression_rules",
-                    None,
-                )
-                semantic_expression_context = getattr(
-                    event,
-                    "private_companion_semantic_expression_context",
-                    None,
-                )
-                if isinstance(expression_rule_details, dict) or (
-                    isinstance(semantic_expression_rules, list) and semantic_expression_rules
-                ):
-                    expression_usage = self._record_expression_rule_injection(
-                        current,
-                        expression_rule_details if isinstance(expression_rule_details, dict) else {},
-                        visible_reply_text,
-                        semantic_rules=semantic_expression_rules if isinstance(semantic_expression_rules, list) else [],
-                        context=semantic_expression_context if isinstance(semantic_expression_context, dict) else {},
-                    )
-                    if expression_usage:
-                        logger.info(
-                            "[PrivateCompanion] 表达规则完成本轮注入: user=%s scene=%s evidence=%s visible=%s",
-                            user_id,
-                            _single_line(expression_usage.get("label"), 32) or "-",
-                            _safe_int(expression_usage.get("evidence_count"), 0, 0),
-                            ",".join(expression_usage.get("visible_signals") or [])
-                            or ("semantic" if _safe_int(expression_usage.get("semantic_rule_count"), 0, 0) else "none"),
-                        )
-                self._remember_passive_reply_topic(current, working_text, inbound_text)
-                self._save_data_sync()
             if working_text != original_text:
                 self._schedule_reply_interception_forward(
                     "rewrite",
@@ -16697,13 +16724,13 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             if action in private_delivery_bind_actions:
                 changed, response = self._bind_private_delivery_umo(user_id, user, event.unified_msg_origin)
                 if changed:
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users"})
             elif action in private_delivery_view_actions:
                 response = self._format_private_delivery_binding_status(user_id, user)
             elif action in private_delivery_unbind_actions:
                 changed, response = self._unbind_private_delivery_umo(user)
                 if changed:
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users"})
             elif action in wakeup_alarm_actions:
                 camera_command_requested = bool(
                     re.sub(r"\s+", "", str(value or "")).lower().startswith(
@@ -16853,7 +16880,10 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                         operation_id="req041-command-open-loop:" + uuid.uuid4().hex,
                     )
                     if committed:
-                        self._save_data_sync()
+                        save_sections = {"users"}
+                        if memory_managed:
+                            save_sections.add("_req041_private_memory")
+                        self._save_data_sync(sections=save_sections)
                     else:
                         response = "记忆已发生并发变更，请重试。"
             elif action in {"长期记忆", "livingmemory", "lmem", "向量记忆"}:
@@ -16886,7 +16916,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                     runtime_access.clear()
                 secret["reset_at"] = _now_ts()
                 await self._ensure_bookshelf_password_async()
-                self._save_data_sync()
+                self._save_data_sync(sections={"bookshelf_secret"})
                 response = "已重新设置书柜夹层密码。需要查看真实密码可用：陪伴 输出夹层密码"
             elif action in {"发说说", "发QQ空间", "发布说说", "空间发布", "发布空间"}:
                 response = "正在发布 QQ 空间说说。"
@@ -16905,10 +16935,10 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             elif action in {"日期添加", "添加日期", "重要日期添加"}:
                 ok, response = self._add_important_date_entry(value)
                 if ok:
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"important_dates"})
             elif action in {"日期删除", "删除日期", "重要日期删除"}:
                 response = self._remove_important_date_entry(value)
-                self._save_data_sync()
+                self._save_data_sync(sections={"important_dates"})
             elif action in {"可做事项", "能做什么"}:
                 items = self.data.get("can_do", [])
                 if items:
@@ -16920,7 +16950,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                     response = "请这样设置：陪伴 昵称 <你喜欢的称呼>"
                 else:
                     user["nickname"] = _single_line(value, 24)
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users"})
                     response = f"记住了,以后我会叫你：{user['nickname']}"
             elif action in {"语气", "风格"}:
                 style_value = _single_line(value, 24)
@@ -16928,11 +16958,11 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                     response = "请这样设置：陪伴 语气 <简短语气描述>"
                 else:
                     user["style"] = style_value
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users"})
                     response = f"语气偏好已记录：{style_value}"
             elif action in {"清空记忆", "忘记我"}:
                 self.data.setdefault("users", {}).pop(user_id, None)
-                self._save_data_sync()
+                self._save_data_sync(sections={"users"})
                 response = "已清空你的陪伴设置和轻量记忆。"
             else:
                 response = self._help_text()
@@ -17098,7 +17128,14 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                     self.data["detail_enhanced_day"] = str((plan or {}).get("date") or _today_key())
                     self.data["detail_enhanced_segments"] = {}
                     self.data["daily_story_plan"] = {}
-                    self._save_data_sync()
+                    self._save_data_sync(
+                        sections={
+                            "daily_plan",
+                            "daily_story_plan",
+                            "detail_enhanced_day",
+                            "detail_enhanced_segments",
+                        }
+                    )
                 await self._reply(event, self._format_daily_plan(plan or {}))
         if action in daily_schedule_cancel_actions:
             _, message = await self._cancel_daily_plan_segment_by_selector(value)
@@ -17140,7 +17177,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             state = await self._ensure_daily_state(force=True)
             async with self._data_lock:
                 self.data["daily_plan"] = {}
-                self._save_data_sync()
+                self._save_data_sync(sections={"daily_plan"})
             await self._reply(
                 event,
                 self._format_state_detail(state)
@@ -17152,7 +17189,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                 async with self._data_lock:
                     self.data["daily_plan"] = {}
                     state = dict(self.data.get("daily_state", {}))
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"daily_plan"})
                 await self._reply(
                     event,
                     message
@@ -17201,6 +17238,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
 
     @filter.event_message_type(filter.EventMessageType.PRIVATE_MESSAGE, priority=220000)
     @_multi_persona_event_context
+    @event_data_save_boundary
     async def guard_req036_private_capability_early(self, event: AstrMessageEvent, *args, **kwargs):
         """Reject an unauthorized private event before any normal message plugin runs."""
         if self is None or bool(getattr(event, "private_companion_req036_denied", False)):
@@ -17239,6 +17277,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
 
     @filter.event_message_type(filter.EventMessageType.PRIVATE_MESSAGE)
     @_multi_persona_event_context
+    @event_data_save_boundary(flush=True)
     async def on_private_message(self, event: AstrMessageEvent, *args, **kwargs):
         if await self._handle_private_message_preflight(event):
             return
@@ -17277,7 +17316,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                         user = users.get(user_id) if isinstance(users, dict) else None
                         if isinstance(user, dict):
                             user.pop("reality_touch_pending_consent", None)
-                            self._save_data_sync()
+                            self._save_data_sync(sections={"users"})
                     confirmation_reply = "主机摄像头只允许 AstrBot 管理员或主要用户本人授权和使用。"
             elif isinstance(user, dict):
                 try:
@@ -17428,6 +17467,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
 
     @filter.event_message_type(filter.EventMessageType.GROUP_MESSAGE, priority=210000)
     @_multi_persona_event_context
+    @event_data_save_boundary
     async def guard_blocked_group_member_early(self, event: AstrMessageEvent, *args, **kwargs):
         """在群聊观察和回复插件之前丢弃已静默成员的消息。"""
         if self is None or self._is_onebot_poke_notice_event(event):
@@ -17455,7 +17495,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             was_blocked = bool(member and (_safe_float(member.get("blocked_at"), 0) > 0 or member.get("manual_blocked")))
             blocked = self._group_member_safety_active(member, expire=True)
             if was_blocked and not blocked:
-                self._save_data_sync()
+                self._save_data_sync(sections={"groups"})
         if blocked:
             logger.info(
                 "[PrivateCompanion] 已静默群成员消息: group=%s sender=%s",
@@ -17466,6 +17506,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
 
     @filter.event_message_type(filter.EventMessageType.GROUP_MESSAGE, priority=200000)
     @_multi_persona_event_context
+    @event_data_save_boundary
     async def capture_group_observation_early(self, event: AstrMessageEvent, *args, **kwargs):
         """Record allowed group messages before reply plugins can stop propagation."""
         if self is None or self._is_onebot_poke_notice_event(event):
@@ -17541,7 +17582,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                         current["interject_day"] = repeat_group_snapshot.get("interject_day", "")
                         current["interject_today"] = repeat_group_snapshot.get("interject_today", 0)
                         current["last_bot_interjection"] = repeat_group_snapshot.get("last_bot_interjection", {})
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"groups"})
         self._start_group_image_understanding(
             event,
             group_id=group_id,
@@ -17551,6 +17592,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
 
     @filter.event_message_type(filter.EventMessageType.GROUP_MESSAGE, priority=190000)
     @_multi_persona_event_context
+    @event_data_save_boundary
     async def review_group_member_safety_early(self, event: AstrMessageEvent, *args, **kwargs):
         """在回复链路前保守审核当前消息，达到阈值时立即静默。"""
         if self is None or self._is_onebot_poke_notice_event(event):
@@ -17594,6 +17636,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
 
     @filter.event_message_type(filter.EventMessageType.GROUP_MESSAGE, priority=180000)
     @_multi_persona_event_context
+    @event_data_save_boundary
     async def guard_req036_group_portrait_queries(self, event: AstrMessageEvent, *args, **kwargs):
         """Reject third-party portrait probing before any retrieval or LLM hook."""
         if self is None or bool(getattr(event, "_private_companion_member_safety_blocked", False)):
@@ -17650,6 +17693,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
 
     @filter.event_message_type(filter.EventMessageType.GROUP_MESSAGE)
     @_multi_persona_event_context
+    @event_data_save_boundary(flush=True)
     async def on_group_message(self, event: AstrMessageEvent, *args, **kwargs):
         return await handle_group_message(self, event, *args, **kwargs)
 

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+from collections.abc import Collection
 from contextlib import asynccontextmanager
 import contextvars
 import functools
@@ -1957,7 +1958,7 @@ class PrivateCompanionPlugin(
             actor_id=actor_id,
         )
         if result.get("ok") and result.get("changed") and schedule_save:
-            self._schedule_data_save()
+            self._schedule_data_save(sections={"unified_person"})
         return result
 
     def _persona_profile_path(self, persona_id: str) -> Path:
@@ -2175,17 +2176,28 @@ class PrivateCompanionPlugin(
                         sync_targets()
                 try:
                     if multi_enabled:
-                        self._save_persona_profile_sync(pid, self.data)
-                        dirty = getattr(self, "_persona_data_save_dirty", None)
-                        if isinstance(dirty, set):
-                            dirty.discard(pid)
+                        self._write_persona_data_snapshot_sync(
+                            pid,
+                            deepcopy(self.data),
+                        )
+                        clear_dirty = getattr(self, "_clear_scheduled_data_save_dirty", None)
+                        if callable(clear_dirty):
+                            clear_dirty(persona_id=pid)
+                        else:
+                            dirty = getattr(self, "_persona_data_save_dirty", None)
+                            if isinstance(dirty, set):
+                                dirty.discard(pid)
                     else:
                         self._write_data_snapshot_sync(deepcopy(self.data))
-                        self._data_save_dirty = False
+                        clear_dirty = getattr(self, "_clear_scheduled_data_save_dirty", None)
+                        if callable(clear_dirty):
+                            clear_dirty()
+                        else:
+                            self._data_save_dirty = False
                 except Exception:
                     self.data = previous
                     if multi_enabled:
-                        self._save_persona_profile_sync(pid, previous)
+                        self._write_persona_data_snapshot_sync(pid, previous)
                     else:
                         self._write_data_snapshot_sync(previous)
                     raise
@@ -4044,7 +4056,7 @@ class PrivateCompanionPlugin(
         if result.get("ok") and result.get("changed"):
             saver = getattr(self, "_schedule_data_save", None)
             if callable(saver):
-                saver()
+                saver(sections={"unified_person"})
         return result
 
     def resolve_unified_person_for_event(self, event: Any | None = None) -> dict[str, Any]:
@@ -5006,9 +5018,13 @@ class PrivateCompanionPlugin(
             }
         async with self._data_lock:
             self._req041_group_reset_sagas_locked().pop(clean_operation, None)
+            deleted_sections: set[str] = set()
             if not self.data.get("_req041_group_reset_sagas"):
                 self.data.pop("_req041_group_reset_sagas", None)
-            self._req041_persist_archive_saga_locked()
+                deleted_sections.add("_req041_group_reset_sagas")
+            self._req041_persist_archive_saga_locked(
+                deleted_sections=deleted_sections,
+            )
         return {
             "ok": True, "state": "completed", "code": "group_reset_completed",
             "operation_id": clean_operation, "config_saved": True,
@@ -5082,13 +5098,17 @@ class PrivateCompanionPlugin(
             "error_codes": sorted(set(errors))[:16],
         }
 
-    def _req041_persist_archive_saga_locked(self) -> None:
+    def _req041_persist_archive_saga_locked(
+        self,
+        *,
+        deleted_sections: Collection[str] = (),
+    ) -> None:
         """Durably persist a destructive saga before any cross-store write."""
         active_persona = str(self._active_persona_scope() or "")
         if bool(getattr(self, "enable_multi_persona_mode", False)) and active_persona:
             self._write_persona_data_snapshot_sync(active_persona, deepcopy(self.data))
             return
-        self._save_data_now_sync()
+        self._save_data_now_sync(deleted_sections=deleted_sections)
 
     async def archive_unified_person(
         self,
@@ -5684,7 +5704,7 @@ class PrivateCompanionPlugin(
             )
             candidate["legacy_result_code"] = str(result.get("code") or "")
             if result.get("changed"):
-                self._schedule_data_save()
+                self._schedule_data_save(sections={"users"})
 
     @filter.after_message_sent(priority=-105000)
     @_multi_persona_event_context
@@ -6264,7 +6284,10 @@ class PrivateCompanionPlugin(
             if changed:
                 needs_startup_save = True
         if needs_startup_save:
-            self._schedule_data_save(delay=0.5)
+            # Startup maintenance can reconcile several legacy sections; retain
+            # the explicit full-save compatibility path until its mutation set
+            # is proven stable across all migration and recovery branches.
+            self._schedule_data_save(sections=None, delay=0.5)
         self._create_startup_background_task(
             "req041_automatic_migration",
             self._req041_initialize_automatic_migration,
@@ -6635,11 +6658,19 @@ class PrivateCompanionPlugin(
         try:
             await asyncio.wait_for(self._flush_scheduled_data_save(), timeout=3.0)
         except asyncio.TimeoutError:
-            logger.warning("[PrivateCompanion] 等待后台合并保存超时，将改用最终快照保存")
+            logger.warning(
+                "[PrivateCompanion] Scheduled persistence did not drain before "
+                "shutdown; final persistence will continue in the background"
+            )
         except asyncio.CancelledError:
             pass
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 等待后台合并保存时收到异常: %s", _single_line(exc, 160))
+            logger.debug(
+                "[PrivateCompanion] Waiting for scheduled persistence during "
+                "shutdown failed: %s",
+                _single_line(exc, 160),
+            )
+        self._termination_flush_already_attempted = True
         close_image_download_session = getattr(self, "_close_external_image_download_session", None)
         if callable(close_image_download_session):
             try:
@@ -6648,29 +6679,102 @@ class PrivateCompanionPlugin(
                 logger.warning("[PrivateCompanion] 终止时关闭在线图片下载会话超时")
             except Exception as exc:
                 logger.debug("[PrivateCompanion] 终止时关闭在线图片下载会话失败: %s", _single_line(exc, 160))
+        final_save_task = asyncio.create_task(self._save_data_on_terminate())
+        self._termination_save_task = final_save_task
+
+        def observe_final_save(task: asyncio.Task) -> None:
+            if getattr(self, "_termination_save_task", None) is task:
+                self._termination_save_task = None
+            if task.cancelled():
+                return
+            try:
+                error = task.exception()
+            except (asyncio.CancelledError, asyncio.InvalidStateError):
+                return
+            if error is not None:
+                logger.warning(
+                    "[PrivateCompanion] Final shutdown persistence failed: %s",
+                    _single_line(error, 160),
+                )
+
+        final_save_task.add_done_callback(observe_final_save)
         try:
-            await asyncio.wait_for(self._save_data_on_terminate(), timeout=3.0)
+            await asyncio.wait_for(asyncio.shield(final_save_task), timeout=3.0)
         except asyncio.TimeoutError:
-            logger.warning("[PrivateCompanion] 终止时保存数据超时,已跳过最终保存以避免卡死卸载")
+            logger.warning(
+                "[PrivateCompanion] Final shutdown persistence timed out; the "
+                "shielded task will continue in the background"
+            )
         if _private_companion_plugin is self:
             _private_companion_plugin = None
 
     async def _save_data_on_terminate(self) -> None:
-        await self._flush_scheduled_data_save()
-        async with self._data_lock:
-            snapshot = deepcopy(getattr(self, "_data_default", self.data))
-            persona_snapshots = {
-                str(persona_id): deepcopy(profile)
-                for persona_id, profile in (getattr(self, "_persona_data_profiles", {}) or {}).items()
-                if isinstance(profile, dict)
-            }
-        await asyncio.to_thread(self._write_data_snapshot_sync, snapshot)
+        if not bool(getattr(self, "_termination_flush_already_attempted", False)):
+            await self._flush_scheduled_data_save()
+
+        manager = getattr(self, "store_manager", None)
+        manager_backend = str(getattr(manager, "backend_name", "") or "").lower()
+        sqlite_incremental = bool(
+            manager_backend == "sqlite"
+            and callable(getattr(manager, "save_sections", None))
+        )
+        if sqlite_incremental:
+            await self._flush_default_data_save_on_terminate()
+        else:
+            task = getattr(self, "_data_save_task", None)
+            if (
+                isinstance(task, asyncio.Task)
+                and not task.done()
+                and task is not asyncio.current_task()
+            ):
+                try:
+                    await asyncio.shield(task)
+                except asyncio.CancelledError:
+                    pass
+                except Exception as exc:
+                    logger.debug(
+                        "[PrivateCompanion] Waiting for the default JSON writer "
+                        "during shutdown failed: %s",
+                        _single_line(exc, 160),
+                    )
+            async with self._data_lock:
+                snapshot = deepcopy(getattr(self, "_data_default", self.data))
+            await asyncio.to_thread(self._write_data_snapshot_sync, snapshot)
+
         if bool(getattr(self, "enable_multi_persona_mode", False)):
-            for persona_id, profile in persona_snapshots.items():
+            profiles = getattr(self, "_persona_data_profiles", {}) or {}
+            persona_ids = (
+                [
+                    str(persona_id)
+                    for persona_id, profile in profiles.items()
+                    if isinstance(profile, dict)
+                ]
+                if isinstance(profiles, dict)
+                else []
+            )
+            for persona_id in persona_ids:
+                task = getattr(self, "_persona_data_save_tasks", {}).get(persona_id)
+                if isinstance(task, asyncio.Task) and not task.done():
+                    try:
+                        await asyncio.shield(task)
+                    except asyncio.CancelledError:
+                        pass
+                    except Exception as exc:
+                        logger.debug(
+                            "[PrivateCompanion] Waiting for a persona writer during "
+                            "shutdown failed: persona=%s error=%s",
+                            persona_id,
+                            _single_line(exc, 160),
+                        )
+                async with self._data_lock:
+                    profile = getattr(self, "_persona_data_profiles", {}).get(persona_id)
+                    if not isinstance(profile, dict):
+                        continue
+                    snapshot = deepcopy(profile)
                 await asyncio.to_thread(
                     self._write_persona_data_snapshot_sync,
                     persona_id,
-                    profile,
+                    snapshot,
                 )
 
     @filter.event_message_type(filter.EventMessageType.ALL, priority=11000)
@@ -13875,7 +13979,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         max_items = max(1, _safe_int(getattr(self, "rest_backlog_max_messages", 4), 4, 1))
         user["rest_reply_backlog"] = backlog[-max_items:]
         user["rest_reply_backlog_updated_at"] = now
-        self._schedule_data_save()
+        self._schedule_data_save(sections={"users"})
         logger.info(
             "[PrivateCompanion] 已记录休息中未回复私聊: user=%s count=%s reason=%s text=%s",
             user_id,
@@ -13895,7 +13999,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         if not items:
             user["rest_reply_backlog"] = []
             user["rest_reply_backlog_updated_at"] = 0
-            self._schedule_data_save()
+            self._schedule_data_save(sections={"users"})
             return ""
         lines: list[str] = []
         for idx, item in enumerate(items, 1):
@@ -13911,7 +14015,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             lines.append(f"{idx}. {when}｜{text}")
         user["rest_reply_backlog"] = []
         user["rest_reply_backlog_updated_at"] = 0
-        self._schedule_data_save()
+        self._schedule_data_save(sections={"users"})
         if not lines:
             return ""
         return "休息时有几条私聊没来得及回，醒来后补看到：\n" + "\n".join(lines)
@@ -14173,7 +14277,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             _single_line(inbound, 120),
         )
         try:
-            self._schedule_data_save()
+            self._schedule_data_save(sections={"passive_no_reply_records"})
         except Exception:
             pass
         self._schedule_reply_interception_forward(
@@ -14393,7 +14497,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         if not self._proactive_only_unlock_store():
             return
         self.data["proactive_only_temp_unlocks"] = []
-        self._schedule_data_save()
+        self._schedule_data_save(sections={"proactive_only_temp_unlocks"})
 
     def _format_proactive_only_temp_unlocks(self) -> str:
         unlocks = self._proactive_only_unlock_store()
@@ -14463,7 +14567,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                 logger.info("[PrivateCompanion] 主动专用模式忽略 poke 回流事件: user=%s", user_id)
                 return
             if self._is_duplicate_inbound_message(event, scope=f"private:{user_id}", sender_id=user_id, text=text):
-                self._schedule_data_save()
+                self._schedule_data_save(sections={"inbound_debounce_stats"})
                 return
             self._note_private_user_umo(user_id, user, event.unified_msg_origin)
             self._note_private_display_name_observation(user, user_id, sender_display_name, now=received_ts)
@@ -14520,9 +14624,13 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             user["ignored_streak"] = 0
             user["friend_unanswered_silenced_since"] = 0
             user["friend_unanswered_silence_note"] = ""
+            meal_care_result: dict[str, Any] = {}
             if self._private_user_role(user, user_id) == "owner" and text:
-                self._handle_meal_care_inbound(user, text, now=received_ts)
-            self._schedule_data_save()
+                meal_care_result = self._handle_meal_care_inbound(user, text, now=received_ts)
+            save_sections = {"users"}
+            if meal_care_result.get("foods"):
+                save_sections.add("food_menu")
+            self._schedule_data_save(sections=save_sections)
         logger.info(
             "[PrivateCompanion] 主动消息专用模式已跳过私聊被动增强: user=%s text=%s",
             user_id,
@@ -16384,7 +16492,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                     user=private_user if isinstance(private_user, dict) else None,
                     source="private_command",
                 )
-                self._schedule_data_save()
+                self._schedule_data_save(sections={"users", "unified_person"})
         self._qzone_note_event_bot(event)
         raw_text = str(event.message_str or "")
         normalized_text = raw_text.replace("\u3000", " ").replace("／", "/").strip()
@@ -17121,7 +17229,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             migrator = getattr(self, "_req036_migrate_configured_target_capability", None)
             migrated = bool(migrator(user_id, private_user)) if callable(migrator) else False
             if migrated:
-                self._schedule_data_save()
+                self._schedule_data_save(sections={"users"})
         if auto_profile_created:
             logger.info(
                 "[PrivateCompanion] 已建立最小用户档案: user=%s platform=%s",
@@ -17287,7 +17395,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                 event=event,
             )
             if captured:
-                self._schedule_data_save()
+                self._schedule_data_save(sections={"groups"})
         activity_recorder = getattr(self, "_record_c3_inbound_activity", None)
         if callable(activity_recorder):
             activity_recorder(
@@ -17411,7 +17519,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                 group_id=group_id,
                 source="group_observation",
             )
-            self._schedule_data_save()
+            self._schedule_data_save(sections={"unified_person"})
         if not self._proactive_only_blocks_passive_event(event, "group_repeat_early"):
             original_repeat_state = deepcopy(repeat_group_snapshot.get("repeat_follow_state", {}))
             original_interject_at = _safe_float(repeat_group_snapshot.get("last_interject_at"), 0)
@@ -17536,7 +17644,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                     group_id=group_id,
                     source="group_portrait_query",
                 )
-                self._schedule_data_save()
+                self._schedule_data_save(sections={"users", "unified_person"})
         event.stop_event()
         await self._reply(event, await self._req036_read_group_self_portrait(event))
 

--- a/memory_companion_adapter.py
+++ b/memory_companion_adapter.py
@@ -3078,7 +3078,7 @@ class MemoryCompanionAdapterMixin:
         if not callable(composer) or not callable(saver):
             return
         data["daily_state"] = composer(data.get("daily_weather", {}))
-        saver()
+        saver(sections={"state_conditions", "daily_state"})
         try:
             await acker(applied_refs, delivery_context=delivery_context)
         except Exception as exc:

--- a/memory_companion_adapter.py
+++ b/memory_companion_adapter.py
@@ -581,7 +581,10 @@ class MemoryCompanionAdapterMixin:
         try:
             current = BotPersonalOutbox(
                 data,
-                save=lambda: self._schedule_data_save(delay=0.5),
+                save=lambda: self._schedule_data_save(
+                    sections={"bot_personal_outbox"},
+                    delay=0.5,
+                ),
             )
         except Exception as exc:
             logger.debug("[PrivateCompanion] Bot Personal outbox 初始化失败: %s", _single_line(exc, 120))

--- a/message_pipeline.py
+++ b/message_pipeline.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import uuid
 from copy import deepcopy
+from functools import wraps
 from typing import Any
 
 from astrbot.api import logger
@@ -18,6 +19,59 @@ from .helpers import (
     _single_line,
 )
 
+
+def _coalesce_event_data_saves(handler: Any) -> Any:
+    """Submit all durable mutations from one message handler as one request."""
+
+    @wraps(handler)
+    async def wrapped(self: Any, event: Any, *args: Any, **kwargs: Any) -> Any:
+        starter = getattr(self, "_begin_event_data_save_batch", None)
+        finisher = getattr(self, "_finish_event_data_save_batch", None)
+        handle = starter(event) if callable(starter) else None
+        try:
+            return await handler(self, event, *args, **kwargs)
+        finally:
+            if callable(finisher):
+                finisher(handle)
+
+    return wrapped
+
+
+def event_data_save_boundary(handler: Any = None, *, flush: bool = False) -> Any:
+    """Share an event-owned save batch across early and final message hooks."""
+
+    if handler is None:
+        return lambda actual: event_data_save_boundary(actual, flush=flush)
+
+    @wraps(handler)
+    async def wrapped(self: Any, event: Any, *args: Any, **kwargs: Any) -> Any:
+        starter = getattr(self, "_begin_event_data_save_batch", None)
+        finisher = getattr(self, "_finish_event_data_save_batch", None)
+        suspender = getattr(self, "_suspend_event_data_save_batch", None)
+        handle = starter(event) if callable(starter) else None
+        completed = False
+        try:
+            result = await handler(self, event, *args, **kwargs)
+            completed = True
+            return result
+        finally:
+            if handle and callable(finisher):
+                stopped = False
+                is_stopped = getattr(event, "is_stopped", None)
+                if callable(is_stopped):
+                    try:
+                        stopped = bool(is_stopped())
+                    except Exception:
+                        stopped = False
+                if flush or stopped or not completed:
+                    finisher(handle)
+                elif callable(suspender):
+                    suspender(handle)
+
+    return wrapped
+
+
+@_coalesce_event_data_saves
 async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: Any) -> Any:
     """记录私聊互动、图片防抖、用户画像和主动陪伴反馈。"""
     if self is None:
@@ -734,6 +788,8 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
         self._note_private_inbound_activity(user, received_ts or _now_ts(), text=text)
         self._mark_greetings_satisfied_by_recent_activity(user, activity_ts=received_ts or _now_ts())
         self._note_morning_greeting_reply(user, now=received_ts or _now_ts())
+        private_memory_managed = False
+        private_memory_revision = None
         if text:
             user["inbound_count"] = _safe_int(user.get("inbound_count"), 0) + 1
         self._apply_relationship_event(
@@ -1029,6 +1085,8 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
                     _single_line(exc, 160),
                 )
         save_sections = {"users"}
+        if private_memory_managed and private_memory_revision is not None:
+            save_sections.add("_req041_private_memory")
         if expression_feedback:
             save_sections.update(expression_feedback.get("updated_sections") or ())
             if _safe_int(expression_feedback.get("updated_rules"), 0, 0) > 0:
@@ -1107,6 +1165,7 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
             label="refresh_dialogue_episode_inbound",
         )
 
+@_coalesce_event_data_saves
 async def handle_group_message(self: Any, event: Any, *args: Any, **kwargs: Any) -> Any:
     """观察群聊消息，维护群上下文并判断是否自然唤醒 Bot。"""
     if self is None:
@@ -1892,6 +1951,8 @@ async def handle_group_message(self: Any, event: Any, *args: Any, **kwargs: Any)
             )
         share_scheduled = self._maybe_schedule_group_private_share(group_id, group, trigger_sender_id=sender_id)
         save_sections = {"groups", "users", "proactive_candidate_pool"}
+        if self._expression_group_learning_source_enabled(group.get("group_id") or group_id):
+            save_sections.add("expression_voice_profile")
         if isinstance(registration_payload, dict):
             if registration_payload.get("updated_observation_profile"):
                 save_sections.add("worldbook_member_profiles")

--- a/message_pipeline.py
+++ b/message_pipeline.py
@@ -51,7 +51,7 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
             user=private_user if isinstance(private_user, dict) else None,
             source="private_auto",
         )
-        self._schedule_data_save()
+        self._schedule_data_save(sections={"users", "unified_person"})
     if auto_profile_created:
         logger.info(
             "[PrivateCompanion] 已建立最小用户档案: user=%s platform=%s",
@@ -387,13 +387,19 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
         fast_user["friend_unanswered_silenced_since"] = 0
         fast_user["friend_unanswered_silence_note"] = ""
         fast_user_is_owner = self._private_user_role(fast_user, user_id) == "owner"
+        fast_meal_care_result: dict[str, Any] = {}
         if fast_user_is_owner:
-            self._handle_meal_care_inbound(fast_user, safe_text or text, now=received_ts)
-        if (
+            fast_meal_care_result = self._handle_meal_care_inbound(
+                fast_user,
+                safe_text or text,
+                now=received_ts,
+            )
+        fast_interaction_warmth_applied = (
             bool(getattr(self, "enable_custom_relationship_stage_policy", False))
             and fast_user_is_owner
             and self._apply_interaction_warmth_to_state(text, fast_user)
-        ):
+        )
+        if fast_interaction_warmth_applied:
             self._apply_relationship_event(
                 fast_user,
                 1,
@@ -401,7 +407,12 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
                 event_id=self._event_message_id(event),
                 now=received_ts,
             )
-        self._schedule_data_save()
+        fast_save_sections = {"users"}
+        if fast_meal_care_result.get("foods"):
+            fast_save_sections.add("food_menu")
+        if fast_interaction_warmth_applied:
+            fast_save_sections.update({"state_conditions", "daily_state"})
+        self._schedule_data_save(sections=fast_save_sections)
         if (
             rest_silence_applied
             and _safe_float(fast_user.get("user_rest_until"), 0) > received_ts
@@ -432,7 +443,7 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
             logger.info("[PrivateCompanion] 忽略 poke 回流事件,不计入用户新消息: %s", user_id)
             return
         if self._is_duplicate_inbound_message(event, scope=f"private:{user_id}", sender_id=user_id, text=text):
-            self._schedule_data_save()
+            self._schedule_data_save(sections={"inbound_debounce_stats"})
             self._record_passive_no_reply(
                 event,
                 source="私聊去重",
@@ -442,13 +453,14 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
             )
             event.stop_event()
             return
+        smart_debounce_state_changed = False
         if is_target_user and text and not forward_only_prompt and not reference_media_with_text:
-            self._maybe_record_smart_message_debounce_followup(
+            smart_debounce_state_changed = bool(self._maybe_record_smart_message_debounce_followup(
                 scope=f"private:{user_id}",
                 sender_id=user_id,
                 text=text,
                 now=received_ts,
-            )
+            ))
         private_image_enhancement_enabled = (
             self._feature_enabled_or_temp_unlocked("enable_private_image_self_recognition")
             and bool(getattr(self, "enable_message_debounce", getattr(self, "enable_semantic_message_debounce", True)))
@@ -560,7 +572,8 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
                 wait_seconds=self._message_debounce_seconds("forward"),
                 kind="forward",
             ):
-                self._schedule_data_save()
+                if smart_debounce_state_changed:
+                    self._schedule_data_save(sections={"smart_message_debounce"})
                 event.stop_event()
                 return
         if private_image_only:
@@ -586,7 +599,8 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
                         user_id,
                         len(persisted_images),
                     )
-                    self._schedule_data_save()
+                    if smart_debounce_state_changed:
+                        self._schedule_data_save(sections={"smart_message_debounce"})
                     return
                 if not has_model_usable_image:
                     logger.info(
@@ -627,7 +641,8 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
                     self._finalize_private_image_buffer_after_wait(key, user_id, received_ts),
                     label="private_image_debounce_finalize",
                 )
-            self._schedule_data_save()
+                if smart_debounce_state_changed:
+                    self._schedule_data_save(sections={"smart_message_debounce"})
             event.stop_event()
             return
         elif is_target_user and not forward_only_prompt and not reference_media_with_text:
@@ -696,6 +711,7 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
                 smart_result = getattr(event, "private_companion_smart_message_debounce_result", None)
                 smart_decision = str(smart_result.get("decision") or "") if isinstance(smart_result, dict) else ""
                 smart_handled = smart_decision in {"complete", "incomplete"}
+                smart_debounce_state_changed = smart_debounce_state_changed or smart_handled
                 wait_seconds = smart_wait if smart_handled else self._message_debounce_seconds("text")
                 if self._note_semantic_message_buffer(
                     key,
@@ -704,11 +720,10 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
                     smart_debounce={"enabled": smart_handled, "decision": smart_decision or "fixed"},
                     kind="text",
                 ):
-                    self._schedule_data_save()
+                    if smart_debounce_state_changed:
+                        self._schedule_data_save(sections={"smart_message_debounce"})
                     event.stop_event()
                     return
-                if smart_handled:
-                    self._schedule_data_save()
         user["umo"] = event.unified_msg_origin
         self._note_private_display_name_observation(user, user_id, sender_display_name, now=received_ts)
         if not is_target_user:
@@ -905,7 +920,12 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
                     self._schedule_next_proactive(user, now=_now_ts())
         user_is_owner = self._private_user_role(user, user_id) == "owner"
         food_feedback = self._detect_food_feedback(text) if text else {"is_food": False}
-        food_feedback_applied = bool(text) and user_is_owner and self._apply_food_feedback_to_state(text)
+        food_feedback_detected = bool(text) and user_is_owner and bool(
+            food_feedback.get("is_food") and food_feedback.get("actionable")
+        )
+        food_feedback_applied = food_feedback_detected and self._apply_food_feedback_to_state(text)
+        used_food_items: list[str] = []
+        meal_care_result: dict[str, Any] = {}
         food_feedback_actionable = bool(
             food_feedback.get("actionable")
             or food_feedback.get("feeding")
@@ -932,7 +952,9 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
                     "text": _single_line(text, 120),
                     "source": "meal_care_reply",
                 }
-        care_feedback_applied = bool(text) and user_is_owner and self._apply_care_feedback_to_state(text)
+        care_feedback = self._detect_care_feedback(text) if text else {"is_care": False}
+        care_feedback_detected = bool(text) and user_is_owner and bool(care_feedback.get("is_care"))
+        care_feedback_applied = care_feedback_detected and self._apply_care_feedback_to_state(text)
         if care_feedback_applied:
             self._apply_relationship_event(
                 user,
@@ -1006,7 +1028,53 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
                     missing,
                     _single_line(exc, 160),
                 )
-        self._schedule_data_save()
+        save_sections = {"users"}
+        if expression_feedback:
+            save_sections.update(expression_feedback.get("updated_sections") or ())
+            if _safe_int(expression_feedback.get("updated_rules"), 0, 0) > 0:
+                save_sections.add("expression_voice_profile")
+        if self._expression_private_learning_source_enabled(user, user_id):
+            save_sections.add("expression_voice_profile")
+        if smart_debounce_state_changed:
+            save_sections.add("smart_message_debounce")
+        if food_feedback_detected:
+            save_sections.update(
+                {
+                    "last_food_state_feedback_at",
+                    "last_food_state_feedback_text",
+                }
+            )
+        if food_feedback_applied:
+            save_sections.update(
+                {
+                    "state_conditions",
+                    "daily_state",
+                }
+            )
+        if care_feedback_detected:
+            save_sections.add("state_conditions")
+        if interaction_warmth_applied:
+            save_sections.update({"state_conditions", "daily_state"})
+        if used_food_items:
+            save_sections.add("food_menu")
+        if meal_care_result.get("foods"):
+            save_sections.add("food_menu")
+        if schedule_adjustment_applied:
+            save_sections.update(
+                {
+                    "schedule_adjustments",
+                    "dialogue_outfit_override",
+                    "detail_enhanced_segments",
+                    "daily_plan",
+                    "daily_story_plan",
+                    "daily_state",
+                }
+            )
+            if isinstance(self.data.get("daily_state"), dict) and isinstance(
+                self.data["daily_state"].get("sleep_runtime"), dict
+            ):
+                save_sections.add("daily_state")
+        self._schedule_data_save(sections=save_sections)
         user_snapshot = dict(user)
 
     if not is_target_user:
@@ -1096,7 +1164,9 @@ async def handle_group_message(self: Any, event: Any, *args: Any, **kwargs: Any)
                     scope_key=self._reaction_expression_scope_key(event, sender_id),
                 )
                 if reaction_expression_feedback:
-                    self._persist_reaction_expression_state()
+                    self._persist_reaction_expression_state(
+                        sections={"reaction_expression_group_states"}
+                    )
     if reaction_expression_feedback:
         self._log_reaction_expression_event(
             event,

--- a/message_pipeline.py
+++ b/message_pipeline.py
@@ -1198,7 +1198,7 @@ async def handle_group_message(self: Any, event: Any, *args: Any, **kwargs: Any)
     if existing_reply_preview:
         async with self._data_lock:
             if self._is_duplicate_inbound_message(event, scope=f"group:{group_id}", sender_id=sender_id, text=text):
-                self._save_data_sync()
+                self._save_data_sync(sections={"inbound_debounce_stats"})
                 return
             group = self._get_group(group_id)
             group["umo"] = _single_line(getattr(event, "unified_msg_origin", ""), 160)
@@ -1213,7 +1213,7 @@ async def handle_group_message(self: Any, event: Any, *args: Any, **kwargs: Any)
                 message_id=self._event_message_id(event),
                 event=event,
             )
-            self._save_data_sync()
+            self._save_data_sync(sections={"groups"})
             group_snapshot = deepcopy(group)
         logger.info(
             "[PrivateCompanion] 已有其他链路回复,仅记录群聊观察: group=%s sender=%s text=%s result=%s",
@@ -1287,7 +1287,7 @@ async def handle_group_message(self: Any, event: Any, *args: Any, **kwargs: Any)
     group_snapshot_high_intensity: dict[str, Any] = {}
     async with self._data_lock:
         if self._is_duplicate_inbound_message(event, scope=f"group:{group_id}", sender_id=sender_id, text=text):
-            self._save_data_sync()
+            self._save_data_sync(sections={"inbound_debounce_stats"})
             event.stop_event()
             return
         group = self._get_group(group_id)
@@ -1384,7 +1384,7 @@ async def handle_group_message(self: Any, event: Any, *args: Any, **kwargs: Any)
             now=received_ts,
         )
         if resting_mention_notice:
-            self._save_data_sync()
+            self._save_data_sync(sections={"groups"})
         scene = self._infer_group_scene(event, group, sender_id=sender_id, sender_name=sender_name, text=text)
         if quoted_link_payload:
             scene["quoted_link_payload"] = True
@@ -1744,7 +1744,7 @@ async def handle_group_message(self: Any, event: Any, *args: Any, **kwargs: Any)
                     message_id=self._event_message_id(event),
                     event=event,
                 )
-                self._save_data_sync()
+                self._save_data_sync(sections={"groups"})
                 logger.info(
                     "[PrivateCompanion] 群聊高强度消息已合并等待: group=%s sender=%s scope=%s recent_wakeups=%s floor=%s reason=%s wait=%ss text=%s",
                     group_id,
@@ -1788,7 +1788,7 @@ async def handle_group_message(self: Any, event: Any, *args: Any, **kwargs: Any)
                     "recent_bot_replies": _safe_int(air_guard.get("recent_bot_replies"), 0, 0, 99),
                     "recent_polite_replies": _safe_int(air_guard.get("recent_polite_replies"), 0, 0, 99),
                 }
-                self._save_data_sync()
+                self._save_data_sync(sections={"groups"})
                 logger.info(
                     "[PrivateCompanion] 群聊读空气拦截回复: group=%s sender=%s reason=%s text=%s",
                     group_id,
@@ -1850,7 +1850,7 @@ async def handle_group_message(self: Any, event: Any, *args: Any, **kwargs: Any)
                 kind="group_short_wakeup" if short_wait > 0 else "group_text",
             )
         ):
-            self._save_data_sync()
+            self._save_data_sync(sections={"smart_message_debounce"})
             event.stop_event()
             return
         self._capture_group_observation_once(
@@ -1891,7 +1891,18 @@ async def handle_group_message(self: Any, event: Any, *args: Any, **kwargs: Any)
                 forwarded=group_reference_media_with_text,
             )
         share_scheduled = self._maybe_schedule_group_private_share(group_id, group, trigger_sender_id=sender_id)
-        self._save_data_sync()
+        save_sections = {"groups", "users", "proactive_candidate_pool"}
+        if isinstance(registration_payload, dict):
+            if registration_payload.get("updated_observation_profile"):
+                save_sections.add("worldbook_member_profiles")
+            if registration_payload.get("user_id"):
+                save_sections.update(
+                    {
+                        "worldbook_member_profiles",
+                        "worldbook_deleted_member_ids",
+                    }
+                )
+        self._save_data_sync(sections=save_sections)
         group_snapshot = deepcopy(group)
         group_snapshot_high_intensity = dict(high_intensity_state)
     await self._dispatch_due_atrelay_tasks(event, group_id, sender_id)
@@ -1956,4 +1967,4 @@ async def handle_group_message(self: Any, event: Any, *args: Any, **kwargs: Any)
             current["interject_today"] = group_snapshot.get("interject_today", current.get("interject_today", 0))
             current["last_bot_interjection"] = group_snapshot.get("last_bot_interjection", current.get("last_bot_interjection", {}))
             current["repeat_follow_state"] = group_snapshot.get("repeat_follow_state", current.get("repeat_follow_state", {}))
-            self._save_data_sync()
+            self._save_data_sync(sections={"groups"})

--- a/migration_source_inspector.py
+++ b/migration_source_inspector.py
@@ -3,23 +3,60 @@
 The inspector deliberately records only structural metadata.  User identifiers,
 profile values, chat text and arbitrary section names never enter its inventory.
 """
+
 from __future__ import annotations
 
 import hashlib
 import json
-from pathlib import Path
 import re
 import sqlite3
-from typing import Any, Sequence
-
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
 
 INVENTORY_SCHEMA = "req041.source_inventory.v1"
 SUPPORTED_STORE_VERSIONS = frozenset({1})
-SUPPORTED_SECTION_SCHEMA_VERSIONS = frozenset({1})
+SUPPORTED_SECTION_SCHEMA_VERSIONS = frozenset({1, 2})
 _REQUIRED_STORE_SECTIONS = frozenset({"version", "users", "groups"})
-_SQLITE_REQUIRED_COLUMNS = frozenset({
-    "section_name", "payload_json", "updated_at", "checksum", "schema_version",
-})
+_SQLITE_V1_REQUIRED_COLUMNS = frozenset(
+    {
+        "section_name",
+        "payload_json",
+        "updated_at",
+        "checksum",
+        "schema_version",
+    }
+)
+_SQLITE_V2_REQUIRED_COLUMNS = _SQLITE_V1_REQUIRED_COLUMNS | frozenset(
+    {
+        "revision",
+        "is_deleted",
+    }
+)
+_SQLITE_V2_ONLY_COLUMNS = _SQLITE_V2_REQUIRED_COLUMNS - _SQLITE_V1_REQUIRED_COLUMNS
+_SQLITE_V2_COLUMNS = (
+    "section_name",
+    "payload_json",
+    "updated_at",
+    "checksum",
+    "schema_version",
+    "revision",
+    "is_deleted",
+)
+_SQLITE_V2_COLUMN_TYPES = (
+    "TEXT",
+    "TEXT",
+    "REAL",
+    "TEXT",
+    "INTEGER",
+    "INTEGER",
+    "INTEGER",
+)
+_SQLITE_META_COLUMNS = ("meta_key", "meta_value")
+_SQLITE_INTEGER_MAX = (1 << 63) - 1
+_MAX_SECTION_REVISION = _SQLITE_INTEGER_MAX - 1
+_MAX_ACTIVE_SECTIONS = 512
+_MAX_PHYSICAL_SECTION_ROWS = 512
 _SAFE_SECTION_NAME = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}\Z")
 
 
@@ -28,7 +65,13 @@ class MigrationSourceInspectionError(ValueError):
 
 
 def _canonical(value: Any) -> str:
-    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"), allow_nan=False)
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
 
 
 def _is_sqlite(path: Path) -> bool:
@@ -40,20 +83,36 @@ def _is_sqlite(path: Path) -> bool:
 
 
 def _store_version(value: Any) -> int:
-    if isinstance(value, bool) or not isinstance(value, int) or value not in SUPPORTED_STORE_VERSIONS:
-        raise MigrationSourceInspectionError("migration_source_store_version_unsupported")
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value not in SUPPORTED_STORE_VERSIONS
+    ):
+        raise MigrationSourceInspectionError(
+            "migration_source_store_version_unsupported"
+        )
     return value
 
 
-def _validate_critical_sections(sections: dict[str, Any]) -> tuple[int, dict[str, bool]]:
+def _validate_critical_sections(
+    sections: dict[str, Any],
+) -> tuple[int, dict[str, bool]]:
     if not _REQUIRED_STORE_SECTIONS.issubset(sections):
-        raise MigrationSourceInspectionError("migration_source_required_section_missing")
+        raise MigrationSourceInspectionError(
+            "migration_source_required_section_missing"
+        )
     version = _store_version(sections.get("version"))
-    if not isinstance(sections.get("users"), dict) or not isinstance(sections.get("groups"), dict):
+    if not isinstance(sections.get("users"), dict) or not isinstance(
+        sections.get("groups"), dict
+    ):
         raise MigrationSourceInspectionError("migration_source_section_shape_invalid")
     for optional_mapping in ("unified_person", "persona_lifecycle"):
-        if optional_mapping in sections and not isinstance(sections[optional_mapping], dict):
-            raise MigrationSourceInspectionError("migration_source_section_shape_invalid")
+        if optional_mapping in sections and not isinstance(
+            sections[optional_mapping], dict
+        ):
+            raise MigrationSourceInspectionError(
+                "migration_source_section_shape_invalid"
+            )
     return version, {
         "has_unified_person": isinstance(sections.get("unified_person"), dict),
         "has_persona_lifecycle": isinstance(sections.get("persona_lifecycle"), dict),
@@ -88,37 +147,228 @@ def _inspect_sqlite(path: Path) -> dict[str, Any]:
     try:
         check = connection.execute("PRAGMA quick_check").fetchone()
         if check is None or str(check[0]).lower() != "ok":
-            raise MigrationSourceInspectionError("migration_source_sqlite_integrity_invalid")
+            raise MigrationSourceInspectionError(
+                "migration_source_sqlite_integrity_invalid"
+            )
         table = connection.execute(
             "SELECT 1 FROM sqlite_master WHERE type='table' AND name='store_sections'"
         ).fetchone()
         if table is None:
-            raise MigrationSourceInspectionError("migration_source_sqlite_contract_missing")
-        columns = {str(row[1]) for row in connection.execute("PRAGMA table_info(store_sections)")}
-        if not _SQLITE_REQUIRED_COLUMNS.issubset(columns):
-            raise MigrationSourceInspectionError("migration_source_sqlite_contract_invalid")
-        rows = connection.execute(
-            "SELECT section_name,payload_json,schema_version FROM store_sections ORDER BY section_name"
-        ).fetchall()
-        if not rows or len(rows) > 512:
+            raise MigrationSourceInspectionError(
+                "migration_source_sqlite_contract_missing"
+            )
+        tables = {
+            str(row[0])
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+            )
+        }
+        section_info = list(connection.execute("PRAGMA table_info(store_sections)"))
+        columns = {str(row[1]) for row in section_info}
+        if not _SQLITE_V1_REQUIRED_COLUMNS.issubset(columns):
+            raise MigrationSourceInspectionError(
+                "migration_source_sqlite_contract_invalid"
+            )
+        v2_columns = columns & _SQLITE_V2_ONLY_COLUMNS
+        if v2_columns and not _SQLITE_V2_ONLY_COLUMNS.issubset(columns):
+            raise MigrationSourceInspectionError(
+                "migration_source_sqlite_contract_invalid"
+            )
+        physical_schema_version = 2 if _SQLITE_V2_ONLY_COLUMNS.issubset(columns) else 1
+        user_version = connection.execute("PRAGMA user_version").fetchone()
+        try:
+            schema_marker = int(user_version[0]) if user_version is not None else 0
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise MigrationSourceInspectionError(
+                "migration_source_sqlite_contract_invalid"
+            ) from exc
+        if schema_marker not in ({0, 1} if physical_schema_version == 1 else {2}):
+            raise MigrationSourceInspectionError(
+                "migration_source_sqlite_contract_invalid"
+            )
+        if physical_schema_version == 2:
+            if tables != {"store_sections", "store_meta"}:
+                raise MigrationSourceInspectionError(
+                    "migration_source_sqlite_contract_invalid"
+                )
+            if (
+                tuple(str(row[1]) for row in section_info) != _SQLITE_V2_COLUMNS
+                or tuple(str(row[2]).upper() for row in section_info)
+                != _SQLITE_V2_COLUMN_TYPES
+                or any(int(row[3] or 0) != 1 for row in section_info)
+                or [str(row[1]) for row in section_info if int(row[5] or 0) > 0]
+                != ["section_name"]
+            ):
+                raise MigrationSourceInspectionError(
+                    "migration_source_sqlite_contract_invalid"
+                )
+            schema_row = connection.execute(
+                "SELECT sql FROM sqlite_master "
+                "WHERE type='table' AND name='store_sections'"
+            ).fetchone()
+            schema_sql = str(schema_row[0] if schema_row else "").casefold()
+            if any(
+                guard not in schema_sql
+                for guard in (
+                    "store_sections_schema_v2",
+                    "store_sections_positive_revision",
+                    "store_sections_deleted_flag",
+                )
+            ):
+                raise MigrationSourceInspectionError(
+                    "migration_source_sqlite_contract_invalid"
+                )
+            meta_table = connection.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='store_meta'"
+            ).fetchone()
+            if meta_table is None:
+                raise MigrationSourceInspectionError(
+                    "migration_source_sqlite_contract_invalid"
+                )
+            meta_info = list(connection.execute("PRAGMA table_info(store_meta)"))
+            if (
+                tuple(str(row[1]) for row in meta_info) != _SQLITE_META_COLUMNS
+                or tuple(str(row[2]).upper() for row in meta_info) != ("TEXT", "TEXT")
+                or any(int(row[3] or 0) != 1 for row in meta_info)
+                or [str(row[1]) for row in meta_info if int(row[5] or 0) > 0]
+                != ["meta_key"]
+            ):
+                raise MigrationSourceInspectionError(
+                    "migration_source_sqlite_contract_invalid"
+                )
+            metadata = {
+                str(key): str(value)
+                for key, value in connection.execute(
+                    "SELECT meta_key,meta_value FROM store_meta"
+                )
+            }
+            if set(metadata) != {"initialized", "next_revision"} or metadata.get(
+                "initialized"
+            ) not in {"0", "1"}:
+                raise MigrationSourceInspectionError(
+                    "migration_source_sqlite_contract_invalid"
+                )
+            raw_next_revision = metadata.get("next_revision", "")
+            try:
+                next_revision = int(raw_next_revision)
+            except (TypeError, ValueError, OverflowError) as exc:
+                raise MigrationSourceInspectionError(
+                    "migration_source_sqlite_contract_invalid"
+                ) from exc
+            if (
+                str(next_revision) != raw_next_revision
+                or next_revision <= 0
+                or next_revision > _SQLITE_INTEGER_MAX
+            ):
+                raise MigrationSourceInspectionError(
+                    "migration_source_sqlite_contract_invalid"
+                )
+            rows = connection.execute(
+                "SELECT section_name,payload_json,checksum,schema_version,revision,is_deleted "
+                "FROM store_sections ORDER BY section_name"
+            ).fetchall()
+        else:
+            rows = [
+                (row[0], row[1], "", row[2], 1, 0)
+                for row in connection.execute(
+                    "SELECT section_name,payload_json,schema_version "
+                    "FROM store_sections ORDER BY section_name"
+                ).fetchall()
+            ]
+            next_revision = 0
+            metadata = {}
+        if not rows or len(rows) > _MAX_PHYSICAL_SECTION_ROWS:
             raise MigrationSourceInspectionError("migration_source_section_set_invalid")
         sections: dict[str, Any] = {}
         schema_versions: set[int] = set()
-        for raw_name, raw_payload, raw_schema_version in rows:
+        section_names: set[str] = set()
+        maximum_revision = 0
+        for (
+            raw_name,
+            raw_payload,
+            raw_checksum,
+            raw_schema_version,
+            raw_revision,
+            raw_is_deleted,
+        ) in rows:
             name = str(raw_name or "")
-            if _SAFE_SECTION_NAME.fullmatch(name) is None or name in sections:
-                raise MigrationSourceInspectionError("migration_source_section_name_invalid")
+            if _SAFE_SECTION_NAME.fullmatch(name) is None:
+                raise MigrationSourceInspectionError(
+                    "migration_source_section_name_invalid"
+                )
+            if name in section_names:
+                raise MigrationSourceInspectionError(
+                    "migration_source_section_name_invalid"
+                )
+            section_names.add(name)
             if (
                 isinstance(raw_schema_version, bool)
                 or not isinstance(raw_schema_version, int)
                 or raw_schema_version not in SUPPORTED_SECTION_SCHEMA_VERSIONS
+                or raw_schema_version != physical_schema_version
             ):
-                raise MigrationSourceInspectionError("migration_source_section_version_unsupported")
+                raise MigrationSourceInspectionError(
+                    "migration_source_section_version_unsupported"
+                )
+            if (
+                isinstance(raw_revision, bool)
+                or not isinstance(raw_revision, int)
+                or raw_revision <= 0
+                or raw_revision > _MAX_SECTION_REVISION
+            ):
+                raise MigrationSourceInspectionError(
+                    "migration_source_revision_invalid"
+                )
+            maximum_revision = max(maximum_revision, raw_revision)
+            if (
+                isinstance(raw_is_deleted, bool)
+                or not isinstance(raw_is_deleted, int)
+                or raw_is_deleted not in (0, 1)
+            ):
+                raise MigrationSourceInspectionError(
+                    "migration_source_tombstone_invalid"
+                )
+            if raw_is_deleted == 1:
+                if raw_payload != "null":
+                    raise MigrationSourceInspectionError(
+                        "migration_source_tombstone_invalid"
+                    )
+                if str(raw_checksum or "") not in {
+                    "",
+                    hashlib.sha256(b"null").hexdigest(),
+                }:
+                    raise MigrationSourceInspectionError(
+                        "migration_source_checksum_invalid"
+                    )
+                continue
+            if len(sections) >= _MAX_ACTIVE_SECTIONS:
+                raise MigrationSourceInspectionError(
+                    "migration_source_section_set_invalid"
+                )
             try:
-                sections[name] = json.loads(raw_payload)
+                parsed = json.loads(raw_payload)
             except (TypeError, json.JSONDecodeError) as exc:
-                raise MigrationSourceInspectionError("migration_source_section_json_invalid") from exc
-            schema_versions.add(raw_schema_version)
+                raise MigrationSourceInspectionError(
+                    "migration_source_section_json_invalid"
+                ) from exc
+            checksum = str(raw_checksum or "")
+            expected_checksum = hashlib.sha256(
+                _canonical(parsed).encode("utf-8")
+            ).hexdigest()
+            if checksum and checksum != expected_checksum:
+                raise MigrationSourceInspectionError(
+                    "migration_source_checksum_invalid"
+                )
+            sections[name] = parsed
+            schema_versions.add(1)
+        if physical_schema_version == 2 and (
+            next_revision <= maximum_revision
+            or (metadata["initialized"] == "0" and rows)
+        ):
+            raise MigrationSourceInspectionError(
+                "migration_source_sqlite_contract_invalid"
+            )
         version, features = _validate_critical_sections(sections)
         return {
             "kind": "sqlite",
@@ -150,21 +400,27 @@ def inspect_migration_sources(
             path = candidate.resolve(strict=True)
             path.relative_to(root)
         except (OSError, ValueError) as exc:
-            raise MigrationSourceInspectionError("migration_source_path_invalid") from exc
+            raise MigrationSourceInspectionError(
+                "migration_source_path_invalid"
+            ) from exc
         if not path.is_file():
             raise MigrationSourceInspectionError("migration_source_file_invalid")
-        inspected.append(_inspect_sqlite(path) if _is_sqlite(path) else _inspect_json(path))
+        inspected.append(
+            _inspect_sqlite(path) if _is_sqlite(path) else _inspect_json(path)
+        )
     if not inspected:
         raise MigrationSourceInspectionError("migration_source_missing")
 
     store_versions = sorted({int(item["store_version"]) for item in inspected})
     if len(store_versions) != 1:
         raise MigrationSourceInspectionError("migration_source_store_version_mixed")
-    section_versions = sorted({
-        int(version)
-        for item in inspected
-        for version in item["section_schema_versions"]
-    })
+    section_versions = sorted(
+        {
+            int(version)
+            for item in inspected
+            for version in item["section_schema_versions"]
+        }
+    )
     formats = {
         kind: sum(1 for item in inspected if item["kind"] == kind)
         for kind in ("json", "sqlite")
@@ -183,13 +439,19 @@ def inspect_migration_sources(
         "formats": formats,
         "store_version": store_versions[0],
         "section_schema_versions": section_versions,
-        "all_have_unified_person": all(item["has_unified_person"] for item in inspected),
-        "all_have_persona_lifecycle": all(item["has_persona_lifecycle"] for item in inspected),
+        "all_have_unified_person": all(
+            item["has_unified_person"] for item in inspected
+        ),
+        "all_have_persona_lifecycle": all(
+            item["has_persona_lifecycle"] for item in inspected
+        ),
         "section_count_min": min(int(item["section_count"]) for item in inspected),
         "section_count_max": max(int(item["section_count"]) for item in inspected),
     }
 
 
 __all__ = [
-    "INVENTORY_SCHEMA", "MigrationSourceInspectionError", "inspect_migration_sources",
+    "INVENTORY_SCHEMA",
+    "MigrationSourceInspectionError",
+    "inspect_migration_sources",
 ]

--- a/news_exploration.py
+++ b/news_exploration.py
@@ -1355,7 +1355,7 @@ class NewsExplorationMixin:
         bili = self._find_bilibili_bot_instance()
         if bili is None:
             state["last_boredom_watch_probe_at"] = now
-            self._save_data_sync()
+            self._save_data_sync(sections={"bilibili_integration"})
             return
         task = getattr(bili, "_proactive_task", None)
         if task is not None and not task.done():
@@ -1388,11 +1388,11 @@ class NewsExplorationMixin:
                 bili._proactive_task.add_done_callback(consume)
             state["last_boredom_watch_at"] = now
             state["last_boredom_watch_status"] = "triggered"
-            self._save_data_sync()
+            self._save_data_sync(sections={"bilibili_integration"})
             logger.info("[PrivateCompanion] 已触发 B站 AI Bot 无聊刷视频联动")
         except Exception as e:
             state["last_boredom_watch_status"] = f"failed:{_single_line(str(e), 80)}"
-            self._save_data_sync()
+            self._save_data_sync(sections={"bilibili_integration"})
             logger.debug(f"[PrivateCompanion] 触发 B站 AI Bot 刷视频失败: {e}")
 
     def _maybe_schedule_bilibili_video_share(self) -> bool:
@@ -3105,7 +3105,7 @@ class NewsExplorationMixin:
         items = await self._fetch_news_reading_candidates()
         if not items:
             state["last_status"] = "no_items"
-            self._save_data_sync()
+            self._save_data_sync(sections={"news_integration"})
             return
         read_keys = state.setdefault("read_keys", [])
         if not isinstance(read_keys, list):
@@ -3117,7 +3117,7 @@ class NewsExplorationMixin:
         digest = await self._summarize_news_items(fresh)
         if not digest:
             state["last_status"] = "digest_failed"
-            self._save_data_sync()
+            self._save_data_sync(sections={"news_integration"})
             return
         selected_key = _single_line(digest.get("selected_key"), 32)
         if selected_key and selected_key not in read_keys:
@@ -3179,7 +3179,7 @@ class NewsExplorationMixin:
             digest["share_status"] = "blocked"
             digest["share_skip_reason"] = "本次新闻阅读不允许主动分享，且自我关联未通过"
             _sync_digest_share_status()
-            self._save_data_sync()
+            self._save_data_sync(sections={"news_integration"})
             logger.info("[PrivateCompanion] 已完成一次新闻阅读: %s", reason)
             return
         users = self.data.get("users")
@@ -3341,7 +3341,7 @@ class NewsExplorationMixin:
             digest["share_status"] = "no_target"
             digest["share_skip_reason"] = "没有可用的目标私聊用户"
         _sync_digest_share_status()
-        self._save_data_sync()
+        self._save_data_sync(sections={"news_integration", "users", "proactive_candidate_pool", "external_event_pool", "external_event_self_link_cache"})
         logger.info("[PrivateCompanion] 已完成一次新闻阅读: %s", reason)
 
     def _ai_daily_state(self) -> dict[str, Any]:
@@ -3600,10 +3600,10 @@ class NewsExplorationMixin:
             status = "waiting_schedule" if future_sources else "all_sources_done"
             if ai_state.get("date") != today or ai_state.get("status") != status:
                 ai_state.update({"date": today, "status": status, "last_checked_at": ai_state.get("last_checked_at", 0)})
-                self._save_data_sync()
+                self._save_data_sync(sections={"news_integration"})
             return
         ai_state.update({"date": today, "last_checked_at": now, "status": "checking"})
-        self._save_data_sync()
+        self._save_data_sync(sections={"news_integration"})
         any_read = False
         for source in due_sources:
             key = str(source.get("key") or self._ai_daily_source_key(source))
@@ -3630,7 +3630,7 @@ class NewsExplorationMixin:
             any_read = any_read or read
         if not any_read and ai_state.get("status") == "checking":
             ai_state["status"] = "waiting_today_video"
-        self._save_data_sync()
+        self._save_data_sync(sections={"news_integration"})
 
     async def _maybe_trigger_news_boredom_read(self) -> None:
         if not (self.enable_news_integration and self.enable_news_boredom_read):
@@ -3812,7 +3812,7 @@ class NewsExplorationMixin:
             "updated_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
         }
         try:
-            self._save_data_sync()
+            self._save_data_sync(sections={"web_search_runtime"})
         except Exception:
             pass
         logger.warning(
@@ -4501,7 +4501,7 @@ class NewsExplorationMixin:
         if not (use_custom_search or search_umo):
             state["last_probe_at"] = now
             state["last_status"] = "web_search_disabled_or_unconfigured"
-            self._save_data_sync()
+            self._save_data_sync(sections={"web_exploration"})
             return
         if random.random() > 0.46:
             return
@@ -4529,7 +4529,7 @@ class NewsExplorationMixin:
                 "no_results": not bool(error_text),
                 "search_failed": bool(error_text),
             }
-            self._save_data_sync()
+            self._save_data_sync(sections={"web_exploration"})
             return
         digest = await self._summarize_web_exploration(query_info, results)
         notes = state.setdefault("notes", [])
@@ -4628,5 +4628,5 @@ class NewsExplorationMixin:
                         user["last_external_event_self_link_at"] = now
                     self._remember_external_event(digest, source_type="web_exploration", reason="web_exploration_share")
                     break
-        self._save_data_sync()
+        self._save_data_sync(sections={"web_exploration", "users", "proactive_candidate_pool", "external_event_pool", "external_event_self_link_cache"})
         logger.info("[PrivateCompanion] 已完成一次网页探索: %s", _single_line(digest.get("topic"), 80))

--- a/page_api.py
+++ b/page_api.py
@@ -925,7 +925,7 @@ class PrivateCompanionPageApi(
                     "updated_at": time.time(),
                 }
                 self.plugin.data["extension_migration_notice_preferences"] = dict(list(preferences.items())[-12:])
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(sections={"extension_migration_notice_preferences"})
             return self._ok({"version": version, "dismissed": dismissed, "persistent": True})
         except Exception as exc:
             logger.warning("[PrivateCompanionPage] 保存拓展迁移提示偏好失败: %s", self._single_line(exc, 160))
@@ -960,67 +960,6 @@ class PrivateCompanionPageApi(
         degraded_sections: list[str] = []
         try:
             async with self.plugin._data_lock:
-                refresher = getattr(self.plugin, "_refresh_sleep_runtime_state", None)
-                if callable(refresher):
-                    self._overview_section_value(
-                        "sleep_runtime",
-                        refresher,
-                        degraded_sections=degraded_sections,
-                    )
-                schedule_content_changed = False
-                plan_sanitizer = getattr(self.plugin, "_sanitize_daily_plan_inplace", None)
-                plan = self.plugin.data.get("daily_plan")
-                plan_sanitized = self._overview_section_value(
-                    "daily_plan_sanitizer",
-                    lambda: plan_sanitizer(plan),
-                    fallback=False,
-                    degraded_sections=degraded_sections,
-                ) if callable(plan_sanitizer) and isinstance(plan, dict) else False
-                if plan_sanitized:
-                    schedule_content_changed = True
-                if isinstance(plan, dict) and isinstance(plan.get("items"), list) and not isinstance(plan.get("quality"), dict):
-                    quality = self._overview_section_value(
-                        "daily_plan_quality",
-                        lambda: evaluate_daily_plan_quality(self.plugin, plan.get("items")),
-                        fallback=None,
-                        degraded_sections=degraded_sections,
-                    )
-                    if isinstance(quality, dict):
-                        plan["quality"] = quality
-                        schedule_content_changed = True
-                detail_sanitizer = getattr(self.plugin, "_sanitize_detail_enhanced_segments_inplace", None)
-                enhanced = self.plugin.data.get("detail_enhanced_segments")
-                detail_sanitized = self._overview_section_value(
-                    "detail_segments_sanitizer",
-                    lambda: detail_sanitizer(enhanced),
-                    fallback=False,
-                    degraded_sections=degraded_sections,
-                ) if callable(detail_sanitizer) and isinstance(enhanced, dict) else False
-                if detail_sanitized:
-                    schedule_content_changed = True
-                story_sanitizer = getattr(self.plugin, "_sanitize_story_plan_social_facts_inplace", None)
-                story = self.plugin.data.get("daily_story_plan")
-                story_sanitized = self._overview_section_value(
-                    "story_plan_sanitizer",
-                    lambda: story_sanitizer(story),
-                    fallback=False,
-                    degraded_sections=degraded_sections,
-                ) if callable(story_sanitizer) and isinstance(story, dict) else False
-                if story_sanitized:
-                    schedule_content_changed = True
-                expression_profile_getter = getattr(self.plugin, "_expression_voice_profile", None)
-                if callable(expression_profile_getter):
-                    self._overview_section_value(
-                        "expression_voice_profile",
-                        expression_profile_getter,
-                        degraded_sections=degraded_sections,
-                    )
-                if schedule_content_changed:
-                    self._overview_section_value(
-                        "data_save",
-                        self.plugin._save_data_sync,
-                        degraded_sections=degraded_sections,
-                    )
                 data = self._overview_section_value(
                     "data_snapshot",
                     lambda: self._overview_data_snapshot_locked(self.plugin.data),
@@ -1042,6 +981,48 @@ class PrivateCompanionPageApi(
                     fallback={},
                     degraded_sections=degraded_sections,
                 )
+            plan = deepcopy(data.get("daily_plan"))
+            if isinstance(plan, dict):
+                data["daily_plan"] = plan
+                plan_sanitizer = getattr(self.plugin, "_sanitize_daily_plan_inplace", None)
+                if callable(plan_sanitizer):
+                    self._overview_section_value(
+                        "daily_plan_sanitizer",
+                        lambda: plan_sanitizer(plan),
+                        fallback=False,
+                        degraded_sections=degraded_sections,
+                    )
+                if isinstance(plan.get("items"), list) and not isinstance(plan.get("quality"), dict):
+                    quality = self._overview_section_value(
+                        "daily_plan_quality",
+                        lambda: evaluate_daily_plan_quality(self.plugin, plan.get("items")),
+                        fallback=None,
+                        degraded_sections=degraded_sections,
+                    )
+                    if isinstance(quality, dict):
+                        plan["quality"] = quality
+            enhanced = deepcopy(data.get("detail_enhanced_segments"))
+            if isinstance(enhanced, dict):
+                data["detail_enhanced_segments"] = enhanced
+                detail_sanitizer = getattr(self.plugin, "_sanitize_detail_enhanced_segments_inplace", None)
+                if callable(detail_sanitizer):
+                    self._overview_section_value(
+                        "detail_segments_sanitizer",
+                        lambda: detail_sanitizer(enhanced),
+                        fallback=False,
+                        degraded_sections=degraded_sections,
+                    )
+            story = deepcopy(data.get("daily_story_plan"))
+            if isinstance(story, dict):
+                data["daily_story_plan"] = story
+                story_sanitizer = getattr(self.plugin, "_sanitize_story_plan_social_facts_inplace", None)
+                if callable(story_sanitizer):
+                    self._overview_section_value(
+                        "story_plan_sanitizer",
+                        lambda: story_sanitizer(story),
+                        fallback=False,
+                        degraded_sections=degraded_sections,
+                    )
             users = data.get("users") if isinstance(data.get("users"), dict) else {}
             groups = data.get("groups") if isinstance(data.get("groups"), dict) else {}
             enabled_users = len(users)
@@ -2567,7 +2548,7 @@ class PrivateCompanionPageApi(
                     if next_scope:
                         item["scope"] = next_scope
                 item["edited_ts"] = time.time()
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(sections={"private_image_vision_cache"})
                 updated = deepcopy(item)
             return self._ok(self._image_cache_item_summary(key, updated))
         except Exception as exc:
@@ -2693,7 +2674,7 @@ class PrivateCompanionPageApi(
             if path is None:
                 return self._error("缓存预览文件不存在")
             if self._restore_image_cache_preview_metadata(key, item):
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(sections={"private_image_vision_cache"})
         return key, path
 
     @staticmethod
@@ -4035,7 +4016,7 @@ class PrivateCompanionPageApi(
             if not replaced:
                 records.append(asset)
             self.plugin.data["photo_reference_assets"] = records
-            self.plugin._save_data_sync()
+            self.plugin._save_data_sync(sections={"photo_reference_assets"})
             data = deepcopy(self.plugin.data)
         return self._ok({"message": "已更新参考资产" if existing else "已上传参考资产", "asset": self._reference_asset_page_item(asset), "worldbook": self._worldbook_summary(data)})
 
@@ -4059,7 +4040,7 @@ class PrivateCompanionPageApi(
                         path.unlink(missing_ok=True)
                 except (OSError, ValueError):
                     pass
-            self.plugin._save_data_sync()
+            self.plugin._save_data_sync(sections={"photo_reference_assets"})
             data = deepcopy(self.plugin.data)
         return self._ok({"message": "已删除参考资产", "worldbook": self._worldbook_summary(data)})
 
@@ -4383,7 +4364,7 @@ class PrivateCompanionPageApi(
             self._photo_reference_asset_raw_items().append(item)
             saver = getattr(self.plugin, "_save_data_sync", None)
             if callable(saver):
-                saver()
+                saver(sections={"photo_reference_assets"})
             return self._ok({"asset": self._photo_reference_asset_page_item(item)})
 
     async def update_photo_reference_asset(self) -> dict[str, Any]:
@@ -4459,7 +4440,7 @@ class PrivateCompanionPageApi(
                         pass
             saver = getattr(self.plugin, "_save_data_sync", None)
             if callable(saver):
-                saver()
+                saver(sections={"photo_reference_assets"})
             return self._ok({"asset": self._photo_reference_asset_page_item(updated)})
 
     async def delete_photo_reference_asset(self) -> dict[str, Any]:
@@ -4479,7 +4460,7 @@ class PrivateCompanionPageApi(
             removed_path = self._photo_reference_asset_path(existing.get("path")) if existing else None
             saver = getattr(self.plugin, "_save_data_sync", None)
             if callable(saver):
-                saver()
+                saver(sections={"photo_reference_assets"})
             if removed_path is not None:
                 try:
                     removed_path.unlink(missing_ok=True)
@@ -4542,7 +4523,7 @@ class PrivateCompanionPageApi(
                 removed = cache.pop(key, None)
                 if isinstance(removed, dict):
                     preview_path = self._single_line(removed.get("preview_path"), 260)
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(sections={"private_image_vision_cache"})
                 remaining = len(cache)
             self._remove_image_cache_preview_file(preview_path, key)
             return self._ok({"key": key, "remaining": remaining})
@@ -4585,7 +4566,7 @@ class PrivateCompanionPageApi(
                         )
                     )
                 if removed_items:
-                    self.plugin._save_data_sync()
+                    self.plugin._save_data_sync(sections={"private_image_vision_cache"})
                 remaining = len(cache)
             for key, preview_path in removed_items:
                 self._remove_image_cache_preview_file(preview_path, key)
@@ -4684,7 +4665,16 @@ class PrivateCompanionPageApi(
         if not callable(importer):
             return
         if importer():
-            self.plugin._save_data_sync()
+            self.plugin._save_data_sync(
+                sections={
+                    "worldbook_entries",
+                    "worldbook_member_profiles",
+                    "worldbook_group_profiles",
+                    "worldbook_import_state",
+                    "worldbook_deleted_member_ids",
+                    "worldbook_deleted_group_ids",
+                }
+            )
 
 
     async def get_reality_touch(self) -> dict[str, Any]:
@@ -4795,11 +4785,17 @@ class PrivateCompanionPageApi(
             }
             relationship_data_changed = bool(apply_overrides.get("__relationship_data_changed"))
             if expression_scope_keys & set(changed) or relationship_data_changed:
+                save_sections: set[str] = set()
+                if expression_scope_keys & set(changed):
+                    save_sections.add("expression_learning_runtime")
+                if relationship_data_changed:
+                    save_sections.add("users")
                 async with self.plugin._data_lock:
                     expression_refresher = getattr(self.plugin, "_refresh_expression_voice_profile", None)
                     if expression_scope_keys & set(changed) and callable(expression_refresher):
                         expression_refresher()
-                    self.plugin._save_data_sync()
+                        save_sections.add("expression_voice_profile")
+                    self.plugin._save_data_sync(sections=save_sections)
             if storage_changed:
                 rebuild = getattr(self.plugin, "_rebuild_store_manager", None)
                 if callable(rebuild):
@@ -5169,7 +5165,9 @@ class PrivateCompanionPageApi(
                     shrinker = getattr(self.plugin, "_shrink_user_proactive_candidates", None)
                     if callable(shrinker):
                         shrinker(user_id, note="page_delete")
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(
+                    sections={"users", "proactive_candidate_pool"}
+                )
                 data = self._overview_data_snapshot_locked(self.plugin.data)
             message = "已删除主动候选"
             if cleared_current_plan:
@@ -5199,7 +5197,7 @@ class PrivateCompanionPageApi(
                 if not callable(shrinker):
                     return self._error("当前插件缺少主动候选收缩能力")
                 removed = int(shrinker(user_id, pending_cap=keep, note="page_prune") or 0)
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(sections={"proactive_candidate_pool"})
                 data = self._overview_data_snapshot_locked(self.plugin.data)
             return self._ok(
                 {
@@ -5423,7 +5421,7 @@ class PrivateCompanionPageApi(
                 changed = records != previous
                 self.plugin.data["troubleshooting_suppressed_warning_types"] = records
                 if changed:
-                    self.plugin._save_data_sync()
+                    self.plugin._save_data_sync(sections={"troubleshooting_suppressed_warning_types"})
             return self._ok(
                 {
                     "items": records,
@@ -5623,7 +5621,7 @@ class PrivateCompanionPageApi(
                     return self._error("这份巡视指导已经过期，请重新执行巡视")
                 guidance["active"] = active
                 guidance["manual_paused"] = not active
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(sections={"daily_review_active_guidance"})
                 status = self.plugin._daily_review_status_payload()
             return self._ok(status)
         except Exception as exc:
@@ -5668,7 +5666,9 @@ class PrivateCompanionPageApi(
                 self._cancel_troubleshooting_proactive_wakeup(str(user_id))
                 recovered += 1
             if recovered:
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(
+                    sections={"users", "troubleshooting_test_results"}
+                )
         return recovered
 
     def _safe_test_diagnostic_text(self, value: Any, limit: int = 1200) -> str:
@@ -5935,7 +5935,7 @@ class PrivateCompanionPageApi(
                 tester.data[state_key] = deepcopy(tester.data[state_key])
         tester._data_lock = asyncio.Lock()
         tester._qweather_location_resolve_lock = asyncio.Lock()
-        tester._save_data_sync = lambda: None
+        tester._save_data_sync = lambda **_kwargs: None
         tester._external_api_test_mode = True
 
         normalized: dict[str, Any] = {}
@@ -7921,7 +7921,7 @@ class PrivateCompanionPageApi(
                 raw = {}
                 self.plugin.data["troubleshooting_test_results"] = raw
             raw["proactive_message"] = self._sanitize_troubleshooting_test_result(result)
-            self.plugin._save_data_sync()
+            self.plugin._save_data_sync(sections={"users", "troubleshooting_test_results"})
         wakeup_task = self._schedule_troubleshooting_proactive_wakeup(target_user_id, scheduled_ts)
         if wakeup_task is None:
             logger.info(
@@ -8947,7 +8947,7 @@ class PrivateCompanionPageApi(
                     )
                     for stale_key, _ in endpoint_results[24:]:
                         raw.pop(stale_key, None)
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(sections={"troubleshooting_test_results"})
         except Exception as exc:
             logger.warning("[PrivateCompanionPage] 保存排障测试结果失败: %s", self._single_line(exc, 120))
 
@@ -10220,7 +10220,7 @@ class PrivateCompanionPageApi(
             async with self.plugin._data_lock:
                 self.plugin.data["token_usage"] = {}
                 balance_state = deepcopy(self.plugin.data.get("balance_awareness", {}))
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(sections={"token_usage"})
             return self._ok(self._token_stats_payload({}, balance_state))
         except Exception as exc:
             logger.error(f"[PrivateCompanionPage] 重置 Token 统计失败: {exc}", exc_info=True)
@@ -10237,7 +10237,7 @@ class PrivateCompanionPageApi(
                 access_token = self._issue_bookshelf_access_token(persist=True)
                 saver = getattr(self.plugin, "_save_data_sync", None)
                 if callable(saver):
-                    saver()
+                    saver(sections={"bookshelf_secret"})
                 data = deepcopy(self.plugin.data)
             return self._ok({"bookshelf": await self._bookshelf_summary(data, unlocked=True, access_token=access_token)})
         except Exception as exc:
@@ -10323,7 +10323,7 @@ class PrivateCompanionPageApi(
                     fromtimestamp=self.plugin._environment_fromtimestamp,
                 )
                 self.plugin.data["memo_notes"] = notes[-200:]
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(sections={"memo_notes"})
                 result = self._memo_notes_payload(self.plugin.data)
             return self._ok({"memo_notes": result})
         except ValueError as exc:
@@ -10980,7 +10980,7 @@ class PrivateCompanionPageApi(
                 if changed:
                     if kind == "jm_album":
                         self._mark_bookshelf_data_changed()
-                    self.plugin._save_data_sync()
+                    self.plugin._save_data_sync(sections={"bookshelf_items"})
                 data = deepcopy(self.plugin.data)
             return self._ok({"changed": changed, "bookshelf": await self._bookshelf_summary(data, unlocked=True, access_token=access_token)})
         except Exception as exc:
@@ -11073,7 +11073,7 @@ class PrivateCompanionPageApi(
                 if safe_total > 0 and page >= safe_total:
                     target["reading_completed_at"] = self._float(target.get("reading_completed_at")) or time.time()
                 self._mark_bookshelf_data_changed()
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(sections={"bookshelf_items"})
                 data = deepcopy(self.plugin.data)
             return self._ok({"bookshelf": await self._bookshelf_summary(data, unlocked=True, access_token=access_token)})
         except Exception as exc:
@@ -11122,7 +11122,7 @@ class PrivateCompanionPageApi(
                 if callable(updater):
                     updater(target)
                 self._mark_bookshelf_data_changed()
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(sections={"bookshelf_items"})
                 data = deepcopy(self.plugin.data)
             return self._ok({"bookshelf": await self._bookshelf_summary(data, unlocked=True, access_token=access_token)})
         except Exception as exc:
@@ -11232,7 +11232,7 @@ class PrivateCompanionPageApi(
                 if callable(updater):
                     updater(target)
                 self._mark_bookshelf_data_changed()
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(sections={"bookshelf_items"})
                 data = deepcopy(self.plugin.data)
             return self._ok({"bookshelf": await self._bookshelf_summary(data, unlocked=True, access_token=access_token)})
         except Exception as exc:
@@ -11377,7 +11377,7 @@ class PrivateCompanionPageApi(
                 if callable(updater):
                     updater(target)
                 self._mark_bookshelf_data_changed()
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(sections={"bookshelf_items"})
                 data = deepcopy(self.plugin.data)
             return self._ok({"message": "Bot 已重新读过并更新读后感", "bookshelf": await self._bookshelf_summary(data, unlocked=True, access_token=access_token)})
         except Exception as exc:
@@ -11388,7 +11388,16 @@ class PrivateCompanionPageApi(
         try:
             async with self.plugin._data_lock:
                 changed = bool(self.plugin._import_worldbook_entries_from_sources())
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(
+                    sections={
+                        "worldbook_entries",
+                        "worldbook_member_profiles",
+                        "worldbook_group_profiles",
+                        "worldbook_import_state",
+                        "worldbook_deleted_member_ids",
+                        "worldbook_deleted_group_ids",
+                    }
+                )
                 data = deepcopy(self.plugin.data)
             return self._ok({"changed": changed, "worldbook": self._worldbook_summary(data)})
         except Exception as exc:
@@ -11425,7 +11434,13 @@ class PrivateCompanionPageApi(
                                 and str(asset.get("owner_id") or "") == user_id
                             )
                         ]
-                    self.plugin._save_data_sync()
+                    self.plugin._save_data_sync(
+                        sections={
+                            "worldbook_member_profiles",
+                            "worldbook_deleted_member_ids",
+                            "photo_reference_assets",
+                        }
+                    )
                     data = deepcopy(self.plugin.data)
                     return self._ok({"changed": changed, "message": "已删除关系节点", "worldbook": self._worldbook_summary(data)})
                 if not self._worldbook_member_id_valid(
@@ -11520,7 +11535,12 @@ class PrivateCompanionPageApi(
                 bind_result: dict[str, Any] | None = None
                 if linked_qq_user_id and linked_qq_user_id != user_id:
                     bind_result = self._bind_worldbook_external_member_locked(profiles, user_id, linked_qq_user_id, profile)
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(
+                    sections={
+                        "worldbook_member_profiles",
+                        "worldbook_deleted_member_ids",
+                    }
+                )
                 data = deepcopy(self.plugin.data)
             if payload.keys() <= {"user_id", "enabled"}:
                 message = "已更新关系节点状态"
@@ -11714,7 +11734,7 @@ class PrivateCompanionPageApi(
                 if user_id and not touched:
                     return self._error("没有找到可清理的待确认观察")
                 if touched:
-                    self.plugin._save_data_sync()
+                    self.plugin._save_data_sync(sections={"worldbook_member_profiles"})
                 data = deepcopy(self.plugin.data)
             message = f"已清理 {cleared} 条待确认观察" if cleared else "没有待确认观察需要清理"
             return self._ok({"message": message, "cleared": cleared, "worldbook": self._worldbook_summary(data)})
@@ -11741,7 +11761,9 @@ class PrivateCompanionPageApi(
                     if group_id not in deleted:
                         deleted.append(group_id)
                     changed = groups.pop(group_id, None) is not None
-                    self.plugin._save_data_sync()
+                    self.plugin._save_data_sync(
+                        sections={"worldbook_group_profiles", "worldbook_deleted_group_ids"}
+                    )
                     data = deepcopy(self.plugin.data)
                     return self._ok({"changed": changed, "message": "已删除群资料", "worldbook": self._worldbook_summary(data)})
                 deleted = self.plugin.data.setdefault("worldbook_deleted_group_ids", [])
@@ -11769,7 +11791,7 @@ class PrivateCompanionPageApi(
                 if "priority" in payload:
                     group["priority"] = self._clamp_int(payload.get("priority"), 110, -1000, 10000)
                 group["manual_edit_ts"] = time.time()
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(sections={"worldbook_group_profiles"})
                 data = deepcopy(self.plugin.data)
             return self._ok({"message": "已保存群资料", "worldbook": self._worldbook_summary(data)})
         except Exception as exc:
@@ -11847,7 +11869,7 @@ class PrivateCompanionPageApi(
                     if not changed:
                         return self._error("没有找到要删除的技能，请刷新后重试")
                     state["updated_ts"] = time.time()
-                    self.plugin._save_data_sync()
+                    self.plugin._save_data_sync(sections={"skill_growth"})
                     return self._ok({"changed": changed, "message": "已删除技能", "skill_growth": self._skill_growth_summary(self.plugin.data)})
 
                 if not name:
@@ -11900,7 +11922,7 @@ class PrivateCompanionPageApi(
                 )
                 skills[skill_id] = skill
                 state["updated_ts"] = time.time()
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(sections={"skill_growth"})
                 return self._ok({"message": "已保存技能", "skill_growth": self._skill_growth_summary(self.plugin.data)})
         except Exception as exc:
             logger.error(f"[PrivateCompanionPage] 更新技能失败: {exc}", exc_info=True)
@@ -11936,7 +11958,7 @@ class PrivateCompanionPageApi(
                     if index < 0:
                         return self._error("没有找到要删除的个人目标，请刷新后重试")
                     goals.pop(index)
-                    self.plugin._save_data_sync()
+                    self.plugin._save_data_sync(sections={"personal_goals"})
                     return self._ok({"changed": True, "message": "已删除个人目标", "personal_goals": self._personal_goal_summary(self.plugin.data)})
                 if not title:
                     return self._error("缺少目标名称")
@@ -12000,7 +12022,7 @@ class PrivateCompanionPageApi(
                     goals[index] = goal
                 else:
                     goals.append(goal)
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(sections={"personal_goals"})
                 return self._ok({"message": "已保存个人目标", "personal_goals": self._personal_goal_summary(self.plugin.data)})
         except Exception as exc:
             logger.error(f"[PrivateCompanionPage] 更新个人目标失败: {exc}", exc_info=True)
@@ -12153,7 +12175,7 @@ class PrivateCompanionPageApi(
                     before = len(items)
                     state["items"] = [item for item in items if not (isinstance(item, dict) and self._single_line(item.get("id"), 48) == item_id)]
                     state["updated_ts"] = time.time()
-                    self.plugin._save_data_sync()
+                    self.plugin._save_data_sync(sections={"food_menu"})
                     return self._ok({
                         "changed": len(state["items"]) != before,
                         "message": "已移出候选",
@@ -12234,7 +12256,7 @@ class PrivateCompanionPageApi(
                 else:
                     items.append(item)
                 state["updated_ts"] = time.time()
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(sections={"food_menu"})
                 return self._ok({"message": "已保存候选", "food_menu": self._food_menu_summary(self.plugin.data)})
         except Exception as exc:
             logger.error(f"[PrivateCompanionPage] 更新吃什么候选失败: {exc}", exc_info=True)
@@ -12321,7 +12343,7 @@ class PrivateCompanionPageApi(
                         items.append(item)
                         added += 1
                 state["updated_ts"] = time.time()
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(sections={"food_menu"})
                 return self._ok(
                     {
                         "message": f"已加入 {added} 个，更新 {updated} 个" + (f"，跳过 {skipped} 个" if skipped else ""),
@@ -12368,7 +12390,7 @@ class PrivateCompanionPageApi(
                 if deleted_ids:
                     state["items"] = remaining
                     state["updated_ts"] = time.time()
-                    self.plugin._save_data_sync()
+                    self.plugin._save_data_sync(sections={"food_menu"})
                 return self._ok(
                     {
                         "message": f"已删除 {len(deleted_ids)} 个候选",
@@ -12413,7 +12435,7 @@ class PrivateCompanionPageApi(
                     item["config"] = config
                 item["updated_ts"] = time.time()
                 store[name] = item
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(sections={"external_proactive_abilities"})
                 data = deepcopy(self.plugin.data)
             return self._ok({"message": "已保存外部主动能力", "external_abilities": self._external_ability_summary(data)})
         except Exception as exc:
@@ -13053,7 +13075,7 @@ class PrivateCompanionPageApi(
             if callable(sync_targets):
                 async with self.plugin._data_lock:
                     sync_targets()
-                    self.plugin._save_data_sync()
+                    self.plugin._save_data_sync(sections={"users"})
 
             worldbook_saved = False
             if worldbook_should_save:
@@ -13092,13 +13114,17 @@ class PrivateCompanionPageApi(
                         self.plugin.data["worldbook_deleted_member_ids"] = [
                             item for item in deleted if str(item) != worldbook_user_id
                         ]
-                    self.plugin._save_data_sync()
+                    self.plugin._save_data_sync(
+                        sections={"worldbook_member_profiles", "worldbook_deleted_member_ids"}
+                    )
                     worldbook_saved = True
 
             async with self.plugin._data_lock:
                 self.plugin.data["setup_guide_completed_at"] = time.time()
                 self.plugin.data["setup_guide_completed_version"] = "5.7.2-first-setup"
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(
+                    sections={"setup_guide_completed_at", "setup_guide_completed_version"}
+                )
 
             config_saved = True
             if changed:
@@ -13166,7 +13192,15 @@ class PrivateCompanionPageApi(
                 self.plugin.data["detail_enhanced_day"] = str((plan or {}).get("date") or today)
                 self.plugin.data["detail_enhanced_segments"] = {}
                 self.plugin.data["daily_story_plan"] = {}
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(
+                    sections={
+                        "daily_plan",
+                        "daily_state",
+                        "detail_enhanced_day",
+                        "detail_enhanced_segments",
+                        "daily_story_plan",
+                    }
+                )
             return plan
 
         if not isinstance(task, asyncio.Task) or task.done():
@@ -13370,7 +13404,16 @@ class PrivateCompanionPageApi(
                     enhanced[key] = cancelled
                     story = self.plugin._rebuild_story_plan_from_detail_snapshots(str(plan.get("date") or _today_key()))
                     self.plugin._remember_detail_enhancement_history(str(plan.get("date") or _today_key()), enhanced, story)
-                    self.plugin._save_data_sync()
+                    self.plugin._save_data_sync(
+                        sections={
+                            "daily_plan",
+                            "detail_enhanced_day",
+                            "detail_enhanced_segments",
+                            "detail_enhanced_history",
+                            "daily_story_plan",
+                            "daily_story_plan_history",
+                        }
+                    )
                     data = self._overview_data_snapshot_locked(self.plugin.data)
                     return self._ok({"key": key, "cancelled": True, "daily_timeline": self._daily_timeline_summary(data)})
                 if isinstance(live_item, dict):
@@ -13397,7 +13440,13 @@ class PrivateCompanionPageApi(
                         for field, (existed, value) in previous_item_state.items()
                     },
                 }
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(
+                    sections={
+                        "daily_plan",
+                        "detail_enhanced_day",
+                        "detail_enhanced_segments",
+                    }
+                )
 
             detail = await generate_detail_enhancement(self.plugin, segment, plan, state)
             if not isinstance(detail.get("today_events"), list) or not detail.get("today_events"):
@@ -13411,7 +13460,13 @@ class PrivateCompanionPageApi(
                     stale_item = stale_items[stale_index] if isinstance(stale_items, list) and 0 <= stale_index < len(stale_items) and isinstance(stale_items[stale_index], dict) else None
                     if isinstance(stale_item, dict) and self._single_line(stale_item.get("_detail_generation_id"), 64) == generation_id:
                         stale_item.pop("_detail_generation_id", None)
-                        self.plugin._save_data_sync()
+                        self.plugin._save_data_sync(
+                            sections={
+                                "daily_plan",
+                                "detail_enhanced_day",
+                                "detail_enhanced_segments",
+                            }
+                        )
                     return self._error("该时间段已被取消、替换或由更新的操作接管，本次迟到结果未写入")
                 current = self.plugin.data.setdefault("detail_enhanced_segments", {})
                 current[key] = {
@@ -13446,7 +13501,17 @@ class PrivateCompanionPageApi(
                     detail=detail,
                     segment=segment,
                 )
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(
+                    sections={
+                        "daily_plan",
+                        "daily_state",
+                        "detail_enhanced_day",
+                        "detail_enhanced_segments",
+                        "detail_enhanced_history",
+                        "daily_story_plan",
+                        "daily_story_plan_history",
+                    }
+                )
                 data = self._overview_data_snapshot_locked(self.plugin.data)
             return self._ok({"key": key, "detail": detail, "daily_timeline": self._daily_timeline_summary(data)})
         except Exception as exc:
@@ -13468,7 +13533,13 @@ class PrivateCompanionPageApi(
                                 live_item[field] = value
                             else:
                                 live_item.pop(field, None)
-                    self.plugin._save_data_sync()
+                    self.plugin._save_data_sync(
+                        sections={
+                            "daily_plan",
+                            "detail_enhanced_day",
+                            "detail_enhanced_segments",
+                        }
+                    )
             return self._exception_error("局部重生成失败")
 
     def _normalize_roleplay_draft_scopes(self, raw: Any) -> list[str]:
@@ -16619,7 +16690,9 @@ class PrivateCompanionPageApi(
                     scope_revision=scope_revision, preview=preview,
                 )
                 if scope_changed:
-                    self.plugin._save_data_sync()
+                    self.plugin._save_data_sync(
+                        sections={"groups" if source_type == "group" else "users"}
+                    )
             return self._ok(preview)
         except ValueError as exc:
             return self._error(str(exc))
@@ -16705,7 +16778,12 @@ class PrivateCompanionPageApi(
                     except Exception:
                         target["expression_profile"] = before
                         raise
-                self.plugin._save_data_sync()
+                save_sections = {
+                    "groups" if source_type == "group" else "users"
+                }
+                if destination == "learned":
+                    save_sections.add("expression_voice_profile")
+                self.plugin._save_data_sync(sections=save_sections)
                 snapshot = deepcopy(self.plugin.data)
             result = self._expression_library_summary(snapshot)
             imported_groups = self._int(preview.get("importable_group_count"))
@@ -16986,12 +17064,14 @@ class PrivateCompanionPageApi(
     async def get_expression_library(self) -> dict[str, Any]:
         try:
             async with self.plugin._data_lock:
-                changed = False
+                # Read endpoints may prepare a disposable view, but must never repair
+                # or persist the live runtime state as a side effect of a GET request.
+                snapshot = deepcopy(self.plugin.data)
                 normalizer = getattr(self.plugin, "_normalize_group_expression_profile", None)
                 pruner = getattr(self.plugin, "_prune_invalid_expression_rules", None)
                 family_backfiller = getattr(self.plugin, "_backfill_expression_rule_families", None)
                 for collection_key in ("users", "groups"):
-                    collection = self.plugin.data.get(collection_key)
+                    collection = snapshot.get(collection_key)
                     if not isinstance(collection, dict):
                         continue
                     source_type = "group" if collection_key == "groups" else "private"
@@ -16999,30 +17079,21 @@ class PrivateCompanionPageApi(
                         profile = item.get("expression_profile") if isinstance(item, dict) else None
                         if not isinstance(profile, dict):
                             continue
-                        if collection_key == "groups" and callable(normalizer) and normalizer(profile):
-                            changed = True
-                        if callable(pruner) and pruner(profile):
-                            changed = True
-                        if callable(family_backfiller) and family_backfiller(profile):
-                            changed = True
+                        if collection_key == "groups" and callable(normalizer):
+                            normalizer(profile)
+                        if callable(pruner):
+                            pruner(profile)
+                        if callable(family_backfiller):
+                            family_backfiller(profile)
                         try:
                             managed, scope_context = self._expression_admin_scope_context(
                                 source_type, self._single_line(source_id, 80), item,
                             )
                             if managed:
-                                before_scope = deepcopy(profile)
                                 self._expression_prepare_admin_profile(item, scope_context)
-                                if before_scope != item.get("expression_profile"):
-                                    changed = True
                         except (ExpressionScopeError, ValueError):
                             # Pending/unresolved legacy sources remain visible but cannot be mutated.
                             pass
-                if changed:
-                    refresher = getattr(self.plugin, "_refresh_expression_voice_profile", None)
-                    if callable(refresher):
-                        refresher()
-                    self.plugin._save_data_sync()
-                snapshot = deepcopy(self.plugin.data)
             return self._ok(self._expression_library_summary(snapshot))
         except Exception as exc:
             logger.error(f"[PrivateCompanionPage] 获取统一表达学习库失败: {exc}", exc_info=True)
@@ -17119,7 +17190,12 @@ class PrivateCompanionPageApi(
                         while len(operations) > 128:
                             operations.pop(next(iter(operations)))
                         self.plugin.data["_req041_expression_promotion_operations"] = operations
-                        self.plugin._save_data_sync()
+                        self.plugin._save_data_sync(
+                            sections={
+                                "_req041_persona_expression_profile",
+                                "_req041_expression_promotion_operations",
+                            }
+                        )
                     snapshot = deepcopy(self.plugin.data)
                 result = self._expression_library_summary(snapshot)
                 result["promotion"] = {
@@ -17148,6 +17224,7 @@ class PrivateCompanionPageApi(
                     results: list[dict[str, Any]] = []
                     seen: set[tuple[str, str, str]] = set()
                     changed = False
+                    save_sections: set[str] = set()
                     for raw_item in raw_items:
                         if not isinstance(raw_item, dict):
                             continue
@@ -17167,6 +17244,7 @@ class PrivateCompanionPageApi(
                         if not isinstance(item, dict):
                             results.append({"status": "skipped", "reason": "来源不存在", "source_id": target_id})
                             continue
+                        mutation_before = deepcopy(item.get("expression_profile") or {})
                         if target_type == "group":
                             normalizer = getattr(self.plugin, "_normalize_group_expression_profile", None)
                             profile = item.get("expression_profile")
@@ -17188,7 +17266,7 @@ class PrivateCompanionPageApi(
                                 "rule_family_id": family_id,
                                 },
                             )
-                            profile_changed = before != (item.get("expression_profile") or {})
+                            profile_changed = mutation_before != (item.get("expression_profile") or {})
                             if managed and profile_changed:
                                 try:
                                     self._expression_finalize_admin_profile(item, before, scope_context)
@@ -17203,7 +17281,10 @@ class PrivateCompanionPageApi(
                             })
                             continue
                         succeeded = not result_message.startswith(("没有找到", "缺少", "规则组中没有"))
-                        changed = changed or (succeeded and profile_changed)
+                        if profile_changed:
+                            save_sections.add(collection_key)
+                            if succeeded:
+                                changed = True
                         results.append(
                             {
                                 "status": "success" if succeeded else "skipped",
@@ -17217,7 +17298,9 @@ class PrivateCompanionPageApi(
                         refresher = getattr(self.plugin, "_refresh_expression_voice_profile", None)
                         if callable(refresher):
                             refresher()
-                    self.plugin._save_data_sync()
+                        save_sections.add("expression_voice_profile")
+                    if save_sections:
+                        self.plugin._save_data_sync(sections=save_sections)
                     snapshot = deepcopy(self.plugin.data)
                 result = self._expression_library_summary(snapshot)
                 success_count = sum(1 for item in results if item.get("status") == "success")
@@ -17238,6 +17321,7 @@ class PrivateCompanionPageApi(
             try:
                 async with self.plugin._data_lock:
                     cleared = 0
+                    save_sections: set[str] = set()
                     for collection_key in ("users", "groups"):
                         collection = self.plugin.data.get(collection_key)
                         if not isinstance(collection, dict):
@@ -17254,6 +17338,7 @@ class PrivateCompanionPageApi(
                             )
                             if item_count:
                                 try:
+                                    mutation_before = deepcopy(item.get("expression_profile") or {})
                                     managed, scope_context = self._expression_admin_scope_context(
                                         source_type, self._single_line(source_id, 80), item,
                                     )
@@ -17267,10 +17352,13 @@ class PrivateCompanionPageApi(
                                         except Exception:
                                             item["expression_profile"] = before
                                             raise
+                                    if mutation_before != (item.get("expression_profile") or {}):
+                                        save_sections.add(collection_key)
                                     cleared += item_count
                                 except (ExpressionScopeError, ValueError):
                                     continue
-                    self.plugin._save_data_sync()
+                    if save_sections:
+                        self.plugin._save_data_sync(sections=save_sections)
                     snapshot = deepcopy(self.plugin.data)
                 result = self._expression_library_summary(snapshot)
                 result["message"] = f"已清空 {cleared} 条待审核表达资料"
@@ -17303,6 +17391,7 @@ class PrivateCompanionPageApi(
                 )
                 if not isinstance(item, dict):
                     return self._error("表达样本来源不存在")
+                mutation_before = deepcopy(item.get("expression_profile") or {})
                 if source_type == "group":
                     normalizer = getattr(self.plugin, "_normalize_group_expression_profile", None)
                     profile = item.get("expression_profile")
@@ -17323,16 +17412,26 @@ class PrivateCompanionPageApi(
                     except Exception:
                         item["expression_profile"] = before
                         raise
+                mutation_changed = mutation_before != (item.get("expression_profile") or {})
                 if persona_target:
                     self.plugin.data["_req041_persona_expression_profile"] = item["expression_profile"]
+                voice_changed = False
                 if action in {
                     "approve", "approve_rule", "approve_rule_group", "delete_sample", "delete_rule", "delete_rule_group",
                     "update_rule_group",
                 }:
+                    voice_before = deepcopy(self.plugin.data.get("expression_voice_profile"))
                     voice_refresher = getattr(self.plugin, "_refresh_expression_voice_profile", None)
                     if callable(voice_refresher):
                         voice_refresher()
-                self.plugin._save_data_sync()
+                        voice_changed = voice_before != self.plugin.data.get("expression_voice_profile")
+                save_sections = {
+                    "_req041_persona_expression_profile" if persona_target else collection_key
+                } if mutation_changed else set()
+                if voice_changed:
+                    save_sections.add("expression_voice_profile")
+                if save_sections:
+                    self.plugin._save_data_sync(sections=save_sections)
                 snapshot = deepcopy(self.plugin.data)
             result = self._expression_library_summary(snapshot)
             result["message"] = action_message
@@ -18834,6 +18933,13 @@ class PrivateCompanionPageApi(
         return selected or {"basic", "relations", "food_skills"}
 
     async def _apply_migration_normalized(self, normalized: dict[str, Any], *, mode: str, conflict: str) -> dict[str, Any]:
+        data_payload = normalized.get("data") if isinstance(normalized.get("data"), dict) else {}
+        if data_payload:
+            # Validate the normalized section set before changing config or live data.
+            validator = getattr(self.plugin, "_validate_save_request", None)
+            if not callable(validator):
+                raise RuntimeError("migration section validator is unavailable")
+            validator(set(data_payload), (), None)
         before = await self._build_migration_package(include_all=True)
         backup_path = self._write_migration_backup(before)
 
@@ -18872,7 +18978,6 @@ class PrivateCompanionPageApi(
             config_saved = await self._save_config_if_possible()
 
         applied_sections: list[dict[str, Any]] = []
-        data_payload = normalized.get("data") if isinstance(normalized.get("data"), dict) else {}
         if data_payload:
             async with self.plugin._data_lock:
                 for section, imported_value in data_payload.items():
@@ -18890,7 +18995,7 @@ class PrivateCompanionPageApi(
                             "count": self._migration_count_items(imported_value),
                         }
                     )
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(sections=set(data_payload))
             self._refresh_migration_runtime_caches(data_payload)
 
         overview = await self.get_overview()
@@ -21364,7 +21469,7 @@ class PrivateCompanionPageApi(
                 applied.pop(key, None)
             state["manual_updated_at"] = time.time()
             state["last_manual_changes"] = deepcopy(manual_changes)
-            self.plugin._save_data_sync()
+            self.plugin._save_data_sync(sections={"personality_iteration_auto_tune"})
 
     async def _maybe_apply_personality_iteration_auto_tune(self, users: dict[str, Any], groups: dict[str, Any]) -> dict[str, Any]:
         if not bool(getattr(self.plugin, "enable_personality_iteration_experiment", False)):
@@ -21400,7 +21505,7 @@ class PrivateCompanionPageApi(
                     state["no_suggestion_streak"] = no_suggestion_streak
                     state["last_suggestion_count"] = len(suggestions)
                     state["last_clear_observed_at"] = now
-                    self.plugin._save_data_sync()
+                    self.plugin._save_data_sync(sections={"personality_iteration_auto_tune"})
                 stable_seconds = max(0.0, now - no_suggestion_since)
                 ready_to_restore = (
                     no_suggestion_streak >= max(1, int(self.PERSONALITY_AUTO_TUNE_RECOVERY_STREAK))
@@ -21429,7 +21534,7 @@ class PrivateCompanionPageApi(
                 ):
                     state["no_suggestion_streak"] = 0
                     state["no_suggestion_since"] = 0
-                    self.plugin._save_data_sync()
+                    self.plugin._save_data_sync(sections={"personality_iteration_auto_tune"})
             await self._remember_personality_auto_tune_status(
                 {
                     "changed": False,
@@ -21494,7 +21599,7 @@ class PrivateCompanionPageApi(
             state["no_suggestion_since"] = 0
             if changes:
                 state["last_changes"] = deepcopy(changes)
-            self.plugin._save_data_sync()
+            self.plugin._save_data_sync(sections={"personality_iteration_auto_tune"})
 
         for change in changes:
             self._apply_config_value(change["key"], change["to"])
@@ -21551,7 +21656,7 @@ class PrivateCompanionPageApi(
                 state["manual_values"] = deepcopy(manual_values)
                 state["applied"] = deepcopy(applied)
                 state["manual_synced_at"] = time.time()
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(sections={"personality_iteration_auto_tune"})
         return manual_values, applied
 
     async def _remember_personality_auto_tune_status(self, status: dict[str, Any]) -> None:
@@ -21562,7 +21667,7 @@ class PrivateCompanionPageApi(
                 self.plugin.data["personality_iteration_auto_tune"] = state
             state["last_status"] = deepcopy(status)
             state["last_status_at"] = time.time()
-            self.plugin._save_data_sync()
+            self.plugin._save_data_sync(sections={"personality_iteration_auto_tune"})
 
     async def _restore_personality_iteration_auto_tune(
         self,
@@ -21622,7 +21727,7 @@ class PrivateCompanionPageApi(
                 "restored_at": time.time(),
                 "config_saved": config_saved,
             }
-            self.plugin._save_data_sync()
+            self.plugin._save_data_sync(sections={"personality_iteration_auto_tune"})
         if changes:
             logger.info(
                 "[PrivateCompanionPage] 角色贴合校准已恢复用户手动参数: %s",
@@ -22715,7 +22820,7 @@ class PrivateCompanionPageApi(
                 if isinstance(overrides, dict) and overrides.get("__defer_relationship_data_save"):
                     overrides["__relationship_data_changed"] = True
                 else:
-                    self.plugin._save_data_sync()
+                    self.plugin._save_data_sync(sections={"users"})
             return
         if key == "normal_interaction_band_cap":
             previous_runtime_cap = normalize_normal_interaction_band_cap(getattr(self.plugin, key, "warm"))
@@ -22751,7 +22856,7 @@ class PrivateCompanionPageApi(
                 if isinstance(overrides, dict) and overrides.get("__defer_relationship_data_save"):
                     overrides["__relationship_data_changed"] = True
                 else:
-                    self.plugin._save_data_sync()
+                    self.plugin._save_data_sync(sections={"users"})
             return
         if key in {"owner_group_relationship_projection", "owner_group_interaction_projection"}:
             normalized = self._normalize_bool_value(value)
@@ -23007,7 +23112,9 @@ class PrivateCompanionPageApi(
         if key == "private_user_aliases":
             self.plugin.private_user_aliases = self.plugin._parse_private_user_aliases(value)
             if self.plugin._merge_private_user_alias_records():
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(
+                    sections={"users", "private_user_alias_merge_backups"}
+                )
             return
         if key == "private_user_delivery_aliases":
             self.plugin.private_user_delivery_aliases = self.plugin._parse_private_user_aliases(value)
@@ -23016,7 +23123,7 @@ class PrivateCompanionPageApi(
                 for raw_user_id, user in users.items():
                     if isinstance(user, dict):
                         self.plugin._ensure_private_user_umo(str(raw_user_id), user)
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(sections={"users"})
             return
         if key == "worldbook_self_registration_block_words":
             parser = getattr(self.plugin, "_parse_text_list_config", None)
@@ -23114,7 +23221,7 @@ class PrivateCompanionPageApi(
                     data["daily_review_case_audit"] = []
                     scheduler = getattr(self.plugin, "_schedule_data_save", None)
                     if callable(scheduler):
-                        scheduler()
+                        scheduler(sections={"daily_review_case_audit"})
             return
         if key in self._allowed_setting_keys():
             setattr(self.plugin, key, value)
@@ -27059,7 +27166,7 @@ class PrivateCompanionPageApi(
                             keywords or ["作品信息"],
                             importance=5,
                         )
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(sections={"creative_projects"})
             return self._ok({"project_id": project_id, "changed": bool(changed_notes), "message": "作品已更新"})
         except Exception as exc:
             logger.error("[PrivateCompanionPage] 更新创作项目失败: %s", exc, exc_info=True)
@@ -27172,7 +27279,7 @@ class PrivateCompanionPageApi(
                     project["quality_reviews"] = reviews
                 reviews.append(review)
                 del reviews[:-20]
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(sections={"creative_projects"})
             return self._ok({"project_id": project_id, "review": review})
         except Exception as exc:
             logger.error("[PrivateCompanionPage] 创作项目质量分析失败: %s", exc, exc_info=True)
@@ -27208,7 +27315,7 @@ class PrivateCompanionPageApi(
                     p for p in projects if not (isinstance(p, dict) and p.get("id") == project_id)
                 ]
                 removed = before - len(self.plugin.data["creative_projects"])
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(sections={"creative_projects"})
             return self._ok({"project_id": project_id, "removed": removed})
         except Exception as exc:
             logger.error("[PrivateCompanionPage] 删除创作项目失败: %s", exc, exc_info=True)

--- a/page_api_users_groups.py
+++ b/page_api_users_groups.py
@@ -382,7 +382,7 @@ class PrivateCompanionPageApiUsersGroupsMixin:
             async with self.plugin._data_lock:
                 cleaner = getattr(self.plugin, "_cleanup_orphan_reaction_expression_users", None)
                 if callable(cleaner) and cleaner():
-                    self.plugin._save_data_sync()
+                    self.plugin._save_data_sync(sections={"users"})
                 users = self.plugin.data.get("users", {})
                 if not isinstance(users, dict):
                     users = {}
@@ -556,7 +556,7 @@ class PrivateCompanionPageApiUsersGroupsMixin:
                             operation_id=operation_id,
                             registry=registry,
                         )
-                    self.plugin._schedule_data_save()
+                    self.plugin._schedule_data_save(sections={"unified_person"})
             if not result.get("ok"):
                 return self._error(str(result.get("code") or "统一身份重新关联失败"))
             return self._ok({"result": result})
@@ -626,7 +626,7 @@ class PrivateCompanionPageApiUsersGroupsMixin:
                             operation_id=operation_id,
                             registry=registry,
                         )
-                    self.plugin._schedule_data_save()
+                    self.plugin._schedule_data_save(sections={"unified_person"})
             if not result.get("ok") and result.get("code") != "split_manual_review_required":
                 return self._error(str(result.get("code") or "统一身份解绑失败"))
             safe_result = self._safe_identity_unlink_result(result)
@@ -771,6 +771,7 @@ class PrivateCompanionPageApiUsersGroupsMixin:
         try:
             action_message = ""
             async with self.plugin._data_lock:
+                save_sections = {"users"}
                 user = self.plugin._get_user(user_id)
                 private_memory_mutation = any(
                     bool(payload.get(key))
@@ -905,6 +906,8 @@ class PrivateCompanionPageApiUsersGroupsMixin:
                             return self._error(
                                 str(profile_result.get("code") or "统一身份档案更新失败")
                             )
+                        if profile_result.get("ok") and profile_result.get("changed"):
+                            save_sections.add("unified_person")
                 if "relationship_role" in payload:
                     user["relationship_role"] = role
                     expression_voice_needs_refresh = role != previous_role
@@ -1051,6 +1054,7 @@ class PrivateCompanionPageApiUsersGroupsMixin:
                     voice_refresher = getattr(self.plugin, "_refresh_expression_voice_profile", None)
                     if callable(voice_refresher):
                         voice_refresher()
+                        save_sections.add("expression_voice_profile")
                 if any(
                     key in payload
                     for key in ("relationship_role", "relationship_mode", "relationship_score", "companion_intimacy")
@@ -1071,7 +1075,8 @@ class PrivateCompanionPageApiUsersGroupsMixin:
                         operation_id=f"req041-page-memory:{user_id}:{uuid.uuid4().hex}",
                     ):
                         return self._error("权威私聊记忆已发生并发变更，请刷新后重试")
-                self.plugin._save_data_sync()
+                    save_sections.add("_req041_private_memory")
+                self.plugin._save_data_sync(sections=save_sections)
                 snapshot = deepcopy(user)
             result = self._user_summary(user_id, snapshot)
             result.update(
@@ -1116,10 +1121,12 @@ class PrivateCompanionPageApiUsersGroupsMixin:
                             removed_ids.add(alias_text)
                 removed_ids = {item for item in removed_ids if item}
                 merge_backups = self.plugin.data.get("private_user_alias_merge_backups")
+                merge_backups_changed = False
                 if isinstance(merge_backups, dict):
                     for removed_id in removed_ids:
                         if removed_id in merge_backups:
                             merge_backups.pop(removed_id, None)
+                            merge_backups_changed = True
 
                 def keep_expression_scope_ids(raw_values: Any) -> list[str]:
                     kept: list[str] = []
@@ -1182,10 +1189,18 @@ class PrivateCompanionPageApiUsersGroupsMixin:
                 self._apply_config_value("private_user_delivery_aliases", delivery_alias_text, overrides)
                 self._apply_config_value("expression_private_learning_source_ids", expression_learning_ids, overrides)
                 self._apply_config_value("expression_private_application_user_ids", expression_application_ids, overrides)
-                voice_refresher = getattr(self.plugin, "_refresh_expression_voice_profile", None)
-                if callable(voice_refresher):
-                    voice_refresher()
-                self.plugin._save_data_sync()
+                save_sections: set[str] = set()
+                if removed_user is not None:
+                    save_sections.add("users")
+                if merge_backups_changed:
+                    save_sections.add("private_user_alias_merge_backups")
+                if removed_user is not None or removed_expression_scope:
+                    voice_refresher = getattr(self.plugin, "_refresh_expression_voice_profile", None)
+                    if callable(voice_refresher):
+                        voice_refresher()
+                        save_sections.add("expression_voice_profile")
+                if save_sections:
+                    self.plugin._save_data_sync(sections=save_sections)
 
             config_saved = await self._save_config_if_possible()
             message_parts = []
@@ -1578,7 +1593,7 @@ class PrivateCompanionPageApiUsersGroupsMixin:
                 if group_id in platform_target_ids:
                     snapshot["last_group_name_lookup_at"] = now
             if changed:
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(sections={"groups"})
     async def get_group(self) -> dict[str, Any]:
         group_id = self._normalize_page_group_id(request.args.get("group_id", ""))
         if not group_id:
@@ -1663,7 +1678,7 @@ class PrivateCompanionPageApiUsersGroupsMixin:
                 if not callable(updater) or not callable(getter):
                     return self._error("当前插件版本不支持成员风控")
                 item = updater(group, user_id=user_id, action=action, name=name)
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(sections={"groups"})
                 summary = getter(group)
             return self._ok({"item": item, "summary": summary})
         except ValueError as exc:
@@ -1762,7 +1777,12 @@ class PrivateCompanionPageApiUsersGroupsMixin:
                     voice_refresher = getattr(self.plugin, "_refresh_expression_voice_profile", None)
                     if callable(voice_refresher):
                         voice_refresher()
-                self.plugin._save_data_sync()
+                save_sections = {"groups"}
+                if payload.get("clear_observation") and callable(
+                    getattr(self.plugin, "_refresh_expression_voice_profile", None)
+                ):
+                    save_sections.add("expression_voice_profile")
+                self.plugin._save_data_sync(sections=save_sections)
                 snapshot = deepcopy(group)
             return self._ok(self._group_summary(group_id, snapshot))
         except Exception as exc:
@@ -1801,6 +1821,7 @@ class PrivateCompanionPageApiUsersGroupsMixin:
                     })
             async with self.plugin._data_lock:
                 groups = self.plugin.data.get("groups")
+                groups_repaired = not isinstance(groups, dict)
                 if not isinstance(groups, dict):
                     groups = {}
                     self.plugin.data["groups"] = groups
@@ -1847,10 +1868,16 @@ class PrivateCompanionPageApiUsersGroupsMixin:
                 }
                 self._apply_config_value("expression_group_learning_source_ids", expression_learning_ids, expression_overrides)
                 self._apply_config_value("expression_group_application_ids", expression_application_ids, expression_overrides)
-                voice_refresher = getattr(self.plugin, "_refresh_expression_voice_profile", None)
-                if callable(voice_refresher):
-                    voice_refresher()
-                self.plugin._save_data_sync()
+                save_sections: set[str] = set()
+                if removed_group or groups_repaired:
+                    save_sections.add("groups")
+                if removed_group or removed_expression_scope:
+                    voice_refresher = getattr(self.plugin, "_refresh_expression_voice_profile", None)
+                    if callable(voice_refresher):
+                        voice_refresher()
+                        save_sections.add("expression_voice_profile")
+                if save_sections:
+                    self.plugin._save_data_sync(sections=save_sections)
 
             config_saved = await self._save_config_if_possible()
             message_parts = []
@@ -1933,7 +1960,7 @@ class PrivateCompanionPageApiUsersGroupsMixin:
                         "updated_at": datetime.now().strftime("%Y-%m-%d %H:%M"),
                     }
                     terms.sort(key=lambda item: (_safe_int(item.get("count"), 0) if isinstance(item, dict) else 0), reverse=True)
-                self.plugin._save_data_sync()
+                self.plugin._save_data_sync(sections={"groups"})
                 snapshot = deepcopy(group)
             detail = self._group_summary(group_id, snapshot)
             detail["slang_items"] = self._group_slang_items(snapshot)

--- a/passive_state_pipeline.py
+++ b/passive_state_pipeline.py
@@ -1089,7 +1089,7 @@ async def inject_humanized_state(
                                 "intent": intent_line,
                                 "source": "reply_image",
                             }
-                            self._save_data_sync()
+                            self._save_data_sync(sections={"users"})
                     except Exception as exc:
                         logger.debug("[PrivateCompanion] 私聊引用图片视觉反馈目标记录失败: %s", exc)
                 try:

--- a/passive_state_pipeline.py
+++ b/passive_state_pipeline.py
@@ -549,7 +549,7 @@ async def inject_humanized_state(
             source="conversation",
         )
     if self._record_recent_private_fact_correction(current_user, inbound_text):
-        self._schedule_data_save()
+        self._schedule_data_save(sections={"users"})
     fact_attribution_guard = self._format_private_fact_attribution_guard(current_user, inbound_text)
     if fact_attribution_guard:
         prompt_surface.add(
@@ -653,7 +653,7 @@ async def inject_humanized_state(
                 priority=28,
                 source="conversation",
             )
-            self._schedule_data_save()
+            self._schedule_data_save(sections={"users"})
     identity_anchor = self._format_private_identity_anchor_for_prompt(user_id, current_user, event)
     if identity_anchor:
         prompt_surface.add("identity.anchor", identity_anchor, priority=10, source="identity")

--- a/place_cognitive_map.py
+++ b/place_cognitive_map.py
@@ -291,7 +291,7 @@ class PlaceCognitiveMapMixin:
             promoted_legacy = True
             saver = getattr(self, "_schedule_data_save", None)
             if callable(saver):
-                saver(delay=0.5)
+                saver(sections={"place_cognitive_maps"}, delay=0.5)
         if not bool(location.get("available")):
             existing = root.get(store_key)
             return self._place_cognitive_map_summary(existing, include_transition=include_transition) if isinstance(existing, dict) else {
@@ -425,7 +425,7 @@ class PlaceCognitiveMapMixin:
         if changed:
             saver = getattr(self, "_schedule_data_save", None)
             if callable(saver) and not promoted_legacy:
-                saver(delay=0.5)
+                saver(sections={"place_cognitive_maps"}, delay=0.5)
             for event in events:
                 try:
                     self._place_cognitive_map_emit_memory_event(event, namespace)

--- a/plugin_bootstrap.py
+++ b/plugin_bootstrap.py
@@ -1989,9 +1989,23 @@ def initialize_plugin_runtime(self: Any) -> None:
     self._passive_light_injection_cache: dict[str, Any] = {}
     self._passive_state_session_cache: dict[str, dict[str, Any]] = {}
     self._data_save_task: asyncio.Task | None = None
-    self._data_save_dirty = False
+    self._data_save_dirty: dict[str, int] = {}
+    self._data_save_deleted: dict[str, int] = {}
+    self._data_save_dirty_since: dict[str, float] = {}
+    self._data_save_section_revisions: dict[str, int] = {}
+    self._data_save_full_revision = 0
+    self._data_save_full_since = 0.0
+    self._data_save_revision = 0
+    self._data_save_max_delay_seconds = 2.0
+    self._data_save_retry_base_seconds = 3.0
+    self._data_save_retry_max_seconds = 30.0
     self._persona_data_save_tasks: dict[str, asyncio.Task] = {}
-    self._persona_data_save_dirty: set[str] = set()
+    self._persona_data_save_dirty: dict[str, dict[str, int]] = {}
+    self._persona_data_save_deleted: dict[str, dict[str, int]] = {}
+    self._persona_data_save_dirty_since: dict[str, dict[str, float]] = {}
+    self._persona_data_save_section_revisions: dict[str, dict[str, int]] = {}
+    self._persona_data_save_full_revision: dict[str, int] = {}
+    self._persona_data_save_revision: dict[str, int] = {}
     self._maintenance_failure_cooldowns: dict[str, dict[str, Any]] = {}
     self._framework_captured_send_cache: dict[str, list[Any]] = {}
     self._framework_captured_send_cache_at: dict[str, float] = {}
@@ -2009,6 +2023,16 @@ def initialize_plugin_runtime(self: Any) -> None:
     self._qzone_last_bot = None
     startup_load_started = time.perf_counter()
     self.data = self._load_data_sync()
+    manager = getattr(self, "store_manager", None)
+    next_revision = getattr(manager, "next_revision", None)
+    if callable(next_revision):
+        try:
+            self._data_save_revision = max(
+                int(self._data_save_revision or 0),
+                max(0, int(next_revision()) - 1),
+            )
+        except Exception:
+            pass
     self._body_monitor_integration = BodyMonitorIntegration(self)
     self._apply_tts_runtime_overrides()
     load_elapsed_ms = int((time.perf_counter() - startup_load_started) * 1000)
@@ -2027,7 +2051,7 @@ def initialize_plugin_post_runtime_state(self: Any, config: Any) -> None:
     self.p5_attestation_registry = P5AttestationRegistry()
     self._bot_personal_outbox = BotPersonalOutbox(
         self.data,
-        save=lambda: self._schedule_data_save(delay=0.5),
+        save=lambda: self._schedule_data_save(sections={"bot_personal_outbox"}, delay=0.5),
         background_task=lambda operation, label: self._create_lifecycle_background_task(
             operation,
             label=label,

--- a/private_image.py
+++ b/private_image.py
@@ -1280,7 +1280,7 @@ class PrivateImageMixin:
         scheduler = getattr(self, "_schedule_data_save", None)
         try:
             if callable(scheduler):
-                scheduler(delay=2.0)
+                scheduler(sections={"private_image_visual_provider_state"}, delay=2.0)
             else:
                 self._save_data_sync()
         except Exception as exc:
@@ -3323,7 +3323,7 @@ class PrivateImageMixin:
                 if updated:
                     scheduler = getattr(self, "_schedule_data_save", None)
                     if callable(scheduler):
-                        scheduler()
+                        scheduler(sections={"groups"})
                 return updated
         return update()
 
@@ -4228,6 +4228,9 @@ class PrivateImageMixin:
                     sender_id,
                     len(learned_messages),
                 )
+            scheduler = getattr(self, "_schedule_data_save", None)
+            if callable(scheduler):
+                scheduler(sections={"smart_message_debounce"})
         lines = []
         for item in messages[:8]:
             if not isinstance(item, dict):

--- a/private_image.py
+++ b/private_image.py
@@ -1037,7 +1037,7 @@ class PrivateImageMixin:
             if evicted:
                 self._record_cache_metric(f"image_vision:{scope}", hit=False, detail=f"evict:{evicted}")
         try:
-            self._save_data_sync()
+            self._save_data_sync(sections={"private_image_vision_cache"})
         except Exception as exc:
             logger.debug("[PrivateCompanion] 私聊图片视觉缓存保存失败: %s", exc)
 
@@ -1063,7 +1063,7 @@ class PrivateImageMixin:
         if removed:
             logger.info("[PrivateCompanion] 私聊图片视觉缓存已因负反馈失效: removed=%s reason=%s", removed, _single_line(reason, 120))
             try:
-                self._save_data_sync()
+                self._save_data_sync(sections={"private_image_vision_cache"})
             except Exception as exc:
                 logger.debug("[PrivateCompanion] 私聊图片视觉缓存失效保存失败: %s", exc)
         return removed
@@ -1282,7 +1282,7 @@ class PrivateImageMixin:
             if callable(scheduler):
                 scheduler(sections={"private_image_visual_provider_state"}, delay=2.0)
             else:
-                self._save_data_sync()
+                self._save_data_sync(sections={"private_image_visual_provider_state"})
         except Exception as exc:
             logger.debug("[PrivateCompanion] 私聊图片视觉成功 provider 状态保存失败: %s", exc)
 
@@ -5359,7 +5359,7 @@ class PrivateImageMixin:
                     "ownership": _single_line(ownership, 120),
                     "intent": _single_line(intent, 160),
                 }
-                self._save_data_sync()
+                self._save_data_sync(sections={"users"})
         except Exception as exc:
             logger.debug("[PrivateCompanion] 私聊图片视觉反馈目标记录失败: %s", exc)
 

--- a/private_reading.py
+++ b/private_reading.py
@@ -1081,7 +1081,7 @@ class PrivateReadingMixin:
             secret["created_at"] = _now_ts()
             if basis:
                 secret["previous_basis"] = basis
-        self._save_data_sync()
+        self._save_data_sync(sections={"bookshelf_secret"})
         return _single_line(secret.get("password") or candidate, 12)
 
     @staticmethod
@@ -1157,7 +1157,7 @@ class PrivateReadingMixin:
             reason = self._bookshelf_password_fallback_reason(password)
         secret["reason"] = reason
         secret["reason_generated_at"] = _now_ts()
-        self._save_data_sync()
+        self._save_data_sync(sections={"bookshelf_secret"})
         return reason
 
     @staticmethod
@@ -2101,7 +2101,7 @@ class PrivateReadingMixin:
         state["last_probe_at"] = now
         if not result:
             state["last_status"] = "no_candidate"
-            self._save_data_sync()
+            self._save_data_sync(sections={"jm_cosmos_integration"})
             return
         state["last_read_at"] = now
         state["last_status"] = "read"
@@ -2127,7 +2127,7 @@ class PrivateReadingMixin:
                 )
                 if accepted:
                     user["last_jm_cosmos_share_at"] = now
-        self._save_data_sync()
+        self._save_data_sync(sections={"jm_cosmos_integration", "users", "proactive_candidate_pool"})
         logger.info("[PrivateCompanion] 已触发夹层私下阅读")
 
     async def _maybe_schedule_private_reading_recommendation_request(self) -> None:
@@ -2149,7 +2149,7 @@ class PrivateReadingMixin:
             return
         state["last_recommendation_request_probe_at"] = now
         if random.random() > self.private_reading_ask_probability:
-            self._save_data_sync()
+            self._save_data_sync(sections={"jm_cosmos_integration"})
             return
         users = self.data.get("users")
         user_items = [
@@ -2162,7 +2162,7 @@ class PrivateReadingMixin:
             and self._friend_can_receive_proactive_reason(item, "jm_cosmos_recommendation_request", "message")
         ]
         if not user_items:
-            self._save_data_sync()
+            self._save_data_sync(sections={"jm_cosmos_integration"})
             return
         random.shuffle(user_items)
         for user_id, user in user_items:
@@ -2193,7 +2193,7 @@ class PrivateReadingMixin:
                 user["last_private_reading_recommendation_request_at"] = now
                 state["last_recommendation_request_at"] = now
                 state["last_status"] = "asked_recommendation"
-                self._save_data_sync()
+                self._save_data_sync(sections={"jm_cosmos_integration", "users", "proactive_candidate_pool"})
                 logger.info("[PrivateCompanion] 已安排夹层阅读推荐征求")
                 return
-        self._save_data_sync()
+        self._save_data_sync(sections={"jm_cosmos_integration"})

--- a/proactive.py
+++ b/proactive.py
@@ -2941,7 +2941,7 @@ class ProactiveMixin(UserRestGateMixin):
                 user["planned_candidate_id"] = item.get("id", "")
                 saver = getattr(self, "_schedule_data_save", None)
                 if callable(saver):
-                    saver()
+                    saver(sections={"users"})
                 return "情绪 hurt 收敛中,亲密主动候选已延后"
             scheduler = getattr(self, "_schedule_next_proactive", None)
             if callable(scheduler):
@@ -2953,7 +2953,7 @@ class ProactiveMixin(UserRestGateMixin):
                 user["planned_proactive_expire_at"] = base_after + 90 * 60
             saver = getattr(self, "_schedule_data_save", None)
             if callable(saver):
-                saver()
+                saver(sections={"users"})
             return f"情绪/关系 {mode} 收敛中,亲密主动候选已清理"
         defer = getattr(self, "_defer_or_replace_planned_impulse", None)
         if callable(defer):
@@ -2970,7 +2970,7 @@ class ProactiveMixin(UserRestGateMixin):
             user["next_proactive_at"] = max(_safe_float(user.get("next_proactive_at"), 0), base_after)
         saver = getattr(self, "_schedule_data_save", None)
         if callable(saver):
-            saver()
+            saver(sections={"users"})
         return f"情绪 {mode} 收敛中,主动候选已延后"
 
     def _normalize_existing_plan_for_emotion(self, user: dict[str, Any], *, now: float | None = None) -> str:
@@ -3002,7 +3002,7 @@ class ProactiveMixin(UserRestGateMixin):
         self._mark_planned_candidate_status(user, "accepted", note)
         saver = getattr(self, "_schedule_data_save", None)
         if callable(saver):
-            saver()
+            saver(sections={"users"})
         return note
 
     def _friend_proactive_scheduled_too_early(
@@ -3682,7 +3682,10 @@ class ProactiveMixin(UserRestGateMixin):
             except Exception as exc:
                 logger.debug("[PrivateCompanion] C3 Bot Personal outbox delivery failed: %s", _single_line(exc, 160))
         if snapshots and callable(getattr(self, "_schedule_data_save", None)):
-            self._schedule_data_save(delay=0.5)
+            self._schedule_data_save(
+                sections={"window_snapshots", "agenda_reconciliation_history"},
+                delay=0.5,
+            )
         return snapshots
 
     def _scheduler_persona_ids(self) -> list[str]:
@@ -3843,7 +3846,7 @@ class ProactiveMixin(UserRestGateMixin):
         if changed:
             saver = getattr(self, "_schedule_data_save", None)
             if callable(saver):
-                saver(delay=0.5)
+                saver(sections={"users"}, delay=0.5)
         if triggered:
             kicker = getattr(self, "_kick_proactive_loop_once", None)
             if callable(kicker):

--- a/proactive_engine.py
+++ b/proactive_engine.py
@@ -5780,7 +5780,7 @@ class ProactiveEngineMixin:
                 "updated_ts": _now_ts(),
             })
             store[name] = item
-            self._save_data_sync()
+            self._save_data_sync(sections={"external_proactive_abilities"})
         except Exception as exc:
             logger.debug("[PrivateCompanion] 外部主动能力状态保存失败: %s", exc)
         logger.info("[PrivateCompanion] 已注册外部主动能力: %s", name)
@@ -5795,7 +5795,7 @@ class ProactiveEngineMixin:
             if isinstance(item, dict):
                 item["registered"] = False
                 item["updated_ts"] = _now_ts()
-                self._save_data_sync()
+                self._save_data_sync(sections={"external_proactive_abilities"})
         except Exception:
             pass
         return removed
@@ -8046,7 +8046,7 @@ class ProactiveEngineMixin:
         user["screen_peek_failure_reason"] = _single_line(reason, 180)
         user["screen_peek_failure_count"] = _safe_int(user.get("screen_peek_failure_count"), 0, 0) + 1
         try:
-            self._save_data_sync()
+            self._save_data_sync(sections={"users"})
         except Exception:
             pass
 

--- a/proactive_engine.py
+++ b/proactive_engine.py
@@ -4006,7 +4006,7 @@ class ProactiveEngineMixin:
             self._clear_pending_proactive_plan(user)
             schedule_save = getattr(self, "_schedule_data_save", None)
             if callable(schedule_save):
-                schedule_save()
+                schedule_save(sections={"users"})
             return False, "创作功能未开启"
         if not is_troubleshooting and planned_source == "timer" and not due_timer_active:
             self._clear_llm_timer_internal_plan_fields(user)
@@ -4099,7 +4099,7 @@ class ProactiveEngineMixin:
                 self._mark_planned_candidate_status(user, "deferred", defer_note)
                 schedule_save = getattr(self, "_schedule_data_save", None)
                 if callable(schedule_save):
-                    schedule_save()
+                    schedule_save(sections={"users"})
                 logger.info(
                     "[PrivateCompanion] %s已顺延主动消息: user=%s until=%s reason=%s source=%s detail=%s",
                     "实时共处期间" if external_realtime else "繁忙回复闸门",

--- a/proactive_message.py
+++ b/proactive_message.py
@@ -838,7 +838,7 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
                 current["proactive_sending_started_at"] = now
                 current["proactive_chat_bridge_token"] = token
                 current["proactive_chat_bridge_session"] = _single_line(session_id, 180)
-                self._save_data_sync()
+                self._save_data_sync(sections={"users"})
         return {
             "enabled": True,
             "allowed": True,
@@ -1016,7 +1016,7 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
                 topic_recorder = getattr(self, "_remember_proactive_topic", None)
                 if callable(topic_recorder):
                     topic_recorder(current, text=visible or text, topic="Proactive Chat", motive="即时主动触发")
-                self._save_data_sync()
+                self._save_data_sync(sections={"users"})
         logger.info(
             "[PrivateCompanion] 已同步 Proactive Chat 主动发送: user=%s session=%s text=%s",
             user_id,
@@ -1041,7 +1041,7 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
             current["proactive_sending_started_at"] = 0
             current["proactive_chat_bridge_token"] = ""
             current["proactive_chat_bridge_session"] = ""
-            self._save_data_sync()
+            self._save_data_sync(sections={"users"})
         return True
 
     @staticmethod
@@ -7386,7 +7386,10 @@ Output:
                     user_last = {}
                     user["external_proactive_ability_last"] = user_last
                 user_last[name] = executed_at
-            self._save_data_sync()
+            save_sections = {"external_proactive_abilities"}
+            if isinstance(user, dict):
+                save_sections.add("users")
+            self._save_data_sync(sections=save_sections)
         except Exception:
             pass
 
@@ -7572,7 +7575,7 @@ Output:
         async with self._data_lock:
             current = self._get_user(user_id)
             self._note_screen_peek_attempt(user_id, reason="goodnight_screen_check", count_daily=True)
-            self._save_data_sync()
+            self._save_data_sync(sections={"users"})
 
         event = None
         target = _single_line(user.get("umo"), 240)
@@ -7637,7 +7640,7 @@ Output:
                 if user_id and episode_at > 0:
                     claimed.append((user_id, episode_at, episode_key))
             if changed:
-                self._save_data_sync()
+                self._save_data_sync(sections={"users"})
 
         for user_id, episode_at, episode_key in claimed:
             async with self._data_lock:
@@ -7651,7 +7654,7 @@ Output:
                 )
                 if block_reason:
                     user["goodnight_screen_check_state"] = block_reason
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users"})
                     continue
                 name = _single_line(user.get("nickname"), 40) or user_id
 
@@ -7660,7 +7663,7 @@ Output:
                 current = self._get_user(user_id)
                 current["goodnight_screen_check_state"] = state
                 current["goodnight_screen_check_result_at"] = _now_ts()
-                self._save_data_sync()
+                self._save_data_sync(sections={"users"})
             if state != "active":
                 continue
 
@@ -7675,14 +7678,14 @@ Output:
                 )
                 if block_reason:
                     current["goodnight_screen_check_state"] = block_reason
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users"})
                     continue
                 current["proactive_sending"] = True
                 current["proactive_sending_started_at"] = _now_ts()
                 user = current
                 name = _single_line(current.get("nickname"), 40) or user_id
                 umo = _single_line(current.get("umo"), 240)
-                self._save_data_sync()
+                self._save_data_sync(sections={"users"})
 
             motive = "互道晚安后仍有明确活动迹象，轻声提醒一次早点休息，不要求回复"
             safe_context = "内部状态判断：晚安后仍有明确活动迹象；没有提供任何屏幕内容或应用信息"
@@ -7777,13 +7780,13 @@ Output:
                     current["goodnight_screen_check_reminded_episode_key"] = episode_key
                     current["sent_today"] = _safe_int(current.get("sent_today"), 0) + 1
                     current["proactive_sent_count"] = _safe_int(current.get("proactive_sent_count"), 0) + 1
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users"})
             finally:
                 async with self._data_lock:
                     current = self._get_user(user_id)
                     current["proactive_sending"] = False
                     current["proactive_sending_started_at"] = 0
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"users"})
 
     async def _run_screen_peek_action(
         self,
@@ -7807,7 +7810,7 @@ Output:
                 reason=reason,
                 count_daily=not quota_exempt,
             )
-            self._save_data_sync()
+            self._save_data_sync(sections={"users"})
         event = None
         if target and hasattr(plugin, "_create_virtual_event"):
             try:
@@ -7917,7 +7920,7 @@ Output:
                     return f"poke：冷却中，约 {max(1, math.ceil(remaining / 60))} 分钟后可再次执行"
                 current["poke_action_inflight_until"] = now + max(30.0, poke_count * 3.0)
                 current["poke_echo_suppress_until"] = now + max(30.0, poke_count * 3.0)
-                self._save_data_sync()
+                self._save_data_sync(sections={"users"})
                 reserved = True
             for index in range(poke_count):
                 await self._send_single_poke(client, user_id=user_id, group_id=group_id)
@@ -7927,7 +7930,7 @@ Output:
                 current = self._get_user(user_id)
                 current["last_poke_action_at"] = _now_ts()
                 current["poke_action_inflight_until"] = 0
-                self._save_data_sync()
+                self._save_data_sync(sections={"users"})
             if poke_count <= 1:
                 return f"poke：已轻轻戳了 {name} 一下\n主动原因：{reason}"
             return f"poke：已轻轻连着戳了 {name} {poke_count} 下\n主动原因：{reason}"
@@ -7937,7 +7940,7 @@ Output:
                     async with self._data_lock:
                         current = self._get_user(user_id)
                         current["poke_action_inflight_until"] = 0
-                        self._save_data_sync()
+                        self._save_data_sync(sections={"users"})
                 except Exception:
                     pass
             logger.warning(f"[PrivateCompanion] poke 主动行为失败: {e}")
@@ -8452,7 +8455,7 @@ Output:
                     "note": _single_line(f"跨日重置：{previous_mode or 'unknown'} -> {note}", 120),
                 }
             )
-            self._save_data_sync()
+            self._save_data_sync(sections={"qq_presence_state"})
 
     def _extract_group_id_from_umo(self, target: str) -> int | None:
         text = str(target or "").strip()
@@ -8923,7 +8926,9 @@ Output:
                             user_id=user_id,
                             scope="proactive",
                         )
-                    self._save_data_sync()
+                    self._save_data_sync(
+                        sections={"users", "photo_generation_scope_attempts"}
+                    )
             return (
                 "photo_text：生图失败,不能假装已经拍照\n"
                 f"画面草稿：{scene['caption']}\n"
@@ -8940,7 +8945,9 @@ Output:
                     user_id=user_id,
                     scope="proactive",
                 )
-            self._save_data_sync()
+            self._save_data_sync(
+                sections={"users", "photo_generation_scope_attempts"}
+            )
         scene_context_line = _single_line(scene.get("scene_context"), 500)
         return (
             f"photo_text：已通过 {backend_name} 生成真实图片\n"
@@ -9122,7 +9129,9 @@ Output:
                 history.insert(0, dict(item))
             self.data["daily_outfit_history"] = history[:30]
             self.data["daily_outfit_photo"] = item
-            self._save_data_sync()
+            self._save_data_sync(
+                sections={"daily_outfit_history", "daily_outfit_photo"}
+            )
         if image_path:
             await self._memory_companion_record_daily_outfit(item)
             logger.info(
@@ -10337,7 +10346,7 @@ Output:
                 self.data["recent_photo_generations"] = raw
             raw.insert(0, item)
             del raw[48:]
-            self._save_data_sync()
+            self._save_data_sync(sections={"recent_photo_generations"})
         except Exception as exc:
             logger.debug("[PrivateCompanion] 记录最近生图提示词失败: %s", _single_line(exc, 120))
 
@@ -10414,7 +10423,9 @@ Output:
             data["photo_reference_feedback"] = records
         records.insert(0, record)
         del records[96:]
-        self._save_data_sync()
+        self._save_data_sync(
+            sections={"recent_photo_generations", "photo_reference_feedback"}
+        )
         return record
 
     def _record_photo_reference_feedback_from_event(self, event: Any) -> dict[str, Any]:
@@ -10812,7 +10823,10 @@ Output:
                 item["annotated_at"] = _now_ts()
                 if sent is True:
                     self._remember_sent_photo_continuity_reference(item)
-                self._save_data_sync()
+                save_sections = {"recent_photo_generations"}
+                if sent is True:
+                    save_sections.add("recent_photo_continuity")
+                self._save_data_sync(sections=save_sections)
                 return
         except Exception as exc:
             logger.debug("[PrivateCompanion] 标注最近生图记录失败: %s", _single_line(exc, 120))
@@ -13652,6 +13666,47 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
         if confidence < 0.7:
             return ReferenceIntent(("identity",), (), "ambiguous", confidence, "model_conservative")
         return ReferenceIntent(requested or ("identity",), excluded, mode, confidence, "model")
+
+    async def _select_photo_reference_image_async(
+        self,
+        workflow_kind: str,
+        *,
+        allow_daily_outfit: bool = True,
+        request_text: str = "",
+        ambient_context: str = "",
+        selection_context: str = "",
+        suggested_scene_preset: str = "",
+    ) -> str:
+        """Return the selected reference path for legacy image-only callers."""
+        selected = await self._select_photo_reference_candidate_async(
+            workflow_kind,
+            allow_daily_outfit=allow_daily_outfit,
+            request_text=request_text,
+            ambient_context=ambient_context,
+            selection_context=selection_context,
+            suggested_scene_preset=suggested_scene_preset,
+        )
+        return str(selected.get("path") or "") if isinstance(selected, dict) else ""
+
+    async def _photo_persona_reference_image_for_kind_async(
+        self,
+        workflow_kind: str,
+        *,
+        allow_daily_outfit: bool = True,
+        request_text: str = "",
+        ambient_context: str = "",
+        selection_context: str = "",
+        suggested_scene_preset: str = "",
+    ) -> str:
+        """Compatibility facade used by extension bridges and legacy workflows."""
+        return await self._select_photo_reference_image_async(
+            workflow_kind,
+            allow_daily_outfit=allow_daily_outfit,
+            request_text=request_text,
+            ambient_context=ambient_context,
+            selection_context=selection_context,
+            suggested_scene_preset=suggested_scene_preset,
+        )
 
     async def _select_photo_reference_plan_async(
         self,

--- a/qzone_auth.py
+++ b/qzone_auth.py
@@ -129,7 +129,7 @@ class QzoneAuthMixin:
             saver = getattr(self, "_save_data_sync", None)
             if callable(saver):
                 try:
-                    saver()
+                    saver(sections={"qzone_integration"})
                 except Exception:
                     pass
 
@@ -157,7 +157,7 @@ class QzoneAuthMixin:
             saver = getattr(self, "_save_data_sync", None)
             if callable(saver):
                 try:
-                    saver()
+                    saver(sections={"qzone_integration"})
                 except Exception:
                     pass
 

--- a/qzone_comments.py
+++ b/qzone_comments.py
@@ -558,7 +558,7 @@ class QzoneCommentMixin:
                 )
             state["last_comment_inbox_status"] = "tool_retryable" if retryable else "tool_delivery_unknown"
             state["last_comment_inbox_reason"] = _single_line(exc, 120)
-            self._save_data_sync()
+            self._save_data_sync(sections={"qzone_integration"})
             return {"status": "error", "message": _single_line(exc, 160), "retryable": retryable}
         now = _now_ts()
         self._qzone_note_comment_inbox_sent(state, best["post"], best["comment"], sent, now=now)
@@ -588,7 +588,7 @@ class QzoneCommentMixin:
         state["last_comment_inbox_reply_at"] = now
         state["last_comment_inbox_status"] = "tool_replied"
         state["last_comment_inbox_reply_text"] = _single_line(sent, 120)
-        self._save_data_sync()
+        self._save_data_sync(sections={"qzone_integration"})
         return {"status": "replied", "comment": best["content"], "reply": sent}
 
     async def _maybe_process_qzone_comment_inbox(self) -> None:
@@ -669,7 +669,7 @@ class QzoneCommentMixin:
                 state["comment_inbox_initialized_at"] = now
                 state["last_comment_inbox_checked_at"] = now
                 state["last_comment_inbox_status"] = f"seeded:{len(observed_ids)}"
-                self._save_data_sync()
+                self._save_data_sync(sections={"qzone_integration"})
                 logger.info("[PrivateCompanion] QQ 空间评论收件箱首次启用,已记录现有评论: count=%s", len(observed_ids))
                 return
             history_lost_after_init = bool(
@@ -685,7 +685,7 @@ class QzoneCommentMixin:
                 state["comment_inbox_seen_keys"] = self._qzone_trim_id_list(observed_keys, limit=500)
                 state["last_comment_inbox_checked_at"] = now
                 state["last_comment_inbox_status"] = f"reseeded:history_lost:{len(observed_ids)}"
-                self._save_data_sync()
+                self._save_data_sync(sections={"qzone_integration"})
                 logger.warning(
                     "[PrivateCompanion] QQ 空间评论收件箱历史 key 为空,已重新播种当前可见评论并跳过本轮回复: count=%s",
                     len(observed_ids),
@@ -709,7 +709,7 @@ class QzoneCommentMixin:
                 state["comment_inbox_seen_keys"] = self._qzone_trim_id_list(seen_keys + observed_keys, limit=500)
                 state["last_comment_inbox_checked_at"] = now
                 state["last_comment_inbox_status"] = f"checking:new={len(candidates)}"
-                self._save_data_sync()
+                self._save_data_sync(sections={"qzone_integration"})
             candidates.sort(key=lambda item: _safe_float(getattr(item[1], "create_time", 0), 0))
             replies = 0
             skipped = 0
@@ -728,7 +728,7 @@ class QzoneCommentMixin:
                 state["last_comment_inbox_reply_comment_id"] = comment_id
                 state["last_comment_inbox_reply_comment_key"] = comment_key
                 state["last_comment_inbox_reply_author"] = _single_line(getattr(comment, "name", ""), 40) or _single_line(getattr(comment, "uin", ""), 40)
-                self._save_data_sync()
+                self._save_data_sync(sections={"qzone_integration"})
                 try:
                     sent_text = await self._qzone_reply_to_comment(None, post, comment, str(decision.get("reply") or ""))
                 except Exception as exc:
@@ -760,7 +760,7 @@ class QzoneCommentMixin:
                         else f"delivery_unknown:{_single_line(comment_id or comment_key, 80)}"
                     )
                     state["last_comment_inbox_reason"] = _single_line(exc, 120)
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"qzone_integration"})
                     logger.warning(
                         "[PrivateCompanion] QQ 空间评论回复失败: retryable=%s error=%s",
                         retryable,
@@ -803,7 +803,7 @@ class QzoneCommentMixin:
                 state["last_comment_inbox_reply_author"] = _single_line(getattr(comment, "name", ""), 40) or _single_line(getattr(comment, "uin", ""), 40)
                 state["last_comment_inbox_reason"] = last_reason
                 state["last_comment_inbox_reply_text"] = _single_line(sent_text, 120)
-                self._save_data_sync()
+                self._save_data_sync(sections={"qzone_integration"})
                 logger.info(
                     "[PrivateCompanion] QQ 空间评论收件箱已追加评论回复: post=%s type=%s comment=%s key=%s author=%s text=%s",
                     state["last_comment_inbox_reply_post_tid"] or "-",
@@ -828,7 +828,7 @@ class QzoneCommentMixin:
             if replies:
                 state["last_comment_inbox_reply_at"] = now
             state.pop("last_comment_inbox_failed_at", None)
-            self._save_data_sync()
+            self._save_data_sync(sections={"qzone_integration"})
         except Exception as exc:
             reason = _single_line(exc, 160)
             if self._qzone_auth_failure_message(reason):
@@ -854,7 +854,7 @@ class QzoneCommentMixin:
             state["last_comment_inbox_failed_at"] = now
             state["last_comment_inbox_checked_at"] = now
             state["last_comment_inbox_status"] = f"failed:{_single_line(reason, 80)}"
-            self._save_data_sync()
+            self._save_data_sync(sections={"qzone_integration"})
             if any(token in reason for token in ("没有可用的 OneBot 连接", "获取 QQ 空间 Cookie 失败", "Cookie")):
                 logger.warning("[PrivateCompanion] QQ 空间评论收件箱处理失败: %s", reason)
             else:

--- a/qzone_publish.py
+++ b/qzone_publish.py
@@ -252,7 +252,7 @@ class QzonePublishMixin:
             except Exception:
                 pass
         try:
-            self._save_data_sync()
+            self._save_data_sync(sections={"qzone_integration"})
         except Exception as exc:
             logger.debug("[PrivateCompanion] QQ 空间发布记录保存失败: %s", _single_line(exc, 120))
 
@@ -702,7 +702,7 @@ class QzonePublishMixin:
         reference_exists = bool(state.get(f"last_{prefix}_generated_image_reference_exists", False))
         if callable(getattr(self, "_save_data_sync", None)):
             try:
-                self._save_data_sync()
+                self._save_data_sync(sections={"qzone_integration"})
             except Exception:
                 pass
         if images:

--- a/qzone_runtime.py
+++ b/qzone_runtime.py
@@ -584,7 +584,7 @@ class QzoneRuntimeMixin:
             elif status == "ok":
                 state.pop("last_cookie_fetch_reason", None)
             if callable(getattr(self, "_save_data_sync", None)):
-                self._save_data_sync()
+                self._save_data_sync(sections={"qzone_integration"})
         except Exception:
             logger.debug("[PrivateCompanion] QQ 空间 Cookie 状态记录失败", exc_info=True)
 

--- a/qzone_schedule.py
+++ b/qzone_schedule.py
@@ -787,7 +787,7 @@ class QzoneScheduleMixin:
             if plan_is_new:
                 state["last_life_publish_status"] = f"skipped:{_single_line(plan.get('skip_reason'), 40)}"
                 state["last_life_publish_checked_at"] = now
-                self._save_data_sync()
+                self._save_data_sync(sections={"qzone_integration"})
             return
         plan_item = self._qzone_life_publish_due_item(plan, now=now)
         if plan_item is None:
@@ -800,21 +800,21 @@ class QzoneScheduleMixin:
                     else "ready:planned"
                 )
                 state["last_life_publish_checked_at"] = now
-                self._save_data_sync()
+                self._save_data_sync(sections={"qzone_integration"})
             return
         if plan_item.get("night") and not self._qzone_night_publish_allowed():
             self._qzone_plan_item_finish(plan, plan_item, "cancelled", now=now)
             plan_item["failed_reason"] = "night_state_inactive"
             state["last_life_publish_status"] = "cancelled:night_state_inactive"
             state["last_life_publish_checked_at"] = now
-            self._save_data_sync()
+            self._save_data_sync(sections={"qzone_integration"})
             return
         reusable_text = self._qzone_reusable_draft(state, "life_publish", now=now)
         block_reason = self._qzone_auto_publish_block_reason(state, now=now)
         if block_reason:
             state["last_life_publish_status"] = f"paused:auth:{_single_line(block_reason, 80)}"
             state["last_life_publish_checked_at"] = now
-            self._save_data_sync()
+            self._save_data_sync(sections={"qzone_integration"})
             return
         if now - _safe_float(state.get("last_life_publish_failed_at"), 0) < 15 * 60:
             return
@@ -843,14 +843,14 @@ class QzoneScheduleMixin:
                 self._qzone_clear_pending_publish_assets(state, "life_publish")
                 state["last_life_publish_status"] = "cancelled:max_attempts"
                 state["last_life_publish_checked_at"] = now
-                self._save_data_sync()
+                self._save_data_sync(sections={"qzone_integration"})
                 return
         preflight_error = await self._qzone_preflight_auto_publish(None, state=state, source="life_publish")
         if preflight_error:
             state["last_life_publish_failed_at"] = now
             state["last_life_publish_status"] = f"paused:auth:{_single_line(preflight_error, 80)}"
             state["last_life_publish_checked_at"] = now
-            self._save_data_sync()
+            self._save_data_sync(sections={"qzone_integration"})
             return
         daily_state = self.data.get("daily_state", {})
         current_item = self._qzone_current_agenda_item()
@@ -950,7 +950,7 @@ class QzoneScheduleMixin:
                 state["last_life_publish_status"] = "cancelled:empty_or_unsafe_draft"
                 state["last_life_publish_checked_at"] = now
                 self._qzone_plan_item_finish(plan, plan_item, "cancelled", now=now)
-                self._save_data_sync()
+                self._save_data_sync(sections={"qzone_integration"})
                 logger.warning("[PrivateCompanion] QQ 空间生活动态草稿为空或不安全,已跳过发布")
                 return
             if not self._qzone_text_length_ok(text, length_profile):
@@ -966,7 +966,7 @@ class QzoneScheduleMixin:
                     state["last_life_publish_status"] = "cancelled:length"
                     state["last_life_publish_checked_at"] = now
                     self._qzone_plan_item_finish(plan, plan_item, "cancelled", now=now)
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"qzone_integration"})
                     logger.info(
                         "[PrivateCompanion] QQ 空间说说字数不合要求且重写失败,已取消: profile=%s len=%s",
                         length_profile,
@@ -983,7 +983,7 @@ class QzoneScheduleMixin:
                 state["last_life_publish_checked_at"] = now
                 self._qzone_clear_pending_publish_assets(state, "life_publish")
                 self._qzone_plan_item_finish(plan, plan_item, "cancelled", now=now)
-                self._save_data_sync()
+                self._save_data_sync(sections={"qzone_integration"})
                 logger.info("[PrivateCompanion] QQ 空间复用草稿与近期说说重复,已取消发布")
                 return
             rewritten = await self._qzone_life_publish_rewrite_deduplicated(
@@ -1005,7 +1005,7 @@ class QzoneScheduleMixin:
                 state["last_life_publish_status"] = "cancelled:duplicate_after_retry"
                 state["last_life_publish_checked_at"] = now
                 self._qzone_plan_item_finish(plan, plan_item, "cancelled", now=now)
-                self._save_data_sync()
+                self._save_data_sync(sections={"qzone_integration"})
                 logger.info("[PrivateCompanion] QQ 空间草稿重写后仍与近期说说重复,已取消发布")
                 return
         if reusable_text:
@@ -1059,7 +1059,7 @@ class QzoneScheduleMixin:
         state["last_life_publish_checked_at"] = now
         state["last_life_publish_text"] = _single_line(result.get("text") or text, 180)
         state["last_life_publish_images"] = _safe_int(result.get("image_count"), len(result.get("images") or []), 0, 99) if result.get("success") else 0
-        self._save_data_sync()
+        self._save_data_sync(sections={"qzone_integration"})
 
     async def _maybe_publish_qzone_emotional_vent(
         self,
@@ -1113,7 +1113,7 @@ class QzoneScheduleMixin:
         if block_reason:
             state["last_emotional_vent_status"] = f"paused:auth:{_single_line(block_reason, 80)}"
             state["last_emotional_vent_checked_at"] = now
-            self._save_data_sync()
+            self._save_data_sync(sections={"qzone_integration"})
             return
         if now - _safe_float(state.get("last_emotional_vent_failed_at"), 0) < 15 * 60:
             return
@@ -1122,14 +1122,14 @@ class QzoneScheduleMixin:
         if not reusable_text and random.random() > probability:
             state["last_emotional_vent_status"] = "skipped:probability_miss"
             state["last_emotional_vent_checked_at"] = now
-            self._save_data_sync()
+            self._save_data_sync(sections={"qzone_integration"})
             return
         preflight_error = await self._qzone_preflight_auto_publish(None, state=state, source="emotional_vent")
         if preflight_error:
             state["last_emotional_vent_failed_at"] = now
             state["last_emotional_vent_status"] = f"paused:auth:{_single_line(preflight_error, 80)}"
             state["last_emotional_vent_checked_at"] = now
-            self._save_data_sync()
+            self._save_data_sync(sections={"qzone_integration"})
             return
         daily_state = self.data.get("daily_state", {})
         current_item = self._qzone_current_agenda_item()
@@ -1196,7 +1196,7 @@ class QzoneScheduleMixin:
                     state["last_emotional_vent_failed_at"] = now
                     state["last_emotional_vent_status"] = "cancelled:empty_or_unsafe_draft"
                     state["last_emotional_vent_checked_at"] = now
-                    self._save_data_sync()
+                    self._save_data_sync(sections={"qzone_integration"})
                     logger.warning("[PrivateCompanion] 公开心情动态草稿为空或不安全,已跳过发布")
                     return
                 state["last_emotional_vent_draft"] = _single_line(text, 240)
@@ -1240,10 +1240,10 @@ class QzoneScheduleMixin:
             state["last_emotional_vent_checked_at"] = now
             state["last_emotional_vent_text"] = _single_line(result.get("text") or text, 180)
             state["last_emotional_vent_images"] = _safe_int(result.get("image_count"), len(result.get("images") or []), 0, 99) if result.get("success") else 0
-            self._save_data_sync()
+            self._save_data_sync(sections={"qzone_integration"})
         except Exception as exc:
             state["last_emotional_vent_failed_at"] = now
             state["last_emotional_vent_status"] = f"failed:{_single_line(exc, 80)}"
             state["last_emotional_vent_checked_at"] = now
-            self._save_data_sync()
+            self._save_data_sync(sections={"qzone_integration"})
             logger.warning("[PrivateCompanion] 公开心情动态异常: %s", _single_line(exc, 160), exc_info=True)

--- a/storage/backend_base.py
+++ b/storage/backend_base.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+from collections.abc import Collection, Mapping
 from typing import Any
 
 
@@ -14,8 +15,23 @@ class StoreBackendBase:
     def save_store(self, data: dict[str, Any]) -> None:
         raise NotImplementedError
 
-    def save_snapshot(self, data: dict[str, Any]) -> None:
+    def save_sections(
+        self,
+        changed_sections: Mapping[str, tuple[int, Any]],
+        deleted_sections: Mapping[str, int],
+    ) -> Mapping[str, int]:
+        raise NotImplementedError
+
+    def save_snapshot(
+        self,
+        data: dict[str, Any],
+        *,
+        minimum_revision: int | None = None,
+        deleted_sections: Mapping[str, int] | None = None,
+        preserve_tombstones: bool = False,
+    ) -> int | None:
         self.save_store(data)
+        return None
 
     def exists(self) -> bool:
         raise NotImplementedError
@@ -23,8 +39,17 @@ class StoreBackendBase:
     def initialize_empty_store(self, default_data: dict[str, Any]) -> None:
         self.save_store(default_data)
 
-    def health_check(self) -> dict[str, Any]:
+    def health_check(self, *, raise_on_error: bool = False) -> dict[str, Any]:
         raise NotImplementedError
+
+    def next_revision(self) -> int:
+        return 1
+
+    def deleted_section_revisions(
+        self,
+        section_names: Collection[str],
+    ) -> Mapping[str, int]:
+        return {}
 
     def export_store(self) -> dict[str, Any]:
         return self.load_store()

--- a/storage/json_backend.py
+++ b/storage/json_backend.py
@@ -6,6 +6,7 @@ import os
 import threading
 import time
 import uuid
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Callable
 
@@ -50,10 +51,18 @@ class JsonStoreBackend(StoreBackendBase):
     def save_store(self, data: dict[str, Any]) -> None:
         self._atomic_write_data_file_sync(data)
 
-    def save_snapshot(self, data: dict[str, Any]) -> None:
+    def save_snapshot(
+        self,
+        data: dict[str, Any],
+        *,
+        minimum_revision: int | None = None,
+        deleted_sections: Mapping[str, int] | None = None,
+        preserve_tombstones: bool = False,
+    ) -> int | None:
         self._atomic_write_data_file_sync(data)
+        return None
 
-    def health_check(self) -> dict[str, Any]:
+    def health_check(self, *, raise_on_error: bool = False) -> dict[str, Any]:
         return {
             "backend": self.backend_name(),
             "path": str(self.data_file),
@@ -63,7 +72,9 @@ class JsonStoreBackend(StoreBackendBase):
 
     def _atomic_write_data_file_sync(self, data: dict[str, Any]) -> None:
         base = str(self.data_file)
-        tmp_file = f"{base}.{os.getpid()}.{threading.get_ident()}.{uuid.uuid4().hex}.tmp"
+        tmp_file = (
+            f"{base}.{os.getpid()}.{threading.get_ident()}.{uuid.uuid4().hex}.tmp"
+        )
         try:
             with open(tmp_file, "w", encoding="utf-8") as f:
                 json.dump(data, f, ensure_ascii=False, indent=2)

--- a/storage/sqlite_backend.py
+++ b/storage/sqlite_backend.py
@@ -1,19 +1,100 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import hashlib
 import json
 import sqlite3
+import threading
 import time
+import uuid
+from collections.abc import Callable, Collection, Mapping
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 from astrbot.api import logger
 
 from .backend_base import StoreBackendBase
 
+_SCHEMA_VERSION = 2
+_SQLITE_INTEGER_MAX = (1 << 63) - 1
+_MAX_SECTION_REVISION = _SQLITE_INTEGER_MAX - 1
+_SECTION_COLUMNS = (
+    "section_name",
+    "payload_json",
+    "updated_at",
+    "checksum",
+    "schema_version",
+    "revision",
+    "is_deleted",
+)
+_V1_SECTION_COLUMNS = _SECTION_COLUMNS[:5]
+_SCHEMA_LOCKS_GUARD = threading.Lock()
+_SCHEMA_LOCKS: dict[str, threading.RLock] = {}
+
 
 class SqliteStoreNotInitializedError(RuntimeError):
     """The database exists, but no store snapshot has been committed yet."""
+
+
+class SqliteSchemaError(RuntimeError):
+    """The database schema or persisted metadata is inconsistent."""
+
+
+class SqliteUnsupportedSchemaError(SqliteSchemaError):
+    """The database was created by a newer unsupported storage implementation."""
+
+
+class SqliteRevisionConflictError(RuntimeError):
+    """A partial write conflicts with the persisted section revision."""
+
+
+def _shared_schema_lock(path: Path) -> threading.RLock:
+    try:
+        marker = str(path.resolve()).casefold()
+    except (OSError, RuntimeError):
+        marker = str(path).casefold()
+    with _SCHEMA_LOCKS_GUARD:
+        lock = _SCHEMA_LOCKS.get(marker)
+        if lock is None:
+            lock = threading.RLock()
+            _SCHEMA_LOCKS[marker] = lock
+        return lock
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+
+
+def _payload_checksum(payload_json: str) -> str:
+    return hashlib.sha256(payload_json.encode("utf-8")).hexdigest()
+
+
+def _section_name(value: Any) -> str:
+    if not isinstance(value, str) or not value or len(value) > 256 or "\x00" in value:
+        raise ValueError(
+            "SQLite section name must be a non-empty string of at most 256 characters"
+        )
+    return value
+
+
+def _revision(value: Any) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value <= 0
+        or value > _MAX_SECTION_REVISION
+    ):
+        raise ValueError(
+            "SQLite section revision must be a positive integer within SQLite range"
+        )
+    return value
 
 
 class SqliteStoreBackend(StoreBackendBase):
@@ -26,6 +107,7 @@ class SqliteStoreBackend(StoreBackendBase):
         self.db_path = Path(db_path)
         self.ensure_defaults = ensure_defaults
         self.new_store = new_store
+        self._schema_lock = _shared_schema_lock(self.db_path)
 
     def backend_name(self) -> str:
         return "sqlite"
@@ -33,45 +115,423 @@ class SqliteStoreBackend(StoreBackendBase):
     def exists(self) -> bool:
         return self.db_path.exists()
 
+    @staticmethod
+    def _create_sections_table(connection: sqlite3.Connection, table_name: str) -> None:
+        if table_name not in {"store_sections", "store_sections_v2_migration"}:
+            raise ValueError("Unexpected SQLite migration table name")
+        connection.execute(
+            f"CREATE TABLE {table_name} ("
+            "section_name TEXT NOT NULL PRIMARY KEY,"
+            "payload_json TEXT NOT NULL,"
+            "updated_at REAL NOT NULL,"
+            "checksum TEXT NOT NULL DEFAULT '',"
+            "schema_version INTEGER NOT NULL DEFAULT 2,"
+            "revision INTEGER NOT NULL DEFAULT 0,"
+            "is_deleted INTEGER NOT NULL DEFAULT 0,"
+            "CONSTRAINT store_sections_schema_v2 "
+            "CHECK(typeof(schema_version)='integer' AND schema_version=2),"
+            "CONSTRAINT store_sections_positive_revision "
+            f"CHECK(typeof(revision)='integer' AND revision>0 AND revision<={_MAX_SECTION_REVISION}),"
+            "CONSTRAINT store_sections_deleted_flag "
+            "CHECK(typeof(is_deleted)='integer' AND is_deleted IN (0,1))"
+            ")"
+        )
+
+    @staticmethod
+    def _create_meta_table(connection: sqlite3.Connection) -> None:
+        connection.execute(
+            "CREATE TABLE store_meta ("
+            "meta_key TEXT NOT NULL PRIMARY KEY,"
+            "meta_value TEXT NOT NULL)"
+        )
+
+    @staticmethod
+    def _table_names(connection: sqlite3.Connection) -> set[str]:
+        return {
+            str(row[0])
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+            )
+        }
+
+    @staticmethod
+    def _table_info(
+        connection: sqlite3.Connection, table_name: str
+    ) -> list[tuple[Any, ...]]:
+        if table_name not in {
+            "store_sections",
+            "store_sections_v2_migration",
+            "store_meta",
+        }:
+            raise ValueError("Unexpected SQLite table name")
+        return list(connection.execute(f"PRAGMA table_info({table_name})"))
+
+    @staticmethod
+    def _metadata(connection: sqlite3.Connection) -> dict[str, str]:
+        return {
+            str(key): str(value)
+            for key, value in connection.execute(
+                "SELECT meta_key,meta_value FROM store_meta"
+            )
+        }
+
+    @staticmethod
+    def _metadata_integer(metadata: Mapping[str, str], key: str) -> int:
+        raw = metadata.get(key)
+        try:
+            value = int(raw) if raw is not None else 0
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise SqliteSchemaError(f"SQLite store meta {key} is invalid") from exc
+        if value <= 0 or value > _SQLITE_INTEGER_MAX:
+            raise SqliteSchemaError(f"SQLite store meta {key} is invalid")
+        return value
+
+    def _validate_v1_schema(self, connection: sqlite3.Connection) -> None:
+        tables = self._table_names(connection)
+        if tables != {"store_sections"}:
+            raise SqliteSchemaError("SQLite v1 store has unexpected tables")
+        info = self._table_info(connection, "store_sections")
+        names = tuple(str(row[1]) for row in info)
+        if names != _V1_SECTION_COLUMNS:
+            raise SqliteSchemaError("SQLite v1 store_sections columns are invalid")
+        expected_types = ("TEXT", "TEXT", "REAL", "TEXT", "INTEGER")
+        if tuple(str(row[2]).upper() for row in info) != expected_types:
+            raise SqliteSchemaError("SQLite v1 store_sections column types are invalid")
+        if any(int(info[index][3] or 0) != 1 for index in (1, 2)):
+            raise SqliteSchemaError("SQLite v1 store_sections nullability is invalid")
+        primary_keys = [str(row[1]) for row in info if int(row[5] or 0) > 0]
+        if primary_keys != ["section_name"]:
+            raise SqliteSchemaError("SQLite v1 store_sections primary key is invalid")
+
+    def _validate_v2_schema(self, connection: sqlite3.Connection) -> None:
+        version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+        if version != _SCHEMA_VERSION:
+            raise SqliteSchemaError("SQLite v2 schema version marker is invalid")
+        tables = self._table_names(connection)
+        if tables != {"store_sections", "store_meta"}:
+            raise SqliteSchemaError(
+                "SQLite v2 schema is incomplete or has unexpected tables"
+            )
+
+        section_info = self._table_info(connection, "store_sections")
+        section_names = tuple(str(row[1]) for row in section_info)
+        if section_names != _SECTION_COLUMNS:
+            raise SqliteSchemaError(
+                "SQLite v2 schema store_sections columns are invalid"
+            )
+        section_primary_keys = [
+            str(row[1]) for row in section_info if int(row[5] or 0) > 0
+        ]
+        if section_primary_keys != ["section_name"]:
+            raise SqliteSchemaError(
+                "SQLite v2 schema store_sections primary key is invalid"
+            )
+        if any(int(row[3] or 0) != 1 for row in section_info):
+            raise SqliteSchemaError(
+                "SQLite v2 schema store_sections nullability is invalid"
+            )
+        expected_section_types = (
+            "TEXT",
+            "TEXT",
+            "REAL",
+            "TEXT",
+            "INTEGER",
+            "INTEGER",
+            "INTEGER",
+        )
+        if tuple(str(row[2]).upper() for row in section_info) != expected_section_types:
+            raise SqliteSchemaError("SQLite v2 schema store_sections types are invalid")
+
+        meta_info = self._table_info(connection, "store_meta")
+        if tuple(str(row[1]) for row in meta_info) != ("meta_key", "meta_value"):
+            raise SqliteSchemaError("SQLite v2 schema store_meta columns are invalid")
+        if [str(row[1]) for row in meta_info if int(row[5] or 0) > 0] != ["meta_key"]:
+            raise SqliteSchemaError(
+                "SQLite v2 schema store_meta primary key is invalid"
+            )
+        if any(int(row[3] or 0) != 1 for row in meta_info):
+            raise SqliteSchemaError(
+                "SQLite v2 schema store_meta nullability is invalid"
+            )
+        if tuple(str(row[2]).upper() for row in meta_info) != ("TEXT", "TEXT"):
+            raise SqliteSchemaError("SQLite v2 schema store_meta types are invalid")
+
+        schema_row = connection.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='store_sections'"
+        ).fetchone()
+        schema_sql = (
+            str(schema_row[0] if schema_row else "").casefold().replace(" ", "")
+        )
+        for constraint_name in (
+            "store_sections_schema_v2",
+            "store_sections_positive_revision",
+            "store_sections_deleted_flag",
+        ):
+            if constraint_name not in schema_sql:
+                raise SqliteSchemaError("SQLite v2 schema write guards are missing")
+
+        metadata = self._metadata(connection)
+        if set(metadata) != {"initialized", "next_revision"}:
+            raise SqliteSchemaError("SQLite store meta keys are invalid")
+        if metadata.get("initialized") not in {"0", "1"}:
+            raise SqliteSchemaError("SQLite store meta initialized is invalid")
+        next_revision = self._metadata_integer(metadata, "next_revision")
+        invalid_row = connection.execute(
+            "SELECT section_name FROM store_sections "
+            "WHERE typeof(schema_version)<>'integer' OR schema_version<>2 "
+            "OR typeof(revision)<>'integer' OR revision<=0 OR revision>? "
+            "OR typeof(is_deleted)<>'integer' OR is_deleted NOT IN (0,1) "
+            "OR (length(checksum) NOT IN (0,64)) "
+            "OR (is_deleted=1 AND payload_json<>'null') LIMIT 1",
+            (_MAX_SECTION_REVISION,),
+        ).fetchone()
+        if invalid_row is not None:
+            raise SqliteSchemaError(
+                f"SQLite v2 section metadata is invalid: {invalid_row[0]}"
+            )
+        row_count, maximum_revision = connection.execute(
+            "SELECT COUNT(*),COALESCE(MAX(revision),0) FROM store_sections"
+        ).fetchone()
+        if next_revision <= int(maximum_revision or 0):
+            raise SqliteSchemaError("SQLite store meta next_revision is stale")
+        if metadata["initialized"] == "0" and (
+            int(row_count or 0) != 0 or next_revision != 1
+        ):
+            raise SqliteSchemaError(
+                "SQLite uninitialized store metadata is inconsistent"
+            )
+        if (
+            metadata["initialized"] == "1"
+            and int(row_count or 0) == 0
+            and next_revision < 2
+        ):
+            raise SqliteSchemaError(
+                "SQLite initialized empty store metadata is inconsistent"
+            )
+
+    def _create_empty_v2_schema(self, connection: sqlite3.Connection) -> None:
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            self._create_sections_table(connection, "store_sections")
+            self._create_meta_table(connection)
+            connection.executemany(
+                "INSERT INTO store_meta(meta_key,meta_value) VALUES(?,?)",
+                (("initialized", "0"), ("next_revision", "1")),
+            )
+            connection.execute(f"PRAGMA user_version={_SCHEMA_VERSION}")
+            self._validate_v2_schema(connection)
+            connection.commit()
+        except Exception:
+            connection.rollback()
+            raise
+
+    def _backup_v1_database(self, source: sqlite3.Connection) -> Path:
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+        backup_path = self.db_path.with_name(
+            f"{self.db_path.name}.pre-v2-{timestamp}-{uuid.uuid4().hex[:12]}.bak"
+        )
+        destination: sqlite3.Connection | None = None
+        try:
+            destination = sqlite3.connect(str(backup_path), timeout=15.0)
+            source.backup(destination)
+            check = destination.execute("PRAGMA quick_check").fetchone()
+            if check is None or str(check[0]).casefold() != "ok":
+                raise SqliteSchemaError(
+                    "SQLite pre-migration backup integrity check failed"
+                )
+            destination.commit()
+            return backup_path
+        except Exception:
+            if destination is not None:
+                destination.close()
+                destination = None
+            try:
+                backup_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise
+        finally:
+            if destination is not None:
+                destination.close()
+
+    def _migrate_v1_to_v2(self, connection: sqlite3.Connection) -> None:
+        self._validate_v1_schema(connection)
+        backup_path = self._backup_v1_database(connection)
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            rows = connection.execute(
+                "SELECT section_name,payload_json,updated_at,checksum,schema_version "
+                "FROM store_sections ORDER BY section_name"
+            ).fetchall()
+            prepared: list[tuple[str, str, float, str, int, int, int]] = []
+            for raw_name, raw_payload, raw_updated_at, raw_checksum, raw_schema in rows:
+                name = _section_name(raw_name)
+                if (
+                    isinstance(raw_schema, bool)
+                    or not isinstance(raw_schema, int)
+                    or raw_schema != 1
+                ):
+                    raise SqliteSchemaError(
+                        f"SQLite v1 section schema version is invalid: {name}"
+                    )
+                try:
+                    parsed = json.loads(raw_payload)
+                except (TypeError, json.JSONDecodeError) as exc:
+                    raise ValueError(
+                        f"SQLite v1 section payload contains invalid JSON: {name}"
+                    ) from exc
+                payload_json = _canonical_json(parsed)
+                checksum = _payload_checksum(payload_json)
+                existing_checksum = str(raw_checksum or "")
+                if existing_checksum and existing_checksum != checksum:
+                    raise SqliteSchemaError(
+                        f"SQLite v1 section checksum mismatch: {name}"
+                    )
+                try:
+                    updated_at = float(raw_updated_at)
+                except (TypeError, ValueError, OverflowError) as exc:
+                    raise SqliteSchemaError(
+                        f"SQLite v1 section timestamp is invalid: {name}"
+                    ) from exc
+                prepared.append(
+                    (name, payload_json, updated_at, checksum, _SCHEMA_VERSION, 1, 0)
+                )
+
+            self._create_sections_table(connection, "store_sections_v2_migration")
+            connection.executemany(
+                "INSERT INTO store_sections_v2_migration("
+                "section_name,payload_json,updated_at,checksum,schema_version,revision,is_deleted"
+                ") VALUES(?,?,?,?,?,?,?)",
+                prepared,
+            )
+            verification_rows = connection.execute(
+                "SELECT section_name,payload_json,checksum FROM store_sections_v2_migration "
+                "ORDER BY section_name"
+            ).fetchall()
+            expected_rows = [(row[0], row[1], row[3]) for row in prepared]
+            if verification_rows != expected_rows:
+                raise SqliteSchemaError("SQLite v1 to v2 copy verification failed")
+
+            connection.execute("DROP TABLE store_sections")
+            connection.execute(
+                "ALTER TABLE store_sections_v2_migration RENAME TO store_sections"
+            )
+            self._create_meta_table(connection)
+            initialized = "1" if prepared else "0"
+            next_revision = "2" if prepared else "1"
+            connection.executemany(
+                "INSERT INTO store_meta(meta_key,meta_value) VALUES(?,?)",
+                (("initialized", initialized), ("next_revision", next_revision)),
+            )
+            connection.execute(f"PRAGMA user_version={_SCHEMA_VERSION}")
+            self._validate_v2_schema(connection)
+            integrity = connection.execute("PRAGMA integrity_check").fetchone()
+            if integrity is None or str(integrity[0]).casefold() != "ok":
+                raise SqliteSchemaError("SQLite v1 to v2 integrity check failed")
+            connection.commit()
+            logger.info(
+                "[PrivateCompanion] Migrated SQLite store schema to v2 after creating backup: %s",
+                backup_path,
+            )
+        except Exception:
+            connection.rollback()
+            raise
+
+    def _ensure_schema(self, connection: sqlite3.Connection) -> None:
+        version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+        if version > _SCHEMA_VERSION:
+            raise SqliteUnsupportedSchemaError(
+                f"Unsupported SQLite store schema version {version}"
+            )
+        if version not in {0, 1, _SCHEMA_VERSION}:
+            raise SqliteSchemaError(
+                f"SQLite schema version marker is invalid: {version}"
+            )
+        if version == _SCHEMA_VERSION:
+            self._validate_v2_schema(connection)
+            return
+
+        tables = self._table_names(connection)
+        if "store_sections" in tables:
+            self._migrate_v1_to_v2(connection)
+            return
+        if version != 0 or tables:
+            raise SqliteSchemaError("SQLite schema marker does not match its tables")
+        self._create_empty_v2_schema(connection)
+
     def _connect(self) -> sqlite3.Connection:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
-        conn = sqlite3.connect(str(self.db_path), timeout=15.0)
-        conn.execute("PRAGMA busy_timeout=15000")
-        conn.execute("PRAGMA journal_mode=WAL")
-        conn.execute("PRAGMA synchronous=NORMAL")
-        conn.execute(
-            "CREATE TABLE IF NOT EXISTS store_sections ("
-            "section_name TEXT PRIMARY KEY, "
-            "payload_json TEXT NOT NULL, "
-            "updated_at REAL NOT NULL, "
-            "checksum TEXT DEFAULT '', "
-            "schema_version INTEGER DEFAULT 1)"
-        )
-        conn.commit()
-        return conn
+        with self._schema_lock:
+            connection = sqlite3.connect(str(self.db_path), timeout=15.0)
+            try:
+                connection.execute("PRAGMA busy_timeout=15000")
+                self._ensure_schema(connection)
+                connection.execute("PRAGMA journal_mode=WAL")
+                connection.execute("PRAGMA synchronous=NORMAL")
+                return connection
+            except Exception:
+                connection.close()
+                raise
+
+    @staticmethod
+    def _initialized(connection: sqlite3.Connection) -> bool:
+        row = connection.execute(
+            "SELECT meta_value FROM store_meta WHERE meta_key='initialized'"
+        ).fetchone()
+        return row is not None and str(row[0]) == "1"
 
     def load_store(self) -> dict[str, Any]:
         if not self.exists():
             return self.new_store()
         try:
-            conn = self._connect()
-            try:
-                rows = conn.execute("SELECT section_name, payload_json FROM store_sections").fetchall()
-            finally:
-                conn.close()
-            if not rows:
-                raise SqliteStoreNotInitializedError(
-                    f"SQLite store is not initialized: {self.db_path}"
-                )
-            data: dict[str, Any] = self.new_store()
-            for section_name, payload_json in rows:
+            with self._schema_lock:
+                connection = self._connect()
                 try:
-                    data[str(section_name)] = json.loads(payload_json)
+                    if not self._initialized(connection):
+                        raise SqliteStoreNotInitializedError(
+                            f"SQLite store is not initialized: {self.db_path}"
+                        )
+                    rows = connection.execute(
+                        "SELECT section_name,payload_json,checksum,schema_version,revision,is_deleted "
+                        "FROM store_sections ORDER BY section_name"
+                    ).fetchall()
+                finally:
+                    connection.close()
+
+            data: dict[str, Any] = {}
+            tombstoned_sections: set[str] = set()
+            for (
+                section_name,
+                payload_json,
+                checksum,
+                schema_version,
+                revision,
+                is_deleted,
+            ) in rows:
+                name = str(section_name)
+                try:
+                    parsed = json.loads(payload_json)
                 except Exception as exc:
                     raise ValueError(
-                        f"SQLite section payload is invalid: {section_name}"
+                        f"SQLite section payload is invalid: {name}"
                     ) from exc
-            return self.ensure_defaults(data)
+                canonical = _canonical_json(parsed)
+                if (
+                    int(schema_version) != _SCHEMA_VERSION
+                    or int(revision) <= 0
+                    or (str(checksum) and str(checksum) != _payload_checksum(canonical))
+                ):
+                    raise ValueError(f"SQLite section checksum is invalid: {name}")
+                if int(is_deleted):
+                    if parsed is not None or str(payload_json) != "null":
+                        raise ValueError(f"SQLite section tombstone is invalid: {name}")
+                    tombstoned_sections.add(name)
+                    continue
+                data[name] = parsed
+            data = self.ensure_defaults(data)
+            for name in tombstoned_sections:
+                data.pop(name, None)
+            return data
         except SqliteStoreNotInitializedError:
             raise
         except Exception as exc:
@@ -81,40 +541,336 @@ class SqliteStoreBackend(StoreBackendBase):
             )
             raise
 
+    @staticmethod
+    def _upsert_sql() -> str:
+        return (
+            "INSERT INTO store_sections("
+            "section_name,payload_json,updated_at,checksum,schema_version,revision,is_deleted"
+            ") VALUES(?,?,?,?,?,?,?) "
+            "ON CONFLICT(section_name) DO UPDATE SET "
+            "payload_json=CASE WHEN (store_sections.checksum=excluded.checksum "
+            "OR (store_sections.checksum='' "
+            "AND store_sections.payload_json=excluded.payload_json)) "
+            "AND store_sections.is_deleted=excluded.is_deleted "
+            "THEN store_sections.payload_json ELSE excluded.payload_json END,"
+            "updated_at=CASE WHEN (store_sections.checksum=excluded.checksum "
+            "OR (store_sections.checksum='' "
+            "AND store_sections.payload_json=excluded.payload_json)) "
+            "AND store_sections.is_deleted=excluded.is_deleted "
+            "THEN store_sections.updated_at ELSE excluded.updated_at END,"
+            "checksum=excluded.checksum,"
+            "schema_version=excluded.schema_version,"
+            "revision=excluded.revision,"
+            "is_deleted=excluded.is_deleted"
+        )
+
+    def _replace_store(
+        self,
+        data: dict[str, Any],
+        *,
+        minimum_revision: int | None = None,
+        deleted_sections: Mapping[str, int] | None = None,
+        preserve_tombstones: bool = False,
+    ) -> int:
+        if not isinstance(data, dict):
+            raise TypeError("SQLite full store payload must be a dictionary")
+        if minimum_revision is not None:
+            minimum_revision = _revision(minimum_revision)
+        if deleted_sections is None:
+            deleted_sections = {}
+        if not isinstance(deleted_sections, Mapping):
+            raise TypeError("SQLite full snapshot deleted sections require a mapping")
+        prepared: list[tuple[str, str, str]] = []
+        prepared_names: set[str] = set()
+        for raw_name, payload in data.items():
+            name = _section_name(raw_name)
+            if name in prepared_names:
+                raise ValueError(f"Duplicate SQLite section name: {name}")
+            prepared_names.add(name)
+            payload_json = _canonical_json(payload)
+            prepared.append((name, payload_json, _payload_checksum(payload_json)))
+        deleted: dict[str, int] = {}
+        for raw_name, raw_revision in deleted_sections.items():
+            name = _section_name(raw_name)
+            if name in prepared_names:
+                raise ValueError(
+                    f"SQLite full snapshot section is both changed and deleted: {name}"
+                )
+            deleted[name] = _revision(raw_revision)
+
+        with self._schema_lock:
+            connection = self._connect()
+            try:
+                connection.execute("BEGIN IMMEDIATE")
+                metadata = self._metadata(connection)
+                baseline_revision = self._metadata_integer(metadata, "next_revision")
+                if minimum_revision is not None:
+                    baseline_revision = max(baseline_revision, minimum_revision)
+                if deleted:
+                    baseline_revision = max(baseline_revision, max(deleted.values()))
+                if preserve_tombstones:
+                    preserved = {
+                        str(name): int(revision)
+                        for name, revision in connection.execute(
+                            "SELECT section_name,revision FROM store_sections "
+                            "WHERE is_deleted=1"
+                        )
+                        if str(name) not in prepared_names and str(name) not in deleted
+                    }
+                    deleted.update(preserved)
+                    if preserved:
+                        baseline_revision = max(baseline_revision, max(preserved.values()))
+                _revision(baseline_revision)
+                now = time.time()
+                connection.execute("DELETE FROM store_sections")
+                connection.executemany(
+                    "INSERT INTO store_sections("
+                    "section_name,payload_json,updated_at,checksum,schema_version,revision,is_deleted"
+                    ") VALUES(?,?,?,?,?,?,0)",
+                    [
+                        (
+                            name,
+                            payload_json,
+                            now,
+                            checksum,
+                            _SCHEMA_VERSION,
+                            baseline_revision,
+                        )
+                        for name, payload_json, checksum in prepared
+                    ],
+                )
+                connection.executemany(
+                    "INSERT INTO store_sections("
+                    "section_name,payload_json,updated_at,checksum,schema_version,revision,is_deleted"
+                    ") VALUES(?,?,?,?,?,?,1)",
+                    [
+                        (
+                            name,
+                            "null",
+                            now,
+                            _payload_checksum("null"),
+                            _SCHEMA_VERSION,
+                            baseline_revision,
+                        )
+                        for name in deleted
+                    ],
+                )
+                connection.execute(
+                    "UPDATE store_meta SET meta_value='1' WHERE meta_key='initialized'"
+                )
+                connection.execute(
+                    "UPDATE store_meta SET meta_value=? WHERE meta_key='next_revision'",
+                    (str(baseline_revision + 1),),
+                )
+                connection.commit()
+                return baseline_revision
+            except Exception:
+                connection.rollback()
+                raise
+            finally:
+                connection.close()
+
     def save_store(self, data: dict[str, Any]) -> None:
-        conn = self._connect()
-        try:
-            now = time.time()
-            with conn:
-                section_names = [str(section_name) for section_name in data.keys()]
-                if section_names:
-                    placeholders = ",".join("?" for _ in section_names)
-                    conn.execute(
-                        f"DELETE FROM store_sections WHERE section_name NOT IN ({placeholders})",
-                        section_names,
-                    )
-                else:
-                    conn.execute("DELETE FROM store_sections")
-                for section_name, payload in data.items():
-                    conn.execute(
-                        "REPLACE INTO store_sections(section_name, payload_json, updated_at, checksum, schema_version) "
-                        "VALUES (?, ?, ?, '', 1)",
-                        (str(section_name), json.dumps(payload, ensure_ascii=False), now),
-                    )
-        finally:
-            conn.close()
+        self._replace_store(data)
 
-    def save_snapshot(self, data: dict[str, Any]) -> None:
-        self.save_store(data)
+    def save_sections(
+        self,
+        changed_sections: Mapping[str, tuple[int, Any]],
+        deleted_sections: Mapping[str, int],
+    ) -> dict[str, int]:
+        if not isinstance(changed_sections, Mapping) or not isinstance(
+            deleted_sections, Mapping
+        ):
+            raise TypeError("SQLite partial writes require mapping inputs")
+        overlap = set(changed_sections).intersection(deleted_sections)
+        if overlap:
+            raise ValueError(
+                f"SQLite changed and deleted sections overlap: {sorted(map(str, overlap))}"
+            )
 
-    def health_check(self) -> dict[str, Any]:
+        prepared: dict[str, tuple[int, str, str, int]] = {}
+        for raw_name, value in changed_sections.items():
+            name = _section_name(raw_name)
+            if not isinstance(value, tuple) or len(value) != 2:
+                raise ValueError(
+                    "SQLite changed section value must be a (revision, payload) tuple"
+                )
+            revision = _revision(value[0])
+            payload_json = _canonical_json(value[1])
+            prepared[name] = (
+                revision,
+                payload_json,
+                _payload_checksum(payload_json),
+                0,
+            )
+        for raw_name, raw_revision in deleted_sections.items():
+            name = _section_name(raw_name)
+            revision = _revision(raw_revision)
+            payload_json = "null"
+            prepared[name] = (
+                revision,
+                payload_json,
+                _payload_checksum(payload_json),
+                1,
+            )
+        if not prepared:
+            return {}
+
+        confirmed = {name: values[0] for name, values in prepared.items()}
+        with self._schema_lock:
+            connection = self._connect()
+            try:
+                connection.execute("BEGIN IMMEDIATE")
+                metadata = self._metadata(connection)
+                next_revision = self._metadata_integer(metadata, "next_revision")
+                persisted: dict[str, tuple[str, int, int] | None] = {}
+                for name in sorted(prepared):
+                    row = connection.execute(
+                        "SELECT payload_json,checksum,revision,is_deleted "
+                        "FROM store_sections WHERE section_name=?",
+                        (name,),
+                    ).fetchone()
+                    if row is None:
+                        persisted[name] = None
+                        continue
+                    stored_payload, stored_checksum, stored_revision, stored_deleted = (
+                        row
+                    )
+                    persisted[name] = (
+                        str(stored_checksum),
+                        int(stored_revision),
+                        int(stored_deleted),
+                    )
+                    requested_revision, payload_json, checksum, is_deleted = prepared[
+                        name
+                    ]
+                    stored_checksum = str(stored_checksum)
+                    stored_payload = str(stored_payload)
+                    stored_deleted = int(stored_deleted)
+                    same_payload = stored_payload == payload_json
+                    same_delete_state = stored_deleted == is_deleted
+                    if requested_revision < int(stored_revision):
+                        raise SqliteRevisionConflictError(
+                            f"SQLite section revision moved backwards: {name}"
+                        )
+                    if requested_revision == int(stored_revision):
+                        checksum_matches = stored_checksum == checksum
+                        legacy_checksum_upgrade = not stored_checksum and same_payload
+                        if (
+                            not same_delete_state
+                            or not same_payload
+                            or (not checksum_matches and not legacy_checksum_upgrade)
+                        ):
+                            raise SqliteRevisionConflictError(
+                                f"SQLite section content conflicts at equal revision: {name}"
+                            )
+                now = time.time()
+                upsert_sql = self._upsert_sql()
+                for name in sorted(prepared):
+                    requested_revision, payload_json, checksum, is_deleted = prepared[
+                        name
+                    ]
+                    stored = persisted[name]
+                    if (
+                        stored is not None
+                        and requested_revision == stored[1]
+                        and stored[0] == checksum
+                    ):
+                        continue
+                    connection.execute(
+                        upsert_sql,
+                        (
+                            name,
+                            payload_json,
+                            now,
+                            checksum,
+                            _SCHEMA_VERSION,
+                            requested_revision,
+                            is_deleted,
+                        ),
+                    )
+                connection.execute(
+                    "UPDATE store_meta SET meta_value='1' WHERE meta_key='initialized'"
+                )
+                connection.execute(
+                    "UPDATE store_meta SET meta_value=? WHERE meta_key='next_revision'",
+                    (str(max(next_revision, max(confirmed.values()) + 1)),),
+                )
+                connection.commit()
+                return confirmed
+            except Exception:
+                connection.rollback()
+                raise
+            finally:
+                connection.close()
+
+    def save_snapshot(
+        self,
+        data: dict[str, Any],
+        *,
+        minimum_revision: int | None = None,
+        deleted_sections: Mapping[str, int] | None = None,
+        preserve_tombstones: bool = False,
+    ) -> int:
+        return self._replace_store(
+            data,
+            minimum_revision=minimum_revision,
+            deleted_sections=deleted_sections,
+            preserve_tombstones=preserve_tombstones,
+        )
+
+    def next_revision(self) -> int:
+        if not self.exists():
+            return 1
+        with self._schema_lock:
+            connection = self._connect()
+            try:
+                return self._metadata_integer(
+                    self._metadata(connection),
+                    "next_revision",
+                )
+            finally:
+                connection.close()
+
+    def deleted_section_revisions(
+        self,
+        section_names: Collection[str],
+    ) -> dict[str, int]:
+        names = sorted({_section_name(name) for name in section_names})
+        if not names or not self.exists():
+            return {}
+        result: dict[str, int] = {}
+        with self._schema_lock:
+            connection = self._connect()
+            try:
+                for name in names:
+                    row = connection.execute(
+                        "SELECT revision FROM store_sections "
+                        "WHERE section_name=? AND is_deleted=1",
+                        (name,),
+                    ).fetchone()
+                    if row is not None:
+                        result[name] = int(row[0])
+            finally:
+                connection.close()
+        return result
+
+    def health_check(self, *, raise_on_error: bool = False) -> dict[str, Any]:
         ok = True
         error = ""
         try:
-            conn = self._connect()
-            conn.execute("SELECT 1")
-            conn.close()
+            if self.exists():
+                with self._schema_lock:
+                    connection = self._connect()
+                    try:
+                        check = connection.execute("PRAGMA integrity_check").fetchone()
+                        if check is None or str(check[0]).casefold() != "ok":
+                            raise SqliteSchemaError("SQLite integrity_check failed")
+                    finally:
+                        connection.close()
         except Exception as exc:
+            if raise_on_error:
+                raise
             ok = False
             error = str(exc)
         return {

--- a/storage/store_manager.py
+++ b/storage/store_manager.py
@@ -2,9 +2,10 @@
 from __future__ import annotations
 
 import threading
+from collections.abc import Callable, Collection, Mapping
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 from astrbot.api import logger
 
@@ -13,7 +14,6 @@ from .factory import build_store_backend
 from .json_backend import JsonStoreBackend
 from .migration import migrate_json_to_backend_if_needed
 from .sqlite_backend import SqliteStoreNotInitializedError
-
 
 _BOOKSHELF_SECTIONS = (
     "bookshelf_items",
@@ -82,10 +82,7 @@ def _is_jm_bookshelf_item(item: Any) -> bool:
     source = str(item.get("source") or "").strip()
     return bool(
         isinstance(item.get("pages"), list)
-        and (
-            str(item.get("album_id") or "").strip()
-            or source.startswith("bookshelf_")
-        )
+        and (str(item.get("album_id") or "").strip() or source.startswith("bookshelf_"))
     )
 
 
@@ -115,7 +112,9 @@ def _bookshelf_item_is_blocked(
     return bool(title and title in deleted_titles)
 
 
-def _merge_string_history(primary: Any, secondary: Any, *, limit: int = 300) -> list[Any]:
+def _merge_string_history(
+    primary: Any, secondary: Any, *, limit: int = 300
+) -> list[Any]:
     merged: list[Any] = []
     seen: set[str] = set()
     for source in (primary, secondary):
@@ -147,8 +146,12 @@ def reconcile_bookshelf_payload(
 
     primary_state_raw = primary.get("jm_cosmos_integration")
     secondary_state_raw = secondary.get("jm_cosmos_integration")
-    primary_state = deepcopy(primary_state_raw) if isinstance(primary_state_raw, dict) else None
-    secondary_state = deepcopy(secondary_state_raw) if isinstance(secondary_state_raw, dict) else None
+    primary_state = (
+        deepcopy(primary_state_raw) if isinstance(primary_state_raw, dict) else None
+    )
+    secondary_state = (
+        deepcopy(secondary_state_raw) if isinstance(secondary_state_raw, dict) else None
+    )
     if primary_state is not None:
         merged_state: dict[str, Any] | None = deepcopy(secondary_state or {})
         merged_state.update(primary_state)
@@ -159,12 +162,18 @@ def reconcile_bookshelf_payload(
 
     if preferred_revision == fallback_revision and merged_state is not None:
         deleted_ids = _merge_string_history(
-            primary_state.get("deleted_album_ids") if primary_state is not None else None,
-            secondary_state.get("deleted_album_ids") if secondary_state is not None else None,
+            primary_state.get("deleted_album_ids")
+            if primary_state is not None
+            else None,
+            secondary_state.get("deleted_album_ids")
+            if secondary_state is not None
+            else None,
         )
         deleted_titles = _merge_string_history(
             primary_state.get("deleted_titles") if primary_state is not None else None,
-            secondary_state.get("deleted_titles") if secondary_state is not None else None,
+            secondary_state.get("deleted_titles")
+            if secondary_state is not None
+            else None,
         )
         if deleted_ids:
             merged_state["deleted_album_ids"] = deleted_ids
@@ -177,7 +186,8 @@ def reconcile_bookshelf_payload(
             for value in merged_state.get("deleted_album_ids", [])
             if str(value).strip()
         }
-        if isinstance(merged_state, dict) and isinstance(merged_state.get("deleted_album_ids"), list)
+        if isinstance(merged_state, dict)
+        and isinstance(merged_state.get("deleted_album_ids"), list)
         else set()
     )
     blocked_titles = (
@@ -186,13 +196,16 @@ def reconcile_bookshelf_payload(
             for value in merged_state.get("deleted_titles", [])
             if (marker := _bookshelf_title_marker(value))
         }
-        if isinstance(merged_state, dict) and isinstance(merged_state.get("deleted_titles"), list)
+        if isinstance(merged_state, dict)
+        and isinstance(merged_state.get("deleted_titles"), list)
         else set()
     )
     primary_items_raw = primary.get("bookshelf_items")
     secondary_items_raw = secondary.get("bookshelf_items")
     primary_items = primary_items_raw if isinstance(primary_items_raw, list) else []
-    secondary_items = secondary_items_raw if isinstance(secondary_items_raw, list) else []
+    secondary_items = (
+        secondary_items_raw if isinstance(secondary_items_raw, list) else []
+    )
     primary_identities = {
         identity
         for raw_item in primary_items
@@ -239,13 +252,10 @@ def reconcile_bookshelf_payload(
         or preferred.get("bookshelf_items") is None
     ):
         result["bookshelf_items"] = merged_items
-    if (
-        merged_state is not None
-        and (
-            isinstance(preferred.get("jm_cosmos_integration"), dict)
-            or bool(merged_state)
-            or preferred.get("jm_cosmos_integration") is None
-        )
+    if merged_state is not None and (
+        isinstance(preferred.get("jm_cosmos_integration"), dict)
+        or bool(merged_state)
+        or preferred.get("jm_cosmos_integration") is None
     ):
         result["jm_cosmos_integration"] = merged_state
 
@@ -291,13 +301,19 @@ class StoreManager:
             ensure_defaults=ensure_defaults,
             new_store=new_store,
         )
-        self.backend = self.sqlite_backend if self.backend_name == "sqlite" else self.json_backend
-        active_path = self.sqlite_path if self.backend_name == "sqlite" else self.data_file
+        self.backend = (
+            self.sqlite_backend if self.backend_name == "sqlite" else self.json_backend
+        )
+        active_path = (
+            self.sqlite_path if self.backend_name == "sqlite" else self.data_file
+        )
         self._store_lock = _shared_store_lock(active_path)
         self._json_store_lock = _shared_store_lock(self.data_file)
 
     @staticmethod
-    def _load_optional_store(backend: Any, *, strict: bool = False) -> dict[str, Any] | None:
+    def _load_optional_store(
+        backend: Any, *, strict: bool = False
+    ) -> dict[str, Any] | None:
         if backend is None or not backend.exists():
             return None
         try:
@@ -324,7 +340,21 @@ class StoreManager:
     ) -> dict[str, Any]:
         if not isinstance(fallback, dict):
             return selected
+        deleted_revisions: Mapping[str, int] = {}
+        if self.backend.backend_name() == "sqlite":
+            deleted_revisions = self.backend.deleted_section_revisions(
+                _BOOKSHELF_SECTIONS
+            )
         reconciled, changed, recovered = reconcile_bookshelf_payload(selected, fallback)
+        if deleted_revisions:
+            for key in deleted_revisions:
+                if key in selected:
+                    reconciled[key] = deepcopy(selected[key])
+                else:
+                    reconciled.pop(key, None)
+            changed = any(
+                reconciled.get(key) != selected.get(key) for key in _BOOKSHELF_SECTIONS
+            )
         if not changed:
             return selected
         logger.warning(
@@ -335,7 +365,17 @@ class StoreManager:
         )
         if persist:
             try:
-                self.backend.save_store(reconciled)
+                if self.backend.backend_name() == "sqlite":
+                    revision = self.backend.next_revision()
+                    changed_sections = {
+                        key: (revision, deepcopy(reconciled[key]))
+                        for key in _BOOKSHELF_SECTIONS
+                        if key in reconciled and key not in deleted_revisions
+                    }
+                    deleted_sections = {key: revision for key in deleted_revisions}
+                    self.backend.save_sections(changed_sections, deleted_sections)
+                else:
+                    self.backend.save_store(reconciled)
             except Exception as exc:
                 logger.warning(
                     "[PrivateCompanion] 夹层恢复结果暂未写回 %s，本进程继续使用已恢复数据: %s",
@@ -355,7 +395,9 @@ class StoreManager:
                     fallback_name="SQLite",
                     persist=True,
                 )
-            selected = migrate_json_to_backend_if_needed(self.backend, self.json_backend, self.new_store())
+            selected = migrate_json_to_backend_if_needed(
+                self.backend, self.json_backend, self.new_store()
+            )
             fallback = self._load_optional_store(self.json_backend)
             return self._apply_bookshelf_recovery(
                 selected,
@@ -384,7 +426,11 @@ class StoreManager:
     def save_store(self, data: dict[str, Any]) -> None:
         with self._store_lock:
             data = self._prepare_store_for_save(data)
-            if self.backend.backend_name() == "json" and not data.get("worldbook_entries") and self.json_backend.exists():
+            if (
+                self.backend.backend_name() == "json"
+                and not data.get("worldbook_entries")
+                and self.json_backend.exists()
+            ):
                 existing = self.json_backend.load_store()
                 if isinstance(existing, dict) and existing.get("worldbook_entries"):
                     for key in (
@@ -396,13 +442,44 @@ class StoreManager:
                         data[key] = existing.get(key, data.get(key))
             self.backend.save_store(data)
 
-    def save_snapshot(self, data: dict[str, Any]) -> None:
+    def save_snapshot(
+        self,
+        data: dict[str, Any],
+        *,
+        minimum_revision: int | None = None,
+        deleted_sections: Mapping[str, int] | None = None,
+        preserve_tombstones: bool = False,
+    ) -> int | None:
         with self._store_lock:
-            self.backend.save_snapshot(self._prepare_store_for_save(data))
+            return self.backend.save_snapshot(
+                self._prepare_store_for_save(data),
+                minimum_revision=minimum_revision,
+                deleted_sections=deleted_sections,
+                preserve_tombstones=preserve_tombstones,
+            )
+
+    def save_sections(
+        self,
+        changed_sections: Mapping[str, tuple[int, Any]],
+        deleted_sections: Mapping[str, int],
+    ) -> Mapping[str, int]:
+        with self._store_lock:
+            return self.backend.save_sections(changed_sections, deleted_sections)
+
+    def next_revision(self) -> int:
+        with self._store_lock:
+            return self.backend.next_revision()
+
+    def deleted_section_revisions(
+        self,
+        section_names: Collection[str],
+    ) -> Mapping[str, int]:
+        with self._store_lock:
+            return self.backend.deleted_section_revisions(section_names)
 
     def export_current_to_json(self, data: dict[str, Any]) -> None:
         with self._json_store_lock:
             self.json_backend.save_store(deepcopy(data))
 
-    def health_check(self) -> dict[str, Any]:
-        return self.backend.health_check()
+    def health_check(self, *, raise_on_error: bool = False) -> dict[str, Any]:
+        return self.backend.health_check(raise_on_error=raise_on_error)

--- a/tests/test_chat_ops_parity_p4_p6.py
+++ b/tests/test_chat_ops_parity_p4_p6.py
@@ -415,7 +415,7 @@ class P4P6ParityTests(unittest.TestCase):
                 self.enable_p4_b_legacy_score_isolation = isolated
                 self.save_calls = 0
 
-            def _schedule_data_save(self) -> None:
+            def _schedule_data_save(self, *_args, **_kwargs) -> None:
                 self.save_calls += 1
 
         isolated_host = Host(True)

--- a/tests/test_command_config_persistence.py
+++ b/tests/test_command_config_persistence.py
@@ -77,7 +77,7 @@ class _WeatherCommandHarness(CommandHandlersMixin, DailyStateMixin):
     async def _save_config_if_possible(self) -> bool:
         return self.save_result
 
-    def _save_data_sync(self) -> None:
+    def _save_data_sync(self, **_kwargs: Any) -> None:
         return None
 
 

--- a/tests/test_core_store_failure_safety.py
+++ b/tests/test_core_store_failure_safety.py
@@ -98,7 +98,7 @@ class _IdentityCoreHarness(CoreStoreMixin):
         user["last_inbound_umo"] = umo
 
     @staticmethod
-    def _schedule_data_save() -> None:
+    def _schedule_data_save(*_args, **_kwargs) -> None:
         return None
 
 

--- a/tests/test_creative_progress_resilience.py
+++ b/tests/test_creative_progress_resilience.py
@@ -163,7 +163,7 @@ class _DisabledCreativePlanHarness(ProactiveMixin, ProactiveEngineMixin):
     def _clear_planned_proactive_trigger(_user) -> None:
         return None
 
-    def _schedule_data_save(self) -> None:
+    def _schedule_data_save(self, *_args, **_kwargs) -> None:
         self.saved += 1
 
 

--- a/tests/test_daily_schedule_segment_api.py
+++ b/tests/test_daily_schedule_segment_api.py
@@ -83,7 +83,7 @@ class SchedulePluginHarness(DailyStateMixin):
             int(match.group(3)) * 60 + int(match.group(4)),
         )
 
-    def _save_data_sync(self) -> None:
+    def _save_data_sync(self, **_kwargs) -> None:
         self.saved += 1
 
     async def _ensure_daily_state(self, force: bool = False):

--- a/tests/test_daily_state_generation_safety.py
+++ b/tests/test_daily_state_generation_safety.py
@@ -68,7 +68,7 @@ class _StateHarness(DailyStateMixin):
     def _record_body_cycle_episode(self, condition) -> None:
         self.data["body_cycle_state"] = deepcopy(condition)
 
-    def _save_data_sync(self) -> None:
+    def _save_data_sync(self, **_kwargs) -> None:
         self.save_count += 1
 
 
@@ -111,7 +111,7 @@ class _DiaryHarness(DailyStateMixin):
     async def _memory_companion_record_dream_fragment(self, **_kwargs) -> None:
         return None
 
-    def _save_data_sync(self) -> None:
+    def _save_data_sync(self, **_kwargs) -> None:
         self.save_count += 1
 
 

--- a/tests/test_environment_change_proactive.py
+++ b/tests/test_environment_change_proactive.py
@@ -43,7 +43,7 @@ class EnvironmentChangeHarness(DailyStateMixin):
     def _schedule_data_save(self, **_kwargs) -> None:
         return None
 
-    def _save_data_sync(self) -> None:
+    def _save_data_sync(self, **_kwargs) -> None:
         return None
 
 

--- a/tests/test_expression_learning.py
+++ b/tests/test_expression_learning.py
@@ -1364,6 +1364,7 @@ class GroupEpisodeExpressionHarness(GroupObservationMixin, ExpressionLearningHar
             "recent_messages": recent,
         }
         self.last_prompt = ""
+        self.last_system_prompt = ""
 
     def _get_group(self, group_id: str) -> dict:
         return self.data["groups"][group_id]
@@ -1379,6 +1380,7 @@ class GroupEpisodeExpressionHarness(GroupObservationMixin, ExpressionLearningHar
 
     async def _llm_call(self, prompt: str, **_kwargs) -> str:
         self.last_prompt = prompt
+        self.last_system_prompt = str(_kwargs.get("system_prompt") or "")
         return json.dumps(
             {
                 "summary": "群友在轻松地延续话题",
@@ -1468,12 +1470,13 @@ class EpisodeExpressionLearningTests(unittest.IsolatedAsyncioTestCase):
         style_rule = next(item for item in profile["pending_rules"] if item["kind"] == "style")
         self.assertEqual("好呀，那就____", style_rule["pattern"])
         self.assertEqual(["好呀~", "行啦~"], style_rule["evidence_examples"])
-        self.assertIn("可直接借鉴的短表达", harness.last_prompt)
-        self.assertIn("【已有表达规则】", harness.last_prompt)
-        self.assertIn("merge_into_id", harness.last_prompt)
-        self.assertIn("只做中性、安全的概括", harness.last_prompt)
-        self.assertIn("不重现敏感原话", harness.last_prompt)
-        self.assertNotIn("严禁复制成员原句", harness.last_prompt)
+        prompt = f"{harness.last_system_prompt}\n{harness.last_prompt}"
+        self.assertIn("可直接借鉴的短表达", prompt)
+        self.assertIn("【已有表达规则】", prompt)
+        self.assertIn("merge_into_id", prompt)
+        self.assertIn("只做中性、安全的概括", prompt)
+        self.assertIn("不得重现敏感原话", prompt)
+        self.assertNotIn("严禁复制成员原句", prompt)
         self.assertTrue(harness._get_group("group-1").get("last_expression_rule_source_ts"))
 
     async def test_group_episode_reports_missing_model_result_without_mislabeling_json(self):
@@ -1810,8 +1813,10 @@ class ExpressionScopeLifecycleTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertTrue(result["success"])
         self.assertEqual(1, result["data"]["rule_group_count"])
-        self.assertEqual(1, len({item.get("family_id") for item in profile["learned_rules"]}))
-        self.assertTrue(profile["learned_rules"][0]["family_id"].startswith("xf-"))
+        summary_rules = result["data"]["rules"]
+        self.assertEqual(1, len({item.get("family_id") for item in summary_rules}))
+        self.assertTrue(summary_rules[0]["family_id"].startswith("xf-"))
+        self.assertNotIn("family_id", profile["learned_rules"][0])
 
     async def test_rule_family_is_reviewed_and_deleted_as_one_group(self):
         profile = self.plugin.data["users"]["owner-1"]["expression_profile"]

--- a/tests/test_expression_learning.py
+++ b/tests/test_expression_learning.py
@@ -1331,7 +1331,7 @@ class PrivateEpisodeExpressionHarness(ExpressionLearningHarness):
         return ""
 
     @staticmethod
-    def _save_data_sync() -> None:
+    def _save_data_sync(**_kwargs) -> None:
         return None
 
 
@@ -1411,7 +1411,7 @@ class GroupEpisodeExpressionHarness(GroupObservationMixin, ExpressionLearningHar
         return ""
 
     @staticmethod
-    def _save_data_sync() -> None:
+    def _save_data_sync(**_kwargs) -> None:
         return None
 
 
@@ -1608,7 +1608,7 @@ class ExpressionScopeLifecyclePlugin(ExpressionLearningHarness):
         return str(user.get("relationship_role") or "friend")
 
     @staticmethod
-    def _save_data_sync() -> None:
+    def _save_data_sync(**_kwargs) -> None:
         return None
 
     def _refresh_expression_voice_profile(self) -> dict:

--- a/tests/test_expression_learning.py
+++ b/tests/test_expression_learning.py
@@ -677,11 +677,65 @@ class ExpressionLearningTests(unittest.TestCase):
             )
             result = self.harness._apply_expression_rule_feedback(recipient, complaint, channel="private")
             self.assertEqual("negative", result["signal"])
+            self.assertEqual(["users"], result["updated_sections"])
 
         profile = source["expression_profile"]
         self.assertEqual([], profile["learned_rules"])
         self.assertEqual("needs_review", profile["pending_rules"][0]["review_status"])
         self.assertEqual(2, profile["pending_rules"][0]["negative_feedback"])
+
+    def test_feedback_reports_group_source_section(self):
+        now = time.time()
+        group = {
+            "group_id": "group-1",
+            "expression_profile": {
+                "learned_rules": [
+                    {
+                        "id": "group-rule",
+                        "kind": "style",
+                        "situation": "casual acknowledgement",
+                        "pattern": "sure, ____",
+                        "instruction": "acknowledge before continuing",
+                        "evidence_count": 2,
+                        "last_seen_ts": now,
+                    }
+                ]
+            },
+        }
+        recipient = {
+            "user_id": "friend-1",
+            "relationship_role": "friend",
+            "expression_profile": {
+                "pending_semantic_feedback": {
+                    "ts": now,
+                    "channel": "private",
+                    "rules": [
+                        {
+                            "source_refs": [
+                                {
+                                    "source_kind": "group",
+                                    "source_id": "group-1",
+                                    "rule_id": "group-rule",
+                                }
+                            ]
+                        }
+                    ],
+                }
+            },
+        }
+        self.harness.data = {
+            "users": {"friend-1": recipient},
+            "groups": {"group-1": group},
+        }
+
+        result = self.harness._apply_expression_rule_feedback(
+            recipient,
+            "别这么说",
+            channel="private",
+        )
+
+        self.assertEqual("negative", result["signal"])
+        self.assertEqual(["groups"], result["updated_sections"])
 
     def test_page_summary_exposes_companion_applicability_and_feedback(self):
         user = {

--- a/tests/test_goodnight_screen_check.py
+++ b/tests/test_goodnight_screen_check.py
@@ -153,7 +153,7 @@ class _GoodnightScreenHarness(ProactiveMessageMixin):
             return raw
         return json.loads(str(raw))
 
-    def _save_data_sync(self) -> None:
+    def _save_data_sync(self, **_kwargs) -> None:
         self.saved += 1
 
     async def _generate_proactive_message_with_llm(

--- a/tests/test_group_member_safety.py
+++ b/tests/test_group_member_safety.py
@@ -142,7 +142,7 @@ class _SafetyHarness(GroupMemberSafetyMixin):
     def _is_group_admin_event(event: _SafetyEvent) -> bool:
         return bool(event.manager)
 
-    def _save_data_sync(self) -> None:
+    def _save_data_sync(self, **_kwargs) -> None:
         self.save_calls += 1
 
 

--- a/tests/test_group_observation_ingress.py
+++ b/tests/test_group_observation_ingress.py
@@ -151,7 +151,9 @@ class GroupObservationIngressTests(unittest.IsolatedAsyncioTestCase):
             event.message_str,
             scope_key=scope_key,
         )
-        plugin._persist_reaction_expression_state.assert_called_once_with()
+        plugin._persist_reaction_expression_state.assert_called_once_with(
+            sections={"reaction_expression_group_states"}
+        )
         plugin._capture_group_observation_event.assert_awaited_once()
 
     async def test_high_priority_observer_only_records_and_does_not_stop_event(self) -> None:

--- a/tests/test_incremental_persistence_callsites.py
+++ b/tests/test_incremental_persistence_callsites.py
@@ -9,10 +9,66 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock
 
+from astrbot_plugin_private_companion.core_store import (
+    CoreStoreMixin,
+    _DURABLE_SECTION_NAMES,
+    _FULL_SAVE_SCOPES,
+)
 from astrbot_plugin_private_companion.event_dispatch import EventDispatchMixin
 
 
 ROOT = Path(__file__).resolve().parents[1]
+SAVE_METHODS = {"_save_data_sync", "_save_data_now_sync", "_schedule_data_save"}
+
+
+def _production_python_paths() -> list[Path]:
+    excluded = {"tests", "__pycache__", ".pytest_cache", ".ruff_cache"}
+    return [
+        path
+        for path in sorted(ROOT.rglob("*.py"))
+        if not excluded.intersection(path.relative_to(ROOT).parts)
+    ]
+
+
+def _save_calls(path: Path) -> list[ast.Call]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in SAVE_METHODS
+    ]
+
+
+def _literal_durable_data_roots(path: Path) -> list[tuple[str, int]]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    roots: list[tuple[str, int]] = []
+    for node in ast.walk(tree):
+        key: str | None = None
+        receiver: ast.AST | None = None
+        if isinstance(node, ast.Subscript):
+            receiver = node.value
+            if isinstance(node.slice, ast.Constant) and isinstance(node.slice.value, str):
+                key = node.slice.value
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in {"get", "setdefault", "pop"}
+            and node.args
+        ):
+            receiver = node.func.value
+            if isinstance(node.args[0], ast.Constant) and isinstance(node.args[0].value, str):
+                key = node.args[0].value
+        if (
+            key is None
+            or not isinstance(receiver, ast.Attribute)
+            or receiver.attr != "data"
+            or ast.unparse(receiver.value) not in {"self", "plugin", "self.plugin"}
+        ):
+            continue
+        roots.append((key, node.lineno))
+    return roots
 
 
 def _private_handler() -> ast.AsyncFunctionDef:
@@ -76,6 +132,97 @@ class _SmartDebounceHarness(EventDispatchMixin):
 
 
 class IncrementalPersistenceCallsiteTests(unittest.TestCase):
+    def test_production_save_calls_declare_a_contract(self) -> None:
+        bare_calls: list[str] = []
+        for path in _production_python_paths():
+            for node in _save_calls(path):
+                if not any(
+                    keyword.arg in {"sections", "deleted_sections", "full_scope"}
+                    for keyword in node.keywords
+                ):
+                    bare_calls.append(
+                        f"{path.relative_to(ROOT).as_posix()}:{node.lineno}"
+                    )
+        self.assertEqual([], bare_calls)
+
+    def test_literal_save_sections_are_registered(self) -> None:
+        unknown: list[str] = []
+        for path in _production_python_paths():
+            for node in _save_calls(path):
+                for keyword in node.keywords:
+                    if keyword.arg not in {"sections", "deleted_sections"}:
+                        continue
+                    if not isinstance(keyword.value, (ast.Set, ast.List, ast.Tuple)):
+                        continue
+                    for item in keyword.value.elts:
+                        if (
+                            isinstance(item, ast.Constant)
+                            and isinstance(item.value, str)
+                            and item.value not in _DURABLE_SECTION_NAMES
+                        ):
+                            unknown.append(
+                                f"{path.relative_to(ROOT).as_posix()}:{node.lineno}:"
+                                f"{item.value}"
+                            )
+        self.assertEqual([], unknown)
+
+    def test_literal_full_scopes_use_the_fixed_allowlist(self) -> None:
+        expected = {
+            "startup_migration",
+            "startup_maintenance",
+            "explicit_reset",
+            "shutdown_flush",
+            "admin_import_export",
+        }
+        self.assertEqual(expected, set(_FULL_SAVE_SCOPES))
+
+        invalid: list[str] = []
+        for path in _production_python_paths():
+            for node in _save_calls(path):
+                for keyword in node.keywords:
+                    if keyword.arg != "full_scope" or not isinstance(
+                        keyword.value, ast.Constant
+                    ):
+                        continue
+                    if keyword.value.value not in _FULL_SAVE_SCOPES:
+                        invalid.append(
+                            f"{path.relative_to(ROOT).as_posix()}:{node.lineno}:"
+                            f"{keyword.value.value}"
+                        )
+        self.assertEqual([], invalid)
+
+    def test_section_registry_matches_both_default_store_builders(self) -> None:
+        new_store = CoreStoreMixin._new_store(object())
+        ensured = CoreStoreMixin._ensure_store_defaults({})
+
+        self.assertEqual(set(_DURABLE_SECTION_NAMES), set(new_store))
+        self.assertEqual(set(_DURABLE_SECTION_NAMES), set(ensured))
+
+    def test_literal_durable_data_roots_are_registered(self) -> None:
+        unknown: list[str] = []
+        for path in _production_python_paths():
+            for section, lineno in _literal_durable_data_roots(path):
+                if section not in _DURABLE_SECTION_NAMES:
+                    unknown.append(
+                        f"{path.relative_to(ROOT).as_posix()}:{lineno}:{section}"
+                    )
+
+        self.assertEqual([], unknown)
+
+    def test_runtime_section_registry_contains_review_and_hot_path_sections(self) -> None:
+        source = (ROOT / "core_store.py").read_text(encoding="utf-8")
+
+        for section in (
+            "proactive_review_runtime",
+            "proactive_runtime",
+            "proactive_audit_log",
+            "passive_no_reply_records",
+            "smart_message_debounce",
+            "external_event_pool",
+            "external_event_self_link_cache",
+        ):
+            self.assertIn(f'"{section}"', source)
+
     def test_first_fast_smart_debounce_decision_is_recorded(self) -> None:
         harness = _SmartDebounceHarness()
         event = SimpleNamespace()
@@ -186,6 +333,60 @@ class IncrementalPersistenceCallsiteTests(unittest.TestCase):
                 for branch in branches
             )
         )
+
+    def test_message_hooks_share_event_batch_inside_persona_context(self) -> None:
+        tree = ast.parse(
+            (ROOT / "main.py").read_text(encoding="utf-8"),
+            filename="main.py",
+        )
+        expected = {
+            "guard_req036_private_capability_early": False,
+            "on_private_message": True,
+            "guard_blocked_group_member_early": False,
+            "capture_group_observation_early": False,
+            "review_group_member_safety_early": False,
+            "guard_req036_group_portrait_queries": False,
+            "on_group_message": True,
+        }
+        functions = {
+            node.name: node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.AsyncFunctionDef)
+            and node.name in expected
+        }
+        self.assertEqual(set(expected), set(functions))
+        for name, flush in expected.items():
+            decorators = functions[name].decorator_list
+            decorator_names = {
+                node.id
+                for node in decorators
+                if isinstance(node, ast.Name)
+            }
+            decorator_names.update(
+                node.func.id
+                for node in decorators
+                if isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+            )
+            self.assertIn("_multi_persona_event_context", decorator_names, name)
+            self.assertIn("event_data_save_boundary", decorator_names, name)
+            if flush:
+                self.assertTrue(
+                    any(
+                        isinstance(node, ast.Call)
+                        and isinstance(node.func, ast.Name)
+                        and node.func.id == "event_data_save_boundary"
+                        and any(
+                            isinstance(keyword, ast.keyword)
+                            and keyword.arg == "flush"
+                            and isinstance(keyword.value, ast.Constant)
+                            and keyword.value.value is True
+                            for keyword in node.keywords
+                        )
+                        for node in decorators
+                    ),
+                    name,
+                )
 
     def test_group_registration_persists_worldbook_profile_sections(self) -> None:
         source = ast.unparse(_group_handler())

--- a/tests/test_incremental_persistence_callsites.py
+++ b/tests/test_incremental_persistence_callsites.py
@@ -28,6 +28,19 @@ def _private_handler() -> ast.AsyncFunctionDef:
     )
 
 
+def _group_handler() -> ast.AsyncFunctionDef:
+    tree = ast.parse(
+        (ROOT / "message_pipeline.py").read_text(encoding="utf-8"),
+        filename="message_pipeline.py",
+    )
+    return next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.AsyncFunctionDef)
+        and node.name == "handle_group_message"
+    )
+
+
 def _if_node(function: ast.AST, condition: str) -> ast.If:
     return next(
         node
@@ -173,6 +186,31 @@ class IncrementalPersistenceCallsiteTests(unittest.TestCase):
                 for branch in branches
             )
         )
+
+    def test_group_registration_persists_worldbook_profile_sections(self) -> None:
+        source = ast.unparse(_group_handler())
+
+        self.assertIn("registration_payload", source)
+        self.assertIn("worldbook_member_profiles", source)
+        self.assertIn("worldbook_deleted_member_ids", source)
+        self.assertIn("self._save_data_sync(sections=save_sections)", source)
+
+    def test_proactive_message_has_no_implicit_full_save_calls(self) -> None:
+        tree = ast.parse(
+            (ROOT / "proactive_message.py").read_text(encoding="utf-8"),
+            filename="proactive_message.py",
+        )
+        bare_calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "_save_data_sync"
+            and not node.args
+            and not node.keywords
+        ]
+
+        self.assertEqual([], bare_calls)
 
     def test_private_image_buffer_persists_smart_learning_state(self) -> None:
         source = (ROOT / "private_image.py").read_text(encoding="utf-8")

--- a/tests/test_incremental_persistence_callsites.py
+++ b/tests/test_incremental_persistence_callsites.py
@@ -1,0 +1,203 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+import ast
+import time
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from astrbot_plugin_private_companion.event_dispatch import EventDispatchMixin
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _private_handler() -> ast.AsyncFunctionDef:
+    tree = ast.parse(
+        (ROOT / "message_pipeline.py").read_text(encoding="utf-8"),
+        filename="message_pipeline.py",
+    )
+    return next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.AsyncFunctionDef)
+        and node.name == "handle_private_message"
+    )
+
+
+def _if_node(function: ast.AST, condition: str) -> ast.If:
+    return next(
+        node
+        for node in ast.walk(function)
+        if isinstance(node, ast.If) and ast.unparse(node.test) == condition
+    )
+
+
+def _if_nodes(function: ast.AST, condition: str) -> list[ast.If]:
+    return [
+        node
+        for node in ast.walk(function)
+        if isinstance(node, ast.If) and ast.unparse(node.test) == condition
+    ]
+
+
+def _string_constants(node: ast.AST) -> set[str]:
+    return {
+        item.value
+        for item in ast.walk(node)
+        if isinstance(item, ast.Constant) and type(item.value) is str
+    }
+
+
+class _SmartDebounceHarness(EventDispatchMixin):
+    def __init__(self) -> None:
+        self.data: dict = {}
+        self.enable_message_debounce = True
+        self.enable_smart_message_debounce = True
+        self.smart_message_debounce_examples_limit = 8
+        self.smart_message_debounce_learning_window_seconds = 8.0
+        self._schedule_data_save = Mock()
+
+
+class IncrementalPersistenceCallsiteTests(unittest.TestCase):
+    def test_first_fast_smart_debounce_decision_is_recorded(self) -> None:
+        harness = _SmartDebounceHarness()
+        event = SimpleNamespace()
+
+        wait = asyncio.run(
+            harness._smart_message_debounce_wait_seconds_for_event(
+                event,
+                key=harness._semantic_buffer_key("private:user-1", "user-1"),
+                text="在吗？",
+                sender_id="user-1",
+            )
+        )
+
+        self.assertEqual(0.0, wait)
+        decisions = harness.data["smart_message_debounce"]["last_decisions"]
+        self.assertEqual(1, len(decisions))
+        self.assertEqual("complete", next(iter(decisions.values()))["decision"])
+
+    def test_smart_debounce_followup_marks_its_durable_section(self) -> None:
+        harness = _SmartDebounceHarness()
+        key = harness._semantic_buffer_key("private:user-1", "user-1")
+        harness.data["smart_message_debounce"] = {
+            "last_decisions": {
+                key: {
+                    "ts": time.time(),
+                    "text": "first",
+                    "decision": "complete",
+                }
+            },
+            "examples": [],
+            "recent_logs": [],
+        }
+
+        changed = harness._maybe_record_smart_message_debounce_followup(
+            scope="private:user-1",
+            sender_id="user-1",
+            text="continued",
+            now=time.time(),
+        )
+
+        self.assertTrue(changed)
+        self.assertEqual(
+            "false_complete",
+            harness.data["smart_message_debounce"]["examples"][0]["kind"],
+        )
+        harness._schedule_data_save.assert_not_called()
+
+    def test_private_pipeline_marks_fast_path_meal_and_warmth_sections(self) -> None:
+        handler = _private_handler()
+        meal_branch = _if_node(handler, "fast_meal_care_result.get('foods')")
+        warmth_branches = _if_nodes(handler, "fast_interaction_warmth_applied")
+
+        self.assertIn("food_menu", _string_constants(meal_branch))
+        self.assertTrue(
+            any(
+                {"state_conditions", "daily_state"}.issubset(_string_constants(branch))
+                for branch in warmth_branches
+            )
+        )
+
+    def test_private_pipeline_marks_normal_state_feedback_sections(self) -> None:
+        handler = _private_handler()
+        care_branches = _if_nodes(handler, "care_feedback_detected")
+        food_branches = _if_nodes(handler, "food_feedback_detected")
+        warmth_branches = _if_nodes(handler, "interaction_warmth_applied")
+
+        self.assertTrue(
+            any(
+                "state_conditions" in _string_constants(branch)
+                for branch in care_branches
+            )
+        )
+        self.assertTrue(
+            any(
+                {
+                    "last_food_state_feedback_at",
+                    "last_food_state_feedback_text",
+                }.issubset(_string_constants(branch))
+                for branch in food_branches
+            )
+        )
+        self.assertTrue(
+            any(
+                {"state_conditions", "daily_state"}.issubset(_string_constants(branch))
+                for branch in warmth_branches
+            )
+        )
+
+    def test_private_pipeline_uses_expression_feedback_source_sections(self) -> None:
+        handler = _private_handler()
+        feedback_branch = _if_node(handler, "expression_feedback")
+        source = ast.unparse(feedback_branch)
+
+        self.assertIn("updated_sections", source)
+        self.assertIn("updated_rules", source)
+        self.assertIn("expression_voice_profile", source)
+
+    def test_private_pipeline_saves_smart_state_at_early_and_final_commit_points(
+        self,
+    ) -> None:
+        handler = _private_handler()
+        branches = _if_nodes(handler, "smart_debounce_state_changed")
+
+        self.assertGreaterEqual(len(branches), 2)
+        self.assertTrue(
+            all(
+                "smart_message_debounce" in _string_constants(branch)
+                for branch in branches
+            )
+        )
+
+    def test_private_image_buffer_persists_smart_learning_state(self) -> None:
+        source = (ROOT / "private_image.py").read_text(encoding="utf-8")
+        self.assertIn(
+            'scheduler(sections={"smart_message_debounce"})',
+            source,
+        )
+
+    def test_proactive_only_meal_care_marks_food_menu(self) -> None:
+        tree = ast.parse(
+            (ROOT / "main.py").read_text(encoding="utf-8"),
+            filename="main.py",
+        )
+        handler = next(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.AsyncFunctionDef)
+            and node.name == "_record_proactive_only_private_feedback"
+        )
+        source = ast.unparse(handler)
+
+        self.assertIn("meal_care_result = self._handle_meal_care_inbound", source)
+        self.assertIn("save_sections.add('food_menu')", source)
+        self.assertIn("self._schedule_data_save(sections=save_sections)", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_incremental_persistence_storage.py
+++ b/tests/test_incremental_persistence_storage.py
@@ -1,0 +1,1122 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import sqlite3
+import tempfile
+import unittest
+from copy import deepcopy
+from pathlib import Path
+from unittest.mock import patch
+
+from astrbot_plugin_private_companion.core_store import CoreStoreMixin
+from astrbot_plugin_private_companion.storage.json_backend import JsonStoreBackend
+from astrbot_plugin_private_companion.storage.migration import (
+    migrate_json_to_backend_if_needed,
+)
+from astrbot_plugin_private_companion.storage.sqlite_backend import (
+    SqliteRevisionConflictError,
+    SqliteSchemaError,
+    SqliteStoreBackend,
+    SqliteStoreNotInitializedError,
+    SqliteUnsupportedSchemaError,
+)
+from astrbot_plugin_private_companion.storage.store_manager import StoreManager
+
+
+def _new_store() -> dict:
+    return {"users": {}, "settings": {"source": "default"}}
+
+
+def _ensure_defaults(data: dict) -> dict:
+    result = deepcopy(data)
+    result.setdefault("users", {})
+    result.setdefault("settings", {"source": "default"})
+    return result
+
+
+def _canonical(value: object) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+
+
+def _checksum(value: object) -> str:
+    return hashlib.sha256(_canonical(value).encode("utf-8")).hexdigest()
+
+
+class _StartupMaintenanceHarness(CoreStoreMixin):
+    def __init__(
+        self,
+        manager: StoreManager,
+        *,
+        recovered_items: list[dict] | None = None,
+        recovery_result: int = 0,
+    ) -> None:
+        self.store_manager = manager
+        self.storage_backend = "sqlite"
+        self.enable_store_control_tag_sanitization = True
+        self.recovered_items = recovered_items
+        self.recovery_result = recovery_result
+
+    def _recover_bookshelf_items_from_local_pages_inplace(self, data: dict) -> int:
+        if self.recovered_items is not None:
+            data["bookshelf_items"] = deepcopy(self.recovered_items)
+        return self.recovery_result
+
+
+class _SqliteWriterHarness(CoreStoreMixin):
+    def __init__(self, manager: StoreManager, data: dict) -> None:
+        self.store_manager = manager
+        self.storage_backend = "sqlite"
+        self.data = data
+        self.enable_multi_persona_mode = False
+        self.enable_store_control_tag_sanitization = True
+        self._data_save_task = None
+        self._stop_event = asyncio.Event()
+
+
+_V1_COLUMNS_FOR_TEST = (
+    "section_name",
+    "payload_json",
+    "updated_at",
+    "checksum",
+    "schema_version",
+)
+
+
+class IncrementalPersistenceStorageTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        self.sqlite_path = self.root / "companions.db"
+        self.json_path = self.root / "companions.json"
+        self.backend = SqliteStoreBackend(
+            self.sqlite_path,
+            _ensure_defaults,
+            _new_store,
+        )
+        self.json_backend = JsonStoreBackend(
+            self.json_path,
+            _ensure_defaults,
+            _new_store,
+        )
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def _manager(self, backend_name: str = "sqlite") -> StoreManager:
+        return StoreManager(
+            backend_name=backend_name,
+            data_file=self.json_path,
+            sqlite_path=self.sqlite_path,
+            ensure_defaults=_ensure_defaults,
+            new_store=_new_store,
+        )
+
+    def _create_v1(self, payload: dict, *, checksum: str = "") -> None:
+        connection = sqlite3.connect(self.sqlite_path)
+        try:
+            connection.execute(
+                "CREATE TABLE store_sections ("
+                "section_name TEXT PRIMARY KEY,"
+                "payload_json TEXT NOT NULL,"
+                "updated_at REAL NOT NULL,"
+                "checksum TEXT DEFAULT '',"
+                "schema_version INTEGER DEFAULT 1)"
+            )
+            connection.executemany(
+                "INSERT INTO store_sections VALUES(?,?,?,?,1)",
+                [
+                    (name, json.dumps(value, ensure_ascii=False), 10.0, checksum)
+                    for name, value in payload.items()
+                ],
+            )
+            connection.commit()
+        finally:
+            connection.close()
+
+    def _row(self, section_name: str) -> tuple:
+        connection = sqlite3.connect(self.sqlite_path)
+        try:
+            row = connection.execute(
+                "SELECT payload_json,updated_at,checksum,schema_version,revision,is_deleted "
+                "FROM store_sections WHERE section_name=?",
+                (section_name,),
+            ).fetchone()
+        finally:
+            connection.close()
+        if row is None:
+            raise AssertionError(f"missing row: {section_name}")
+        return row
+
+    def _meta(self) -> dict[str, str]:
+        connection = sqlite3.connect(self.sqlite_path)
+        try:
+            return dict(
+                connection.execute("SELECT meta_key,meta_value FROM store_meta")
+            )
+        finally:
+            connection.close()
+
+    def test_v1_database_is_backed_up_and_migrated_to_v2_once(self) -> None:
+        payload = {
+            "users": {"42": {"name": "中文"}},
+            "settings": {"source": "sqlite"},
+        }
+        self._create_v1(payload)
+
+        self.assertEqual(payload, self.backend.load_store())
+
+        connection = sqlite3.connect(self.sqlite_path)
+        try:
+            self.assertEqual(2, connection.execute("PRAGMA user_version").fetchone()[0])
+            columns = {
+                row[1]
+                for row in connection.execute("PRAGMA table_info(store_sections)")
+            }
+        finally:
+            connection.close()
+        self.assertEqual(
+            {
+                "section_name",
+                "payload_json",
+                "updated_at",
+                "checksum",
+                "schema_version",
+                "revision",
+                "is_deleted",
+            },
+            columns,
+        )
+        self.assertEqual({"next_revision": "2", "initialized": "1"}, self._meta())
+        for name, value in payload.items():
+            row = self._row(name)
+            self.assertEqual(value, json.loads(row[0]))
+            self.assertEqual(_checksum(value), row[2])
+            self.assertEqual((2, 1, 0), row[3:])
+
+        backups = list(self.root.glob("companions.db.pre-v2-*.bak"))
+        self.assertEqual(1, len(backups))
+        backup = sqlite3.connect(backups[0])
+        try:
+            self.assertEqual(0, backup.execute("PRAGMA user_version").fetchone()[0])
+            backup_columns = {
+                row[1] for row in backup.execute("PRAGMA table_info(store_sections)")
+            }
+        finally:
+            backup.close()
+        self.assertNotIn("revision", backup_columns)
+
+        self.assertEqual(payload, self.backend.load_store())
+        self.assertEqual(1, len(list(self.root.glob("companions.db.pre-v2-*.bak"))))
+        self.assertEqual(2, self.backend.next_revision())
+
+    def test_empty_v1_store_remains_uninitialized_and_recovers_from_json(self) -> None:
+        self._create_v1({})
+        json_payload = {
+            "users": {"42": {"name": "from-json"}},
+            "settings": {"source": "json"},
+        }
+        self.json_backend.save_store(json_payload)
+
+        loaded = migrate_json_to_backend_if_needed(
+            self.backend,
+            self.json_backend,
+            _new_store(),
+        )
+
+        self.assertEqual(json_payload, loaded)
+        self.assertEqual(json_payload, self.backend.load_store())
+        self.assertEqual({"next_revision": "2", "initialized": "1"}, self._meta())
+        self.assertEqual(1, len(list(self.root.glob("companions.db.pre-v2-*.bak"))))
+
+    def test_invalid_v1_json_rolls_back_schema_migration(self) -> None:
+        self._create_v1({"users": {}})
+        connection = sqlite3.connect(self.sqlite_path)
+        try:
+            connection.execute(
+                "UPDATE store_sections SET payload_json='{invalid' WHERE section_name='users'"
+            )
+            connection.commit()
+        finally:
+            connection.close()
+
+        with self.assertRaisesRegex(ValueError, "invalid JSON"):
+            self.backend.load_store()
+
+        connection = sqlite3.connect(self.sqlite_path)
+        try:
+            self.assertEqual(0, connection.execute("PRAGMA user_version").fetchone()[0])
+            columns = {
+                row[1]
+                for row in connection.execute("PRAGMA table_info(store_sections)")
+            }
+            stored = connection.execute(
+                "SELECT payload_json FROM store_sections WHERE section_name='users'"
+            ).fetchone()[0]
+        finally:
+            connection.close()
+        self.assertNotIn("revision", columns)
+        self.assertEqual("{invalid", stored)
+        self.assertEqual(1, len(list(self.root.glob("companions.db.pre-v2-*.bak"))))
+
+    def test_user_version_one_uses_the_same_transactional_migration(self) -> None:
+        payload = {"users": {"42": {"name": "version-one"}}}
+        self._create_v1(payload)
+        connection = sqlite3.connect(self.sqlite_path)
+        try:
+            connection.execute("PRAGMA user_version=1")
+            connection.commit()
+        finally:
+            connection.close()
+
+        self.assertEqual(_ensure_defaults(payload), self.backend.load_store())
+
+        connection = sqlite3.connect(self.sqlite_path)
+        try:
+            self.assertEqual(2, connection.execute("PRAGMA user_version").fetchone()[0])
+        finally:
+            connection.close()
+        self.assertEqual(1, len(list(self.root.glob("companions.db.pre-v2-*.bak"))))
+
+    def test_negative_schema_marker_fails_closed_without_v1_migration(self) -> None:
+        self._create_v1({"users": {"42": {"name": "untouched"}}})
+        connection = sqlite3.connect(self.sqlite_path)
+        try:
+            connection.execute("PRAGMA user_version=-1")
+            connection.commit()
+        finally:
+            connection.close()
+
+        with self.assertRaisesRegex(SqliteSchemaError, "marker is invalid"):
+            self.backend.load_store()
+
+        connection = sqlite3.connect(self.sqlite_path)
+        try:
+            self.assertEqual(
+                -1, connection.execute("PRAGMA user_version").fetchone()[0]
+            )
+            columns = {
+                row[1]
+                for row in connection.execute("PRAGMA table_info(store_sections)")
+            }
+        finally:
+            connection.close()
+        self.assertNotIn("revision", columns)
+        self.assertEqual([], list(self.root.glob("companions.db.pre-v2-*.bak")))
+
+    def test_injected_migration_failure_leaves_the_complete_v1_table(self) -> None:
+        payload = {"users": {"42": {"name": "untouched"}}}
+        self._create_v1(payload)
+
+        with (
+            patch.object(
+                self.backend,
+                "_create_sections_table",
+                side_effect=RuntimeError("injected migration failure"),
+            ),
+            self.assertRaisesRegex(RuntimeError, "injected migration failure"),
+        ):
+            self.backend.load_store()
+
+        connection = sqlite3.connect(self.sqlite_path)
+        try:
+            self.assertEqual(0, connection.execute("PRAGMA user_version").fetchone()[0])
+            self.assertEqual(
+                _V1_COLUMNS_FOR_TEST,
+                tuple(
+                    row[1]
+                    for row in connection.execute("PRAGMA table_info(store_sections)")
+                ),
+            )
+            rows = connection.execute(
+                "SELECT section_name,payload_json FROM store_sections"
+            ).fetchall()
+        finally:
+            connection.close()
+        self.assertEqual(
+            [("users", json.dumps(payload["users"], ensure_ascii=False))], rows
+        )
+        self.assertEqual(1, len(list(self.root.glob("companions.db.pre-v2-*.bak"))))
+
+    def test_invalid_nonempty_v1_checksum_rolls_back_schema_migration(self) -> None:
+        self._create_v1({"users": {}}, checksum="0" * 64)
+
+        with self.assertRaisesRegex(SqliteSchemaError, "checksum"):
+            self.backend.load_store()
+
+        connection = sqlite3.connect(self.sqlite_path)
+        try:
+            self.assertEqual(0, connection.execute("PRAGMA user_version").fetchone()[0])
+            columns = {
+                row[1]
+                for row in connection.execute("PRAGMA table_info(store_sections)")
+            }
+        finally:
+            connection.close()
+        self.assertNotIn("revision", columns)
+
+    def test_unknown_newer_schema_is_rejected_without_mutation(self) -> None:
+        connection = sqlite3.connect(self.sqlite_path)
+        try:
+            connection.execute("CREATE TABLE future_data(value TEXT)")
+            connection.execute("PRAGMA user_version=3")
+            connection.commit()
+        finally:
+            connection.close()
+        original = self.sqlite_path.read_bytes()
+
+        with self.assertRaisesRegex(SqliteUnsupportedSchemaError, "version 3"):
+            self.backend.health_check(raise_on_error=True)
+
+        self.assertEqual(original, self.sqlite_path.read_bytes())
+        self.assertEqual([], list(self.root.glob("companions.db.pre-v2-*.bak")))
+
+    def test_v2_marker_with_v1_columns_fails_closed(self) -> None:
+        self._create_v1({"users": {}})
+        connection = sqlite3.connect(self.sqlite_path)
+        try:
+            connection.execute("PRAGMA user_version=2")
+            connection.commit()
+        finally:
+            connection.close()
+
+        with self.assertRaisesRegex(SqliteSchemaError, "v2 schema"):
+            self.backend.load_store()
+
+    def test_v2_missing_meta_and_invalid_next_revision_fail_closed(self) -> None:
+        self.backend.save_store({"users": {}})
+        connection = sqlite3.connect(self.sqlite_path)
+        try:
+            connection.execute("DROP TABLE store_meta")
+            connection.commit()
+        finally:
+            connection.close()
+
+        with self.assertRaisesRegex(SqliteSchemaError, "incomplete"):
+            self.backend.load_store()
+
+        self.sqlite_path.unlink()
+        self.backend.save_store({"users": {}})
+        connection = sqlite3.connect(self.sqlite_path)
+        try:
+            connection.execute(
+                "UPDATE store_meta SET meta_value='0' WHERE meta_key='next_revision'"
+            )
+            connection.commit()
+        finally:
+            connection.close()
+
+        with self.assertRaisesRegex(SqliteSchemaError, "next_revision"):
+            self.backend.load_store()
+
+    def test_v2_rejects_unexpected_tables_and_meta_keys(self) -> None:
+        self.backend.save_store({"users": {}})
+        connection = sqlite3.connect(self.sqlite_path)
+        try:
+            connection.execute("CREATE TABLE unrelated(value TEXT)")
+            connection.commit()
+        finally:
+            connection.close()
+
+        with self.assertRaisesRegex(SqliteSchemaError, "unexpected tables"):
+            self.backend.load_store()
+
+        connection = sqlite3.connect(self.sqlite_path)
+        try:
+            connection.execute("DROP TABLE unrelated")
+            connection.execute("INSERT INTO store_meta VALUES('future_key','1')")
+            connection.commit()
+        finally:
+            connection.close()
+
+        with self.assertRaisesRegex(SqliteSchemaError, "meta keys"):
+            self.backend.load_store()
+
+    def test_v2_missing_column_and_bad_primary_key_fail_closed(self) -> None:
+        connection = sqlite3.connect(self.sqlite_path)
+        try:
+            connection.execute(
+                "CREATE TABLE store_sections("
+                "section_name TEXT NOT NULL PRIMARY KEY,payload_json TEXT NOT NULL,"
+                "updated_at REAL NOT NULL,checksum TEXT NOT NULL,schema_version INTEGER NOT NULL,"
+                "revision INTEGER NOT NULL)"
+            )
+            connection.execute(
+                "CREATE TABLE store_meta(meta_key TEXT NOT NULL PRIMARY KEY,meta_value TEXT NOT NULL)"
+            )
+            connection.executemany(
+                "INSERT INTO store_meta VALUES(?,?)",
+                (("initialized", "0"), ("next_revision", "1")),
+            )
+            connection.execute("PRAGMA user_version=2")
+            connection.commit()
+        finally:
+            connection.close()
+
+        with self.assertRaisesRegex(SqliteSchemaError, "columns"):
+            self.backend.load_store()
+
+        self.sqlite_path.unlink()
+        connection = sqlite3.connect(self.sqlite_path)
+        try:
+            connection.execute(
+                "CREATE TABLE store_sections("
+                "section_name TEXT NOT NULL,payload_json TEXT NOT NULL,updated_at REAL NOT NULL,"
+                "checksum TEXT NOT NULL DEFAULT '',schema_version INTEGER NOT NULL DEFAULT 2,"
+                "revision INTEGER NOT NULL DEFAULT 0,is_deleted INTEGER NOT NULL DEFAULT 0,"
+                "CONSTRAINT store_sections_checksum_sha256 CHECK(length(checksum)=64),"
+                "CONSTRAINT store_sections_schema_v2 CHECK(schema_version=2),"
+                "CONSTRAINT store_sections_positive_revision CHECK(revision>0),"
+                "CONSTRAINT store_sections_deleted_flag CHECK(is_deleted IN (0,1)))"
+            )
+            connection.execute(
+                "CREATE TABLE store_meta(meta_key TEXT NOT NULL PRIMARY KEY,meta_value TEXT NOT NULL)"
+            )
+            connection.executemany(
+                "INSERT INTO store_meta VALUES(?,?)",
+                (("initialized", "0"), ("next_revision", "1")),
+            )
+            connection.execute("PRAGMA user_version=2")
+            connection.commit()
+        finally:
+            connection.close()
+
+        with self.assertRaisesRegex(SqliteSchemaError, "primary key"):
+            self.backend.load_store()
+
+    def test_v2_rejects_non_integer_storage_classes_for_integer_metadata(self) -> None:
+        for column, value in (
+            ("schema_version", 2.5),
+            ("revision", 1.5),
+            ("is_deleted", 0.5),
+        ):
+            with self.subTest(column=column):
+                if self.sqlite_path.exists():
+                    self.sqlite_path.unlink()
+                self.backend.save_store({"users": {"value": "safe"}})
+                connection = sqlite3.connect(self.sqlite_path)
+                try:
+                    connection.execute("PRAGMA ignore_check_constraints=ON")
+                    connection.execute(
+                        f"UPDATE store_sections SET {column}=? WHERE section_name='users'",
+                        (value,),
+                    )
+                    connection.commit()
+                finally:
+                    connection.close()
+
+                with self.assertRaisesRegex(SqliteSchemaError, "metadata is invalid"):
+                    self.backend.load_store()
+
+    def test_revision_outside_safe_sqlite_range_is_rejected_before_connect(
+        self,
+    ) -> None:
+        with (
+            patch.object(self.backend, "_connect") as connect,
+            self.assertRaisesRegex(ValueError, "within SQLite range"),
+        ):
+            self.backend.save_sections(
+                {"users": (((1 << 63) - 1), {"value": "too-large"})},
+                {},
+            )
+
+        connect.assert_not_called()
+
+    def test_incremental_write_only_changes_requested_section(self) -> None:
+        payload = {
+            "users": {"42": {"name": "before"}},
+            "settings": {"source": "before"},
+        }
+        self.backend.save_store(payload)
+        connection = sqlite3.connect(self.sqlite_path)
+        try:
+            connection.execute(
+                "UPDATE store_sections SET updated_at=111.0 WHERE section_name='settings'"
+            )
+            connection.commit()
+        finally:
+            connection.close()
+        settings_before = self._row("settings")
+
+        confirmed = self.backend.save_sections(
+            {"users": (2, {"42": {"name": "after"}})},
+            {},
+        )
+
+        self.assertEqual({"users": 2}, confirmed)
+        self.assertEqual(settings_before, self._row("settings"))
+        users = self._row("users")
+        self.assertEqual({"42": {"name": "after"}}, json.loads(users[0]))
+        self.assertEqual(2, users[4])
+        self.assertEqual(3, self.backend.next_revision())
+
+    def test_legacy_v2_row_with_empty_checksum_is_upgraded_on_first_partial_write(
+        self,
+    ) -> None:
+        self.backend.save_store({"users": {"value": "legacy"}})
+        connection = sqlite3.connect(self.sqlite_path)
+        try:
+            connection.execute(
+                "UPDATE store_sections SET checksum='' WHERE section_name='users'"
+            )
+            connection.commit()
+        finally:
+            connection.close()
+
+        self.assertEqual({"value": "legacy"}, self.backend.load_store()["users"])
+        self.assertEqual(
+            {"users": 2},
+            self.backend.save_sections({"users": (2, {"value": "upgraded"})}, {}),
+        )
+        self.assertEqual(_checksum({"value": "upgraded"}), self._row("users")[2])
+
+    def test_legacy_v2_empty_checksum_same_revision_is_upgraded_idempotently(
+        self,
+    ) -> None:
+        payload = {"value": "legacy"}
+        self.backend.save_store({"users": payload})
+        connection = sqlite3.connect(self.sqlite_path)
+        try:
+            connection.execute(
+                "UPDATE store_sections SET checksum='',updated_at=333.0 "
+                "WHERE section_name='users'"
+            )
+            connection.commit()
+        finally:
+            connection.close()
+        before = self._row("users")
+
+        self.assertEqual(
+            {"users": 1},
+            self.backend.save_sections({"users": (1, payload)}, {}),
+        )
+
+        after = self._row("users")
+        self.assertEqual(_checksum(payload), after[2])
+        self.assertEqual(before[0], after[0])
+        self.assertEqual(before[1], after[1])
+        self.assertEqual(before[3], after[3])
+        self.assertEqual(before[4:], after[4:])
+
+    def test_legacy_v2_tombstone_empty_checksum_is_upgraded_idempotently(
+        self,
+    ) -> None:
+        self.backend.save_store({"obsolete": {"value": "legacy"}})
+        self.backend.save_sections({}, {"obsolete": 2})
+        connection = sqlite3.connect(self.sqlite_path)
+        try:
+            connection.execute(
+                "UPDATE store_sections SET checksum='',updated_at=444.0 "
+                "WHERE section_name='obsolete'"
+            )
+            connection.commit()
+        finally:
+            connection.close()
+
+        self.assertNotIn("obsolete", self.backend.load_store())
+        before = self._row("obsolete")
+        self.assertEqual(
+            {"obsolete": 2},
+            self.backend.save_sections({}, {"obsolete": 2}),
+        )
+
+        after = self._row("obsolete")
+        self.assertEqual(_checksum(None), after[2])
+        self.assertEqual(before[0], after[0])
+        self.assertEqual(before[1], after[1])
+        self.assertEqual(before[3:], after[3:])
+
+    def test_same_payload_advances_revision_without_touching_payload_or_timestamp(
+        self,
+    ) -> None:
+        payload = {"users": {"42": {"name": "same"}}}
+        self.backend.save_store(payload)
+        connection = sqlite3.connect(self.sqlite_path)
+        try:
+            connection.execute(
+                "UPDATE store_sections SET updated_at=222.0 WHERE section_name='users'"
+            )
+            connection.commit()
+        finally:
+            connection.close()
+        before = self._row("users")
+
+        self.assertEqual(
+            {"users": 2},
+            self.backend.save_sections({"users": (2, payload["users"])}, {}),
+        )
+
+        after = self._row("users")
+        self.assertEqual(before[:4], after[:4])
+        self.assertEqual((2, 0), after[4:])
+
+    def test_equal_revision_retry_is_idempotent_but_conflicting_batch_rolls_back(
+        self,
+    ) -> None:
+        self.backend.save_store({"users": {"value": 1}, "settings": {"value": 1}})
+        self.backend.save_sections(
+            {"users": (2, {"value": 2}), "settings": (2, {"value": 2})},
+            {},
+        )
+        users_before = self._row("users")
+        settings_before = self._row("settings")
+
+        self.assertEqual(
+            {"users": 2},
+            self.backend.save_sections({"users": (2, {"value": 2})}, {}),
+        )
+        with self.assertRaises(SqliteRevisionConflictError):
+            self.backend.save_sections(
+                {"users": (2, {"value": "conflict"}), "settings": (3, {"value": 3})},
+                {},
+            )
+
+        self.assertEqual(users_before, self._row("users"))
+        self.assertEqual(settings_before, self._row("settings"))
+
+    def test_lower_revision_is_rejected(self) -> None:
+        self.backend.save_store({"users": {"value": 1}})
+        self.backend.save_sections({"users": (2, {"value": 2})}, {})
+
+        with self.assertRaises(SqliteRevisionConflictError):
+            self.backend.save_sections({"users": (1, {"value": 3})}, {})
+
+        self.assertEqual({"value": 2}, json.loads(self._row("users")[0]))
+
+    def test_revision_retry_can_advance_an_older_row_after_other_section_progress(
+        self,
+    ) -> None:
+        self.backend.save_store({"users": {"value": 1}, "settings": {"value": 1}})
+        self.backend.save_sections({"settings": (3, {"value": 3})}, {})
+
+        self.assertEqual(
+            {"users": 2},
+            self.backend.save_sections({"users": (2, {"value": "retry"})}, {}),
+        )
+
+        self.assertEqual({"value": "retry"}, json.loads(self._row("users")[0]))
+
+    def test_restart_continues_from_persisted_next_revision(self) -> None:
+        self.backend.save_store({"users": {"value": 1}, "settings": {"value": 1}})
+        self.backend.save_sections({"users": (2, {"value": 2})}, {})
+        restarted = SqliteStoreBackend(
+            self.sqlite_path,
+            _ensure_defaults,
+            _new_store,
+        )
+
+        self.assertEqual(3, restarted.next_revision())
+        self.assertEqual(
+            {"settings": 3},
+            restarted.save_sections({"settings": (3, {"value": 3})}, {}),
+        )
+        self.assertEqual(4, restarted.next_revision())
+
+    def test_changed_deleted_overlap_is_rejected_before_opening_database(self) -> None:
+        with (
+            patch.object(self.backend, "_connect") as connect,
+            self.assertRaises(ValueError),
+        ):
+            self.backend.save_sections({"users": (1, {})}, {"users": 1})
+
+        connect.assert_not_called()
+
+    def test_batch_database_failure_rolls_back_every_section(self) -> None:
+        self.backend.save_store({"users": {"value": 1}, "settings": {"value": 1}})
+        connection = sqlite3.connect(self.sqlite_path)
+        try:
+            connection.execute(
+                "CREATE TRIGGER reject_settings_update BEFORE UPDATE ON store_sections "
+                "WHEN NEW.section_name='settings' BEGIN "
+                "SELECT RAISE(ABORT, 'settings rejected'); END"
+            )
+            connection.commit()
+        finally:
+            connection.close()
+        users_before = self._row("users")
+
+        with self.assertRaisesRegex(sqlite3.IntegrityError, "settings rejected"):
+            self.backend.save_sections(
+                {"users": (2, {"value": 2}), "settings": (2, {"value": 2})},
+                {},
+            )
+
+        self.assertEqual(users_before, self._row("users"))
+
+    def test_tombstone_only_store_is_initialized_and_blocks_json_reimport(self) -> None:
+        self.backend.save_store({"obsolete": {"source": "sqlite"}})
+        self.backend.save_sections({}, {"obsolete": 2})
+        self.json_backend.save_store({"obsolete": {"source": "json"}})
+
+        restarted = SqliteStoreBackend(
+            self.sqlite_path,
+            _ensure_defaults,
+            _new_store,
+        )
+        loaded = migrate_json_to_backend_if_needed(
+            restarted,
+            self.json_backend,
+            _new_store(),
+        )
+
+        self.assertNotIn("obsolete", loaded)
+        row = self._row("obsolete")
+        self.assertEqual("null", row[0])
+        self.assertEqual(_checksum(None), row[2])
+        self.assertEqual((2, 1), row[4:])
+        self.assertEqual("1", self._meta()["initialized"])
+        self.assertEqual(3, restarted.next_revision())
+
+    def test_tombstone_remains_absent_when_store_defaults_include_that_section(
+        self,
+    ) -> None:
+        def new_store_with_secret() -> dict:
+            return {"users": {}, "bookshelf_secret": {"password": "default"}}
+
+        def ensure_defaults_with_secret(data: dict) -> dict:
+            result = deepcopy(data)
+            result.setdefault("users", {})
+            result.setdefault("bookshelf_secret", {"password": "default"})
+            return result
+
+        backend = SqliteStoreBackend(
+            self.sqlite_path,
+            ensure_defaults_with_secret,
+            new_store_with_secret,
+        )
+        backend.save_store({"users": {}, "bookshelf_secret": {"password": "persisted"}})
+        backend.save_sections({}, {"bookshelf_secret": 2})
+
+        loaded = backend.load_store()
+
+        self.assertNotIn("bookshelf_secret", loaded)
+        self.assertEqual({}, loaded["users"])
+        self.assertEqual((2, 1), self._row("bookshelf_secret")[4:])
+
+    def test_full_replace_removes_old_tombstones(self) -> None:
+        self.backend.save_store({"obsolete": {"value": 1}})
+        self.backend.save_sections({}, {"obsolete": 2})
+
+        self.backend.save_store({"users": {"fresh": True}})
+
+        connection = sqlite3.connect(self.sqlite_path)
+        try:
+            names = {
+                row[0]
+                for row in connection.execute("SELECT section_name FROM store_sections")
+            }
+        finally:
+            connection.close()
+        self.assertEqual({"users"}, names)
+
+    def test_full_snapshot_can_commit_explicit_tombstones(self) -> None:
+        self.backend.save_store(
+            {"users": {"fresh": True}, "obsolete": {"value": "old"}}
+        )
+
+        persisted_revision = self.backend.save_snapshot(
+            {"users": {"fresh": "latest"}},
+            minimum_revision=7,
+            deleted_sections={"obsolete": 8},
+        )
+
+        self.assertGreaterEqual(persisted_revision, 8)
+        self.assertEqual({"fresh": "latest"}, self.backend.load_store()["users"])
+        self.assertEqual((2, persisted_revision, 1), self._row("obsolete")[3:])
+
+    def test_full_snapshot_can_preserve_existing_tombstones(self) -> None:
+        self.backend.save_store(
+            {"users": {"fresh": True}, "obsolete": {"value": "old"}}
+        )
+        self.backend.save_sections({}, {"obsolete": 2})
+
+        persisted_revision = self.backend.save_snapshot(
+            {"users": {"fresh": "latest"}},
+            minimum_revision=3,
+            preserve_tombstones=True,
+        )
+
+        self.assertGreaterEqual(persisted_revision, 3)
+        self.assertEqual({"fresh": "latest"}, self.backend.load_store()["users"])
+        self.assertEqual((2, persisted_revision, 1), self._row("obsolete")[3:])
+
+    def test_v2_check_constraints_reject_legacy_five_column_writer(self) -> None:
+        self.backend.save_store({"users": {"value": "safe"}})
+        connection = sqlite3.connect(self.sqlite_path)
+        try:
+            with self.assertRaises(sqlite3.IntegrityError):
+                connection.execute(
+                    "REPLACE INTO store_sections("
+                    "section_name,payload_json,updated_at,checksum,schema_version"
+                    ") VALUES(?,?,?,?,1)",
+                    (
+                        "users",
+                        "{}",
+                        1.0,
+                        "",
+                    ),
+                )
+            connection.rollback()
+        finally:
+            connection.close()
+
+        self.assertEqual({"value": "safe"}, self.backend.load_store()["users"])
+
+    def test_store_manager_incremental_path_never_loads_or_exports_full_store(
+        self,
+    ) -> None:
+        manager = self._manager("sqlite")
+        manager.save_store({"users": {"value": 1}, "settings": {"value": 1}})
+
+        with (
+            patch.object(
+                manager.backend, "load_store", side_effect=AssertionError("full load")
+            ),
+            patch.object(
+                manager.json_backend,
+                "save_store",
+                side_effect=AssertionError("json export"),
+            ),
+        ):
+            confirmed = manager.save_sections({"users": (2, {"value": 2})}, {})
+
+        self.assertEqual({"users": 2}, confirmed)
+        self.assertEqual(3, manager.next_revision())
+
+    def test_sqlite_full_compatibility_mark_preserves_existing_tombstone(self) -> None:
+        manager = self._manager("sqlite")
+        manager.save_store(
+            {
+                "users": {"owner": {"name": "before"}},
+                "settings": {"source": "sqlite"},
+                "obsolete": {"must": "stay-deleted"},
+            }
+        )
+        manager.save_sections({}, {"obsolete": 2})
+        data = manager.load_initial_store()
+        data["users"]["owner"]["name"] = "after"
+        harness = _SqliteWriterHarness(manager, data)
+
+        async def flush() -> None:
+            harness._schedule_data_save(sections=None, delay=0.0)
+            await harness._flush_scheduled_data_save()
+
+        asyncio.run(flush())
+
+        self.assertEqual({"obsolete": 2}, manager.deleted_section_revisions(["obsolete"]))
+        self.assertEqual(
+            "after",
+            manager.load_initial_store()["users"]["owner"]["name"],
+        )
+
+    def test_terminate_full_dirty_removes_live_missing_section(self) -> None:
+        manager = self._manager("sqlite")
+        manager.save_store(
+            {
+                "users": {"owner": {"name": "before"}},
+                "obsolete": {"must": "be-removed"},
+            }
+        )
+        data = manager.load_initial_store()
+        harness = _SqliteWriterHarness(manager, data)
+        harness._stop_event.set()
+
+        async def flush() -> None:
+            harness._schedule_data_save(sections=None, delay=0.0)
+            harness.data.pop("obsolete")
+            await harness._flush_default_data_save_on_terminate()
+
+        asyncio.run(flush())
+
+        self.assertNotIn("obsolete", manager.load_initial_store())
+        self.assertNotIn("obsolete", manager.deleted_section_revisions(["obsolete"]))
+
+    def test_startup_cleanup_updates_only_changed_section_and_preserves_tombstone(
+        self,
+    ) -> None:
+        manager = self._manager("sqlite")
+        manager.save_store(
+            {
+                "users": {},
+                "settings": {"source": "sqlite"},
+                "memory": {"summary": "clean <bubble/> me"},
+                "obsolete": {"must": "stay-deleted"},
+            }
+        )
+        manager.save_sections({}, {"obsolete": 2})
+
+        loaded = _StartupMaintenanceHarness(manager)._load_data_sync()
+
+        self.assertEqual("clean me", loaded["memory"]["summary"])
+        self.assertEqual((3, 0), self._row("memory")[4:])
+        self.assertEqual((1, 0), self._row("settings")[4:])
+        self.assertEqual((2, 1), self._row("obsolete")[4:])
+        self.assertNotIn("obsolete", manager.load_initial_store())
+
+    def test_startup_local_recovery_cannot_revive_bookshelf_tombstone(self) -> None:
+        manager = self._manager("sqlite")
+        manager.save_store(
+            {
+                "users": {},
+                "settings": {"source": "sqlite"},
+                "bookshelf_items": [{"key": "stored"}],
+                "bookshelf_secret": {"password": "safe"},
+                "bookshelf_store_revision": 1,
+                "jm_cosmos_integration": {},
+            }
+        )
+        manager.save_sections({}, {"bookshelf_items": 2})
+
+        for recovered_items, recovery_result in (
+            ([], 0),
+            ([{"key": "local-page"}], 1),
+        ):
+            with self.subTest(recovery_result=recovery_result):
+                loaded = _StartupMaintenanceHarness(
+                    manager,
+                    recovered_items=recovered_items,
+                    recovery_result=recovery_result,
+                )._load_data_sync()
+
+                self.assertNotIn("bookshelf_items", loaded)
+                self.assertEqual((2, 1), self._row("bookshelf_items")[4:])
+
+    def test_startup_bookshelf_group_rewrites_tombstone_with_shared_revision(
+        self,
+    ) -> None:
+        manager = self._manager("sqlite")
+        manager.save_store(
+            {
+                "users": {},
+                "settings": {"source": "sqlite"},
+                "bookshelf_items": [],
+                "bookshelf_secret": {"password": "delete-me"},
+                "bookshelf_store_revision": 1,
+                "jm_cosmos_integration": {},
+            }
+        )
+        manager.save_sections({}, {"bookshelf_secret": 2})
+
+        loaded = _StartupMaintenanceHarness(
+            manager,
+            recovered_items=[{"key": "local-page"}],
+            recovery_result=1,
+        )._load_data_sync()
+
+        self.assertEqual([{"key": "local-page"}], loaded["bookshelf_items"])
+        self.assertNotIn("bookshelf_secret", loaded)
+        revisions = {
+            self._row(section)[4]
+            for section in (
+                "bookshelf_items",
+                "bookshelf_secret",
+                "bookshelf_store_revision",
+                "jm_cosmos_integration",
+            )
+        }
+        self.assertEqual({3}, revisions)
+        self.assertEqual(1, self._row("bookshelf_secret")[5])
+
+    def test_bookshelf_recovery_preserves_unrelated_sqlite_tombstone(self) -> None:
+        selected = {
+            "users": {},
+            "settings": {"source": "sqlite"},
+            "bookshelf_items": [],
+            "bookshelf_secret": {},
+            "bookshelf_store_revision": 1,
+            "jm_cosmos_integration": {},
+            "obsolete": {"must": "stay-deleted"},
+        }
+        fallback = deepcopy(selected)
+        fallback["settings"] = {"source": "json"}
+        fallback["bookshelf_items"] = [
+            {
+                "key": "jm_album:42",
+                "type": "jm_album",
+                "album_id": "42",
+                "title": "recovered",
+                "pages": [],
+            }
+        ]
+        fallback["bookshelf_store_revision"] = 2
+        self.backend.save_store(selected)
+        self.backend.save_sections({}, {"obsolete": 2})
+        self.json_backend.save_store(fallback)
+
+        loaded = self._manager("sqlite").load_initial_store()
+
+        self.assertEqual(
+            ["42"], [item["album_id"] for item in loaded["bookshelf_items"]]
+        )
+        obsolete = self._row("obsolete")
+        self.assertEqual((2, 1), obsolete[4:])
+        self.assertNotIn("obsolete", self.backend.load_store())
+
+    def test_bookshelf_recovery_does_not_revive_its_own_section_tombstone(self) -> None:
+        selected = {
+            "users": {},
+            "settings": {"source": "sqlite"},
+            "bookshelf_items": [],
+            "bookshelf_secret": {"password": "delete-me"},
+            "bookshelf_store_revision": 1,
+            "jm_cosmos_integration": {},
+        }
+        fallback = deepcopy(selected)
+        fallback["bookshelf_items"] = [
+            {
+                "key": "jm_album:77",
+                "type": "jm_album",
+                "album_id": "77",
+                "title": "fallback",
+                "pages": [],
+            }
+        ]
+        fallback["bookshelf_secret"] = {"password": "stale-secret"}
+        fallback["bookshelf_store_revision"] = 2
+        self.backend.save_store(selected)
+        self.backend.save_sections({}, {"bookshelf_secret": 2})
+        self.json_backend.save_store(fallback)
+
+        loaded = self._manager("sqlite").load_initial_store()
+
+        self.assertEqual(
+            ["77"], [item["album_id"] for item in loaded["bookshelf_items"]]
+        )
+        self.assertNotIn("bookshelf_secret", loaded)
+        tombstone = self._row("bookshelf_secret")
+        self.assertEqual(1, tombstone[5])
+        self.assertGreaterEqual(tombstone[4], 3)
+        self.assertNotIn("bookshelf_secret", self.backend.load_store())
+
+    def test_new_writes_use_canonical_compact_unicode_json(self) -> None:
+        self.backend.save_store({"ordered": {"b": "中文", "a": 1}})
+
+        row = self._row("ordered")
+        self.assertEqual('{"a":1,"b":"中文"}', row[0])
+        self.assertEqual(hashlib.sha256(row[0].encode("utf-8")).hexdigest(), row[2])
+
+    def test_uninitialized_v2_schema_remains_distinct_from_committed_empty_store(
+        self,
+    ) -> None:
+        sqlite3.connect(self.sqlite_path).close()
+
+        with self.assertRaises(SqliteStoreNotInitializedError):
+            self.backend.load_store()
+        self.assertEqual({"next_revision": "1", "initialized": "0"}, self._meta())
+
+        self.backend.save_store({})
+
+        self.assertEqual(_new_store(), self.backend.load_store())
+        self.assertEqual({"next_revision": "2", "initialized": "1"}, self._meta())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_incremental_persistence_storage.py
+++ b/tests/test_incremental_persistence_storage.py
@@ -906,7 +906,7 @@ class IncrementalPersistenceStorageTests(unittest.TestCase):
         harness = _SqliteWriterHarness(manager, data)
 
         async def flush() -> None:
-            harness._schedule_data_save(sections=None, delay=0.0)
+            harness._schedule_data_save(full_scope="admin_import_export", delay=0.0)
             await harness._flush_scheduled_data_save()
 
         asyncio.run(flush())
@@ -930,7 +930,7 @@ class IncrementalPersistenceStorageTests(unittest.TestCase):
         harness._stop_event.set()
 
         async def flush() -> None:
-            harness._schedule_data_save(sections=None, delay=0.0)
+            harness._schedule_data_save(full_scope="admin_import_export", delay=0.0)
             harness.data.pop("obsolete")
             await harness._flush_default_data_save_on_terminate()
 

--- a/tests/test_incremental_persistence_writer.py
+++ b/tests/test_incremental_persistence_writer.py
@@ -1,0 +1,830 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+import threading
+import unittest
+from copy import deepcopy
+from typing import Any
+
+from astrbot_plugin_private_companion.core_store import CoreStoreMixin
+
+
+class _RecordingManager:
+    def __init__(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        *,
+        next_revision: int = 1,
+        backend_name: str = "sqlite",
+    ) -> None:
+        self.loop = loop
+        self.backend_name = backend_name
+        self.revision_seed = next_revision
+        self.section_attempts = 0
+        self.section_writes: list[
+            tuple[dict[str, tuple[int, Any]], dict[str, int]]
+        ] = []
+        self.snapshot_writes: list[dict[str, Any]] = []
+        self.snapshot_deletions: list[dict[str, int]] = []
+        self.snapshot_preserve_tombstones: list[bool] = []
+        self.fail_section_attempts = 0
+        self.confirm_only_on_attempt: dict[int, set[str]] = {}
+        self.blocked_section_attempts: dict[
+            int, tuple[asyncio.Event, asyncio.Event]
+        ] = {}
+        self.blocked_snapshot_attempts: dict[
+            int, tuple[asyncio.Event, asyncio.Event]
+        ] = {}
+        self.snapshot_attempts = 0
+        self._active_writers = 0
+        self.max_active_writers = 0
+        self._lock = threading.Lock()
+
+    def next_revision(self) -> int:
+        return self.revision_seed
+
+    def block_section_attempt(
+        self, attempt: int
+    ) -> tuple[asyncio.Event, asyncio.Event]:
+        started = asyncio.Event()
+        release = asyncio.Event()
+        self.blocked_section_attempts[attempt] = (started, release)
+        return started, release
+
+    def block_snapshot_attempt(
+        self, attempt: int
+    ) -> tuple[asyncio.Event, asyncio.Event]:
+        started = asyncio.Event()
+        release = asyncio.Event()
+        self.blocked_snapshot_attempts[attempt] = (started, release)
+        return started, release
+
+    def _enter_writer(self) -> None:
+        with self._lock:
+            self._active_writers += 1
+            self.max_active_writers = max(self.max_active_writers, self._active_writers)
+
+    def _leave_writer(self) -> None:
+        with self._lock:
+            self._active_writers -= 1
+
+    def _wait_for_gate(
+        self,
+        gate: tuple[asyncio.Event, asyncio.Event] | None,
+    ) -> None:
+        if gate is None:
+            return
+        started, release = gate
+        self.loop.call_soon_threadsafe(started.set)
+        future = asyncio.run_coroutine_threadsafe(release.wait(), self.loop)
+        future.result(timeout=3.0)
+
+    def save_sections(
+        self,
+        changed_sections: dict[str, tuple[int, Any]],
+        deleted_sections: dict[str, int],
+    ) -> dict[str, int]:
+        self._enter_writer()
+        try:
+            self.section_attempts += 1
+            attempt = self.section_attempts
+            self._wait_for_gate(self.blocked_section_attempts.get(attempt))
+            if attempt <= self.fail_section_attempts:
+                raise OSError("injected section failure")
+            changed_copy = {
+                name: (revision, deepcopy(payload))
+                for name, (revision, payload) in changed_sections.items()
+            }
+            deleted_copy = dict(deleted_sections)
+            self.section_writes.append((changed_copy, deleted_copy))
+            confirmed = {
+                name: revision for name, (revision, _payload) in changed_copy.items()
+            }
+            confirmed.update(deleted_copy)
+            if attempt in self.confirm_only_on_attempt:
+                allowed = self.confirm_only_on_attempt[attempt]
+                confirmed = {
+                    name: revision
+                    for name, revision in confirmed.items()
+                    if name in allowed
+                }
+            if confirmed:
+                self.revision_seed = max(
+                    self.revision_seed, max(confirmed.values()) + 1
+                )
+            return confirmed
+        finally:
+            self._leave_writer()
+
+    def save_snapshot(
+        self,
+        data: dict[str, Any],
+        *,
+        minimum_revision: int | None = None,
+        deleted_sections: dict[str, int] | None = None,
+        preserve_tombstones: bool = False,
+    ) -> int:
+        self._enter_writer()
+        try:
+            self.snapshot_attempts += 1
+            self._wait_for_gate(
+                self.blocked_snapshot_attempts.get(self.snapshot_attempts)
+            )
+            self.snapshot_writes.append(deepcopy(data))
+            self.snapshot_deletions.append(dict(deleted_sections or {}))
+            self.snapshot_preserve_tombstones.append(bool(preserve_tombstones))
+            persisted_revision = max(
+                self.revision_seed,
+                int(minimum_revision or self.revision_seed),
+            )
+            self.revision_seed = persisted_revision + 1
+            return persisted_revision
+        finally:
+            self._leave_writer()
+
+    def save_store(self, data: dict[str, Any]) -> None:
+        self.save_snapshot(data)
+
+
+class _WriterHarness(CoreStoreMixin):
+    def __init__(
+        self, data: dict[str, Any], *, backend: str = "sqlite", seed: int = 1
+    ) -> None:
+        self.data = data
+        self.storage_backend = backend
+        self.store_manager = _RecordingManager(
+            asyncio.get_running_loop(),
+            next_revision=seed,
+            backend_name=backend,
+        )
+        self.enable_multi_persona_mode = False
+        self.enable_store_control_tag_sanitization = True
+        self._stop_event = asyncio.Event()
+        self._data_save_task = None
+        self._data_save_dirty: dict[str, int] = {}
+        self._data_save_deleted: dict[str, int] = {}
+        self._data_save_full_revision = 0
+        self._data_save_revision = seed - 1
+        self._persona_data_save_tasks: dict[str, asyncio.Task] = {}
+        self._persona_data_save_dirty: dict[str, dict[str, int]] = {}
+        self._persona_data_save_deleted: dict[str, dict[str, int]] = {}
+        self._persona_data_save_full_revision: dict[str, int] = {}
+        self._persona_data_save_revision: dict[str, int] = {}
+        self._data_save_max_delay_seconds = 0.05
+        self._data_save_retry_base_seconds = 0.01
+        self._data_save_retry_max_seconds = 0.03
+        self.sanitized_roots: list[tuple[str, ...]] = []
+
+    def _sanitize_store_control_tags_inplace(
+        self,
+        value: Any,
+        _path: tuple[Any, ...] = (),
+    ) -> int:
+        if not _path and isinstance(value, dict):
+            self.sanitized_roots.append(tuple(str(key) for key in value))
+        return super()._sanitize_store_control_tags_inplace(value, _path)
+
+
+class _PersonaWriterHarness(_WriterHarness):
+    def __init__(self) -> None:
+        self._active_persona_id = ""
+        self._data_default = {"users": {}}
+        self._persona_data_profiles = {
+            "main": {"users": {}, "groups": {}},
+            "alt": {"users": {}, "groups": {}},
+        }
+        super().__init__(self._data_default, backend="json")
+        self.enable_multi_persona_mode = True
+        self.persona_attempts: dict[str, int] = {}
+        self.persona_failures: dict[str, int] = {}
+        self.persona_writes: list[tuple[str, dict[str, Any]]] = []
+        self.persona_gates: dict[
+            tuple[str, int], tuple[asyncio.Event, asyncio.Event]
+        ] = {}
+
+    @property
+    def data(self) -> dict[str, Any]:
+        if self._active_persona_id:
+            return self._persona_data_profiles[self._active_persona_id]
+        return self._data_default
+
+    @data.setter
+    def data(self, value: dict[str, Any]) -> None:
+        self._data_default = value
+
+    def _active_persona_scope(self) -> str:
+        return self._active_persona_id
+
+    def activate(self, persona_id: str) -> None:
+        self._active_persona_id = persona_id
+
+    def block_persona_attempt(
+        self,
+        persona_id: str,
+        attempt: int,
+    ) -> tuple[asyncio.Event, asyncio.Event]:
+        started = asyncio.Event()
+        release = asyncio.Event()
+        self.persona_gates[(persona_id, attempt)] = (started, release)
+        return started, release
+
+    def _save_persona_profile_sync(
+        self,
+        persona_id: str,
+        data: dict[str, Any] | None = None,
+    ) -> None:
+        attempt = self.persona_attempts.get(persona_id, 0) + 1
+        self.persona_attempts[persona_id] = attempt
+        self.store_manager._wait_for_gate(self.persona_gates.get((persona_id, attempt)))
+        if attempt <= self.persona_failures.get(persona_id, 0):
+            raise OSError(f"injected persona failure: {persona_id}")
+        self.persona_writes.append((persona_id, deepcopy(data or {})))
+
+
+class IncrementalPersistenceWriterTests(unittest.IsolatedAsyncioTestCase):
+    async def test_section_marks_share_revision_and_empty_mark_is_noop(self) -> None:
+        harness = _WriterHarness({"users": {}, "groups": {}})
+        harness._stop_event.set()
+
+        harness._schedule_data_save(sections={"users", "groups"})
+        revision = harness._data_save_dirty["users"]
+
+        self.assertGreaterEqual(revision, 1)
+        self.assertEqual(revision, harness._data_save_dirty["groups"])
+        before = harness._data_save_revision
+        harness._schedule_data_save(sections=set())
+        self.assertEqual(before, harness._data_save_revision)
+        self.assertIsNone(harness._data_save_task)
+
+    async def test_full_fallback_marks_every_live_root_with_one_revision(self) -> None:
+        harness = _WriterHarness({"users": {}, "groups": {}, "daily_state": {}})
+        harness._stop_event.set()
+
+        harness._schedule_data_save(sections=None)
+
+        self.assertEqual(
+            {"users", "groups", "daily_state"}, set(harness._data_save_dirty)
+        )
+        self.assertEqual(1, len(set(harness._data_save_dirty.values())))
+        self.assertEqual(
+            next(iter(harness._data_save_dirty.values())),
+            harness._data_save_full_revision,
+        )
+
+    async def test_writer_uses_store_manager_backend_over_config_string(self) -> None:
+        harness = _WriterHarness({"users": {}}, backend="sqlite")
+        harness.storage_backend = "json"
+
+        harness._schedule_data_save(sections={"users"}, delay=0.0)
+        await asyncio.wait_for(harness._flush_scheduled_data_save(), timeout=1.0)
+
+        self.assertEqual(1, len(harness.store_manager.section_writes))
+        self.assertFalse(harness.store_manager.snapshot_writes)
+
+    async def test_writer_keeps_newer_same_section_revision_for_second_batch(
+        self,
+    ) -> None:
+        harness = _WriterHarness({"users": {"owner": {"name": "old"}}, "groups": {}})
+        started, release = harness.store_manager.block_section_attempt(1)
+
+        harness._schedule_data_save(sections={"users"}, delay=0.0)
+        await asyncio.wait_for(started.wait(), timeout=0.5)
+        harness.data["users"]["owner"]["name"] = "latest"
+        harness._schedule_data_save(sections={"users"}, delay=0.0)
+        release.set()
+        await asyncio.wait_for(harness._flush_scheduled_data_save(), timeout=1.0)
+
+        self.assertEqual(2, len(harness.store_manager.section_writes))
+        first = harness.store_manager.section_writes[0][0]["users"][1]
+        second = harness.store_manager.section_writes[1][0]["users"][1]
+        self.assertEqual("old", first["owner"]["name"])
+        self.assertEqual("latest", second["owner"]["name"])
+        self.assertFalse(harness._data_save_dirty)
+
+    async def test_section_added_during_write_is_not_cleared_by_first_batch(
+        self,
+    ) -> None:
+        harness = _WriterHarness({"users": {"owner": {}}, "groups": {}})
+        started, release = harness.store_manager.block_section_attempt(1)
+
+        harness._schedule_data_save(sections={"users"}, delay=0.0)
+        await asyncio.wait_for(started.wait(), timeout=0.5)
+        harness.data["groups"]["room"] = {"name": "new"}
+        harness._schedule_data_save(sections={"groups"}, delay=0.0)
+        release.set()
+        await asyncio.wait_for(harness._flush_scheduled_data_save(), timeout=1.0)
+
+        self.assertEqual({"users"}, set(harness.store_manager.section_writes[0][0]))
+        self.assertEqual({"groups"}, set(harness.store_manager.section_writes[1][0]))
+
+    async def test_failed_write_retries_in_one_writer_and_retains_dirty_revision(
+        self,
+    ) -> None:
+        harness = _WriterHarness({"users": {"owner": {"name": "kept"}}})
+        harness.store_manager.fail_section_attempts = 1
+
+        harness._schedule_data_save(sections={"users"}, delay=0.0)
+        await asyncio.wait_for(harness._flush_scheduled_data_save(), timeout=1.0)
+
+        self.assertEqual(2, harness.store_manager.section_attempts)
+        self.assertEqual(1, len(harness.store_manager.section_writes))
+        self.assertEqual(1, harness.store_manager.max_active_writers)
+        self.assertFalse(harness._data_save_dirty)
+
+    async def test_only_explicit_delete_becomes_tombstone(self) -> None:
+        harness = _WriterHarness({"users": {}})
+
+        harness._schedule_data_save(
+            sections={"users"},
+            deleted_sections={"obsolete"},
+            delay=0.0,
+        )
+        await asyncio.wait_for(harness._flush_scheduled_data_save(), timeout=1.0)
+
+        changed, deleted = harness.store_manager.section_writes[0]
+        self.assertEqual({"users"}, set(changed))
+        self.assertEqual({"obsolete"}, set(deleted))
+        with self.assertRaises(ValueError):
+            harness._schedule_data_save(
+                sections={"users"},
+                deleted_sections={"users"},
+            )
+        harness._schedule_data_save(
+            sections=None,
+            deleted_sections={"obsolete"},
+        )
+        self.assertEqual({"obsolete"}, set(harness._data_save_deleted))
+
+    async def test_bookshelf_group_is_captured_with_one_revision(self) -> None:
+        harness = _WriterHarness(
+            {
+                "bookshelf_items": [{"id": "one"}],
+                "bookshelf_secret": {"token": "secret"},
+                "bookshelf_store_revision": 7,
+                "jm_cosmos_integration": {"enabled": True},
+                "users": {},
+            }
+        )
+
+        harness._schedule_data_save(sections={"bookshelf_items"}, delay=0.0)
+        await asyncio.wait_for(harness._flush_scheduled_data_save(), timeout=1.0)
+
+        changed, deleted = harness.store_manager.section_writes[0]
+        expected = {
+            "bookshelf_items",
+            "bookshelf_secret",
+            "bookshelf_store_revision",
+            "jm_cosmos_integration",
+        }
+        self.assertEqual(expected, set(changed))
+        self.assertFalse(deleted)
+        self.assertEqual(1, len({revision for revision, _payload in changed.values()}))
+
+    async def test_partial_backend_confirmation_keeps_unconfirmed_section_dirty(
+        self,
+    ) -> None:
+        harness = _WriterHarness({"users": {}, "groups": {}})
+        harness.store_manager.confirm_only_on_attempt[1] = {"users"}
+
+        harness._schedule_data_save(sections={"users", "groups"}, delay=0.0)
+        await asyncio.wait_for(harness._flush_scheduled_data_save(), timeout=1.0)
+
+        self.assertEqual(2, harness.store_manager.section_attempts)
+        self.assertEqual(
+            {"users", "groups"}, set(harness.store_manager.section_writes[0][0])
+        )
+        self.assertEqual({"groups"}, set(harness.store_manager.section_writes[1][0]))
+        self.assertFalse(harness._data_save_dirty)
+
+    async def test_sqlite_full_fallback_upsert_precedes_partial_with_fresh_revision(
+        self,
+    ) -> None:
+        harness = _WriterHarness({"users": {"owner": {"name": "full"}}}, seed=20)
+
+        harness._schedule_data_save(sections=None, delay=0.0)
+        await asyncio.wait_for(harness._flush_scheduled_data_save(), timeout=1.0)
+        harness.data["users"]["owner"]["name"] = "partial"
+        harness._schedule_data_save(sections={"users"}, delay=0.0)
+        await asyncio.wait_for(harness._flush_scheduled_data_save(), timeout=1.0)
+
+        self.assertFalse(harness.store_manager.snapshot_writes)
+        self.assertEqual(2, len(harness.store_manager.section_writes))
+        full_revision = harness.store_manager.section_writes[0][0]["users"][0]
+        partial_revision = harness.store_manager.section_writes[1][0]["users"][0]
+        self.assertGreater(partial_revision, full_revision)
+
+    async def test_full_compatibility_upsert_keeps_mutation_for_second_batch(self) -> None:
+        harness = _WriterHarness(
+            {"users": {"owner": {"name": "old"}}, "groups": {}}, seed=20
+        )
+        started, release = harness.store_manager.block_section_attempt(1)
+
+        harness._schedule_data_save(sections=None, delay=0.0)
+        await asyncio.wait_for(started.wait(), timeout=0.5)
+        harness.data["users"]["owner"]["name"] = "latest"
+        harness._schedule_data_save(sections={"users"}, delay=0.0)
+        release.set()
+
+        await asyncio.wait_for(harness._flush_scheduled_data_save(), timeout=1.0)
+
+        self.assertFalse(harness.store_manager.snapshot_writes)
+        self.assertEqual(2, len(harness.store_manager.section_writes))
+        self.assertEqual(
+            "latest",
+            harness.store_manager.section_writes[1][0]["users"][1]["owner"]["name"],
+        )
+        self.assertFalse(harness._data_save_dirty)
+
+    async def test_full_compatibility_upsert_keeps_newer_revision_before_capture(
+        self,
+    ) -> None:
+        harness = _WriterHarness(
+            {"users": {"owner": {"name": "old"}}, "groups": {}}, seed=20
+        )
+
+        harness._schedule_data_save(sections=None, delay=0.05)
+        harness.data["users"]["owner"]["name"] = "latest"
+        harness._schedule_data_save(sections={"users"}, delay=0.0)
+        await asyncio.wait_for(harness._flush_scheduled_data_save(), timeout=1.0)
+
+        self.assertFalse(harness.store_manager.snapshot_writes)
+        self.assertEqual(1, len(harness.store_manager.section_writes))
+        changed = harness.store_manager.section_writes[0][0]
+        self.assertGreater(changed["users"][0], changed["groups"][0])
+        self.assertEqual(22, harness.store_manager.next_revision())
+        self.assertFalse(harness._data_save_dirty)
+        self.assertEqual(0, harness._data_save_full_revision)
+
+    async def test_full_compatibility_upsert_preserves_explicit_tombstone(self) -> None:
+        harness = _WriterHarness(
+            {"users": {}, "obsolete": {"value": "legacy"}}, seed=20
+        )
+        harness._stop_event.set()
+        harness._schedule_data_save(sections=None, delay=0.0)
+        harness.data.pop("obsolete")
+        harness._schedule_data_save(
+            sections=set(),
+            deleted_sections={"obsolete"},
+            delay=0.0,
+        )
+        harness._stop_event.clear()
+        harness._start_default_data_save_writer(0.0)
+
+        await asyncio.wait_for(harness._flush_scheduled_data_save(), timeout=1.0)
+
+        self.assertFalse(harness.store_manager.snapshot_writes)
+        changed, deleted = harness.store_manager.section_writes[0]
+        self.assertEqual({"users"}, set(changed))
+        self.assertEqual({"obsolete": 21}, deleted)
+
+    async def test_terminate_full_dirty_uses_snapshot_for_missing_section(
+        self,
+    ) -> None:
+        harness = _WriterHarness(
+            {"users": {}, "obsolete": {"value": "legacy"}}, seed=20
+        )
+        harness._stop_event.set()
+        harness._schedule_data_save(sections=None, delay=0.0)
+        harness.data.pop("obsolete")
+
+        await harness._flush_default_data_save_on_terminate()
+
+        self.assertEqual(1, len(harness.store_manager.snapshot_writes))
+        self.assertEqual({"users": {}}, harness.store_manager.snapshot_writes[0])
+        self.assertEqual([{}], harness.store_manager.snapshot_deletions)
+        self.assertEqual([True], harness.store_manager.snapshot_preserve_tombstones)
+        self.assertFalse(harness.store_manager.section_writes)
+        self.assertFalse(harness._default_data_save_is_dirty())
+
+    async def test_terminate_partial_dirty_does_not_infer_missing_section_delete(
+        self,
+    ) -> None:
+        harness = _WriterHarness(
+            {"users": {}, "obsolete": {"value": "legacy"}}, seed=20
+        )
+        harness._stop_event.set()
+        harness._schedule_data_save(sections={"users"}, delay=0.0)
+        harness.data.pop("obsolete")
+
+        await harness._flush_default_data_save_on_terminate()
+
+        self.assertFalse(harness.store_manager.snapshot_writes)
+        self.assertEqual(1, len(harness.store_manager.section_writes))
+        changed, deleted = harness.store_manager.section_writes[0]
+        self.assertEqual({"users"}, set(changed))
+        self.assertEqual({}, deleted)
+        self.assertFalse(harness._default_data_save_is_dirty())
+
+    async def test_partial_dirty_missing_section_requires_explicit_tombstone(self) -> None:
+        harness = _WriterHarness(
+            {"users": {}, "obsolete": {"value": "legacy"}}, seed=20
+        )
+        harness._stop_event.set()
+        harness._schedule_data_save(sections={"obsolete"}, delay=0.0)
+        revision = harness._data_save_dirty["obsolete"]
+        harness.data.pop("obsolete")
+
+        with self.assertRaisesRegex(RuntimeError, "explicit tombstones"):
+            await harness._flush_default_data_save_on_terminate()
+
+        self.assertFalse(harness.store_manager.section_writes)
+        self.assertEqual(revision, harness._data_save_dirty["obsolete"])
+        self.assertTrue(harness._default_data_save_is_dirty())
+
+    async def test_reset_remains_an_explicit_full_snapshot(self) -> None:
+        harness = _WriterHarness(
+            {"users": {"owner": {}}, "obsolete": {"value": "legacy"}},
+            seed=20,
+        )
+        harness._data_lock = asyncio.Lock()
+        harness.default_enable_configured_targets = False
+        harness._new_store = lambda: {"users": {"reset": True}}
+
+        await harness._reset_plugin_store()
+
+        self.assertEqual({"users": {"reset": True}}, harness.data)
+        self.assertEqual([{"users": {"reset": True}}], harness.store_manager.snapshot_writes)
+        self.assertFalse(harness.store_manager.section_writes)
+        self.assertFalse(harness._default_data_save_is_dirty())
+
+    async def test_max_delay_bounds_first_write(self) -> None:
+        harness = _WriterHarness({"users": {}})
+        started, release = harness.store_manager.block_section_attempt(1)
+
+        harness._schedule_data_save(sections={"users"}, delay=60.0)
+        await asyncio.wait_for(started.wait(), timeout=0.3)
+        release.set()
+        await asyncio.wait_for(harness._flush_scheduled_data_save(), timeout=1.0)
+
+        self.assertEqual(1, len(harness.store_manager.section_writes))
+
+    async def test_json_writes_full_file_but_sanitizes_only_dirty_roots(self) -> None:
+        harness = _WriterHarness(
+            {
+                "users": {"owner": {"summary": "clean <bubble/> me"}},
+                "groups": {"room": {"summary": "leave <bubble/> alone"}},
+            },
+            backend="json",
+        )
+
+        users_identity = harness.data["users"]
+        harness._schedule_data_save(sections={"users"}, delay=0.0)
+        await asyncio.wait_for(harness._flush_scheduled_data_save(), timeout=1.0)
+
+        self.assertEqual([("users",)], harness.sanitized_roots)
+        snapshot = harness.store_manager.snapshot_writes[0]
+        self.assertNotIn("<bubble/>", snapshot["users"]["owner"]["summary"])
+        self.assertIn("<bubble/>", snapshot["groups"]["room"]["summary"])
+        self.assertNotIn("<bubble/>", harness.data["users"]["owner"]["summary"])
+        self.assertIn("<bubble/>", harness.data["groups"]["room"]["summary"])
+        self.assertIs(users_identity, harness.data["users"])
+
+    async def test_candidate_compaction_uses_users_as_unsanitized_readonly_context(
+        self,
+    ) -> None:
+        candidates = [
+            {"id": f"candidate-{index}", "status": "blocked", "created_ts": index}
+            for index in range(601)
+        ]
+        harness = _WriterHarness(
+            {
+                "users": {
+                    "owner": {
+                        "planned_candidate_id": "candidate-0",
+                        "summary": "raw <bubble/> user",
+                    }
+                },
+                "proactive_candidate_pool": candidates,
+            }
+        )
+        pool_identity = harness.data["proactive_candidate_pool"]
+
+        harness._schedule_data_save(sections={"proactive_candidate_pool"}, delay=0.0)
+        await asyncio.wait_for(harness._flush_scheduled_data_save(), timeout=1.0)
+
+        changed = harness.store_manager.section_writes[0][0]
+        self.assertEqual({"proactive_candidate_pool"}, set(changed))
+        self.assertEqual([("proactive_candidate_pool",)], harness.sanitized_roots)
+        self.assertEqual(
+            "raw <bubble/> user", harness.data["users"]["owner"]["summary"]
+        )
+        self.assertIs(pool_identity, harness.data["proactive_candidate_pool"])
+        self.assertEqual(600, len(pool_identity))
+        self.assertIn("candidate-0", {item["id"] for item in pool_identity})
+
+    async def test_repeat_count_sanitizer_persists_derived_timestamp_at_same_revision(
+        self,
+    ) -> None:
+        harness = _WriterHarness(
+            {
+                "users": {},
+                "proactive_candidate_pool": [
+                    {"id": "candidate", "status": "blocked", "repeat_count": 99}
+                ],
+            }
+        )
+
+        harness._schedule_data_save(sections={"proactive_candidate_pool"}, delay=0.0)
+        await asyncio.wait_for(harness._flush_scheduled_data_save(), timeout=1.0)
+
+        changed = harness.store_manager.section_writes[0][0]
+        self.assertEqual(
+            {"proactive_candidate_pool", "proactive_candidate_repeat_sanitized_at"},
+            set(changed),
+        )
+        self.assertEqual(1, len({revision for revision, _payload in changed.values()}))
+        self.assertIn("proactive_candidate_repeat_sanitized_at", harness.data)
+        self.assertEqual(6, harness.data["proactive_candidate_pool"][0]["repeat_count"])
+
+    async def test_stale_sanitizer_result_does_not_overwrite_newer_live_value(
+        self,
+    ) -> None:
+        harness = _WriterHarness(
+            {"users": {"owner": {"summary": "old<bubble/>"}}},
+            backend="json",
+        )
+        first_started, first_release = harness.store_manager.block_snapshot_attempt(1)
+        second_started, second_release = harness.store_manager.block_snapshot_attempt(2)
+
+        harness._schedule_data_save(sections={"users"}, delay=0.0)
+        await asyncio.wait_for(first_started.wait(), timeout=0.5)
+        harness.data["users"]["owner"]["summary"] = "latest<bubble/>"
+        harness._schedule_data_save(sections={"users"}, delay=0.0)
+        first_release.set()
+        await asyncio.wait_for(second_started.wait(), timeout=0.5)
+
+        self.assertEqual("latest<bubble/>", harness.data["users"]["owner"]["summary"])
+        second_release.set()
+        await asyncio.wait_for(harness._flush_scheduled_data_save(), timeout=1.0)
+        self.assertEqual("latest", harness.data["users"]["owner"]["summary"])
+
+    async def test_sync_snapshot_supersedes_captured_default_writer_batch(
+        self,
+    ) -> None:
+        harness = _WriterHarness(
+            {"users": {"owner": {"name": "old"}}},
+            backend="json",
+        )
+        harness._stop_event.set()
+        harness._schedule_data_save(sections={"users"}, delay=0.0)
+        batch = harness._capture_default_data_save_batch()
+        harness.data["users"]["owner"]["name"] = "sync-latest"
+
+        lock = harness._data_save_io_lock()
+        lock.acquire()
+        try:
+            stale_writer = asyncio.create_task(
+                asyncio.to_thread(harness._write_default_data_save_batch_sync, batch)
+            )
+            await asyncio.sleep(0)
+            # Re-entering the lock is intentional: the event-loop thread owns
+            # it while the captured writer is queued behind it.
+            harness._save_data_now_sync()
+        finally:
+            lock.release()
+        result = await asyncio.wait_for(stale_writer, timeout=1.0)
+        harness._finish_default_data_save_batch(batch, result)
+
+        self.assertTrue(result["superseded"])
+        self.assertEqual(1, len(harness.store_manager.snapshot_writes))
+        self.assertEqual(
+            "sync-latest",
+            harness.store_manager.snapshot_writes[0]["users"]["owner"]["name"],
+        )
+        self.assertTrue(harness._data_save_dirty)
+
+    async def test_stopping_keeps_dirty_without_starting_writer(self) -> None:
+        harness = _WriterHarness({"users": {}})
+        harness._stop_event.set()
+
+        harness._schedule_data_save(sections={"users"}, delay=0.0)
+        await asyncio.wait_for(harness._flush_scheduled_data_save(), timeout=0.2)
+
+        self.assertTrue(harness._data_save_dirty)
+        self.assertIsNone(harness._data_save_task)
+
+    async def test_persona_writers_are_isolated_and_failure_does_not_clear_peer(
+        self,
+    ) -> None:
+        harness = _PersonaWriterHarness()
+        harness.persona_failures["main"] = 1
+        harness.activate("main")
+        harness.data["users"]["owner"] = {"name": "main"}
+        harness._schedule_data_save(sections={"users"}, delay=0.0)
+        harness.activate("alt")
+        harness.data["groups"]["room"] = {"name": "alt"}
+        harness._schedule_data_save(sections={"groups"}, delay=0.0)
+        harness.activate("")
+
+        await asyncio.wait_for(harness._flush_scheduled_data_save(), timeout=1.0)
+
+        self.assertEqual(2, harness.persona_attempts["main"])
+        self.assertEqual(1, harness.persona_attempts["alt"])
+        self.assertEqual(
+            {"main", "alt"}, {persona for persona, _data in harness.persona_writes}
+        )
+        self.assertFalse(harness._persona_data_save_dirty)
+        self.assertFalse(harness._persona_data_save_tasks)
+
+    async def test_persona_full_file_sanitizes_only_dirty_root(self) -> None:
+        harness = _PersonaWriterHarness()
+        harness._persona_data_profiles["main"] = {
+            "users": {"owner": {"summary": "clean <bubble/> me"}},
+            "groups": {"room": {"summary": "keep <bubble/> raw"}},
+        }
+        harness.activate("main")
+
+        harness._schedule_data_save(sections={"users"}, delay=0.0)
+        harness.activate("")
+        await asyncio.wait_for(harness._flush_scheduled_data_save(), timeout=1.0)
+
+        saved = next(
+            data for persona, data in harness.persona_writes if persona == "main"
+        )
+        self.assertNotIn("<bubble/>", saved["users"]["owner"]["summary"])
+        self.assertIn("<bubble/>", saved["groups"]["room"]["summary"])
+        self.assertNotIn(
+            "<bubble/>",
+            harness._persona_data_profiles["main"]["users"]["owner"]["summary"],
+        )
+
+    async def test_persona_mutation_during_write_is_saved_in_second_batch(self) -> None:
+        harness = _PersonaWriterHarness()
+        started, release = harness.block_persona_attempt("main", 1)
+        harness.activate("main")
+        harness.data["users"]["owner"] = {"name": "old"}
+        harness._schedule_data_save(sections={"users"}, delay=0.0)
+        await asyncio.wait_for(started.wait(), timeout=0.5)
+        harness.data["users"]["owner"]["name"] = "latest"
+        harness._schedule_data_save(sections={"users"}, delay=0.0)
+        harness.activate("")
+        release.set()
+
+        await asyncio.wait_for(harness._flush_scheduled_data_save(), timeout=1.0)
+
+        writes = [data for persona, data in harness.persona_writes if persona == "main"]
+        self.assertEqual(2, len(writes))
+        self.assertEqual("old", writes[0]["users"]["owner"]["name"])
+        self.assertEqual("latest", writes[1]["users"]["owner"]["name"])
+
+    async def test_sync_persona_snapshot_supersedes_captured_writer_batch(self) -> None:
+        harness = _PersonaWriterHarness()
+        harness._stop_event.set()
+        harness.activate("main")
+        harness.data["users"]["owner"] = {"name": "old"}
+        harness._schedule_data_save(sections={"users"}, delay=0.0)
+        batch = harness._capture_persona_data_save_batch("main")
+
+        harness.data["users"]["owner"]["name"] = "sync-latest"
+        lock = harness._data_save_io_lock("main")
+        lock.acquire()
+        try:
+            stale_writer = asyncio.create_task(
+                asyncio.to_thread(
+                    harness._write_persona_data_save_batch_sync,
+                    "main",
+                    batch,
+                )
+            )
+            await asyncio.sleep(0)
+            harness._write_persona_data_snapshot_sync("main", deepcopy(harness.data))
+        finally:
+            lock.release()
+        harness.activate("")
+        result = await asyncio.wait_for(stale_writer, timeout=1.0)
+        harness._finish_persona_data_save_batch("main", batch, result)
+
+        writes = [data for persona, data in harness.persona_writes if persona == "main"]
+        self.assertTrue(result["superseded"])
+        self.assertEqual(1, len(writes))
+        self.assertEqual("sync-latest", writes[0]["users"]["owner"]["name"])
+        self.assertTrue(harness._persona_data_save_dirty)
+
+    async def test_flush_waits_for_default_and_all_persona_writers(self) -> None:
+        harness = _PersonaWriterHarness()
+        default_started, default_release = harness.store_manager.block_snapshot_attempt(
+            1
+        )
+        persona_started, persona_release = harness.block_persona_attempt("main", 1)
+        harness._data_default["users"]["default"] = {"name": "default"}
+        harness._schedule_default_data_save(0.0, sections={"users"})
+        harness.activate("main")
+        harness.data["users"]["owner"] = {"name": "main"}
+        harness._schedule_data_save(sections={"users"}, delay=0.0)
+        harness.activate("")
+        await asyncio.wait_for(default_started.wait(), timeout=0.5)
+        await asyncio.wait_for(persona_started.wait(), timeout=0.5)
+
+        flushing = asyncio.create_task(harness._flush_scheduled_data_save())
+        await asyncio.sleep(0)
+        self.assertFalse(flushing.done())
+        default_release.set()
+        await asyncio.sleep(0.01)
+        self.assertFalse(flushing.done())
+        persona_release.set()
+        await asyncio.wait_for(flushing, timeout=1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_incremental_persistence_writer.py
+++ b/tests/test_incremental_persistence_writer.py
@@ -5,9 +5,11 @@ import asyncio
 import threading
 import unittest
 from copy import deepcopy
+from types import SimpleNamespace
 from typing import Any
 
 from astrbot_plugin_private_companion.core_store import CoreStoreMixin
+from astrbot_plugin_private_companion.message_pipeline import event_data_save_boundary
 
 
 class _RecordingManager:
@@ -242,7 +244,152 @@ class _PersonaWriterHarness(_WriterHarness):
         self.persona_writes.append((persona_id, deepcopy(data or {})))
 
 
+class _BatchEvent:
+    def __init__(self) -> None:
+        self.stopped = False
+
+    def stop_event(self) -> None:
+        self.stopped = True
+
+    def is_stopped(self) -> bool:
+        return self.stopped
+
+
+class _BoundaryHarness(_WriterHarness):
+    @event_data_save_boundary
+    async def early_mutation(self, event: _BatchEvent) -> None:
+        self._schedule_data_save(sections={"users"})
+
+    @event_data_save_boundary
+    async def stopped_early_mutation(self, event: _BatchEvent) -> None:
+        self._schedule_data_save(sections={"users"})
+        event.stop_event()
+
+    @event_data_save_boundary(flush=True)
+    async def final_mutation(self, event: _BatchEvent) -> None:
+        self._schedule_data_save(sections={"groups"})
+
+    @event_data_save_boundary
+    async def failed_mutation(self, event: _BatchEvent) -> None:
+        self._schedule_data_save(sections={"users"})
+        raise RuntimeError("injected event hook failure")
+
+
 class IncrementalPersistenceWriterTests(unittest.IsolatedAsyncioTestCase):
+    async def test_event_owned_batch_resumes_across_filter_tasks(self) -> None:
+        harness = _BoundaryHarness({"users": {}, "groups": {}})
+        harness._stop_event.set()
+        event = _BatchEvent()
+
+        await harness.early_mutation(event)
+        self.assertTrue(hasattr(event, "_private_companion_event_data_save_batch"))
+        await harness.final_mutation(event)
+
+        self.assertFalse(hasattr(event, "_private_companion_event_data_save_batch"))
+        self.assertEqual({"users", "groups"}, set(harness._data_save_dirty))
+        self.assertEqual(1, len(set(harness._data_save_dirty.values())))
+        self.assertEqual(1, harness._data_save_revision)
+
+    async def test_stopped_early_filter_flushes_pending_sections(self) -> None:
+        harness = _BoundaryHarness({"users": {}})
+        harness._stop_event.set()
+        event = _BatchEvent()
+
+        await harness.stopped_early_mutation(event)
+
+        self.assertTrue(event.is_stopped())
+        self.assertFalse(hasattr(event, "_private_companion_event_data_save_batch"))
+        self.assertEqual({"users"}, set(harness._data_save_dirty))
+        self.assertEqual(1, harness._data_save_revision)
+
+    async def test_failed_filter_flushes_pending_sections(self) -> None:
+        harness = _BoundaryHarness({"users": {}})
+        harness._stop_event.set()
+        event = _BatchEvent()
+
+        with self.assertRaisesRegex(RuntimeError, "injected event hook failure"):
+            await harness.failed_mutation(event)
+
+        self.assertFalse(hasattr(event, "_private_companion_event_data_save_batch"))
+        self.assertEqual({"users"}, set(harness._data_save_dirty))
+        self.assertEqual(1, harness._data_save_revision)
+
+    async def test_event_batch_submits_one_union_revision(self) -> None:
+        harness = _WriterHarness({"users": {}, "groups": {}})
+        harness._stop_event.set()
+        event = SimpleNamespace()
+        handle = harness._begin_event_data_save_batch(event)
+
+        harness._schedule_data_save(sections={"users"}, delay=0.8)
+        harness._save_data_sync(sections={"groups"})
+
+        self.assertEqual(0, harness._data_save_revision)
+        self.assertEqual(
+            {"users", "groups"},
+            event._private_companion_pending_save_sections,
+        )
+
+        harness._finish_event_data_save_batch(handle)
+
+        self.assertFalse(
+            hasattr(event, "_private_companion_pending_save_sections")
+        )
+        self.assertEqual({"users", "groups"}, set(harness._data_save_dirty))
+        self.assertEqual(1, len(set(harness._data_save_dirty.values())))
+        self.assertEqual(1, harness._data_save_revision)
+
+    async def test_empty_event_batch_does_not_allocate_revision(self) -> None:
+        harness = _WriterHarness({"users": {}})
+        event = SimpleNamespace()
+
+        handle = harness._begin_event_data_save_batch(event)
+        harness._finish_event_data_save_batch(handle)
+
+        self.assertEqual(0, harness._data_save_revision)
+        self.assertFalse(harness._default_data_save_is_dirty())
+
+    async def test_child_task_does_not_write_into_closed_event_batch(self) -> None:
+        harness = _WriterHarness({"users": {}})
+        harness._stop_event.set()
+        event = SimpleNamespace()
+        release = asyncio.Event()
+        handle = harness._begin_event_data_save_batch(event)
+
+        async def save_after_event() -> None:
+            await release.wait()
+            harness._schedule_data_save(sections={"users"})
+
+        task = asyncio.create_task(save_after_event())
+        harness._finish_event_data_save_batch(handle)
+        release.set()
+        await task
+
+        self.assertEqual({"users"}, set(harness._data_save_dirty))
+        self.assertEqual(1, harness._data_save_revision)
+
+    async def test_save_contract_requires_explicit_sections_or_allowlisted_scope(self) -> None:
+        harness = _WriterHarness({"users": {}})
+
+        with self.assertRaisesRegex(ValueError, "sections must be explicit"):
+            harness._schedule_data_save()
+        with self.assertRaisesRegex(ValueError, "unknown full save scope"):
+            harness._schedule_data_save(full_scope="not-allowed")
+        with self.assertRaisesRegex(ValueError, "unknown durable sections"):
+            harness._schedule_data_save(sections={"not-a-section"})
+        with self.assertRaisesRegex(ValueError, "disjoint"):
+            harness._schedule_data_save(
+                sections={"users"},
+                deleted_sections={"users"},
+            )
+
+    def test_runtime_sections_are_initialized_in_new_store(self) -> None:
+        store = CoreStoreMixin._new_store(object())
+
+        self.assertEqual({}, store["proactive_review_runtime"])
+        self.assertEqual({}, store["proactive_runtime"])
+        self.assertEqual([], store["proactive_audit_log"])
+        self.assertEqual({}, store["passive_no_reply_records"])
+
     async def test_section_marks_share_revision_and_empty_mark_is_noop(self) -> None:
         harness = _WriterHarness({"users": {}, "groups": {}})
         harness._stop_event.set()
@@ -261,7 +408,7 @@ class IncrementalPersistenceWriterTests(unittest.IsolatedAsyncioTestCase):
         harness = _WriterHarness({"users": {}, "groups": {}, "daily_state": {}})
         harness._stop_event.set()
 
-        harness._schedule_data_save(sections=None)
+        harness._schedule_data_save(full_scope="admin_import_export")
 
         self.assertEqual(
             {"users", "groups", "daily_state"}, set(harness._data_save_dirty)
@@ -299,7 +446,7 @@ class IncrementalPersistenceWriterTests(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(deleted)
         self.assertFalse(harness._default_data_save_is_dirty())
 
-    async def test_sync_save_without_sections_keeps_full_compatibility_scope(self) -> None:
+    async def test_sync_save_requires_an_explicit_full_compatibility_scope(self) -> None:
         harness = _WriterHarness(
             {
                 "users": {},
@@ -308,7 +455,13 @@ class IncrementalPersistenceWriterTests(unittest.IsolatedAsyncioTestCase):
             }
         )
 
-        await asyncio.to_thread(harness._save_data_sync)
+        with self.assertRaisesRegex(ValueError, "sections must be explicit"):
+            await asyncio.to_thread(harness._save_data_sync)
+
+        await asyncio.to_thread(
+            harness._save_data_sync,
+            full_scope="admin_import_export",
+        )
 
         self.assertEqual(1, len(harness.store_manager.section_writes))
         changed, deleted = harness.store_manager.section_writes[0]
@@ -389,24 +542,24 @@ class IncrementalPersistenceWriterTests(unittest.IsolatedAsyncioTestCase):
 
         harness._schedule_data_save(
             sections={"users"},
-            deleted_sections={"obsolete"},
+            deleted_sections={"memo_notes"},
             delay=0.0,
         )
         await asyncio.wait_for(harness._flush_scheduled_data_save(), timeout=1.0)
 
         changed, deleted = harness.store_manager.section_writes[0]
         self.assertEqual({"users"}, set(changed))
-        self.assertEqual({"obsolete"}, set(deleted))
+        self.assertEqual({"memo_notes"}, set(deleted))
         with self.assertRaises(ValueError):
             harness._schedule_data_save(
                 sections={"users"},
                 deleted_sections={"users"},
             )
-        harness._schedule_data_save(
-            sections=None,
-            deleted_sections={"obsolete"},
-        )
-        self.assertEqual({"obsolete"}, set(harness._data_save_deleted))
+        with self.assertRaisesRegex(ValueError, "full_scope cannot be combined"):
+            harness._schedule_data_save(
+                full_scope="admin_import_export",
+                deleted_sections={"memo_notes"},
+            )
 
     async def test_bookshelf_group_is_captured_with_one_revision(self) -> None:
         harness = _WriterHarness(
@@ -454,7 +607,7 @@ class IncrementalPersistenceWriterTests(unittest.IsolatedAsyncioTestCase):
     ) -> None:
         harness = _WriterHarness({"users": {"owner": {"name": "full"}}}, seed=20)
 
-        harness._schedule_data_save(sections=None, delay=0.0)
+        harness._schedule_data_save(full_scope="admin_import_export", delay=0.0)
         await asyncio.wait_for(harness._flush_scheduled_data_save(), timeout=1.0)
         harness.data["users"]["owner"]["name"] = "partial"
         harness._schedule_data_save(sections={"users"}, delay=0.0)
@@ -472,7 +625,7 @@ class IncrementalPersistenceWriterTests(unittest.IsolatedAsyncioTestCase):
         )
         started, release = harness.store_manager.block_section_attempt(1)
 
-        harness._schedule_data_save(sections=None, delay=0.0)
+        harness._schedule_data_save(full_scope="admin_import_export", delay=0.0)
         await asyncio.wait_for(started.wait(), timeout=0.5)
         harness.data["users"]["owner"]["name"] = "latest"
         harness._schedule_data_save(sections={"users"}, delay=0.0)
@@ -495,7 +648,7 @@ class IncrementalPersistenceWriterTests(unittest.IsolatedAsyncioTestCase):
             {"users": {"owner": {"name": "old"}}, "groups": {}}, seed=20
         )
 
-        harness._schedule_data_save(sections=None, delay=0.05)
+        harness._schedule_data_save(full_scope="admin_import_export", delay=0.05)
         harness.data["users"]["owner"]["name"] = "latest"
         harness._schedule_data_save(sections={"users"}, delay=0.0)
         await asyncio.wait_for(harness._flush_scheduled_data_save(), timeout=1.0)
@@ -510,14 +663,14 @@ class IncrementalPersistenceWriterTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_full_compatibility_upsert_preserves_explicit_tombstone(self) -> None:
         harness = _WriterHarness(
-            {"users": {}, "obsolete": {"value": "legacy"}}, seed=20
+            {"users": {}, "memo_notes": {"value": "legacy"}}, seed=20
         )
         harness._stop_event.set()
-        harness._schedule_data_save(sections=None, delay=0.0)
-        harness.data.pop("obsolete")
+        harness._schedule_data_save(full_scope="admin_import_export", delay=0.0)
+        harness.data.pop("memo_notes")
         harness._schedule_data_save(
             sections=set(),
-            deleted_sections={"obsolete"},
+            deleted_sections={"memo_notes"},
             delay=0.0,
         )
         harness._stop_event.clear()
@@ -528,17 +681,17 @@ class IncrementalPersistenceWriterTests(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(harness.store_manager.snapshot_writes)
         changed, deleted = harness.store_manager.section_writes[0]
         self.assertEqual({"users"}, set(changed))
-        self.assertEqual({"obsolete": 21}, deleted)
+        self.assertEqual({"memo_notes": 21}, deleted)
 
     async def test_terminate_full_dirty_uses_snapshot_for_missing_section(
         self,
     ) -> None:
         harness = _WriterHarness(
-            {"users": {}, "obsolete": {"value": "legacy"}}, seed=20
+            {"users": {}, "memo_notes": {"value": "legacy"}}, seed=20
         )
         harness._stop_event.set()
-        harness._schedule_data_save(sections=None, delay=0.0)
-        harness.data.pop("obsolete")
+        harness._schedule_data_save(full_scope="admin_import_export", delay=0.0)
+        harness.data.pop("memo_notes")
 
         await harness._flush_default_data_save_on_terminate()
 
@@ -553,11 +706,11 @@ class IncrementalPersistenceWriterTests(unittest.IsolatedAsyncioTestCase):
         self,
     ) -> None:
         harness = _WriterHarness(
-            {"users": {}, "obsolete": {"value": "legacy"}}, seed=20
+            {"users": {}, "memo_notes": {"value": "legacy"}}, seed=20
         )
         harness._stop_event.set()
         harness._schedule_data_save(sections={"users"}, delay=0.0)
-        harness.data.pop("obsolete")
+        harness.data.pop("memo_notes")
 
         await harness._flush_default_data_save_on_terminate()
 
@@ -570,18 +723,18 @@ class IncrementalPersistenceWriterTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_partial_dirty_missing_section_requires_explicit_tombstone(self) -> None:
         harness = _WriterHarness(
-            {"users": {}, "obsolete": {"value": "legacy"}}, seed=20
+            {"users": {}, "memo_notes": {"value": "legacy"}}, seed=20
         )
         harness._stop_event.set()
-        harness._schedule_data_save(sections={"obsolete"}, delay=0.0)
-        revision = harness._data_save_dirty["obsolete"]
-        harness.data.pop("obsolete")
+        harness._schedule_data_save(sections={"memo_notes"}, delay=0.0)
+        revision = harness._data_save_dirty["memo_notes"]
+        harness.data.pop("memo_notes")
 
         with self.assertRaisesRegex(RuntimeError, "explicit tombstones"):
             await harness._flush_default_data_save_on_terminate()
 
         self.assertFalse(harness.store_manager.section_writes)
-        self.assertEqual(revision, harness._data_save_dirty["obsolete"])
+        self.assertEqual(revision, harness._data_save_dirty["memo_notes"])
         self.assertTrue(harness._default_data_save_is_dirty())
 
     async def test_reset_remains_an_explicit_full_snapshot(self) -> None:
@@ -732,7 +885,7 @@ class IncrementalPersistenceWriterTests(unittest.IsolatedAsyncioTestCase):
             await asyncio.sleep(0)
             # Re-entering the lock is intentional: the event-loop thread owns
             # it while the captured writer is queued behind it.
-            harness._save_data_now_sync()
+            harness._save_data_now_sync(full_scope="admin_import_export")
         finally:
             lock.release()
         result = await asyncio.wait_for(stale_writer, timeout=1.0)

--- a/tests/test_incremental_persistence_writer.py
+++ b/tests/test_incremental_persistence_writer.py
@@ -282,6 +282,58 @@ class IncrementalPersistenceWriterTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(1, len(harness.store_manager.section_writes))
         self.assertFalse(harness.store_manager.snapshot_writes)
 
+    async def test_sync_save_with_explicit_sections_only_writes_target_section(self) -> None:
+        harness = _WriterHarness(
+            {
+                "users": {"owner": {"name": "changed"}},
+                "groups": {"room": {"name": "untouched"}},
+                "daily_state": {"mood": "steady"},
+            }
+        )
+
+        await asyncio.to_thread(harness._save_data_sync, sections={"users"})
+
+        self.assertEqual(1, len(harness.store_manager.section_writes))
+        changed, deleted = harness.store_manager.section_writes[0]
+        self.assertEqual({"users"}, set(changed))
+        self.assertFalse(deleted)
+        self.assertFalse(harness._default_data_save_is_dirty())
+
+    async def test_sync_save_without_sections_keeps_full_compatibility_scope(self) -> None:
+        harness = _WriterHarness(
+            {
+                "users": {},
+                "groups": {},
+                "daily_state": {},
+            }
+        )
+
+        await asyncio.to_thread(harness._save_data_sync)
+
+        self.assertEqual(1, len(harness.store_manager.section_writes))
+        changed, deleted = harness.store_manager.section_writes[0]
+        self.assertEqual({"users", "groups", "daily_state"}, set(changed))
+        self.assertFalse(deleted)
+
+    async def test_sync_json_save_keeps_full_file_replacement_but_dirty_scope(self) -> None:
+        harness = _WriterHarness(
+            {
+                "users": {"owner": {"summary": "clean <bubble/> me"}},
+                "groups": {"room": {"summary": "keep <bubble/> raw"}},
+            },
+            backend="json",
+        )
+
+        await asyncio.to_thread(harness._save_data_sync, sections={"users"})
+
+        self.assertFalse(harness.store_manager.section_writes)
+        self.assertEqual(1, len(harness.store_manager.snapshot_writes))
+        snapshot = harness.store_manager.snapshot_writes[0]
+        self.assertNotIn("<bubble/>", snapshot["users"]["owner"]["summary"])
+        self.assertIn("<bubble/>", snapshot["groups"]["room"]["summary"])
+        self.assertNotIn("<bubble/>", harness.data["users"]["owner"]["summary"])
+        self.assertIn("<bubble/>", harness.data["groups"]["room"]["summary"])
+
     async def test_writer_keeps_newer_same_section_revision_for_second_batch(
         self,
     ) -> None:

--- a/tests/test_multi_persona_isolation.py
+++ b/tests/test_multi_persona_isolation.py
@@ -19,6 +19,7 @@ from astrbot_plugin_private_companion.main import (
 )
 from astrbot_plugin_private_companion.page_api import PrivateCompanionPageApi
 from astrbot_plugin_private_companion.plugin_identity import PLUGIN_ID
+from astrbot_plugin_private_companion.storage.store_manager import StoreManager
 
 
 def _plugin_harness(root: str) -> PrivateCompanionPlugin:
@@ -1022,10 +1023,10 @@ class MultiPersonaIsolationTests(unittest.IsolatedAsyncioTestCase):
             self.assertFalse(plugin._persona_data_save_dirty)
             self.assertEqual({}, plugin._persona_data_save_tasks)
 
-    async def test_terminate_waits_for_inflight_persona_writer_before_final_snapshot(self):
+    async def test_terminate_queues_final_snapshot_after_timed_out_persona_writer(self):
         with tempfile.TemporaryDirectory() as root:
             plugin = _plugin_harness(root)
-            original_writer = plugin._write_persona_data_snapshot_sync
+            original_saver = plugin._save_persona_profile_sync
             writer_started = threading.Event()
             writer_release = threading.Event()
             first_write = True
@@ -1036,9 +1037,9 @@ class MultiPersonaIsolationTests(unittest.IsolatedAsyncioTestCase):
                     first_write = False
                     writer_started.set()
                     writer_release.wait(timeout=3)
-                return original_writer(persona_id, snapshot)
+                return original_saver(persona_id, snapshot)
 
-            plugin._write_persona_data_snapshot_sync = blocking_writer
+            plugin._save_persona_profile_sync = blocking_writer
             plugin._write_data_snapshot_sync = lambda _snapshot: 0
             token = plugin._activate_persona_id("main")
             try:
@@ -1055,6 +1056,7 @@ class MultiPersonaIsolationTests(unittest.IsolatedAsyncioTestCase):
             finally:
                 plugin._deactivate_persona_for_event(token)
             plugin._stop_event.set()
+            plugin._termination_flush_already_attempted = True
             final_save = asyncio.create_task(plugin._save_data_on_terminate())
             await asyncio.sleep(0.05)
             self.assertFalse(final_save.done())
@@ -1080,6 +1082,77 @@ class MultiPersonaIsolationTests(unittest.IsolatedAsyncioTestCase):
                     Path(root) / "persona_profiles" / f"{persona_id}.json"
                 ).read_text(encoding="utf-8")
                 self.assertIn(f'"final_marker": "{persona_id}"', stored)
+
+    async def test_sqlite_terminate_preserves_bookshelf_tombstone_on_restart(self):
+        with tempfile.TemporaryDirectory() as root:
+            root_path = Path(root)
+            data_file = root_path / "companion.json"
+            sqlite_path = root_path / "companion.sqlite3"
+
+            def new_store() -> dict:
+                return {
+                    "users": {},
+                    "bookshelf_items": [],
+                    "bookshelf_secret": {},
+                    "bookshelf_store_revision": 0,
+                    "jm_cosmos_integration": {},
+                }
+
+            def ensure_defaults(data: dict) -> dict:
+                result = dict(data)
+                for section, value in new_store().items():
+                    result.setdefault(section, value)
+                return result
+
+            manager = StoreManager(
+                backend_name="sqlite",
+                data_file=data_file,
+                sqlite_path=sqlite_path,
+                ensure_defaults=ensure_defaults,
+                new_store=new_store,
+            )
+            stale = new_store()
+            stale["bookshelf_items"] = [
+                {
+                    "key": "jm_album:deleted",
+                    "type": "jm_album",
+                    "album_id": "deleted",
+                }
+            ]
+            stale["bookshelf_store_revision"] = 1
+            manager.save_store(stale)
+            data_file.write_text(json.dumps(stale, ensure_ascii=False), encoding="utf-8")
+            manager.save_sections({}, {"bookshelf_items": 2})
+
+            plugin = _plugin_harness(root)
+            plugin.enable_multi_persona_mode = False
+            plugin.storage_backend = "sqlite"
+            plugin.store_manager = manager
+            plugin._data_default = manager.backend.load_store()
+            plugin._data_save_task = None
+            plugin._data_save_dirty = {}
+            plugin._data_save_deleted = {}
+            plugin._data_save_dirty_since = {}
+            plugin._data_save_section_revisions = {}
+            plugin._data_save_full_revision = 0
+            plugin._data_save_revision = manager.next_revision() - 1
+            plugin._termination_flush_already_attempted = True
+            plugin._stop_event.set()
+
+            await plugin._save_data_on_terminate()
+
+            self.assertEqual(
+                {"bookshelf_items": 2},
+                manager.backend.deleted_section_revisions(["bookshelf_items"]),
+            )
+            restarted = StoreManager(
+                backend_name="sqlite",
+                data_file=data_file,
+                sqlite_path=sqlite_path,
+                ensure_defaults=ensure_defaults,
+                new_store=new_store,
+            )
+            self.assertNotIn("bookshelf_items", restarted.load_initial_store())
 
     async def test_force_state_results_do_not_cross_persona_scopes(self):
         with tempfile.TemporaryDirectory() as root:

--- a/tests/test_multi_persona_isolation.py
+++ b/tests/test_multi_persona_isolation.py
@@ -998,15 +998,15 @@ class MultiPersonaIsolationTests(unittest.IsolatedAsyncioTestCase):
 
             main_token = plugin._activate_persona_id("main")
             try:
-                plugin.data["save_marker"] = "main"
-                plugin._save_data_sync()
+                plugin.data["users"]["save_marker"] = "main"
+                plugin._save_data_sync(sections={"users"})
             finally:
                 plugin._deactivate_persona_for_event(main_token)
 
             alt_token = plugin._activate_persona_id("alt")
             try:
-                plugin.data["save_marker"] = "alt"
-                plugin._save_data_sync()
+                plugin.data["users"]["save_marker"] = "alt"
+                plugin._save_data_sync(sections={"users"})
             finally:
                 plugin._deactivate_persona_for_event(alt_token)
 
@@ -1043,8 +1043,8 @@ class MultiPersonaIsolationTests(unittest.IsolatedAsyncioTestCase):
             plugin._write_data_snapshot_sync = lambda _snapshot: 0
             token = plugin._activate_persona_id("main")
             try:
-                plugin.data["final_marker"] = "old"
-                plugin._schedule_data_save(delay=0.0)
+                plugin.data["users"]["final_marker"] = "old"
+                plugin._schedule_data_save(sections={"users"}, delay=0.0)
             finally:
                 plugin._deactivate_persona_for_event(token)
             started = await asyncio.to_thread(writer_started.wait, 1.0)
@@ -1052,7 +1052,7 @@ class MultiPersonaIsolationTests(unittest.IsolatedAsyncioTestCase):
 
             token = plugin._activate_persona_id("main")
             try:
-                plugin.data["final_marker"] = "latest"
+                plugin.data["users"]["final_marker"] = "latest"
             finally:
                 plugin._deactivate_persona_for_event(token)
             plugin._stop_event.set()

--- a/tests/test_official_timer_lifecycle.py
+++ b/tests/test_official_timer_lifecycle.py
@@ -95,7 +95,7 @@ class _TimerHarness(UserMemoryMixin, DailyStateMixin):
     def _get_user(self, user_id: str):
         return self.data.setdefault("users", {}).setdefault(user_id, {"user_id": user_id})
 
-    def _save_data_sync(self) -> None:
+    def _save_data_sync(self, **_kwargs) -> None:
         self.saved += 1
 
     def _user_enabled_for_proactive(self, _user_id, _user) -> bool:

--- a/tests/test_page_api_incremental_persistence.py
+++ b/tests/test_page_api_incremental_persistence.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import ast
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PAGE_API = ROOT / "page_api.py"
+USERS_GROUPS_API = ROOT / "page_api_users_groups.py"
+SAVE_METHODS = {"_save_data_sync", "_save_data_now_sync", "_schedule_data_save"}
+
+
+def _function(path: Path, name: str) -> ast.FunctionDef | ast.AsyncFunctionDef:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    return next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == name
+    )
+
+
+def _direct_save_calls(node: ast.AST) -> list[ast.Call]:
+    return [
+        item
+        for item in ast.walk(node)
+        if isinstance(item, ast.Call)
+        and isinstance(item.func, ast.Attribute)
+        and item.func.attr in SAVE_METHODS
+    ]
+
+
+def _literal_sections(call: ast.Call) -> set[str] | None:
+    keyword = next((item for item in call.keywords if item.arg == "sections"), None)
+    if keyword is None or not isinstance(keyword.value, (ast.Set, ast.List, ast.Tuple)):
+        return None
+    if not all(
+        isinstance(item, ast.Constant) and type(item.value) is str
+        for item in keyword.value.elts
+    ):
+        return None
+    return {str(item.value) for item in keyword.value.elts}
+
+
+def _single_literal_save_sections(path: Path, function_name: str) -> set[str]:
+    calls = _direct_save_calls(_function(path, function_name))
+    literal = [sections for call in calls if (sections := _literal_sections(call)) is not None]
+    if len(literal) != 1:
+        raise AssertionError(
+            f"expected one literal save in {path.name}:{function_name}, got {literal}"
+        )
+    return literal[0]
+
+
+class PageApiIncrementalPersistenceTests(unittest.TestCase):
+    def test_page_read_endpoints_do_not_repair_or_persist_live_state(self) -> None:
+        overview = ast.unparse(_function(PAGE_API, "get_overview"))
+        expression_library = ast.unparse(_function(PAGE_API, "get_expression_library"))
+
+        for source in (overview, expression_library):
+            self.assertNotIn("_save_data_sync", source)
+            self.assertNotIn("_schedule_data_save", source)
+        self.assertNotIn("_refresh_sleep_runtime_state", overview)
+        self.assertNotIn("_expression_voice_profile", overview)
+
+    def test_indirect_page_savers_declare_sections(self) -> None:
+        failures: list[str] = []
+        for path in (PAGE_API, USERS_GROUPS_API):
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for function in (
+                item
+                for item in ast.walk(tree)
+                if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef))
+            ):
+                aliases = {
+                    target.id
+                    for assignment in ast.walk(function)
+                    if isinstance(assignment, ast.Assign)
+                    and isinstance(assignment.value, ast.Call)
+                    and isinstance(assignment.value.func, ast.Name)
+                    and assignment.value.func.id == "getattr"
+                    and len(assignment.value.args) >= 2
+                    and isinstance(assignment.value.args[1], ast.Constant)
+                    and assignment.value.args[1].value in SAVE_METHODS
+                    for target in assignment.targets
+                    if isinstance(target, ast.Name)
+                }
+                for call in ast.walk(function):
+                    if not (
+                        isinstance(call, ast.Call)
+                        and isinstance(call.func, ast.Name)
+                        and call.func.id in aliases
+                    ):
+                        continue
+                    if not any(
+                        keyword.arg in {"sections", "deleted_sections", "full_scope"}
+                        for keyword in call.keywords
+                    ):
+                        failures.append(f"{path.name}:{function.name}:{call.lineno}")
+        self.assertEqual([], failures)
+
+    def test_fixed_page_mutations_use_their_owned_sections(self) -> None:
+        expected = {
+            "bulk_update_food_menu": {"food_menu"},
+            "update_external_ability": {"external_proactive_abilities"},
+            "update_creative_project": {"creative_projects"},
+            "reanalyze_creative_project": {"creative_projects"},
+            "delete_creative_project": {"creative_projects"},
+        }
+        for function_name, sections in expected.items():
+            with self.subTest(function=function_name):
+                self.assertEqual(
+                    sections,
+                    _single_literal_save_sections(PAGE_API, function_name),
+                )
+
+    def test_user_and_group_mutations_do_not_mark_unrelated_identity_sections(self) -> None:
+        expected = {
+            "list_users": {"users"},
+            "link_unified_identity": {"unified_person"},
+            "unlink_unified_identity": {"unified_person"},
+            "_refresh_group_names_from_platform": {"groups"},
+            "update_group_member_safety": {"groups"},
+            "update_group_slang": {"groups"},
+        }
+        for function_name, sections in expected.items():
+            with self.subTest(function=function_name):
+                self.assertEqual(
+                    sections,
+                    _single_literal_save_sections(USERS_GROUPS_API, function_name),
+                )
+
+    def test_dynamic_user_update_tracks_secondary_sections(self) -> None:
+        source = ast.unparse(_function(USERS_GROUPS_API, "update_user"))
+
+        self.assertIn("save_sections = {'users'}", source)
+        self.assertIn("save_sections.add('expression_voice_profile')", source)
+        self.assertIn("save_sections.add('unified_person')", source)
+        self.assertIn("save_sections.add('_req041_private_memory')", source)
+        self.assertIn("_save_data_sync(sections=save_sections)", source)
+
+    def test_migration_import_saves_the_normalized_data_sections(self) -> None:
+        source = ast.unparse(_function(PAGE_API, "_apply_migration_normalized"))
+
+        self.assertIn("validator(set(data_payload), (), None)", source)
+        self.assertLess(
+            source.index("validator(set(data_payload), (), None)"),
+            source.index("before = await self._build_migration_package"),
+        )
+        self.assertIn("_save_data_sync(sections=set(data_payload))", source)
+
+    def test_setup_and_schedule_mutations_declare_their_owned_sections(self) -> None:
+        expected = {
+            "apply_setup_guide": {
+                "worldbook_member_profiles",
+                "worldbook_deleted_member_ids",
+                "setup_guide_completed_at",
+                "setup_guide_completed_version",
+            },
+            "_setup_guide_generate_daily_plan_fast": {
+                "daily_plan",
+                "daily_state",
+                "detail_enhanced_day",
+                "detail_enhanced_segments",
+                "daily_story_plan",
+            },
+            "regenerate_daily_detail_segment": {
+                "daily_plan",
+                "daily_state",
+                "detail_enhanced_day",
+                "detail_enhanced_segments",
+                "detail_enhanced_history",
+                "daily_story_plan",
+                "daily_story_plan_history",
+            },
+        }
+        for function_name, sections in expected.items():
+            with self.subTest(function=function_name):
+                source = ast.unparse(_function(PAGE_API, function_name))
+                self.assertNotIn("data_payload", source)
+                for section in sections:
+                    self.assertIn(repr(section), source)
+
+    def test_expression_management_saves_users_groups_persona_and_voice_sections(self) -> None:
+        preview = ast.unparse(_function(PAGE_API, "preview_expression_library_import"))
+        apply_import = ast.unparse(_function(PAGE_API, "apply_expression_library_import"))
+        update = ast.unparse(_function(PAGE_API, "update_expression_library"))
+
+        self.assertIn("source_type == 'group'", preview)
+        self.assertIn("source_type == 'group'", apply_import)
+        for section in (
+            "expression_voice_profile",
+            "_req041_persona_expression_profile",
+            "_req041_expression_promotion_operations",
+            "groups",
+            "users",
+        ):
+            self.assertIn(repr(section), update)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_personal_goal_proactive.py
+++ b/tests/test_personal_goal_proactive.py
@@ -46,7 +46,7 @@ class PersonalGoalHarness(DailyStateMixin):
         self.events.append((deepcopy(goal), deepcopy(event)))
         return 1
 
-    def _save_data_sync(self):
+    def _save_data_sync(self, **_kwargs):
         return None
 
 

--- a/tests/test_photo_followup_fixes.py
+++ b/tests/test_photo_followup_fixes.py
@@ -53,7 +53,7 @@ class _PhotoActionHarness(ProactiveMessageMixin):
     def _note_photo_generation_attempt(self, *_args, **_kwargs) -> None:
         return None
 
-    def _save_data_sync(self) -> None:
+    def _save_data_sync(self, **_kwargs) -> None:
         return None
 
 

--- a/tests/test_photo_generation_continuity.py
+++ b/tests/test_photo_generation_continuity.py
@@ -28,7 +28,7 @@ class _ContinuityHarness(ProactiveMessageMixin):
         self.model_reply = model_reply
         self.selection_prompt = ""
 
-    def _save_data_sync(self) -> None:
+    def _save_data_sync(self, **_kwargs) -> None:
         return None
 
     def _task_provider(self, *_args) -> str:

--- a/tests/test_private_delivery_binding_command.py
+++ b/tests/test_private_delivery_binding_command.py
@@ -59,7 +59,7 @@ class _Harness(InteractionUtilsMixin):
         return {"state": "profile_exact"}
 
     @staticmethod
-    def _schedule_data_save() -> None:
+    def _schedule_data_save(*_args, **_kwargs) -> None:
         return None
 
     @staticmethod

--- a/tests/test_proactive_chat_integration.py
+++ b/tests/test_proactive_chat_integration.py
@@ -50,7 +50,7 @@ class _BridgeHarness(ProactiveMessageMixin):
     def _get_user(self, user_id: str) -> dict:
         return self.data["users"][user_id]
 
-    def _save_data_sync(self) -> None:
+    def _save_data_sync(self, **_kwargs) -> None:
         self.saved += 1
 
     @staticmethod
@@ -174,7 +174,7 @@ def _plugin_harness() -> PrivateCompanionPlugin:
     plugin._canonical_private_user_id = lambda value: str(value or "")
     plugin._user_enabled_for_proactive = lambda _user_id, user: bool(user.get("enabled", True))
     plugin._get_user = lambda user_id: plugin.data["users"][user_id]
-    plugin._save_data_sync = lambda: None
+    plugin._save_data_sync = lambda **_kwargs: None
     plugin._sanitize_proactive_text = lambda text: str(text or "").strip()
     plugin._visible_text_without_tts_reading = lambda text, limit=500: str(text or "").strip()[:limit]
     plugin._reset_daily_counter_if_needed = lambda user: user.update({"sent_day": "test-day", "sent_today": 0})

--- a/tests/test_proactive_fact_grounding.py
+++ b/tests/test_proactive_fact_grounding.py
@@ -113,7 +113,9 @@ class _ReplyContextHarness(UserMemoryMixin):
     def _get_user(self, user_id: str):
         return self.data["users"][str(user_id)]
 
-    def _save_data_sync(self) -> None:
+    def _save_data_sync(self, *, sections=(), **_kwargs) -> None:
+        self.saved_sections = getattr(self, "saved_sections", [])
+        self.saved_sections.append(set(sections or ()))
         return None
 
 

--- a/tests/test_proactive_photo_scope_quota.py
+++ b/tests/test_proactive_photo_scope_quota.py
@@ -96,7 +96,7 @@ class _PhotoActionHarness(ProactiveMessageMixin):
     def _note_photo_generation_scope_attempt(self, **kwargs: Any) -> None:
         self.scope_attempts.append(dict(kwargs))
 
-    def _save_data_sync(self) -> None:
+    def _save_data_sync(self, **_kwargs: Any) -> None:
         self.save_calls += 1
 
 

--- a/tests/test_qq_presence_sync.py
+++ b/tests/test_qq_presence_sync.py
@@ -27,7 +27,7 @@ class _PresenceHarness(DailyStateMixin):
         self.calls += 1
         return False, "unsupported action"
 
-    def _save_data_sync(self) -> None:
+    def _save_data_sync(self, **_kwargs) -> None:
         return None
 
 

--- a/tests/test_relationship_system_pr.py
+++ b/tests/test_relationship_system_pr.py
@@ -485,7 +485,7 @@ class _RelationshipLedgerHost:
     _apply_relationship_event = APPLY_RELATIONSHIP_EVENT
 
     @staticmethod
-    def _schedule_data_save() -> None:
+    def _schedule_data_save(*_args, **_kwargs) -> None:
         return None
 
 

--- a/tests/test_relationship_violation_penalty.py
+++ b/tests/test_relationship_violation_penalty.py
@@ -54,7 +54,7 @@ class _Host:
         return str(user.get("relationship_role") or "friend")
 
     @staticmethod
-    def _schedule_data_save() -> None:
+    def _schedule_data_save(*_args, **_kwargs) -> None:
         return None
 
     @staticmethod

--- a/tests/test_req027_user_profiles_relationship_policy.py
+++ b/tests/test_req027_user_profiles_relationship_policy.py
@@ -157,7 +157,7 @@ class _AutoProfileHost:
     def _note_private_user_umo(self, _user_id: str, user: dict[str, Any], umo: str) -> None:
         user["umo"] = umo
 
-    def _schedule_data_save(self) -> None:
+    def _schedule_data_save(self, *_args, **_kwargs) -> None:
         self.saved += 1
 
 

--- a/tests/test_req036_unified_profile.py
+++ b/tests/test_req036_unified_profile.py
@@ -359,7 +359,7 @@ class _CommandGateHost(_EventIngressHost):
         return {"state": "profile_exact"}
 
     @staticmethod
-    def _schedule_data_save() -> None:
+    def _schedule_data_save(*_args, **_kwargs) -> None:
         return None
 
     @staticmethod

--- a/tests/test_req041_expression_admin_scope.py
+++ b/tests/test_req041_expression_admin_scope.py
@@ -130,7 +130,7 @@ class Harness:
     def _expression_rule_definition_is_valid(rule):
         return bool(rule.get("kind") in {"style", "grammar"} and rule.get("situation") and rule.get("pattern") and rule.get("instruction"))
 
-    def _save_data_sync(self):
+    def _save_data_sync(self, **_kwargs):
         self.saved += 1
 
     @staticmethod

--- a/tests/test_req041_group_reset_saga.py
+++ b/tests/test_req041_group_reset_saga.py
@@ -157,7 +157,7 @@ class _Host:
     def _normalize_group_identity_id(value: Any) -> str:
         return str(value or "").strip()
 
-    def _save_data_now_sync(self) -> None:
+    def _save_data_now_sync(self, **_kwargs: Any) -> None:
         self.persisted += 1
 
     async def _save_config_if_possible(self) -> bool:

--- a/tests/test_req041_group_reset_saga.py
+++ b/tests/test_req041_group_reset_saga.py
@@ -146,6 +146,7 @@ class _Host:
         self.req041_migration_status = {"required": True}
         self.req041_scoped_projection_sync = _Remote()
         self.persisted = 0
+        self.persistence_calls: list[dict[str, Any]] = []
         self.config_save_ok = True
         self.voice_refreshes = 0
 
@@ -157,17 +158,75 @@ class _Host:
     def _normalize_group_identity_id(value: Any) -> str:
         return str(value or "").strip()
 
-    def _save_data_now_sync(self, **_kwargs: Any) -> None:
+    def _save_data_now_sync(self, **kwargs: Any) -> None:
         self.persisted += 1
+        self.persistence_calls.append(deepcopy(kwargs))
 
     async def _save_config_if_possible(self) -> bool:
         return self.config_save_ok
 
     def _refresh_expression_voice_profile(self) -> None:
         self.voice_refreshes += 1
+        self.data["expression_voice_profile"] = {
+            "refresh_count": self.voice_refreshes,
+        }
 
 
 class GroupResetSagaTests(unittest.TestCase):
+    def test_archive_saga_persistence_requires_an_explicit_contract(self) -> None:
+        host = _Host()
+
+        with self.assertRaisesRegex(ValueError, "sections must be explicit"):
+            host._req041_persist_archive_saga_locked()
+
+    def test_completed_reset_persists_each_mutation_with_disjoint_sections(self) -> None:
+        host = _Host()
+
+        result = asyncio.run(host.reset_group_scoped_data("group-a"))
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(3, len(host.persistence_calls))
+        self.assertEqual(
+            {"_req041_group_reset_sagas"},
+            host.persistence_calls[0]["sections"],
+        )
+        self.assertEqual(
+            {
+                "groups",
+                "expression_voice_profile",
+                "_req041_group_reset_sagas",
+            },
+            host.persistence_calls[1]["sections"],
+        )
+        self.assertEqual(set(), host.persistence_calls[2]["sections"])
+        self.assertEqual(
+            {"_req041_group_reset_sagas"},
+            host.persistence_calls[2]["deleted_sections"],
+        )
+        for call in host.persistence_calls:
+            self.assertFalse(
+                set(call.get("sections") or ())
+                & set(call.get("deleted_sections") or ())
+            )
+
+    def test_overlapping_saga_request_keeps_a_concurrently_present_saga(self) -> None:
+        host = _Host()
+        host.data["_req041_group_reset_sagas"] = {
+            "new-operation": {"state": "confirmed"},
+        }
+
+        host._req041_persist_archive_saga_locked(
+            sections={"_req041_group_reset_sagas"},
+            deleted_sections={"_req041_group_reset_sagas"},
+        )
+
+        self.assertEqual(1, len(host.persistence_calls))
+        self.assertEqual(
+            {"_req041_group_reset_sagas"},
+            host.persistence_calls[0]["sections"],
+        )
+        self.assertEqual(set(), host.persistence_calls[0]["deleted_sections"])
+
     def test_remote_failure_persists_saga_without_mutating_local_then_restart_resumes(self) -> None:
         host = _Host()
         host.req041_scoped_projection_sync.ok = False

--- a/tests/test_req041_identity_admin_ui.py
+++ b/tests/test_req041_identity_admin_ui.py
@@ -147,7 +147,9 @@ class _PageHost:
     def _error(message: str) -> dict[str, Any]:
         return {"ok": False, "error": message}
 
-    def _schedule_data_save(self) -> None:
+    def _schedule_data_save(self, *, sections=(), **_kwargs) -> None:
+        self.assert_saved_sections = getattr(self, "assert_saved_sections", [])
+        self.assert_saved_sections.append(set(sections or ()))
         self.saved += 1
 
     def _req041_emit_identity_dual_write(self, result, *, action, operation_id, registry):

--- a/tests/test_req041_memory_write_gate.py
+++ b/tests/test_req041_memory_write_gate.py
@@ -133,6 +133,12 @@ class ScopedMemoryWriteGateTests(unittest.TestCase):
             command_source.index("_req041_commit_authoritative_private_memory", command_branch),
             command_branch,
         )
+        self.assertGreater(
+            command_source.index(
+                'save_sections.add("_req041_private_memory")', command_branch
+            ),
+            command_branch,
+        )
 
     def test_two_explicit_identities_converge_on_one_authoritative_private_memory(self) -> None:
         data: dict = {}

--- a/tests/test_req041_migration_dual_write.py
+++ b/tests/test_req041_migration_dual_write.py
@@ -343,7 +343,7 @@ class MigrationDualWriteTests(unittest.TestCase):
             def _unified_persona_domain():
                 return ""
 
-            def _schedule_data_save(self):
+            def _schedule_data_save(self, *_args, **_kwargs):
                 self.saved = True
 
         host = Host()
@@ -383,7 +383,7 @@ class MigrationDualWriteTests(unittest.TestCase):
             def _unified_persona_domain():
                 return ""
 
-            def _schedule_data_save(self):
+            def _schedule_data_save(self, *_args, **_kwargs):
                 self.saved = True
 
         host = Host()

--- a/tests/test_req041_migration_source_inspector.py
+++ b/tests/test_req041_migration_source_inspector.py
@@ -1,19 +1,20 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 import shutil
 import sqlite3
 import tempfile
 import unittest
+from pathlib import Path
 
 from migration_source_inspector import (
     MigrationSourceInspectionError,
     inspect_migration_sources,
 )
 
-
-FIXTURE = Path(__file__).parent / "fixtures" / "req041" / "companion-v6.0.8-sanitized.json"
+FIXTURE = (
+    Path(__file__).parent / "fixtures" / "req041" / "companion-v6.0.8-sanitized.json"
+)
 
 
 class MigrationSourceInspectorTests(unittest.TestCase):
@@ -29,20 +30,69 @@ class MigrationSourceInspectorTests(unittest.TestCase):
         shutil.copyfile(FIXTURE, target)
         return target
 
-    def _sqlite_from_fixture(self) -> Path:
+    def _sqlite_from_fixture(
+        self,
+        *,
+        schema_version: int = 1,
+        name: str | None = None,
+        tombstones: tuple[str, ...] = (),
+        include_write_guards: bool = True,
+    ) -> Path:
         payload = json.loads(FIXTURE.read_text(encoding="utf-8"))
-        target = self.data_dir / "companions.db"
+        target = self.data_dir / (name or f"companions-v{schema_version}.db")
         connection = sqlite3.connect(target)
         try:
-            connection.execute(
-                "CREATE TABLE store_sections ("
-                "section_name TEXT PRIMARY KEY,payload_json TEXT NOT NULL,updated_at REAL NOT NULL,"
-                "checksum TEXT DEFAULT '',schema_version INTEGER DEFAULT 1)"
-            )
-            connection.executemany(
-                "INSERT INTO store_sections VALUES(?,?,0,'',1)",
-                [(key, json.dumps(value, ensure_ascii=False)) for key, value in payload.items()],
-            )
+            if schema_version == 1:
+                connection.execute(
+                    "CREATE TABLE store_sections ("
+                    "section_name TEXT PRIMARY KEY,payload_json TEXT NOT NULL,updated_at REAL NOT NULL,"
+                    "checksum TEXT DEFAULT '',schema_version INTEGER DEFAULT 1)"
+                )
+                connection.executemany(
+                    "INSERT INTO store_sections VALUES(?,?,0,'',1)",
+                    [
+                        (key, json.dumps(value, ensure_ascii=False))
+                        for key, value in payload.items()
+                    ],
+                )
+            else:
+                write_guards = (
+                    ",CONSTRAINT store_sections_schema_v2 CHECK(schema_version=2)"
+                    ",CONSTRAINT store_sections_positive_revision CHECK(revision>0)"
+                    ",CONSTRAINT store_sections_deleted_flag CHECK(is_deleted IN (0,1))"
+                    if include_write_guards
+                    else ""
+                )
+                connection.execute(
+                    "CREATE TABLE store_sections ("
+                    "section_name TEXT NOT NULL PRIMARY KEY,payload_json TEXT NOT NULL,updated_at REAL NOT NULL,"
+                    "checksum TEXT NOT NULL DEFAULT '',schema_version INTEGER NOT NULL DEFAULT 2,"
+                    "revision INTEGER NOT NULL DEFAULT 0,is_deleted INTEGER NOT NULL DEFAULT 0"
+                    f"{write_guards})"
+                )
+                connection.executemany(
+                    "INSERT INTO store_sections VALUES(?,?,0,'',2,1,0)",
+                    [
+                        (key, json.dumps(value, ensure_ascii=False))
+                        for key, value in payload.items()
+                    ],
+                )
+                connection.executemany(
+                    "INSERT INTO store_sections VALUES(?,?,0,'',2,2,1)",
+                    [(section_name, "null") for section_name in tombstones],
+                )
+                connection.execute(
+                    "CREATE TABLE store_meta ("
+                    "meta_key TEXT NOT NULL PRIMARY KEY,meta_value TEXT NOT NULL)"
+                )
+                connection.executemany(
+                    "INSERT INTO store_meta VALUES(?,?)",
+                    (
+                        ("initialized", "1"),
+                        ("next_revision", "3" if tombstones else "2"),
+                    ),
+                )
+                connection.execute("PRAGMA user_version=2")
             connection.commit()
         finally:
             connection.close()
@@ -56,10 +106,17 @@ class MigrationSourceInspectorTests(unittest.TestCase):
         self.assertEqual({"json": 1, "sqlite": 0}, inventory["formats"])
         self.assertTrue(inventory["all_have_unified_person"])
         encoded = json.dumps(inventory, ensure_ascii=False)
-        for private_value in ("10001", "20001", "Fixture Owner", "fixture-private-sentinel"):
+        for private_value in (
+            "10001",
+            "20001",
+            "Fixture Owner",
+            "fixture-private-sentinel",
+        ):
             self.assertNotIn(private_value, encoded)
 
-    def test_json_and_sqlite_share_store_version_but_have_distinct_contract_fingerprints(self) -> None:
+    def test_json_and_sqlite_share_store_version_but_have_distinct_contract_fingerprints(
+        self,
+    ) -> None:
         json_source = self._copy_fixture()
         json_inventory = inspect_migration_sources(self.data_dir, [json_source])
         sqlite_source = self._sqlite_from_fixture()
@@ -67,14 +124,69 @@ class MigrationSourceInspectorTests(unittest.TestCase):
         self.assertEqual(1, sqlite_inventory["store_version"])
         self.assertEqual([1], sqlite_inventory["section_schema_versions"])
         self.assertEqual({"json": 0, "sqlite": 1}, sqlite_inventory["formats"])
-        self.assertNotEqual(json_inventory["source_schema_version"], sqlite_inventory["source_schema_version"])
+        self.assertNotEqual(
+            json_inventory["source_schema_version"],
+            sqlite_inventory["source_schema_version"],
+        )
 
-    def test_rejects_invalid_json_root_missing_sections_and_unsupported_version(self) -> None:
+    def test_sqlite_v1_and_v2_normalize_to_the_same_inventory_contract(self) -> None:
+        v1_inventory = inspect_migration_sources(
+            self.data_dir,
+            [self._sqlite_from_fixture(schema_version=1)],
+        )
+        v2_inventory = inspect_migration_sources(
+            self.data_dir,
+            [self._sqlite_from_fixture(schema_version=2)],
+        )
+        self.assertEqual([1], v1_inventory["section_schema_versions"])
+        self.assertEqual([1], v2_inventory["section_schema_versions"])
+        self.assertEqual(v1_inventory["fingerprint"], v2_inventory["fingerprint"])
+        self.assertEqual(
+            v1_inventory["source_schema_version"],
+            v2_inventory["source_schema_version"],
+        )
+
+    def test_sqlite_v2_tombstones_do_not_affect_inventory(self) -> None:
+        baseline = inspect_migration_sources(
+            self.data_dir,
+            [self._sqlite_from_fixture(schema_version=2, name="baseline.db")],
+        )
+        with_tombstone = inspect_migration_sources(
+            self.data_dir,
+            [
+                self._sqlite_from_fixture(
+                    schema_version=2,
+                    name="with-tombstone.db",
+                    tombstones=("retired_section",),
+                )
+            ],
+        )
+        for key in (
+            "fingerprint",
+            "source_schema_version",
+            "section_count_min",
+            "section_count_max",
+            "all_have_unified_person",
+            "all_have_persona_lifecycle",
+        ):
+            self.assertEqual(baseline[key], with_tombstone[key])
+
+    def test_rejects_invalid_json_root_missing_sections_and_unsupported_version(
+        self,
+    ) -> None:
         cases = (
             ("broken.json", "{", "migration_source_json_invalid"),
             ("list.json", "[]", "migration_source_root_invalid"),
-            ("missing.json", '{"version":1,"users":{}}', "migration_source_required_section_missing"),
-            ("future.json", '{"version":2,"users":{},"groups":{}}', "migration_source_store_version_unsupported"),
+            (
+                "missing.json",
+                '{"version":1,"users":{}}',
+                "migration_source_required_section_missing",
+            ),
+            (
+                "future.json",
+                '{"version":2,"users":{},"groups":{}}',
+                "migration_source_store_version_unsupported",
+            ),
         )
         for name, content, error in cases:
             with self.subTest(name=name):
@@ -83,30 +195,253 @@ class MigrationSourceInspectorTests(unittest.TestCase):
                 with self.assertRaisesRegex(MigrationSourceInspectionError, error):
                     inspect_migration_sources(self.data_dir, [path])
 
-    def test_rejects_sqlite_without_contract_bad_columns_or_invalid_section_json(self) -> None:
+    def test_rejects_sqlite_without_contract_bad_columns_or_invalid_section_json(
+        self,
+    ) -> None:
         missing = self.data_dir / "missing.db"
         connection = sqlite3.connect(missing)
         connection.execute("CREATE TABLE unrelated(value TEXT)")
         connection.commit()
         connection.close()
-        with self.assertRaisesRegex(MigrationSourceInspectionError, "migration_source_sqlite_contract_missing"):
+        with self.assertRaisesRegex(
+            MigrationSourceInspectionError, "migration_source_sqlite_contract_missing"
+        ):
             inspect_migration_sources(self.data_dir, [missing])
 
         bad_columns = self.data_dir / "bad-columns.db"
         connection = sqlite3.connect(bad_columns)
-        connection.execute("CREATE TABLE store_sections(section_name TEXT,payload_json TEXT)")
+        connection.execute(
+            "CREATE TABLE store_sections(section_name TEXT,payload_json TEXT)"
+        )
         connection.commit()
         connection.close()
-        with self.assertRaisesRegex(MigrationSourceInspectionError, "migration_source_sqlite_contract_invalid"):
+        with self.assertRaisesRegex(
+            MigrationSourceInspectionError, "migration_source_sqlite_contract_invalid"
+        ):
             inspect_migration_sources(self.data_dir, [bad_columns])
 
-        invalid_payload = self._sqlite_from_fixture()
+        invalid_payload = self._sqlite_from_fixture(name="invalid-payload.db")
         connection = sqlite3.connect(invalid_payload)
-        connection.execute("UPDATE store_sections SET payload_json='{' WHERE section_name='users'")
+        connection.execute(
+            "UPDATE store_sections SET payload_json='{' WHERE section_name='users'"
+        )
         connection.commit()
         connection.close()
-        with self.assertRaisesRegex(MigrationSourceInspectionError, "migration_source_section_json_invalid"):
+        with self.assertRaisesRegex(
+            MigrationSourceInspectionError, "migration_source_section_json_invalid"
+        ):
             inspect_migration_sources(self.data_dir, [invalid_payload])
+
+    def test_rejects_partial_v2_contract_and_invalid_tombstone(self) -> None:
+        partial_v2 = self.data_dir / "partial-v2.db"
+        connection = sqlite3.connect(partial_v2)
+        connection.execute(
+            "CREATE TABLE store_sections ("
+            "section_name TEXT PRIMARY KEY,payload_json TEXT NOT NULL,updated_at REAL NOT NULL,"
+            "checksum TEXT DEFAULT '',schema_version INTEGER DEFAULT 2,revision INTEGER DEFAULT 0)"
+        )
+        connection.commit()
+        connection.close()
+        with self.assertRaisesRegex(
+            MigrationSourceInspectionError, "migration_source_sqlite_contract_invalid"
+        ):
+            inspect_migration_sources(self.data_dir, [partial_v2])
+
+        invalid_flag = self._sqlite_from_fixture(
+            schema_version=2, name="invalid-flag.db"
+        )
+        connection = sqlite3.connect(invalid_flag)
+        connection.execute("PRAGMA ignore_check_constraints=ON")
+        connection.execute(
+            "UPDATE store_sections SET is_deleted=2 WHERE section_name='users'"
+        )
+        connection.commit()
+        connection.close()
+        with self.assertRaisesRegex(
+            MigrationSourceInspectionError, "migration_source_tombstone_invalid"
+        ):
+            inspect_migration_sources(self.data_dir, [invalid_flag])
+
+        invalid_payload = self._sqlite_from_fixture(
+            schema_version=2,
+            name="invalid-tombstone-payload.db",
+            tombstones=("retired_section",),
+        )
+        connection = sqlite3.connect(invalid_payload)
+        connection.execute(
+            "UPDATE store_sections SET payload_json='{}' WHERE section_name='retired_section'"
+        )
+        connection.commit()
+        connection.close()
+        with self.assertRaisesRegex(
+            MigrationSourceInspectionError, "migration_source_tombstone_invalid"
+        ):
+            inspect_migration_sources(self.data_dir, [invalid_payload])
+
+    def test_rejects_schema_marker_and_physical_contract_mismatch(self) -> None:
+        v1_with_v2_marker = self._sqlite_from_fixture(
+            schema_version=1,
+            name="v1-with-v2-marker.db",
+        )
+        connection = sqlite3.connect(v1_with_v2_marker)
+        connection.execute("PRAGMA user_version=2")
+        connection.commit()
+        connection.close()
+        with self.assertRaisesRegex(
+            MigrationSourceInspectionError,
+            "migration_source_sqlite_contract_invalid",
+        ):
+            inspect_migration_sources(self.data_dir, [v1_with_v2_marker])
+
+        v2_with_v1_marker = self._sqlite_from_fixture(
+            schema_version=2,
+            name="v2-with-v1-marker.db",
+        )
+        connection = sqlite3.connect(v2_with_v1_marker)
+        connection.execute("PRAGMA user_version=1")
+        connection.commit()
+        connection.close()
+        with self.assertRaisesRegex(
+            MigrationSourceInspectionError,
+            "migration_source_sqlite_contract_invalid",
+        ):
+            inspect_migration_sources(self.data_dir, [v2_with_v1_marker])
+
+    def test_sqlite_v2_requires_valid_meta_primary_key_and_revision_contract(
+        self,
+    ) -> None:
+        missing_meta = self._sqlite_from_fixture(
+            schema_version=2,
+            name="missing-meta.db",
+        )
+        connection = sqlite3.connect(missing_meta)
+        connection.execute("DROP TABLE store_meta")
+        connection.commit()
+        connection.close()
+        with self.assertRaisesRegex(
+            MigrationSourceInspectionError,
+            "migration_source_sqlite_contract_invalid",
+        ):
+            inspect_migration_sources(self.data_dir, [missing_meta])
+
+        stale_meta = self._sqlite_from_fixture(
+            schema_version=2,
+            name="stale-meta.db",
+        )
+        connection = sqlite3.connect(stale_meta)
+        connection.execute(
+            "UPDATE store_meta SET meta_value='1' WHERE meta_key='next_revision'"
+        )
+        connection.commit()
+        connection.close()
+        with self.assertRaisesRegex(
+            MigrationSourceInspectionError,
+            "migration_source_sqlite_contract_invalid",
+        ):
+            inspect_migration_sources(self.data_dir, [stale_meta])
+
+        invalid_revision = self._sqlite_from_fixture(
+            schema_version=2,
+            name="invalid-revision.db",
+        )
+        connection = sqlite3.connect(invalid_revision)
+        connection.execute(
+            "UPDATE store_sections SET revision=1.5 WHERE section_name='users'"
+        )
+        connection.commit()
+        connection.close()
+        with self.assertRaisesRegex(
+            MigrationSourceInspectionError,
+            "migration_source_revision_invalid",
+        ):
+            inspect_migration_sources(self.data_dir, [invalid_revision])
+
+    def test_sqlite_v2_rejects_unexpected_extensions_and_missing_guards(self) -> None:
+        unexpected_table = self._sqlite_from_fixture(
+            schema_version=2,
+            name="unexpected-table.db",
+        )
+        connection = sqlite3.connect(unexpected_table)
+        connection.execute("CREATE TABLE unrelated(value TEXT)")
+        connection.commit()
+        connection.close()
+        with self.assertRaisesRegex(
+            MigrationSourceInspectionError,
+            "migration_source_sqlite_contract_invalid",
+        ):
+            inspect_migration_sources(self.data_dir, [unexpected_table])
+
+        extra_meta = self._sqlite_from_fixture(
+            schema_version=2,
+            name="extra-meta.db",
+        )
+        connection = sqlite3.connect(extra_meta)
+        connection.execute("INSERT INTO store_meta VALUES('future_key','1')")
+        connection.commit()
+        connection.close()
+        with self.assertRaisesRegex(
+            MigrationSourceInspectionError,
+            "migration_source_sqlite_contract_invalid",
+        ):
+            inspect_migration_sources(self.data_dir, [extra_meta])
+
+        missing_guards = self._sqlite_from_fixture(
+            schema_version=2,
+            name="missing-guards.db",
+            include_write_guards=False,
+        )
+        with self.assertRaisesRegex(
+            MigrationSourceInspectionError,
+            "migration_source_sqlite_contract_invalid",
+        ):
+            inspect_migration_sources(self.data_dir, [missing_guards])
+
+    def test_sqlite_v2_validates_checksum_and_bounds_physical_rows(self) -> None:
+        invalid_checksum = self._sqlite_from_fixture(
+            schema_version=2,
+            name="invalid-checksum.db",
+        )
+        connection = sqlite3.connect(invalid_checksum)
+        connection.execute(
+            "UPDATE store_sections SET checksum=? WHERE section_name='users'",
+            ("0" * 64,),
+        )
+        connection.commit()
+        connection.close()
+        with self.assertRaisesRegex(
+            MigrationSourceInspectionError,
+            "migration_source_checksum_invalid",
+        ):
+            inspect_migration_sources(self.data_dir, [invalid_checksum])
+
+        excessive_rows = self._sqlite_from_fixture(
+            schema_version=2,
+            name="excessive-rows.db",
+        )
+        connection = sqlite3.connect(excessive_rows)
+        connection.executemany(
+            "INSERT INTO store_sections VALUES(?,?,0,'',2,1,1)",
+            [(f"retired_{index:04d}", "null") for index in range(513)],
+        )
+        connection.commit()
+        connection.close()
+        with self.assertRaisesRegex(
+            MigrationSourceInspectionError,
+            "migration_source_section_set_invalid",
+        ):
+            inspect_migration_sources(self.data_dir, [excessive_rows])
+
+    def test_sqlite_v2_legacy_empty_tombstone_checksum_is_supported(self) -> None:
+        source = self._sqlite_from_fixture(
+            schema_version=2,
+            name="legacy-tombstone.db",
+            tombstones=("retired_section",),
+        )
+
+        inventory = inspect_migration_sources(self.data_dir, [source])
+
+        self.assertEqual({"json": 0, "sqlite": 1}, inventory["formats"])
+        self.assertEqual([1], inventory["section_schema_versions"])
 
     def test_rejects_symlink_and_path_escape(self) -> None:
         outside = self.data_dir.parent / f"{self.data_dir.name}-outside.json"
@@ -114,9 +449,13 @@ class MigrationSourceInspectorTests(unittest.TestCase):
         self.addCleanup(outside.unlink, missing_ok=True)
         link = self.data_dir / "linked.json"
         link.symlink_to(outside)
-        with self.assertRaisesRegex(MigrationSourceInspectionError, "migration_source_file_invalid"):
+        with self.assertRaisesRegex(
+            MigrationSourceInspectionError, "migration_source_file_invalid"
+        ):
             inspect_migration_sources(self.data_dir, [link])
-        with self.assertRaisesRegex(MigrationSourceInspectionError, "migration_source_path_invalid"):
+        with self.assertRaisesRegex(
+            MigrationSourceInspectionError, "migration_source_path_invalid"
+        ):
             inspect_migration_sources(self.data_dir, [outside])
 
 

--- a/tests/test_req041_person_archive.py
+++ b/tests/test_req041_person_archive.py
@@ -195,6 +195,7 @@ class _Host:
         self._data_lock = _AsyncLock()
         self.enable_multi_persona_mode = False
         self.persisted = 0
+        self.persistence_calls: list[dict[str, Any]] = []
         self.req041_migration_coordinator = _Coordinator()
         self.req041_migration_outbox = MigrationOutbox(
             relationship_path.with_name("outbox.sqlite3"), clock=lambda: 100.0,
@@ -236,8 +237,9 @@ class _Host:
     def _active_persona_scope() -> str:
         return ""
 
-    def _save_data_now_sync(self, **_kwargs: Any) -> None:
+    def _save_data_now_sync(self, **kwargs: Any) -> None:
         self.persisted += 1
+        self.persistence_calls.append(deepcopy(kwargs))
 
 
 class PersonArchiveSagaTests(unittest.TestCase):
@@ -348,6 +350,17 @@ class PersonArchiveSagaTests(unittest.TestCase):
                 "10001": {"user_id": "10001", "content": "remove-profile"},
                 "20002": {"user_id": "20002", "content": "keep-profile"},
             },
+            "legacy_private_cache": {
+                "10001": {"user_id": "10001", "content": "remove-legacy"},
+                "20002": {"user_id": "20002", "content": "keep-legacy"},
+            },
+            "_req041_private_memory": {
+                "schema": "req041.person_private_memory.v1",
+                "records": {
+                    self.host.person_id: {"content": {"open_loops": ["private"]}},
+                    "person-other": {"content": {"open_loops": ["keep"]}},
+                },
+            },
         })
         purge_preview = asyncio.run(self.host.purge_unified_person(
             self.host.person_id, operation_id="purge-1", dry_run=True,
@@ -363,8 +376,17 @@ class PersonArchiveSagaTests(unittest.TestCase):
         self.assertNotIn("10001", self.host.data["groups"]["group-a"]["members"])
         self.assertEqual(["keep-me"], [item["text"] for item in self.host.data["groups"]["group-a"]["recent_messages"]])
         self.assertNotIn("10001", self.host.data["worldbook_member_profiles"])
+        self.assertNotIn("10001", self.host.data["legacy_private_cache"])
+        self.assertIn("20002", self.host.data["legacy_private_cache"])
+        private_records = self.host.data["_req041_private_memory"]["records"]
+        self.assertNotIn(self.host.person_id, private_records)
+        self.assertIn("person-other", private_records)
         self.assertIsNone(self.host.registry.read_projection(self.host.person_id))
         self.assertIn(self.host.person_id, root["person_tombstones"])
+        self.assertEqual(
+            {"full_scope": "admin_import_export"},
+            self.host.persistence_calls[-1],
+        )
 
     def test_confirmed_purge_resumes_without_page_reconfirmation(self) -> None:
         preview = asyncio.run(self.host.archive_unified_person(

--- a/tests/test_req041_person_archive.py
+++ b/tests/test_req041_person_archive.py
@@ -236,7 +236,7 @@ class _Host:
     def _active_persona_scope() -> str:
         return ""
 
-    def _save_data_now_sync(self) -> None:
+    def _save_data_now_sync(self, **_kwargs: Any) -> None:
         self.persisted += 1
 
 

--- a/tests/test_req041_persona_reset_saga.py
+++ b/tests/test_req041_persona_reset_saga.py
@@ -122,7 +122,7 @@ class _Host:
     async def _flush_scheduled_data_save() -> None:
         return None
 
-    def _save_data_now_sync(self) -> None:
+    def _save_data_now_sync(self, **_kwargs: Any) -> None:
         self.persisted = deepcopy(self.data)
 
     def _write_persona_reset_backup_sync(self, persona_id: str, snapshot: dict[str, Any]) -> Path:

--- a/tests/test_req041_scoped_runtime_view.py
+++ b/tests/test_req041_scoped_runtime_view.py
@@ -328,7 +328,8 @@ class ConsumerWiringTests(unittest.TestCase):
 
     def test_sync_save_invalidates_scoped_projection_before_persisting(self) -> None:
         source = (ROOT / "core_store.py").read_text(encoding="utf-8")
-        method = source[source.index("    def _save_data_sync(self):"):source.index("    def _save_data_now_sync", source.index("    def _save_data_sync(self):"))]
+        start = source.index("    def _save_data_sync(")
+        method = source[start:source.index("    def _save_data_now_sync", start)]
         self.assertLess(method.index("_req041_schedule_scoped_sync"), method.index("_active_persona_scope"))
 
 

--- a/tests/test_storage_path_validation.py
+++ b/tests/test_storage_path_validation.py
@@ -1,11 +1,17 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import json
 import tempfile
 import unittest
+from copy import deepcopy
 from pathlib import Path
+from unittest.mock import patch
 
 from astrbot_plugin_private_companion.core_store import CoreStoreMixin
+from astrbot_plugin_private_companion.storage.json_backend import JsonStoreBackend
+from astrbot_plugin_private_companion.storage.sqlite_backend import SqliteStoreBackend
+from astrbot_plugin_private_companion.storage.store_manager import StoreManager
 
 
 class _StorePathHost(CoreStoreMixin):
@@ -14,6 +20,8 @@ class _StorePathHost(CoreStoreMixin):
         self.data_file = str(root / "companions.json")
         self.storage_backend = "sqlite"
         self.storage_sqlite_path = configured_path
+        self.storage_sqlite_effective_path = ""
+        self.data = {"users": {}, "groups": {}}
 
     @staticmethod
     def _ensure_store_defaults(data: dict) -> dict:
@@ -22,6 +30,34 @@ class _StorePathHost(CoreStoreMixin):
     @staticmethod
     def _new_store() -> dict:
         return {"users": {}, "groups": {}}
+
+    def manager(self, backend: str, sqlite_path: Path) -> StoreManager:
+        return StoreManager(
+            backend_name=backend,
+            data_file=self.data_file,
+            sqlite_path=sqlite_path,
+            ensure_defaults=self._ensure_store_defaults,
+            new_store=self._new_store,
+        )
+
+    def install_manager(
+        self,
+        backend: str,
+        sqlite_path: Path,
+        data: dict,
+    ) -> StoreManager:
+        manager = self.manager(backend, sqlite_path)
+        manager.backend.save_store(deepcopy(data))
+        self.store_manager = manager
+        self.storage_backend = backend
+        self.storage_sqlite_path = str(sqlite_path) if backend == "sqlite" else ""
+        self.storage_sqlite_effective_path = str(
+            sqlite_path if backend == "sqlite" else self.data_file
+        )
+        self._storage_backend_applied = backend
+        self._storage_sqlite_path_applied = self.storage_sqlite_path
+        self.data = deepcopy(data)
+        return manager
 
 
 class StoragePathValidationTests(unittest.TestCase):
@@ -34,10 +70,16 @@ class StoragePathValidationTests(unittest.TestCase):
 
             host._rebuild_store_manager()
 
-            self.assertEqual(str(root / "companions.db"), host.storage_sqlite_effective_path)
-            self.assertEqual(root / "companions.db", host.store_manager.sqlite_backend.db_path)
+            self.assertEqual(
+                str(root / "companions.db"), host.storage_sqlite_effective_path
+            )
+            self.assertEqual(
+                root / "companions.db", host.store_manager.sqlite_backend.db_path
+            )
 
-    def test_uncreatable_parent_falls_back_without_opening_directory_as_database(self) -> None:
+    def test_uncreatable_parent_falls_back_without_opening_directory_as_database(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             parent_file = root / "parent-file"
@@ -46,7 +88,160 @@ class StoragePathValidationTests(unittest.TestCase):
 
             host._rebuild_store_manager()
 
-            self.assertEqual(str(root / "companions.db"), host.storage_sqlite_effective_path)
+            self.assertEqual(
+                str(root / "companions.db"), host.storage_sqlite_effective_path
+            )
+
+    def test_switch_from_sqlite_authority_overwrites_stale_json_and_backs_it_up(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            sqlite_path = root / "authority.db"
+            stale = {"users": {"owner": {"name": "stale-json"}}, "groups": {}}
+            authoritative = {
+                "users": {"owner": {"name": "sqlite-authority"}},
+                "groups": {"room": {"name": "kept"}},
+            }
+            json_path = root / "companions.json"
+            json_path.write_text(
+                json.dumps(stale, ensure_ascii=False, indent=2), encoding="utf-8"
+            )
+            stale_bytes = json_path.read_bytes()
+            host = _StorePathHost(root, str(sqlite_path))
+            old_manager = host.install_manager("sqlite", sqlite_path, authoritative)
+
+            host.storage_backend = "json"
+            host.storage_sqlite_path = ""
+            host._rebuild_store_manager(reload_data=True)
+
+            self.assertIsNot(old_manager, host.store_manager)
+            self.assertEqual(authoritative, host.data)
+            self.assertEqual(
+                authoritative, json.loads(json_path.read_text(encoding="utf-8"))
+            )
+            backups = sorted(root.glob("companions.json.before-switch-*.bak"))
+            self.assertEqual(1, len(backups))
+            self.assertEqual(stale_bytes, backups[0].read_bytes())
+
+    def test_switch_between_sqlite_files_copies_authority_and_backs_up_target(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            source_path = root / "source.db"
+            target_path = root / "target.db"
+            source_data = {"users": {"owner": {"name": "source"}}, "groups": {}}
+            target_data = {"users": {"owner": {"name": "target-old"}}, "groups": {}}
+            host = _StorePathHost(root, str(source_path))
+            host.install_manager("sqlite", source_path, source_data)
+            target_manager = host.manager("sqlite", target_path)
+            target_manager.backend.save_store(target_data)
+            target_before = SqliteStoreBackend(
+                target_path, host._ensure_store_defaults, host._new_store
+            ).load_store()
+
+            host.storage_backend = "sqlite"
+            host.storage_sqlite_path = str(target_path)
+            host._rebuild_store_manager(reload_data=True)
+
+            self.assertEqual(source_data, host.data)
+            self.assertEqual(source_data, host.store_manager.backend.load_store())
+            self.assertEqual(1, len(list(root.glob("target.db.before-switch-*.bak"))))
+            backup_path = next(root.glob("target.db.before-switch-*.bak"))
+            self.assertEqual(
+                target_before,
+                SqliteStoreBackend(
+                    backup_path, host._ensure_store_defaults, host._new_store
+                ).load_store(),
+            )
+
+    def test_failed_target_write_restores_target_and_runtime_state(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            source_path = root / "source.db"
+            target_path = root / "companions.json"
+            source_data = {"users": {"owner": {"name": "source"}}, "groups": {}}
+            target_path.write_text(
+                '{"users":{"owner":{"name":"old"}}}', encoding="utf-8"
+            )
+            original_target = target_path.read_bytes()
+            host = _StorePathHost(root, str(source_path))
+            old_manager = host.install_manager("sqlite", source_path, source_data)
+            host.storage_backend = "json"
+            host.storage_sqlite_path = str(root / "attempted.db")
+
+            with (
+                patch.object(
+                    JsonStoreBackend, "save_store", side_effect=OSError("write failed")
+                ),
+                self.assertRaises(OSError),
+            ):
+                host._rebuild_store_manager(reload_data=True)
+
+            self.assertIs(old_manager, host.store_manager)
+            self.assertEqual(source_data, host.data)
+            self.assertEqual("sqlite", host.storage_backend)
+            self.assertEqual(str(source_path), host.storage_sqlite_path)
+            self.assertEqual(str(source_path), host.storage_sqlite_effective_path)
+            self.assertEqual(original_target, target_path.read_bytes())
+
+    def test_failed_target_readback_restores_target_and_runtime_state(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            source_path = root / "source.db"
+            target_path = root / "companions.json"
+            source_data = {"users": {"owner": {"name": "source"}}, "groups": {}}
+            target_path.write_text(
+                '{"users":{"owner":{"name":"old"}}}', encoding="utf-8"
+            )
+            original_target = target_path.read_bytes()
+            host = _StorePathHost(root, str(source_path))
+            old_manager = host.install_manager("sqlite", source_path, source_data)
+            host.storage_backend = "json"
+            host.storage_sqlite_path = str(root / "attempted.db")
+
+            with (
+                patch.object(
+                    JsonStoreBackend, "load_store", side_effect=OSError("read failed")
+                ),
+                self.assertRaises(OSError),
+            ):
+                host._rebuild_store_manager(reload_data=True)
+
+            self.assertIs(old_manager, host.store_manager)
+            self.assertEqual(source_data, host.data)
+            self.assertEqual("sqlite", host.storage_backend)
+            self.assertEqual(str(source_path), host.storage_sqlite_path)
+            self.assertEqual(str(source_path), host.storage_sqlite_effective_path)
+            self.assertEqual(original_target, target_path.read_bytes())
+
+    def test_non_object_target_readback_is_rejected_and_rolled_back(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            source_path = root / "source.db"
+            target_path = root / "companions.json"
+            source_data = {"users": {"owner": {"name": "source"}}, "groups": {}}
+            target_path.write_text(
+                '{"users":{"owner":{"name":"old"}}}', encoding="utf-8"
+            )
+            original_target = target_path.read_bytes()
+            host = _StorePathHost(root, str(source_path))
+            old_manager = host.install_manager("sqlite", source_path, source_data)
+            host.storage_backend = "json"
+            host.storage_sqlite_path = str(root / "attempted.db")
+
+            with (
+                patch.object(JsonStoreBackend, "load_store", return_value=[]),
+                self.assertRaisesRegex(RuntimeError, "non-object store"),
+            ):
+                host._rebuild_store_manager(reload_data=True)
+
+            self.assertIs(old_manager, host.store_manager)
+            self.assertEqual(source_data, host.data)
+            self.assertEqual("sqlite", host.storage_backend)
+            self.assertEqual(str(source_path), host.storage_sqlite_path)
+            self.assertEqual(original_target, target_path.read_bytes())
 
 
 if __name__ == "__main__":

--- a/tests/test_store_compaction.py
+++ b/tests/test_store_compaction.py
@@ -91,7 +91,7 @@ class StoreCompactionTests(unittest.IsolatedAsyncioTestCase):
     async def test_snapshot_cleanup_updates_live_data_without_full_followup_write(self) -> None:
         harness = _CanonicalSanitizeHarness({"memory": {"text": "残留 <bubble/> 内容"}})
 
-        harness._save_data_sync()
+        harness._save_data_sync(full_scope="admin_import_export")
         await harness._flush_scheduled_data_save()
 
         self.assertEqual(harness.data["memory"]["text"], "残留 内容")
@@ -187,9 +187,9 @@ class StoreCompactionTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_repeated_sync_save_calls_are_coalesced_off_loop(self) -> None:
         harness = _StoreHarness({"users": {}})
-        harness._save_data_sync()
-        harness._save_data_sync()
-        harness._save_data_sync()
+        harness._save_data_sync(full_scope="admin_import_export")
+        harness._save_data_sync(full_scope="admin_import_export")
+        harness._save_data_sync(full_scope="admin_import_export")
 
         self.assertEqual(harness.writes, [])
         await asyncio.sleep(0.55)
@@ -197,7 +197,7 @@ class StoreCompactionTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_flush_waits_for_pending_coalesced_save(self) -> None:
         harness = _StoreHarness({"users": {"10001": {"nickname": "before switch"}}})
-        harness._save_data_sync()
+        harness._save_data_sync(full_scope="admin_import_export")
 
         await harness._flush_scheduled_data_save()
 

--- a/tests/test_store_compaction.py
+++ b/tests/test_store_compaction.py
@@ -88,15 +88,15 @@ class StoreCompactionTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("<bubble/>", data["groups"]["10001"]["summary"])
         self.assertEqual(data["memory"]["code"], "示例是 `<widget/>`，泄漏是。")
 
-    async def test_snapshot_cleanup_updates_live_data_and_writes_clean_followup(self) -> None:
+    async def test_snapshot_cleanup_updates_live_data_without_full_followup_write(self) -> None:
         harness = _CanonicalSanitizeHarness({"memory": {"text": "残留 <bubble/> 内容"}})
 
         harness._save_data_sync()
         await harness._flush_scheduled_data_save()
 
         self.assertEqual(harness.data["memory"]["text"], "残留 内容")
-        self.assertEqual(len(harness.writes), 2)
-        self.assertEqual(harness.writes[0], harness.writes[1])
+        self.assertEqual(len(harness.writes), 1)
+        self.assertEqual(harness.writes[0], harness.data)
 
     def test_cleanup_logs_are_aggregated_within_cooldown(self) -> None:
         harness = _ControlTagSanitizerHarness(True)

--- a/tests/test_tts_language_group_command.py
+++ b/tests/test_tts_language_group_command.py
@@ -84,7 +84,7 @@ class _Harness(InteractionUtilsMixin, TtsEnhancementMixin):
         return {"state": "profile_exact"}
 
     @staticmethod
-    def _schedule_data_save() -> None:
+    def _schedule_data_save(*_args, **_kwargs) -> None:
         return None
 
     @staticmethod

--- a/token_budget.py
+++ b/token_budget.py
@@ -577,7 +577,7 @@ class TokenBudgetMixin:
         if now_ts - last_save >= 60:
             self._token_usage_last_save_at = now_ts
             try:
-                self._save_data_sync()
+                self._save_data_sync(sections={"token_usage"})
             except Exception:
                 pass
 
@@ -693,7 +693,7 @@ class TokenBudgetMixin:
         if now_ts - last_save >= 30:
             self._external_token_usage_last_save_at = now_ts
             try:
-                self._save_data_sync()
+                self._save_data_sync(sections={"token_usage"})
             except Exception:
                 pass
 
@@ -891,7 +891,7 @@ class TokenBudgetMixin:
         if now_ts - last_save >= 60:
             self._token_usage_last_save_at = now_ts
             try:
-                self._save_data_sync()
+                self._save_data_sync(sections={"token_usage"})
             except Exception:
                 pass
 

--- a/token_budget.py
+++ b/token_budget.py
@@ -686,7 +686,7 @@ class TokenBudgetMixin:
         schedule_save = getattr(self, "_schedule_data_save", None)
         if callable(schedule_save):
             try:
-                schedule_save(delay=2.0)
+                schedule_save(sections={"token_usage"}, delay=2.0)
             except Exception:
                 pass
         last_save = _safe_float(getattr(self, "_external_token_usage_last_save_at", 0), 0)

--- a/tts_enhancement.py
+++ b/tts_enhancement.py
@@ -1054,14 +1054,14 @@ class TtsEnhancementMixin:
             settings.pop("tts_voice_language", None)
             configured = self._normalize_tts_voice_language_value(getattr(self, "config", {}).get("tts_voice_language", "zh") if getattr(self, "config", None) is not None else "zh")
             self.tts_voice_language = configured or "zh"
-            self._save_data_sync()
+            self._save_data_sync(sections={"runtime_settings"})
             return f"已恢复 TTS 语音语种为配置页设置：{self._tts_language_label()}。"
         lang = self._normalize_tts_voice_language_value(text)
         if not lang:
             return "没认出这个 TTS 语种。可用：日语 / 中文 / 英语；例如：陪伴 TTS语种 日语。"
         self.tts_voice_language = lang
         settings["tts_voice_language"] = lang
-        self._save_data_sync()
+        self._save_data_sync(sections={"runtime_settings"})
         return f"已切换 TTS 语音语种：{self._tts_language_label()}。之后 <tts> 和自动语音转换会按这个语种处理。"
 
     def _normalize_tts_tags(self, text: str) -> str:

--- a/user_memory.py
+++ b/user_memory.py
@@ -6175,7 +6175,7 @@ Character-specific bottom-line baseline (reference only; empty means use the con
                 )
             else:
                 user["last_emotion_judgement_error"] = review_outcome
-            self._save_data_sync()
+            self._save_data_sync(sections={"users"})
 
     def _decay_relationship_mood_score(self, state: dict[str, Any], *, now: float | None = None) -> int:
         now = now or _now_ts()
@@ -7056,7 +7056,7 @@ Character-specific bottom-line baseline (reference only; empty means use the con
                         item["status"] = "delivered"
                         item["delivered_at"] = _now_ts()
                         break
-            self._save_data_sync()
+            self._save_data_sync(sections={"boundary_feedback_reports"})
 
     def _register_relationship_boundary_proactive_ability(self) -> bool:
         registrar = getattr(self, "register_external_proactive_ability", None)
@@ -8877,7 +8877,7 @@ Character-specific bottom-line baseline (reference only; empty means use the con
                 consume_suspended = True
                 current = self._get_user(user_id)
                 current["suspended_proactive"] = {}
-                self._save_data_sync()
+                self._save_data_sync(sections={"users"})
 
             last_proactive_text = _single_line(user.get("last_proactive_message"), 500)
             last_proactive_at = _safe_float(user.get("last_proactive_sent_at"), 0)
@@ -8920,7 +8920,7 @@ Character-specific bottom-line baseline (reference only; empty means use the con
                     )
                 current = self._get_user(user_id)
                 current["last_proactive_reply_context_consumed_for"] = last_proactive_at
-                self._save_data_sync()
+                self._save_data_sync(sections={"users"})
 
         suspended = user.get("suspended_proactive")
         if isinstance(suspended, dict) and suspended.get("active") and (
@@ -9245,7 +9245,7 @@ bot_promises 只记录 Bot 明确承诺要提醒、记住、转述、发送或�
                     operation_id=f"req041-dialogue-episode:{user_id}:{expression_batch_key}",
                 ):
                     return
-            self._save_data_sync()
+            self._save_data_sync(sections={"users"})
 
     def _build_expression_decision_for_user(
         self,
@@ -9686,7 +9686,7 @@ bot_promises 只记录 Bot 明确承诺要提醒、记住、转述、发送或�
                     operation_id=f"req041-memory-profile:{user_id}:{memory_fingerprint}",
                 ):
                     return
-            self._save_data_sync()
+            self._save_data_sync(sections={"users"})
 
     async def _try_acquire_user_background_task(
         self,
@@ -9709,7 +9709,7 @@ bot_promises 只记录 Bot 明确承诺要提醒、记住、转述、发送或�
             if running_at > 0 and now - running_at < 10 * 60:
                 return False
             current[running_key] = now
-            self._save_data_sync()
+            self._save_data_sync(sections={"users"})
         return True
 
     async def _mark_user_background_retry(self, user_id: str, task: str, now: float, error: Any) -> None:
@@ -9728,7 +9728,7 @@ bot_promises 只记录 Bot 明确承诺要提醒、记住、转述、发送或�
             current[retry_key] = now + delay
             current[error_key] = _single_line(error, 180)
             current[running_key] = 0
-            self._save_data_sync()
+            self._save_data_sync(sections={"users"})
         logger.warning(
             "[PrivateCompanion] 私聊后台整理失败,已进入短冷却避免重复请求: user=%s task=%s retry=%ss error=%s",
             user_id,

--- a/user_memory.py
+++ b/user_memory.py
@@ -3456,6 +3456,7 @@ class UserMemoryMixin:
         try:
             store = AuthoritativePrivateMemoryStore(self.data)
             result = store.read(person_id)
+            bootstrapped = False
             if result.get("code") == "not_found":
                 seed = (
                     private_memory_content(user)
@@ -3468,6 +3469,7 @@ class UserMemoryMixin:
                     expected_revision=0,
                     operation_id=f"req041-private-memory-bootstrap:{person_id}",
                 )
+                bootstrapped = result.get("ok") is True
             record = result.get("record") if isinstance(result, dict) else None
             if result.get("ok") is not True or not isinstance(record, dict):
                 return None
@@ -3475,6 +3477,10 @@ class UserMemoryMixin:
             if not isinstance(content, dict):
                 return None
             apply_private_memory_content(user, content)
+            if bootstrapped:
+                scheduler = getattr(self, "_schedule_data_save", None)
+                if callable(scheduler):
+                    scheduler(sections={"users", "_req041_private_memory"})
             return int(record.get("revision") or 0) or None
         except (AuthoritativePrivateMemoryError, TypeError, ValueError) as exc:
             logger.warning(
@@ -3593,6 +3599,7 @@ class UserMemoryMixin:
             return {}
         current_channel = _single_line((context or {}).get("channel"), 24).lower()
         source_kind = "group" if current_channel == "group" or user.get("group_id") else "private"
+        updated_sections = {"groups" if source_kind == "group" else "users"}
         scope_managed, scope_context = self._expression_formal_scope_for_owner(
             user, source_kind=source_kind,
         )
@@ -3712,6 +3719,7 @@ class UserMemoryMixin:
                             continue
                         source_owner["expression_profile"] = source_profile
                         source_rules = source_profile.get("learned_rules")
+                        updated_sections.add(collection_key)
                         scoped_changed[id(source_owner)] = (source_owner, source_scope_context)
                     for source_rule in source_rules:
                         if not isinstance(source_rule, dict) or _single_line(source_rule.get("id"), 40) != ref["rule_id"]:
@@ -3721,6 +3729,7 @@ class UserMemoryMixin:
                         binding = source_rule.get("scope_binding") if isinstance(source_rule.get("scope_binding"), dict) else None
                         if binding is not None:
                             binding["revision"] = max(1, _safe_int(binding.get("revision"), 1, 1) + 1)
+                        updated_sections.add(collection_key)
                         break
                 if compact_refs:
                     feedback_rules.append(
@@ -3745,7 +3754,9 @@ class UserMemoryMixin:
                 changed_owner["expression_profile"] = self._expression_bind_profile_scope(
                     changed_profile, changed_context, bump_revision=True,
                 )
-        return last
+        result = dict(last)
+        result["updated_sections"] = sorted(updated_sections)
+        return result
 
     def _record_staged_expression_rule_injection(
         self,
@@ -9245,7 +9256,10 @@ bot_promises 只记录 Bot 明确承诺要提醒、记住、转述、发送或�
                     operation_id=f"req041-dialogue-episode:{user_id}:{expression_batch_key}",
                 ):
                     return
-            self._save_data_sync(sections={"users"})
+            save_sections = {"users"}
+            if memory_managed:
+                save_sections.add("_req041_private_memory")
+            self._save_data_sync(sections=save_sections)
 
     def _build_expression_decision_for_user(
         self,
@@ -9686,7 +9700,10 @@ bot_promises 只记录 Bot 明确承诺要提醒、记住、转述、发送或�
                     operation_id=f"req041-memory-profile:{user_id}:{memory_fingerprint}",
                 ):
                     return
-            self._save_data_sync(sections={"users"})
+            save_sections = {"users"}
+            if memory_managed:
+                save_sections.add("_req041_private_memory")
+            self._save_data_sync(sections=save_sections)
 
     async def _try_acquire_user_background_task(
         self,

--- a/user_memory.py
+++ b/user_memory.py
@@ -3859,6 +3859,7 @@ class UserMemoryMixin:
         feedback_field = "positive_feedback" if signal == "positive" else "negative_feedback"
         updated = 0
         demoted = 0
+        updated_sections: set[str] = set()
         processed: set[tuple[str, str, str]] = set()
         for pending_rule in pending.get("rules", []) if isinstance(pending.get("rules"), list) else []:
             if not isinstance(pending_rule, dict):
@@ -3909,6 +3910,7 @@ class UserMemoryMixin:
                     source_rule["last_feedback"] = signal
                     source_rule["last_feedback_ts"] = now
                     updated += 1
+                    updated_sections.add(collection_key)
                     if (
                         signal == "negative"
                         and _safe_int(source_rule.get("negative_feedback"), 0, 0) >= 2
@@ -3962,7 +3964,12 @@ class UserMemoryMixin:
                 )
         if updated:
             self._refresh_expression_voice_profile()
-        return {"signal": signal, "updated_rules": updated, "demoted_rules": demoted}
+        return {
+            "signal": signal,
+            "updated_rules": updated,
+            "demoted_rules": demoted,
+            "updated_sections": sorted(updated_sections),
+        }
 
     def _format_companion_memory_for_prompt(self, user: dict[str, Any], *, style_only: bool = False) -> str:
         memory = user.get("companion_memory")
@@ -6521,7 +6528,7 @@ Character-specific bottom-line baseline (reference only; empty means use the con
             state["confession_until"] = ts + 30 * 60
             state["last_reason"] = _single_line(intent.get("boundary_feedback_reason") or "表达喜欢或想念", 120)
             state["last_event_id"] = explicit_id
-            self._schedule_data_save()
+            self._schedule_data_save(sections={"users"})
             boundary_logger = getattr(self, "_log_relationship_boundary_event", None)
             if callable(boundary_logger):
                 boundary_logger(
@@ -6575,7 +6582,7 @@ Character-specific bottom-line baseline (reference only; empty means use the con
                 stage_refresher = getattr(self, "_refresh_relationship_violation_stage", None)
                 if callable(stage_refresher):
                     stage_refresher(state, now=ts)
-                self._schedule_data_save()
+                self._schedule_data_save(sections={"users"})
                 boundary_logger = getattr(self, "_log_relationship_boundary_event", None)
                 if callable(boundary_logger):
                     boundary_logger(
@@ -6707,7 +6714,7 @@ Character-specific bottom-line baseline (reference only; empty means use the con
         side_effects = getattr(self, "_record_relationship_boundary_side_effects", None)
         if callable(side_effects) and (applied_penalty or clawed_back):
             side_effects(user, intent, state, now=ts)
-        self._schedule_data_save()
+        self._schedule_data_save(sections={"users", "boundary_feedback_reports"})
         boundary_logger = getattr(self, "_log_relationship_boundary_event", None)
         if callable(boundary_logger):
             boundary_logger(
@@ -7144,7 +7151,7 @@ Character-specific bottom-line baseline (reference only; empty means use the con
         candidate["excerpt"] = _single_line(candidate.get("excerpt"), max_chars)
         candidate["status"] = "delivered"
         candidate["delivered_at"] = _now_ts()
-        self._schedule_data_save()
+        self._schedule_data_save(sections={"boundary_feedback_reports"})
         text = self._format_relationship_boundary_owner_report(candidate)
         return {
             "success": True,

--- a/worldbook.py
+++ b/worldbook.py
@@ -1290,7 +1290,7 @@ class WorldbookMixin:
                 )
             profile["auto_registration_pending"] = False
             profile["auto_impression_ts"] = _now_ts()
-            self._save_data_sync()
+            self._save_data_sync(sections={"worldbook_member_profiles"})
         logger.info("[PrivateCompanion] 群聊关系网自登记印象已生成: user=%s name=%s", user_id, name)
 
     def _group_member_identity_label_for_token(self, group: dict[str, Any], token: str) -> str:


### PR DESCRIPTION
## 修复内容

核心陪伴插件的多个高频状态更新仍可能触发全量持久化，增加 I/O 和并发覆盖风险；SQLite 删除状态在迁移或后端切换时也需要明确保护。

## 实现方式

- 增加按数据 section 跟踪 dirty、deleted 和 full revision 的增量保存机制。
- 为删除的 section 增加 SQLite tombstone 保护，避免旧镜像数据重新出现。
- 加强 JSON/SQLite 后端切换时的数据备份、写入、回滚和并发代数控制。
- 将日状态、消息、最终回复、主动行为、用户记忆、QQ 空间和页面 API 等高频调用点迁移到增量写入。
- 增加存储、写入器、调用点和页面 API 回归测试。

## 验证

- 使用 AstrBot 4.27.3 专用 Python 运行：
  `python -m pytest tests/test_incremental_persistence_callsites.py tests/test_incremental_persistence_storage.py tests/test_incremental_persistence_writer.py tests/test_page_api_incremental_persistence.py -q`
- 结果：106 项通过，19 个子测试通过，1 个依赖警告。
- `git diff --check upstream/main...codex/incremental-persistence`：通过。

## 兼容性

- 保留旧的全量保存入口，并兼容旧 writer 签名。
- 不改变现有 JSON/SQLite 配置格式和数据目录约定。
