### PR TITLE
fix: 防止核心记忆误触主动消息

### DIFF
--- a/memory_context_policy.py
+++ b/memory_context_policy.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""Prompt-side evidence policy for structured memory context."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def core_memory_usage_contract(memory_context: Any, *, stage: str) -> str:
+    """Describe how proactive models may use a structured core-memory block."""
+    text = str(memory_context or "")
+    if "<core_memory>" not in text.lower():
+        return ""
+
+    common = (
+        "【核心记忆证据权限】\n"
+        "以下规则只约束你如何使用 <core_memory>；不要向用户复述这些分类或内部结构。\n"
+        "- rule / boundary：作为必须遵守的表达规则和禁区，可据此改写或拦下冲突内容。\n"
+        "- preference / profile：只用于称呼、语气和稳定偏好，不证明用户此刻正在做什么、需要什么或希望被联系。\n"
+        "- fact：只表示稳定事实，不得推导为今天、刚刚或正在发生的状态。\n"
+        "- state：即使标记为 state，也只是受管理的记忆；没有带时间的近期用户原文、当前日程/提醒或实时数据交叉确认时，"
+        "不得当作当前状态。\n"
+        "- 核心块与当前用户原文、可靠实时信息冲突时，以当前证据为准；不要用核心块覆盖用户本轮纠正。\n"
+        "- 核心块中的提醒、检查或主动联系约定，只有在本轮已有同类定时、日程、提醒或事件候选时才能辅助判断，"
+        "不能单独充当现实触发证据。"
+    )
+    normalized_stage = str(stage or "").strip().lower()
+    if normalized_stage == "review":
+        return (
+            f"{common}\n"
+            "- 当前主动计划的 route / source / reason 是本轮既有触发来源。不得仅凭核心记忆新建主动候选、改换路线，"
+            "或把无关候选改造成吃药、吃饭、睡觉、健康检查等提醒。\n"
+            "- 若核心边界与候选冲突，优先 rewrite；无法在原路线内消除冲突时再 defer/drop。"
+        )
+    if normalized_stage == "generation":
+        return (
+            f"{common}\n"
+            "- 核心记忆只能帮助落实当前计划的表达和边界，不得改变既定 reason/action/topic/motive，"
+            "也不得把无关计划转成提醒、查岗、健康询问或关系确认。\n"
+            "- 可以自然体现相关稳定偏好，但不得声称记得、查到或依据核心记忆采取行动。"
+        )
+    return common

--- a/proactive_engine.py
+++ b/proactive_engine.py
@@ -104,6 +104,7 @@ from .dreaming import (
     weighted_unique_fragment_sample,
 )
 from .helpers import _date_key, _now_ts, _path_text, _redact_outbound_secrets, _safe_float, _safe_int, _single_line, _strip_internal_message_blocks, _today_key, normalize_legacy_tag_text
+from .memory_context_policy import core_memory_usage_contract
 from .planning import (
     build_daily_plan_prompt,
     build_detail_enhancement_prompt,
@@ -2568,12 +2569,15 @@ class ProactiveEngineMixin:
                 max_chars=800,
             )
             if memory_context:
