### PR TITLE
fix: 外部信息分享（新闻/B站/主动搜索）跳过「疑似混入其他私聊互动」检查

### DIFF
--- a/proactive_message.py
+++ b/proactive_message.py
@@ -4755,7 +4755,11 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
             if external_fix:
                 return external_fix
         role = self._private_user_role(user) if isinstance(user, dict) else "friend"
-        if role == "owner":
+        # 外部分享（新闻/B站/搜索）跳过「疑似混入其他私聊互动」检查（与 PR #168 同源）：
+        # 该检查的 _daily_plan_clause_has_named_message_interaction 正则会把新闻正文
+        # 「看到个消息」的「个」误判为私聊 target（08-25 16:19 红色沙漠新闻被此误杀实锤）。
+        # 外部分享 gen 不含对其他用户的私聊互动描述，跳过不会漏真问题。
+        if role == "owner" and not external_share_active:
             social_checker = getattr(self, "_daily_plan_clause_has_named_message_interaction", None)
             has_cross_private_interaction = False
             if callable(social_checker):


### PR DESCRIPTION
## 问题

主动消息的本地发送决策（`_local_proactive_send_decision`）里有一道
「疑似混入其他私聊互动」检查（`role == "owner"` 分支），它调用
`_daily_plan_clause_has_named_message_interaction` 的正则：

```
(?:收到|看见|看到|点开|翻到)(?P<target>[^，。；;,.!?？！、\s]{1,14}?)(?:的)?(?:消息|微信|QQ|私信|短信|语音|提醒)
```

该正则会把新闻正文里的「**看到个消息**」匹配成 `target='个'` + 消息，
而 `'个'`（量词）不在 `_daily_plan_message_target_is_allowed` 的白名单里
→ 判定为「疑似混入其他私聊互动」→ `hard drop` 整条消息丢弃。

外部信息分享（news_share / bili_video_share / web_exploration_share）的
生成提示词只提供新闻标题/摘要，**不包含任何对其他用户的私聊互动描述**——
不存在"混入其他私聊"的可能；而这类分享的正文天然以「看到个消息/看到条新闻」
开头，必然命中该规则。

实测影响（08-25）：唯一一条 accepted 的新闻（user_pref=4 命中用户偏好、
概率 1.0）gen 正文「麦麦刚看到个消息，Pearl Abyss 那个《红色沙漠》…」
被该检查整体丢弃，日志实锤：

```
Proactive final content gate dropped: user=... reason=疑似混入其他私聊互动
```

## 修法

`_local_proactive_send_decision` 对 reason ∈
{news_share, bili_video_share, web_exploration_share} 跳过「疑似混入
其他私聊互动」检查（与 #168 跳过回复空气检查同源）——这类消息是
"分享外界信息"场景，gen 不含对其他用户的私聊互动，该检查对它不适用。

```python
role = self._private_user_role(user) if isinstance(user, dict) else "friend"
# 外部分享（新闻/B站/搜索）跳过「疑似混入其他私聊互动」检查（与 PR #168 同源）：
# 该检查的 _daily_plan_clause_has_named_message_interaction 正则会把新闻正文
# 「看到个消息」的「个」误判为私聊 target（08-25 16:19 红色沙漠新闻被此误杀实锤）。
# 外部分享 gen 不含对其他用户的私聊互动描述，跳过不会漏真问题。
if role == "owner" and not external_share_active:
    social_checker = getattr(self, "_daily_plan_clause_has_named_message_interaction", None)
    ...
```

其余主动消息（问候/关心/日程等）逻辑一字未动；`external_share_active`
在第 4463 行已有定义（`reason in {news_share, bili_video_share, web_exploration_share}`），
本改动仅把该检查限定在非外部分享场景。