### PR TITLE
feat: 将全局智能画像改为下拉模式

### DIFF
--- a/pages/companion-panel/app.js
+++ b/pages/companion-panel/app.js
@@ -4212,6 +4212,7 @@ const featureSettingTypes = {
   photo_generation_group_max_daily: { type: "number", min: -1, max: 100, step: 1 },
   photo_generation_proactive_max_daily: { type: "number", min: -1, max: 100, step: 1 },
   default_interaction_band: { type: "select", options: [["avoidant", "回避"], ["hurt", "受伤"], ["relaxed", "放松"], ["lively", "活泼"], ["warm", "温暖"]] },
+  portrait_global_mode: { type: "select", options: [["disabled", "关闭智能画像"], ["use_existing", "仅使用已有画像"], ["learn_and_use", "持续学习与使用"]] },
   relationship_positive_stage_cap_key: { type: "select", options: [["familiar", "熟悉"], ["close", "亲近"], ["intimate", "亲密"], ["deeply_bonded", "深度联结"]] },
   normal_interaction_band_cap: { type: "select", options: [["relaxed", "放松"], ["lively", "活泼"], ["warm", "温暖"]] },
   owner_group_relationship_projection: { type: "checkbox" },

--- a/pages/陪伴面板/app.js
+++ b/pages/陪伴面板/app.js
@@ -4212,6 +4212,7 @@ const featureSettingTypes = {
   photo_generation_group_max_daily: { type: "number", min: -1, max: 100, step: 1 },
   photo_generation_proactive_max_daily: { type: "number", min: -1, max: 100, step: 1 },
   default_interaction_band: { type: "select", options: [["avoidant", "回避"], ["hurt", "受伤"], ["relaxed", "放松"], ["lively", "活泼"], ["warm", "温暖"]] },
+  portrait_global_mode: { type: "select", options: [["disabled", "关闭智能画像"], ["use_existing", "仅使用已有画像"], ["learn_and_use", "持续学习与使用"]] },
   relationship_positive_stage_cap_key: { type: "select", options: [["familiar", "熟悉"], ["close", "亲近"], ["intimate", "亲密"], ["deeply_bonded", "深度联结"]] },
   normal_interaction_band_cap: { type: "select", options: [["relaxed", "放松"], ["lively", "活泼"], ["warm", "温暖"]] },
   owner_group_relationship_projection: { type: "checkbox" },

--- a/tests/test_portrait_global_mode_ui.py
+++ b/tests/test_portrait_global_mode_ui.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PANEL_SCRIPTS = (
+    ROOT / "pages" / "陪伴面板" / "app.js",
+    ROOT / "pages" / "companion-panel" / "app.js",
+)
+
+
+class PortraitGlobalModeUiTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.scripts = tuple(path.read_text(encoding="utf-8") for path in PANEL_SCRIPTS)
+        schema = json.loads((ROOT / "_conf_schema.json").read_text(encoding="utf-8"))
+        cls.schema_setting = schema["basic_config"]["items"]["portrait_global_mode"]
+
+    def test_both_mirrored_bundles_use_the_schema_backed_global_select(self) -> None:
+        expected = list(zip(self.schema_setting["options"], self.schema_setting["labels"]))
+        expected_literal = ", ".join(
+            f'["{value}", "{label}"]' for value, label in expected
+        )
+        entry_pattern = re.compile(
+            r"portrait_global_mode:\s*\{(?P<body>[^}]+)\},",
+            re.MULTILINE,
+        )
+
+        entries = []
+        for script in self.scripts:
+            match = entry_pattern.search(script)
+            self.assertIsNotNone(match)
+            body = match.group("body")
+            entries.append(body)
+            self.assertIn('type: "select"', body)
+            self.assertIn(f"options: [{expected_literal}]", body)
+            self.assertNotIn("follow_global", body)
+
+        self.assertEqual(entries[0], entries[1])
+
+    def test_generic_select_renderer_preserves_feature_key_and_save_contract(self) -> None:
+        for script in self.scripts:
+            select_start = script.index('if (spec.type === "select")')
+            select_end = script.index('if (spec.type === "provider")', select_start)
+            renderer = script[select_start:select_end]
+            self.assertIn('<select data-feature-param="${safeKey}"', renderer)
+            self.assertIn('(spec.options || []).map(([optionValue, label])', renderer)
+
+            payload_start = script.index("function collectFeatureDetailPayload")
+            payload_end = script.index("function collectFeatureSwitchPayload", payload_start)
+            payload = script[payload_start:payload_end]
+            self.assertIn('querySelectorAll("[data-feature-param]")', payload)
+            self.assertIn("assignParam(key, collectSettingValue(key, input));", payload)
+
+            save_start = script.index("async function saveFeatureSwitchChanges")
+            save_end = script.index("async function saveCurrentFeatureDetail", save_start)
+            save = script[save_start:save_end]
+            self.assertIn('postJson("/settings/update", payload)', save)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 修复了什么

将 Companion 面板两份镜像 bundle 中的 `portrait_global_mode` 从自由文本输入改为受 schema 约束的下拉选择，避免输入无效全局模式。

## 怎么修复

在两份 `app.js` 的通用设置类型映射中增加 `select` 配置，严格提供以下三个既有值：

- `disabled`：关闭智能画像
- `use_existing`：仅使用已有画像
- `learn_and_use`：持续学习与使用

未加入用户级的 `follow_global`，没有改变保存字段、后端校验、禁用态或通用渲染逻辑；两份 bundle 保持字节一致。

## 已验证

- `python -m pytest tests/test_portrait_global_mode_ui.py -q`：2 passed。
- 两份 bundle SHA-256 一致。
- `git diff --check`：通过。
- 依赖 AstrBot 本体的其他配置回归在当前系统 Python 下无法收集（缺少 `astrbot` 模块）。
