### PR TITLE
fix: 主动去重签名剔除模板化 motive，只按 topic 判定主题相似

### DIFF
--- a/proactive_engine.py
+++ b/proactive_engine.py
@@ -744,11 +744,11 @@ class ProactiveEngineMixin:
         route_key = _single_line(item.get("route_dedupe_key"), 160)
         if route_key:
             return route_key
+        # motive 是模板化动机文本，不参与主题相似判定，避免不同内容被误判重复。
         return self._proactive_topic_signature(
             item.get("reason"),
             item.get("source"),
             item.get("topic"),
-            item.get("motive"),
         )
 
     def _proactive_impulse_default_window_seconds(self, reason: str, *, source: str = "") -> tuple[float, float]:
@@ -1136,9 +1136,9 @@ class ProactiveEngineMixin:
         return priority
 
     def _proactive_impulse_content_signature(self, impulse: dict[str, Any]) -> str:
+        # 只按内容（topic）比对；motive 是模板化动机文本，计入会把不同内容误判为相似而合并。
         return self._proactive_topic_signature(
             impulse.get("topic"),
-            impulse.get("motive"),
         )
 
     def _merge_proactive_impulse_timing(self, target: dict[str, Any], incoming: dict[str, Any]) -> None:
@@ -3537,9 +3537,10 @@ class ProactiveEngineMixin:
         # generic topic similarity must not suppress a new reminder or alert.
         if candidate_kind in {"transactional", "safety_event"}:
             return False
+        # 只按内容（topic）判定重复；外部分享类的 motive 是统一模板，计入签名
+        # 会让不同内容被判"主题过于相似"而误杀。
         signature = self._proactive_topic_signature(
             candidate.get("topic"),
-            candidate.get("motive"),
         )
         if not signature:
             return False
@@ -4736,9 +4737,9 @@ class ProactiveEngineMixin:
         return True, "ok"
 
     def _planned_proactive_signature(self, user: dict[str, Any]) -> str:
+        # motive 不参与计划重复判定（模板化动机文本）；source/reason 保留以区分主动类型。
         return self._proactive_topic_signature(
             user.get("planned_proactive_topic"),
-            user.get("planned_proactive_motive"),
             self._normalize_legacy_proactive_text(user.get("planned_proactive_source"), limit=40),
             self._normalize_legacy_proactive_text(user.get("planned_proactive_reason"), limit=40),
         )

