### PR TITLE
fix: restore reference image consistency settings for NAI direct backend

### DIFF
--- a/pages/companion-panel/app.js
+++ b/pages/companion-panel/app.js
@@ -27449,9 +27449,7 @@ function photoSettingVisibleForValues(settingKey, values = {}) {
   const backend = String(values.photo_generation_backend || "auto").trim().toLowerCase();
   const enabled = (key) => toBool(values[key]);
   const naiUnavailable = new Set([
-    "enable_photo_reference_image",
     "enable_p5_structured_reference_assets",
-    "photo_reference_catalog",
     "photo_generation_style",
     "photo_generation_style_custom_prompt",
     "photo_generation_negative_prompt_mode",

--- a/pages/陪伴面板/app.js
+++ b/pages/陪伴面板/app.js
@@ -27449,9 +27449,7 @@ function photoSettingVisibleForValues(settingKey, values = {}) {
   const backend = String(values.photo_generation_backend || "auto").trim().toLowerCase();
   const enabled = (key) => toBool(values[key]);
   const naiUnavailable = new Set([
-    "enable_photo_reference_image",
     "enable_p5_structured_reference_assets",
-    "photo_reference_catalog",
     "photo_generation_style",
     "photo_generation_style_custom_prompt",
     "photo_generation_negative_prompt_mode",

--- a/tests/test_photo_tool_delivery_contract.py
+++ b/tests/test_photo_tool_delivery_contract.py
@@ -285,7 +285,7 @@ class _CommandEntryPhotoHarness(_PromptAwarePhotoToolHarness):
         return None
 
     @staticmethod
-    def _save_data_sync() -> None:
+    def _save_data_sync(**_kwargs) -> None:
         return None
 
 


### PR DESCRIPTION
## Summary

- The companion panel hid the "参考图一致性" settings (`enable_photo_reference_image` and `photo_reference_catalog`) whenever `photo_generation_backend` was set to `nai`, so users on the NAI direct backend could not enable reference-image consistency. This PR removes the two keys from the `naiUnavailable` set in `photoSettingVisibleForValues` (both mirrored panel scripts), so the switch and catalog are visible again. `enable_p5_structured_reference_assets` stays hidden since only ComfyUI can consume those assets.
- No runtime change is needed: reference-image selection is gated only by `enable_photo_reference_image`, and the reference path is already forwarded through `NAIImageBridgeMixin._nai_image_generate` to the NAI plugin's `generate_for_companion`.
- Also fixes a pre-existing test-stub drift in `tests/test_photo_tool_delivery_contract.py`: `_save_data_sync` was stubbed as a zero-arg staticmethod while production calls it with `sections=...`, causing a `TypeError` after successful generation in three tests. The stub now accepts `**_kwargs`, matching every other test harness.

## Test plan

- [x] `python -m pytest tests/test_photo_reference_library.py tests/test_photo_backend_reference_contract.py tests/test_photo_prompt_reliability.py tests/test_photo_generation_continuity.py tests/test_photo_tool_delivery_contract.py tests/test_nai_image_bridge.py` — 119 passed
- [x] `node --check` on both panel `app.js` files; the two mirrored copies remain byte-identical