### PR TITLE
fix: 防止 TTS 语音发送后丢失配套文字

### DIFF
--- a/main.py
+++ b/main.py
@@ -8264,25 +8264,11 @@ class PrivateCompanionPlugin(
         chunks = pending.get("chunks")
         if not isinstance(chunks, list) or not chunks:
             return
-        scope_getter = getattr(self, "_event_scope_key", None)
-        if callable(scope_getter):
-            scope = scope_getter(event)
-        else:
-            scope = _single_line(getattr(event, "unified_msg_origin", ""), 160) or "unknown"
-        generation_checker = getattr(self, "_reply_turn_is_current", None)
-        if callable(generation_checker) and not generation_checker(
-            scope,
-            pending.get("turn_generation", 0),
-        ):
-            logger.info(
-                "[PrivateCompanion] 新回合已到达，跳过旧 TTS 尾段: session=%s",
-                _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
-            )
-            return
         operation = self._send_tts_chain_chunks_after_first(
             event,
             chunks,
             started_at=_safe_float(pending.get("started_at"), time.time(), 0.0),
+            primary_delivery_confirmed=True,
         )
         self._create_lifecycle_background_task(
             operation,

--- a/tests/test_background_task_lifecycle.py
+++ b/tests/test_background_task_lifecycle.py
@@ -6,8 +6,9 @@ import unittest
 from datetime import datetime
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock, patch
 
-from astrbot.api.message_components import Plain
+from astrbot.api.message_components import Plain, Record
 
 from astrbot_plugin_private_companion.main import PrivateCompanionPlugin
 from astrbot_plugin_private_companion.private_image import PrivateImageMixin
@@ -118,7 +119,7 @@ class _TtsRemainderHarness(TtsEnhancementMixin):
 
     @staticmethod
     def _split_tts_chain_for_ordered_send(_chain: list[Any]) -> list[list[Any]]:
-        return [[Plain("voice")], [Plain("caption")]]
+        return [[Record(file="voice.wav")], [Plain("caption")]]
 
     @staticmethod
     def _tts_segment_plain_chunk_for_ordered_send(_event: Any, chunk: list[Any]) -> list[list[Any]]:
@@ -135,6 +136,10 @@ class _TtsRemainderHarness(TtsEnhancementMixin):
     def _create_lifecycle_background_task(self, operation: Any, *, label: str) -> None:
         self.background_jobs.append((operation, label))
 
+    def _create_tts_background_task(self, operation: Any, *, label: str) -> None:
+        self.background_jobs.append((operation, label))
+
+    _reply_turn_generation = PrivateCompanionPlugin._reply_turn_generation
     _reply_turn_is_current = PrivateCompanionPlugin._reply_turn_is_current
 
     @staticmethod
@@ -214,16 +219,25 @@ class BackgroundTaskLifecycleTests(unittest.IsolatedAsyncioTestCase):
 
     @staticmethod
     def _tts_remainder_event(*, proactive: bool = False) -> Any:
+        sent: list[Any] = []
         event = SimpleNamespace(
             _private_companion_tts_request_applied=True,
             unified_msg_origin="default:FriendMessage:1",
-            get_result=lambda: SimpleNamespace(chain=[Plain("reply")]),
+            result=SimpleNamespace(chain=[Plain("reply")]),
+            sent=sent,
         )
         if proactive:
             event._private_companion_proactive_delivery_umo = (
                 "default:FriendMessage:1"
             )
         event.set_result = lambda result: setattr(event, "result", result)
+        event.get_result = lambda: event.result
+        event.chain_result = lambda chain: SimpleNamespace(chain=list(chain))
+
+        async def send(result: Any) -> None:
+            sent.append(result)
+
+        event.send = send
         return event
 
     async def test_passive_tts_remainder_waits_for_platform_send_confirmation(self) -> None:
@@ -232,7 +246,7 @@ class BackgroundTaskLifecycleTests(unittest.IsolatedAsyncioTestCase):
 
         await harness.apply_tts_enhancement_before_send(event)
 
-        self.assertEqual("voice", event.result.chain[0].text)
+        self.assertIsInstance(event.result.chain[0], Record)
         self.assertEqual([], harness.background_jobs)
         self.assertEqual(
             "caption",
@@ -291,22 +305,67 @@ class BackgroundTaskLifecycleTests(unittest.IsolatedAsyncioTestCase):
 
         await harness.apply_tts_enhancement_before_send(event)
 
-        self.assertEqual("voice", event.result.chain[0].text)
+        self.assertIsInstance(event.result.chain[0], Record)
         self.assertEqual("tts_reply_remainder", harness.background_jobs[0][1])
         self.assertFalse(hasattr(event, "_private_companion_tts_reply_remainder"))
         harness.background_jobs[0][0].close()
 
-    async def test_passive_tts_remainder_is_dropped_after_new_inbound_turn(self) -> None:
+    async def test_passive_tts_remainder_is_released_after_generation_state_reset(self) -> None:
         harness = _TtsRemainderHarness()
         event = self._tts_remainder_event()
         event._private_companion_reply_turn_generation = 1
-        harness._reply_turn_generation_by_scope[event.unified_msg_origin] = 2
+        event._has_send_oper = True
+        harness._reply_turn_generation_by_scope[event.unified_msg_origin] = 1
+
+        await harness.apply_tts_enhancement_before_send(event)
+        harness._reply_turn_generation_by_scope.clear()
+        await harness.release_tts_reply_remainder_after_send(event)
+
+        self.assertEqual("tts_reply_remainder", harness.background_jobs[0][1])
+        with patch(
+            "astrbot_plugin_private_companion.tts_enhancement.asyncio.sleep",
+            new=AsyncMock(),
+        ):
+            await harness.background_jobs[0][0]
+        self.assertEqual(["caption"], [item.chain[0].text for item in event.sent])
+
+    async def test_committed_tts_remainder_survives_new_turn_during_wait(self) -> None:
+        harness = _TtsRemainderHarness()
+        event = self._tts_remainder_event()
+        event._private_companion_reply_turn_generation = 1
+        harness._reply_turn_generation_by_scope[event.unified_msg_origin] = 1
         event._has_send_oper = True
 
         await harness.apply_tts_enhancement_before_send(event)
         await harness.release_tts_reply_remainder_after_send(event)
 
-        self.assertEqual([], harness.background_jobs)
+        async def note_new_turn(_delay: float) -> None:
+            harness._reply_turn_generation_by_scope[event.unified_msg_origin] = 2
+
+        with patch(
+            "astrbot_plugin_private_companion.tts_enhancement.asyncio.sleep",
+            new=AsyncMock(side_effect=note_new_turn),
+        ):
+            await harness.background_jobs[0][0]
+        self.assertEqual(["caption"], [item.chain[0].text for item in event.sent])
+
+    async def test_unconfirmed_proactive_tts_remainder_still_stops_after_new_turn(self) -> None:
+        harness = _TtsRemainderHarness()
+        event = self._tts_remainder_event(proactive=True)
+        event._private_companion_reply_turn_generation = 1
+        harness._reply_turn_generation_by_scope[event.unified_msg_origin] = 1
+
+        await harness.apply_tts_enhancement_before_send(event)
+
+        async def note_new_turn(_delay: float) -> None:
+            harness._reply_turn_generation_by_scope[event.unified_msg_origin] = 2
+
+        with patch(
+            "astrbot_plugin_private_companion.tts_enhancement.asyncio.sleep",
+            new=AsyncMock(side_effect=note_new_turn),
+        ):
+            await harness.background_jobs[0][0]
+        self.assertEqual([], event.sent)
 
     async def test_reply_interception_forward_uses_lifecycle_tracker(self) -> None:
         harness = _ReplyInterceptionHarness()

--- a/tts_enhancement.py
+++ b/tts_enhancement.py
@@ -3588,6 +3588,7 @@ TTS 朗读文本：
         chunks: list[list[Any]],
         *,
         started_at: float | None = None,
+        primary_delivery_confirmed: bool = False,
     ) -> None:
         if not chunks:
             return
@@ -3667,7 +3668,11 @@ TTS 朗读文本：
             for chunk in expanded_chunks:
                 if not chunk:
                     continue
-                if callable(generation_checker) and not generation_checker(scope, turn_generation):
+                if (
+                    not primary_delivery_confirmed
+                    and callable(generation_checker)
+                    and not generation_checker(scope, turn_generation)
+                ):
                     logger.info(
                         "[PrivateCompanion] 新回合已到达，停止旧 TTS 尾段: session=%s sent=%s/%s",
                         _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
@@ -3688,7 +3693,11 @@ TTS 朗读文本：
                         except Exception:
                             delay = 0.45
                 await asyncio.sleep(delay)
-                if callable(generation_checker) and not generation_checker(scope, turn_generation):
+                if (
+                    not primary_delivery_confirmed
+                    and callable(generation_checker)
+                    and not generation_checker(scope, turn_generation)
+                ):
                     logger.info(
                         "[PrivateCompanion] 等待期间收到新回合，停止旧 TTS 尾段: session=%s",
                         _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",


### PR DESCRIPTION
## 问题说明

在 `voice_and_text` 配合语音独立发送时，插件会先发送语音组件，再后台补发对应文字。

旧实现会在语音已经由平台确认发送后，继续依据内存中的回合编号决定是否取消文字尾段。这会在以下场景中错误丢弃文字：

- 群聊在等待期间收到新消息；
- 请求处理中插件被热重载，导致旧实例的回合状态在新实例中被重置。

本次实况属于第二种情况：群里没有新消息，但插件在 TTS 请求处理中被重载。旧事件保留的回合编号为 `1`，新实例中的状态重置为 `0`，因而被错误判断为“新回合已到达”。最终语音成功发送，配套文字却被取消。

## 修复内容

- 首个语音组件由平台确认发送后，将剩余文字视为该回复已经承诺投递的组成部分。
- 已确认回复的文字尾段不再受后续回合编号变化或插件重载状态重置影响。
- 分段等待期间发生新回合时，已确认语音的配套文字仍会补齐。
- 未确认的主动 TTS 任务继续保留原有回合保护，避免过期消息被错误发送。

## 测试

新增或更新回归测试，覆盖：

- 模拟插件重载后，回合状态从 `1` 重置为 `0`，已确认语音的配套文字仍会发送；
- 分段等待期间出现真实新回合（`1 → 2`），已确认语音的配套文字仍会补齐；
- 未确认的主动 TTS 在等待期间出现新回合时仍会取消。

测试结果：

- 后台任务生命周期测试：`11 passed`
- TTS 聚焦测试：
  - 本分支：`233 passed, 6 failed, 36 subtests passed`
  - 最新 `main`：`230 passed, 7 failed, 36 subtests passed`
- 完整可比测试：
  - 本分支：`3468 passed, 334 failed, 2 skipped, 729 subtests passed`
  - 最新 `main`：`3465 passed, 335 failed, 2 skipped, 729 subtests passed`
- 失败用例 ID 对比：本分支独有失败 `0`；最新 `main` 独有失败 `1`，即旧的 TTS 尾段丢弃行为测试。
- 当前环境中完整测试的其余失败均可在最新 `main` 复现，主要来自既有测试桩与增量持久化接口不兼容。
- 四个无法在当前本机环境纳入可比运行的测试文件：
  - `test_c1_contract.py`
  - `test_c1_dual_plugin_link.py`
  - `test_chat_memory_p4_p6_integration.py`
  - `test_reaction_image_format.py`（当前 AstrBot 核心缺少 `astrbot.core.platform.sources`）

实机验证：

- 修复已叠加部署到 AstrBot 运行副本，同时保留已合并的 #157 媒体标记清理。
- 运行副本组合回归：`18 passed`，包含 `3 subtests`。
- 群聊实测中，语音确认发送后，三段对应文字均成功补发。

其他检查：

- Python 语法检查：通过
- `git diff --check`：通过