--- a/tests/test_proactive_candidate_repeated.py
+++ b/tests/test_proactive_candidate_repeated.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+"""Regression tests: proactive candidate duplicate detection.
+
+外部分享类候选的 motive 是统一模板文本，原先参与 _proactive_topic_signature
+会把 topic 不同的内容误判为重复。修复后主题相似判定只基于 topic。
+"""
+from astrbot_plugin_private_companion.daily_state import DailyStateMixin
+from astrbot_plugin_private_companion.proactive_engine import ProactiveEngineMixin
+
+import time
+
+
+class _CandidateRepeatHarness(ProactiveEngineMixin, DailyStateMixin):
+    pass
+
+
+_MOTIVE_TEMPLATE = "刚读到的新闻和自己的能力、兴趣或最近状态有一点关系,想按人格私下找用户说说"
+
+
+def _harness() -> _CandidateRepeatHarness:
+    harness = _CandidateRepeatHarness()
+    harness.data = {"proactive_candidate_pool": [], "users": {}}
+    return harness
+
+
+def test_different_news_topics_with_shared_motive_template_are_not_repeated():
+    harness = _harness()
+    # _proactive_candidate_repeated 内部用 _now_ts()（真实时间）过滤 8h 窗口，
+    # 所以候选时间戳必须贴近当前时间，不能用固定常数。
+    now = time.time()
+    user = {"user_id": "u1", "recent_proactive_topics": []}
+    # 候选池内已有 8h 内 sent 的 news 候选：Koei TGS（topic 与待测候选不同，
+    # 但 motive 是同一条模板文本——修复前正是这里被误判为相似）。
+    harness.data["proactive_candidate_pool"].append(
+        {
+            "user_id": "u1",
+            "status": "sent",
+            "kind": "content_share",
+            "reason": "news_share",
+            "source": "news",
+            "created_ts": now - 3600,
+            "signature": harness._proactive_topic_signature(
+                "Koei Tecmo announces TGS 2026 lineup",
+                _MOTIVE_TEMPLATE,
+            ),
+        }
+    )
+    candidate = {
+        "kind": "content_share",
+        "reason": "news_share",
+        "source": "news",
+        "topic": "中元已近，黑暗降临。卡牌战斗游戏《恶魔召唤》正式加入机核发行",
+        "motive": _MOTIVE_TEMPLATE,
+    }
+
+    assert harness._proactive_candidate_repeated(user, candidate) is False
+
+
+def test_same_news_topic_repeated_is_still_blocked():
+    harness = _harness()
+    now = time.time()
+    user = {"user_id": "u1", "recent_proactive_topics": []}
+    topic = "Koei Tecmo announces TGS 2026 lineup"
+    harness.data["proactive_candidate_pool"].append(
+        {
+            "user_id": "u1",
+            "status": "sent",
+            "kind": "content_share",
+            "reason": "news_share",
+            "source": "news",
+            "created_ts": now - 3600,
+            "signature": harness._proactive_topic_signature(topic),
+        }
+    )
+    candidate = {
+        "kind": "content_share",
+        "reason": "news_share",
+        "source": "news",
+        "topic": topic,
+        "motive": _MOTIVE_TEMPLATE,
+    }
+
+    assert harness._proactive_candidate_repeated(user, candidate) is True
+
+
+def test_same_topic_different_motive_wording_is_still_blocked():
+    # 同一新闻 topic 换一种 motive 措辞，仍应判重复（topic 是唯一判定维度）。
+    harness = _harness()
+    now = time.time()
+    user = {"user_id": "u1", "recent_proactive_topics": []}
+    topic = "Blue Box Season 2 Reveals Main Visual"
+    harness.data["proactive_candidate_pool"].append(
+        {
+            "user_id": "u1",
+            "status": "sent",
+            "kind": "content_share",
+            "reason": "news_share",
+            "source": "news",
+            "created_ts": now - 3600,
+            "signature": harness._proactive_topic_signature(topic),
+        }
+    )
+    candidate = {
+        "kind": "content_share",
+        "reason": "news_share",
+        "source": "news",
+        "topic": topic,
+        "motive": "换了一种表达想法的动机文本",
+    }
+
+    assert harness._proactive_candidate_repeated(user, candidate) is True


### PR DESCRIPTION
## 背景

news / bili / web_exploration 等外部分享候选的 `motive` 是统一模板文本（"刚读到的新闻和自己的能力、兴趣或最近状态有一点关系,想按人格私下找用户说说"）。实测（08-26）：同一会话 8 小时窗口内先实发了一条 Koei TGS 新闻（sent），随后又来一条 topic 完全不同的《恶魔召唤》机核发行新闻，入池时被 `_proactive_candidate_repeated` 判「近期主题过于相似」直接 blocked——两条新闻内容毫无交集，纯因共享同一段 motive 模板被误杀。

## 根因

- `_proactive_candidate_repeated` 用 `_proactive_topic_signature(topic, motive)` 生成签名，motive 模板段占签名 token 的绝大部分；
- `_topic_signature_similar` 按「交集 token 数 / 较小签名大小」判定（min_shared_tokens=2、overlap≥0.5 即判相似），不同 topic 的新闻因 motive 段完全重合，overlap≈0.9 → 误判重复；
- 同源问题另有两处：`_proactive_impulse_content_signature`（冲动池合并/替换判定，会导致不同内容在池内被误合并）、`_planned_proactive_signature`（计划物化后的重复闸门）。

## 修复

四处「主题相似」签名统一只取 `topic`（内容维度），motive 作为表达动机不再参与：

- `_proactive_candidate_repeated`：入池重复拦截（本次误杀点）
- `_proactive_impulse_content_signature`：冲动池合并/替换判定
- `_planned_proactive_signature`：计划重复判定（保留 source/reason 以区分主动类型，不同主动类型的同话题不互压）
- `_proactive_impulse_signature`：冲动去重 fallback

正文级去重（`_recent_proactive_text_duplicate_reason`，发送前正文相似度检查）仍使用完整文本，不受影响。

## 验证

- 新增回归测试 `tests/test_proactive_candidate_repeated.py` 3 用例：不同 topic+同 motive 模板 → 不判重；同 topic → 仍判重；同 topic 换 motive 措辞 → 仍判重
- 既有 `test_proactive_duplicate_guard.py` 15 用例全部通过

## 兼容性

只收紧误判方向（放行不同 topic），真重复（同 topic）的拦截行为不变；不涉及配置项，默认行为无其他变化。