### PR TITLE
fix: 主动消息切句不再按英文空格拆分——句子边界仅取中文/全角结束标点后的空白

### DIFF
--- a/proactive_message.py
+++ b/proactive_message.py
@@ -17422,8 +17422,11 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
         cleaned = str(text or "").strip()
         if not cleaned:
             return []
+        # 句子边界 = 中文/全角结束标点后的空白（含换行）。英文单词之间的空格
+        # 不是句子边界——新闻标题/品牌名（如 "Koei Tecmo"、"TGS 2026"）里的空格
+        # 必须保留，否则外来文本会被按单词切碎
         units: list[str] = []
-        for part in [item.strip() for item in re.split(r"\s+", cleaned) if item.strip()]:
+        for part in [item.strip() for item in re.split(r"(?<=[。！？!?；;…~～])\s+", cleaned) if item.strip()]:
             if re.search(r"[。！？!?；;…~～]", part):
                 matches = re.findall(r"[^。！？!?；;…~～]+[。！？!?；;…~～]+|[^。！？!?；;…~～]+$", part)
                 units.extend(match.strip() for match in matches if match.strip())


### PR DESCRIPTION
### 问题

主动消息（新闻/外部分享/B站分享等）正文含英文空格时，发送前会被切碎成残句：

- 08-23 GTA6 新闻：`"Rockstar 给微软和 Discord 发传票"` → 实发 `"刚看到"Rockstar。 向微软和。 Discord。"`
- 08-26 Koei Tecmo 新闻：`"刚看到TGS 2026的阵容，Koei Tecmo那边……"` → 实发 `"刚看到TGS。 2026的阵容，Koei。"`

`_split_proactive_sentence_units` 用 `re.split(r"\s+")` 按**一切空白**切句，把英文单词之间的空格当成句子边界；切出的单词片段再被 `_ensure_chat_sentence_punctuation` 逐段补句号、2+2 截断，最终实发为不知所云的碎片。该函数是主动消息"句子单元"基础设施（`_normalize_proactive_sentence_flow`、`_trim_performative_self_state_tail`、`_trim_abrupt_closing_topic_shift`、回复空气修复等 10+ 处共用），切句本意是整理成短句聊天风格，但按空白切对外来文本（新闻标题/品牌名）是结构性缺陷，**影响所有主动消息**，不限于新闻。

### 修法

句子边界 = **中文/全角结束标点后的空白（含换行）**；英文单词间空格保留在段内：

```python
# 旧：re.split(r"\s+", cleaned)
# 新：re.split(r"(?<=[。！？!?；;…~～])\s+", cleaned)