### PR TITLE
fix: avoid false positive group portrait interception

### DIFF
--- a/main.py
+++ b/main.py
@@ -4717,6 +4717,14 @@ class PrivateCompanionPlugin(
     @staticmethod
     def _req036_group_portrait_query_kind(text: Any) -> str:
         value = _single_line(text, 240)
+        # A preference phrase followed by advice or a conclusion is ordinary
+        # group chatter, not a request to summarize anyone's profile.
+        ordinary_statement_patterns = (
+            r"(?:^|[\s，,：:@])(?:自己|按自己|个人|各自)\s*(?:喜欢|爱)(?:吃|喝|玩|看|听)?什么\s*(?:就|便|吧|呀|喵|都|随便)",
+            r"(?:喜欢|爱)(?:吃|喝|玩|看|听)?什么\s*(?:就|便|吧|呀|喵|都|随便)",
+        )
+        if any(re.search(pattern, value) for pattern in ordinary_statement_patterns):
+            return ""
         probe_patterns = (
             r"喜欢(?:吃|喝|玩|看|听)?什么",
             r"爱(?:吃|喝|玩|看|听)什么",
@@ -18830,9 +18838,10 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             return
         if kind == "third_party":
             logger.info(
-                "[PrivateCompanion] 群聊第三方画像查询已拦截: group=%s text=%s",
-                group_id,
-                _single_line(text, 120),
+                "[PrivateCompanion] 群聊第三方画像查询已拦截: reason=explicit_third_party_query group_hash=%s text_hash=%s text_len=%s",
+                hashlib.sha256(str(group_id).encode("utf-8", errors="ignore")).hexdigest()[:12],
+                hashlib.sha256(str(text).encode("utf-8", errors="ignore")).hexdigest()[:12],
+                len(str(text)),
             )
             event.stop_event()
             await self._reply(event, "这个我不方便替别人整理啦。")

--- a/tests/test_req036_unified_profile.py
+++ b/tests/test_req036_unified_profile.py
@@ -1640,6 +1640,8 @@ class Req036CompanionTests(unittest.TestCase):
         self.assertEqual("bot_self", classify("@bot 你喜欢什么"))
         self.assertEqual("bot_self", classify("@bot 我想知道你有什么爱好"))
         self.assertEqual("third_party", classify("@bot 你姐姐喜欢什么"))
+        self.assertEqual("", classify("@用户甲 自己喜欢什么就玩什么喵"))
+        self.assertEqual("", classify("喜欢什么就玩什么呀"))
         self.assertEqual("", classify("@bot 喜欢什么发型的女孩子"))
         self.assertEqual("", classify("@bot 什么爱好"))
         self.assertEqual("", classify("@bot 你觉得喜欢什么"))
@@ -1660,6 +1662,12 @@ class Req036CompanionTests(unittest.TestCase):
         asyncio.run(REQ036_GROUP_GATE(host, event))
         self.assertFalse(event.stopped)
         self.assertEqual([], host.replies)
+
+    def test_req036_intercept_log_does_not_include_group_or_message_text(self) -> None:
+        source = (ROOT / "main.py").read_text(encoding="utf-8")
+        self.assertIn("group_hash=", source)
+        self.assertIn("text_hash=", source)
+        self.assertNotIn("群聊第三方画像查询已拦截: group=%s text=%s", source)
 
     def test_ordinary_group_preference_chatter_is_not_intercepted(self) -> None:
         host = _GroupGateHost()


### PR DESCRIPTION
Fixes #165.

- 放行“自己喜欢什么就玩什么”等普通陈述句。
- 拦截日志改为 group/text 哈希和长度，避免默认日志暴露群号、用户标识和原文。
- 增加 REQ036 回归断言。