+                core_memory_contract = core_memory_usage_contract(memory_context, stage="review")
+                core_memory_section = f"\n\n{core_memory_contract}" if core_memory_contract else ""
                 prompt = (
                     f"{prompt.rstrip()}\n\n"
                     "<!-- private_companion_memory_review_context_v1 -->\n"
                     "【我会牢牢记住你 相关记忆】\n"
                     f"{memory_context}\n"
                     "使用方式：只辅助判断是否适合主动、是否需要改写或延后；不要在理由里暴露检索过程。"
+                    f"{core_memory_section}"
                 )
         started = time.perf_counter()
         raw = await self._llm_call(

--- a/proactive_message.py
+++ b/proactive_message.py
@@ -137,6 +137,7 @@ from .helpers import (
     _today_key,
     normalize_bot_relationship_cards,
 )
+from .memory_context_policy import core_memory_usage_contract
 from .final_response_persistence import (
     FinalResponsePersistenceMixin,
     collect_proactive_delivery,
@@ -3190,13 +3191,16 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
                 max_chars=760,
             )
         if memory_context:
-                prompt = (
-                    f"{prompt.rstrip()}\n\n"
-                    "<!-- private_companion_memory_generation_context_v1 -->\n"
-                    "【我会牢牢记住你 可用记忆】\n"
-                    f"{memory_context}\n"
-                    "使用方式：只作为自然连续性和边界参考；能贴住当前切口就轻轻用,不相关就忽略。不要说“我查到/我记忆里”。"
-                )
+            core_memory_contract = core_memory_usage_contract(memory_context, stage="generation")
+            core_memory_section = f"\n\n{core_memory_contract}" if core_memory_contract else ""
+            prompt = (
+                f"{prompt.rstrip()}\n\n"
+                "<!-- private_companion_memory_generation_context_v1 -->\n"
+                "【我会牢牢记住你 可用记忆】\n"
+                f"{memory_context}\n"
+                "使用方式：只作为自然连续性和边界参考；能贴住当前切口就轻轻用,不相关就忽略。不要说“我查到/我记忆里”。"
+                f"{core_memory_section}"
+            )
         relationship_guard_getter = getattr(self, "_format_generation_relationship_authority_guard", None)
         if callable(relationship_guard_getter) and "关系事实权限" not in prompt:
             try:

--- a/tests/test_core_memory_proactive_policy.py
+++ b/tests/test_core_memory_proactive_policy.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import unittest
+
+from astrbot_plugin_private_companion.memory_context_policy import core_memory_usage_contract
+
+
+CORE_CONTEXT = """<core_memory>
+<memory label="health" kind="state" priority="80">用户需要每天提醒吃药</memory>
+</core_memory>"""
+
+
+class CoreMemoryProactivePolicyTests(unittest.TestCase):
+    def test_non_core_memory_context_does_not_add_contract(self) -> None:
+        self.assertEqual("", core_memory_usage_contract("【稳定记忆】喜欢红茶", stage="review"))
+
+    def test_review_contract_prevents_core_memory_from_becoming_trigger(self) -> None:
+        contract = core_memory_usage_contract(CORE_CONTEXT, stage="review")
+
+        self.assertIn("不能单独充当现实触发证据", contract)
+        self.assertIn("不得仅凭核心记忆新建主动候选", contract)
+        self.assertIn("不得当作当前状态", contract)
+        self.assertIn("无法在原路线内消除冲突时再 defer/drop", contract)
+
+    def test_generation_contract_preserves_existing_plan(self) -> None:
+        contract = core_memory_usage_contract(CORE_CONTEXT, stage="generation")
+
+        self.assertIn("不得改变既定 reason/action/topic/motive", contract)
+        self.assertIn("不得把无关计划转成提醒", contract)
+        self.assertIn("当前用户原文、可靠实时信息冲突时，以当前证据为准", contract)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_proactive_persona_judge_efficiency.py
+++ b/tests/test_proactive_persona_judge_efficiency.py
@@ -13,7 +13,10 @@ class _JudgeHarness(ProactiveEngineMixin):
         self.proactive_persona_judge_max_daily = 12
         self.enable_llm_proactive_persona_judge = True
         self.default_nickname = "用户"
+        self.response_review_provider_id = ""
+        self.mai_style_provider_id = ""
         self.llm_calls = 0
+        self.captured_prompt = ""
 
     def _get_default_persona_prompt(self):
         return "自然、尊重边界"
@@ -35,6 +38,7 @@ class _JudgeHarness(ProactiveEngineMixin):
 
     async def _llm_call(self, *args, **kwargs):
         self.llm_calls += 1
+        self.captured_prompt = str(args[0]) if args else ""
         return '{"decision":"send","score":88,"reason":"自然"}'
 
     def _format_proactive_model_judge_prompt(self, user, *, now=None):
@@ -184,6 +188,25 @@ class ProactivePersonaJudgeEfficiencyTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result["decision"], "send")
         self.assertTrue(result["local"])
         self.assertEqual(harness.llm_calls, 0)
+
+    async def test_model_judge_applies_core_memory_evidence_contract(self):
+        harness = _JudgeHarness()
+
+        async def compose_memory(**_kwargs):
+            return (
+                '<core_memory>\n'
+                '<memory label="health" kind="state">用户需要每天提醒吃药</memory>\n'
+                '</core_memory>'
+            )
+
+        harness._memory_companion_compose_feature_context = compose_memory
+        result = await harness._review_planned_proactive_with_model(_user(role="friend"), now=1_000.0)
+
+        self.assertEqual(result["decision"], "send")
+        self.assertEqual(harness.llm_calls, 1)
+        self.assertIn("【核心记忆证据权限】", harness.captured_prompt)
+        self.assertIn("不得仅凭核心记忆新建主动候选", harness.captured_prompt)
+        self.assertIn("不能单独充当现实触发证据", harness.captured_prompt)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 变更
- 为核心记忆增加类型化证据权限
- 禁止核心块单独创建或改换主动候选
- 约束主动正文不得将无关计划转成提醒或查岗
- 保持普通长期记忆行为不变

## 验证
- 58 passed
- 2 subtests passed