### PR TITLE
fix: 外部信息分享（新闻/B站/主动搜索）跳过回复空气检查，修复分享消息被整体丢弃

### DIFF
--- a/proactive_message.py
+++ b/proactive_message.py
@@ -6470,6 +6470,9 @@ Output:
         if not cleaned or action not in {"message", "photo_text"}:
             return []
         flags: list[str] = []
+        # 外部分享（新闻/B站/搜索）是「分享外界信息」场景，不做回复空气检查，直接放行。
+        if reason in {"news_share", "bili_video_share", "web_exploration_share"}:
+            return flags
         reply_opener_pattern = (
             r"^(?:好呀|好啊|可以呀|可以啊|行呀|行啊|嗯好|那就|你说呢|要不|不然|"
             r"确实|对呀|对啊|是吧|也是|哈哈[,，\s]*我也|我也觉得|你说得对)"


### PR DESCRIPTION
## 问题

主动消息的「回复空气」检查（`_proactive_reply_air_flags` 的
`pretends_recent_inbound`）会把正文里出现的「刚看到/才看到/刚才看到」
当作「假装回复用户」处理：认为 Bot 在没有收到用户消息时，却写成了
"刚看到你发来的消息"这类回复口吻。

但外部信息分享（news_share / bili_video_share / web_exploration_share）
的生成提示词只提供新闻标题/摘要，**不包含任何用户对话**——不存在"假装
回复用户"的可能；而这类分享的正文天然以「刚看到个新闻…」开头，必然命中
该规则：

1. gen 输出「刚看到个新闻…」→ 命中 `pretends_recent_inbound`；
2. 回复复核（`_review_proactive_message_stance`）要求 LLM 改写，
   但改写结果仍以「刚看到」开头（新闻场景开头难以改掉）；
3. 改写后复查仍命中 → 直接 `return ""`，整条分享消息被丢弃。

实测影响：新闻主动消息（如磁星观测、GTA6 泄密等）被静默吞掉，
分享链路 6 次 accepted 仅 1 次落地，且落地那条是用了繁体「剛刷到」
（不在正则内）才侥幸通过。

## 修法

`_proactive_reply_air_flags` 对 reason ∈
{news_share, bili_video_share, web_exploration_share} 直接放行，
不做回复空气检查——这类消息是"分享外界信息"场景，gen 不含用户对话，
回复空气检查对它不适用。其余主动消息（问候/关心等）逻辑一字未动。

```python
flags: list[str] = []
# 外部分享（新闻/B站/搜索）是「分享外界信息」场景，不做回复空气检查，直接放行。
if reason in {"news_share", "bili_video_share", "web_exploration_share"}:
    return flags