### PR TITLE
feat: 主动候选被挤占时可选择入池排队（proactive_preempt_queue_enabled），修复低时效主动消息被直接丢弃

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -5301,6 +5301,12 @@
           "在线陪伴：不省成本"
         ]
       },
+      "proactive_preempt_queue_enabled": {
+        "description": "主动候选挤占时入池排队",
+        "type": "bool",
+        "hint": "默认关闭：保持原行为——已有更早/同级主动候选时，新候选被直接丢弃（blocked「已有更早主动候选」）。开启后：被挤占的候选转为 deferred 入潜在念头池排队，当前计划发送完成后自动晋升为下一条（不会连发轰炸，仍受免打扰/冷却/日上限等闸门约束）。适合希望新闻、B站分享等低时效内容在活跃时段也不被丢弃的场景。",
+        "default": false
+      },
       "max_daily_messages": {
         "description": "每日主动消息配额",
         "type": "int",

--- a/plugin_bootstrap.py
+++ b/plugin_bootstrap.py
@@ -336,6 +336,7 @@ def _initialize_core_and_relationship_config(self: Any, c: Any) -> None:
     self.proactive_intensity_preset = self._normalize_proactive_intensity_preset(
         self._cfg_str(c, "proactive_intensity_preset", "off", "off")
     )
+    self.proactive_preempt_queue_enabled = self._cfg_bool(c, "proactive_preempt_queue_enabled", False)
     self.enable_experimental_motivation_model = self._cfg_bool(c, "enable_experimental_motivation_model", False)
     self.check_interval_seconds = self._cfg_int(c, "check_interval_seconds", 60, 30)
     self.idle_minutes = self._cfg_int(c, "idle_minutes", 60, 5)

--- a/proactive_engine.py
+++ b/proactive_engine.py
@@ -3749,7 +3749,32 @@ class ProactiveEngineMixin:
         if current_next > 0 and current_next <= scheduled:
             current_timeliness = self._planned_proactive_timeliness_level(user)
             if self._proactive_timeliness_rank(incoming_timeliness) <= self._proactive_timeliness_rank(current_timeliness):
-                self._record_proactive_candidate(user_id, candidate, status="blocked", note="已有更早主动候选", user=user)
+                # 挤占策略：默认直接丢弃（blocked，保持原行为）；
+                # 开启 proactive_preempt_queue_enabled 后改为入池排队（deferred），
+                # 当前计划发送完成后由 _schedule_next_proactive 自动晋升为下一条。
+                if bool(runtime_persona_setting(self, "proactive_preempt_queue_enabled", False)):
+                    queued_impulse = self._candidate_to_impulse(user, candidate, source=source, now=now)
+                    if isinstance(queued_impulse, dict):
+                        queued_impulse["state"] = "deferred"
+                        queued_impulse["last_note"] = "已有更早主动候选，挤占入池排队"
+                        queued_impulse["updated_ts"] = now
+                        # 入池时把窗口整体后移：保证 expire_at 至少到入池时刻 +2h，
+                        # 避免排队等待期间窗口过期被 _cleanup_proactive_impulses 清掉。
+                        min_expire = now + 2 * 3600
+                        shift = max(0.0, min_expire - _safe_float(queued_impulse.get("expire_at"), 0))
+                        if shift > 0:
+                            for key in ("window_start_at", "preferred_ts", "best_until_at", "expire_at"):
+                                value = _safe_float(queued_impulse.get(key), 0)
+                                if value > 0:
+                                    queued_impulse[key] = value + shift
+                        self._queue_proactive_impulse(user, queued_impulse)
+                        self._record_proactive_candidate(
+                            user_id, candidate, status="deferred", note="已有更早主动候选，已入池排队等待", user=user
+                        )
+                    else:
+                        self._record_proactive_candidate(user_id, candidate, status="blocked", note="已有更早主动候选", user=user)
+                else:
+                    self._record_proactive_candidate(user_id, candidate, status="blocked", note="已有更早主动候选", user=user)
                 return False
             preempted_for_timeliness = True
         action = _single_line(candidate.get("action"), 40) or "message"


### PR DESCRIPTION
## 问题

`_offer_proactive_candidate` 的挤占判定：当用户已有更早/同级的主动计划
（`next_proactive_at` 单槽）时，新候选（如 news_share / bili_video_share /
web_exploration_share 等 routine 档内容）会被直接 `blocked` 丢弃：

```python
if self._proactive_timeliness_rank(incoming_timeliness) <= self._proactive_timeliness_rank(current_timeliness):
    self._record_proactive_candidate(user_id, candidate, status="blocked", note="已有更早主动候选", user=user)
    return False
```

后果：
- **低时效内容在活跃时段基本必丢**：新闻/B站分享是 routine（0）最低档，
  问候、习惯、饭点关心等日常主动同档，谁先排谁占唯一的 `next_proactive_at` 槽，
  新闻候选排不上就被整体丢弃（实测一天 7 次阅读、2 次 accepted、0 实发，
  其中多次死于「已有更早主动候选」）；
- **丢失完全静默**：audit 只记 `blocked`，被挤的候选没有"等待/补位"概念，
  调度阶段不留可观测痕迹。

## 修法

新增配置 `proactive_preempt_queue_enabled`（bool，**默认 false = 完全保持原行为**）。
开启后，挤占分支不再丢弃，而是复用已有的潜在念头池（`proactive_impulses`，
本就是列表、保留 16 条）把候选转 `deferred` 入池排队：

```python
if bool(runtime_persona_setting(self, "proactive_preempt_queue_enabled", False)):
    queued_impulse = self._candidate_to_impulse(user, candidate, source=source, now=now)
    if isinstance(queued_impulse, dict):
        queued_impulse["state"] = "deferred"
        queued_impulse["last_note"] = "已有更早主动候选，挤占入池排队"
        # 入池时把窗口整体后移：保证 expire_at 至少到入池时刻 +2h，
        # 避免排队等待期间窗口过期被 _cleanup_proactive_impulses 清掉。
        min_expire = now + 2 * 3600
        shift = max(0.0, min_expire - _safe_float(queued_impulse.get("expire_at"), 0))
        if shift > 0:
            for key in ("window_start_at", "preferred_ts", "best_until_at", "expire_at"):
                value = _safe_float(queued_impulse.get(key), 0)
                if value > 0:
                    queued_impulse[key] = value + shift
        self._queue_proactive_impulse(user, queued_impulse)
        self._record_proactive_candidate(user_id, candidate, status="deferred", note="已有更早主动候选，已入池排队等待", user=user)
    else:
        self._record_proactive_candidate(user_id, candidate, status="blocked", note="已有更早主动候选", user=user)
else:
    self._record_proactive_candidate(user_id, candidate, status="blocked", note="已有更早主动候选", user=user)
```

机制说明：
- **晋升链路是现成的**：`_schedule_next_proactive`（proactive.py:3425-3435）已有
  「池里有 queued/deferred → `_materialize_best_proactive_impulse` 自动挑 best 晋升」
  逻辑，本改动只是让被挤占的候选进得了池；
- **不会连发轰炸**：晋升后仍走完整发送闸门（免打扰/休息/冷却/idle/日上限），
  且 `_queue_proactive_impulse` 有 signature 相似合并，同源候选不会重复堆；
- **窗口后移**：入池候选的 `expire_at` 至少推到入池时刻 +2h，排队期间不会
  被 `_cleanup_proactive_impulses` 因窗口过期清掉；
- **留痕**：audit 记 `status=deferred`（「已入池排队等待」），调度阶段可观测。

改动面：3 文件 +33/-1（`_conf_schema.json` 配置项 / `plugin_bootstrap.py` 读取 /
`proactive_engine.py` 挤占分支）。**默认关闭，其他用户升级后行为完全不变**；
需要该行为的用户打开开关即可。