### PR TITLE
feat: 可自定义 LLM 自主分段提示词 及 完善分段标记清理

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -13336,10 +13336,20 @@
       "enable_llm_controlled_segmenting": {
         "description": "LLM 自主分段",
         "type": "bool",
-        "hint": "开启后，直接回复使用的 LLM 可以通过单独一行 <<PRIVATE_COMPANION_SPLIT>> 控制消息边界；默认输出一条消息，长文、代码、列表和引用尽量不要主动分段。",
+        "hint": "允许直接回复使用的 LLM 在适合时自主安排消息边界。",
         "default": false,
         "condition": {
           "enable_segmented_proactive_reply": true
+        }
+      },
+      "llm_controlled_segmenting_prompt": {
+        "description": "自主分段提示词",
+        "type": "text",
+        "hint": "留空使用默认提示词。可使用 {{split_marker}} 表示消息分隔标记，发送给模型前会自动替换。",
+        "default": "",
+        "condition": {
+          "enable_segmented_proactive_reply": true,
+          "enable_llm_controlled_segmenting": true
         }
       },
       "enable_segmented_plugin_rules": {

--- a/final_response_persistence.py
+++ b/final_response_persistence.py
@@ -28,9 +28,22 @@ from .helpers import (
 )
 from .llm_tool_actions import PHOTO_TOOL_SILENT_SENTINEL
 from .persona_config import runtime_persona_setting
+from .segmented_message import sanitize_llm_segment_control_tokens
 
 
 _DELIVERY_TASK_LABELS = frozenset({"segmented_llm_remainder"})
+
+
+@dataclass(slots=True)
+class ConfirmedDelivery:
+    """One platform-confirmed send and its optional logical segment mapping."""
+
+    chain: list[Any]
+    sent_at: float
+    logical_segment_ids: tuple[int, ...] = ()
+    # Positions in the planned chunk list make a single combined-forward
+    # confirmation unambiguous even when several chunks share one logical ID.
+    logical_segment_indices: tuple[int, ...] = ()
 
 
 @dataclass(slots=True)
@@ -41,6 +54,7 @@ class DeliveryLedger:
     event: AstrMessageEvent | None = None
     passive: bool = False
     confirmed_chains: list[list[Any]] = field(default_factory=list)
+    confirmed_deliveries: list[ConfirmedDelivery] = field(default_factory=list)
     candidate_chain: list[Any] = field(default_factory=list)
     background_tasks: set[asyncio.Task] = field(default_factory=set)
     original_send: Any = None
@@ -51,6 +65,7 @@ class DeliveryLedger:
     final_chain_start: int | None = None
     finalized: bool = False
     finalize_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    logical_plan_cursor: int = 0
 
     @property
     def delivered_chain(self) -> list[Any]:
@@ -121,7 +136,13 @@ class FinalResponsePersistenceCoordinator:
                 updates["delivered_text"] = delivered_text
         return replace(outcome, **updates) if updates else outcome
 
-    def confirm(self, umo: str, chain: list[Any] | tuple[Any, ...]) -> None:
+    def confirm(
+        self,
+        umo: str,
+        chain: list[Any] | tuple[Any, ...],
+        *,
+        logical_segment_ids: tuple[int, ...] | list[int] | None = None,
+    ) -> None:
         components = list(chain or [])
         if not components:
             return
@@ -130,14 +151,33 @@ class FinalResponsePersistenceCoordinator:
             return
         if ledger.umo and umo and str(umo) != ledger.umo:
             return
-        self._append_confirmation(ledger, components)
+        self._append_confirmation(
+            ledger,
+            components,
+            logical_segment_ids=logical_segment_ids,
+        )
 
     def _append_confirmation(
         self,
         ledger: DeliveryLedger,
         components: list[Any],
+        *,
+        logical_segment_ids: tuple[int, ...] | list[int] | None = None,
     ) -> None:
         ledger.confirmed_chains.append(components)
+        resolved_ids, resolved_indices = self._resolve_logical_segment_metadata(
+            ledger,
+            components,
+            logical_segment_ids=logical_segment_ids,
+        )
+        ledger.confirmed_deliveries.append(
+            ConfirmedDelivery(
+                chain=components,
+                sent_at=_now_ts(),
+                logical_segment_ids=resolved_ids,
+                logical_segment_indices=resolved_indices,
+            )
+        )
         event = ledger.event
         # A normal passive turn is finalized by the after-send hook.  Only
         # schedule the delayed fallback when propagation has already stopped;
@@ -381,7 +421,22 @@ class FinalResponsePersistenceCoordinator:
                     sent_chain == ledger.candidate_chain
                     for sent_chain in ledger.confirmed_chains
                 ):
+                    candidate_ids, candidate_indices = (
+                        self._resolve_logical_segment_metadata(
+                            ledger,
+                            list(ledger.candidate_chain),
+                        )
+                    )
                     ledger.confirmed_chains.insert(0, list(ledger.candidate_chain))
+                    ledger.confirmed_deliveries.insert(
+                        0,
+                        ConfirmedDelivery(
+                            chain=list(ledger.candidate_chain),
+                            sent_at=_now_ts(),
+                            logical_segment_ids=candidate_ids,
+                            logical_segment_indices=candidate_indices,
+                        ),
+                    )
             confirmed_chains = ledger.confirmed_chains
             if ledger.final_chain_start is not None:
                 confirmed_chains = confirmed_chains[ledger.final_chain_start :]
@@ -391,6 +446,15 @@ class FinalResponsePersistenceCoordinator:
                 confirmed_chains,
                 separator="" if ledger.streaming else "\n",
             )
+            llm_segments = self._confirmed_llm_history_segments(
+                event,
+                confirmed_chains,
+                confirmed_deliveries=(
+                    ledger.confirmed_deliveries[ledger.final_chain_start :]
+                    if ledger.final_chain_start is not None
+                    else ledger.confirmed_deliveries
+                ),
+            )
             written = await self.owner._finalize_passive_delivered_response(
                 event,
                 chain=[
@@ -399,6 +463,7 @@ class FinalResponsePersistenceCoordinator:
                     for component in sent_chain
                 ],
                 fallback_text=delivered_text,
+                llm_segments=llm_segments,
                 force=True,
             )
             ledger.finalized = True
@@ -419,6 +484,197 @@ class FinalResponsePersistenceCoordinator:
             for text in [extractor(chain)]
             if text
         ).strip()
+
+    def _planned_segment_metadata(
+        self,
+        ledger: DeliveryLedger,
+    ) -> tuple[tuple[str, ...], tuple[int, ...]]:
+        event = ledger.event
+        if event is None:
+            return (), ()
+        planned = getattr(event, "_private_companion_llm_planned_chunk_texts", ())
+        segment_ids = getattr(event, "_private_companion_llm_planned_segment_ids", ())
+        if not (
+            isinstance(planned, tuple)
+            and isinstance(segment_ids, tuple)
+            and len(planned) == len(segment_ids)
+            and len(planned) >= 2
+        ):
+            return (), ()
+        normalized = tuple(
+            sanitize_llm_segment_control_tokens(str(item or "")).strip()
+            for item in planned
+        )
+        try:
+            normalized_ids = tuple(int(item) for item in segment_ids)
+        except (TypeError, ValueError):
+            return (), ()
+        if any(not text for text in normalized):
+            return (), ()
+        return normalized, normalized_ids
+
+    def _resolve_logical_segment_metadata(
+        self,
+        ledger: DeliveryLedger,
+        components: list[Any],
+        *,
+        logical_segment_ids: tuple[int, ...] | list[int] | None = None,
+    ) -> tuple[tuple[int, ...], tuple[int, ...]]:
+        """Associate one confirmed chain with contiguous planned chunks.
+
+        The sender can confirm an individual chunk, several chunks in one
+        merged-forward chain, or a partial prefix after a later send fails.
+        Matching the actual text against the plan preserves that distinction
+        without requiring adapter-specific send metadata.
+        """
+        explicit: tuple[int, ...] = ()
+        if logical_segment_ids is not None:
+            try:
+                explicit = tuple(int(item) for item in logical_segment_ids)
+            except (TypeError, ValueError):
+                explicit = ()
+        extractor = getattr(self.owner, "_actual_text_from_delivered_chain", None)
+        if not callable(extractor):
+            return (), ()
+        try:
+            actual = sanitize_llm_segment_control_tokens(extractor(components)).strip()
+        except Exception:
+            actual = ""
+        if not actual:
+            return (), ()
+        planned, ids = self._planned_segment_metadata(ledger)
+        if not planned:
+            return (), ()
+
+        # Normal segmented sends and merged-forward sends both appear as one
+        # contiguous slice of the plan. Start at the cursor first to prevent a
+        # repeated text chunk from being attributed to an earlier chunk.
+        cursor = min(max(0, ledger.logical_plan_cursor), len(planned))
+        starts = list(range(cursor, len(planned)))
+        for start in starts:
+            combined = ""
+            for end in range(start, len(planned)):
+                combined += planned[end]
+                if combined == actual:
+                    ledger.logical_plan_cursor = max(ledger.logical_plan_cursor, end + 1)
+                    matched_indices = tuple(range(start, end + 1))
+                    matched_ids = (
+                        explicit
+                        if explicit and len(explicit) == len(matched_indices)
+                        else ids[start : end + 1]
+                    )
+                    return matched_ids, matched_indices
+                if len(combined) >= len(actual):
+                    break
+        return explicit, ()
+
+    def _confirmed_llm_history_segments(
+        self,
+        event: AstrMessageEvent,
+        confirmed_chains: list[list[Any]],
+        *,
+        confirmed_deliveries: list[ConfirmedDelivery] | None = None,
+    ) -> tuple[str, ...]:
+        """Return LLM logical segments only after the full send plan is confirmed."""
+        streaming_checker = getattr(self.owner, "_event_uses_streaming_result", None)
+        if callable(streaming_checker) and streaming_checker(event):
+            return ()
+        planned = getattr(event, "_private_companion_llm_planned_chunk_texts", ())
+        segment_ids = getattr(
+            event,
+            "_private_companion_llm_planned_segment_ids",
+            (),
+        )
+        if not (
+            isinstance(planned, tuple)
+            and isinstance(segment_ids, tuple)
+            and len(planned) >= 2
+            and len(segment_ids) == len(planned)
+            and len(set(segment_ids)) >= 2
+        ):
+            return ()
+        extractor = getattr(self.owner, "_actual_text_from_delivered_chain", None)
+        if not callable(extractor):
+            return ()
+
+        # Prefer the delivery metadata collected at confirmation time. This
+        # handles merged-forward sends and partial delivery while retaining a
+        # single assistant history turn. A metadata record without plan
+        # positions is deliberately rejected here; the exact-text fallback
+        # below is safer than guessing how a combined chain was split.
+        if confirmed_deliveries:
+            grouped: dict[int, list[str]] = {}
+            order: list[int] = []
+            metadata_valid = True
+            for delivery in confirmed_deliveries:
+                ids = tuple(delivery.logical_segment_ids or ())
+                indices = tuple(delivery.logical_segment_indices or ())
+                if not ids or len(ids) != len(indices):
+                    metadata_valid = False
+                    break
+                delivered_text = sanitize_llm_segment_control_tokens(
+                    extractor(delivery.chain)
+                ).strip()
+                if not delivered_text:
+                    metadata_valid = False
+                    break
+                expected_parts = [
+                    sanitize_llm_segment_control_tokens(str(planned[index] or "")).strip()
+                    for index in indices
+                    if 0 <= index < len(planned)
+                ]
+                if len(expected_parts) != len(indices) or "".join(expected_parts) != delivered_text:
+                    metadata_valid = False
+                    break
+                for segment_id, text in zip(ids, expected_parts):
+                    normalized_id = int(segment_id)
+                    if normalized_id not in grouped:
+                        grouped[normalized_id] = []
+                        order.append(normalized_id)
+                    grouped[normalized_id].append(text)
+            if metadata_valid:
+                cleaned = tuple(
+                    segment
+                    for segment_id in order
+                    if (
+                        segment := sanitize_llm_segment_control_tokens(
+                            "".join(grouped[segment_id])
+                        ).strip()
+                    )
+                )
+                return cleaned if len(cleaned) >= 2 else ()
+
+        delivered = tuple(
+            sanitize_llm_segment_control_tokens(extractor(chain)).strip()
+            for chain in confirmed_chains
+        )
+        expected = tuple(
+            sanitize_llm_segment_control_tokens(item).strip()
+            for item in planned
+        )
+        if delivered != expected:
+            return ()
+        grouped: dict[int, list[str]] = {}
+        order: list[int] = []
+        for segment_id, text in zip(segment_ids, delivered):
+            try:
+                normalized_id = int(segment_id)
+            except (TypeError, ValueError):
+                return ()
+            if normalized_id not in grouped:
+                grouped[normalized_id] = []
+                order.append(normalized_id)
+            grouped[normalized_id].append(text)
+        cleaned = tuple(
+            segment
+            for segment_id in order
+            if (
+                segment := sanitize_llm_segment_control_tokens(
+                    "".join(grouped[segment_id])
+                ).strip()
+            )
+        )
+        return cleaned if len(cleaned) >= 2 else ()
 
 
 def collect_proactive_delivery(
@@ -777,7 +1033,7 @@ class FinalResponsePersistenceMixin:
         event: AstrMessageEvent,
         assistant_response: str,
     ) -> bool:
-        response_text = str(assistant_response or "").strip()
+        response_text = sanitize_llm_segment_control_tokens(assistant_response)
         # Media markers are useful to the companion's private continuity state,
         # but AstrBot's official conversation history is rendered directly by
         # chat clients. Keep internal metadata out of that user-visible field.
@@ -841,7 +1097,7 @@ class FinalResponsePersistenceMixin:
         assistant_response: str,
     ) -> bool:
         umo = str(getattr(event, "unified_msg_origin", "") or "").strip()
-        response_text = str(assistant_response or "").strip()
+        response_text = sanitize_llm_segment_control_tokens(assistant_response)
         visible_response_text = _strip_outbound_control_blocks(response_text)
         conv_mgr = getattr(getattr(self, "context", None), "conversation_manager", None)
         if not umo or not visible_response_text or conv_mgr is None:
@@ -900,7 +1156,7 @@ class FinalResponsePersistenceMixin:
         delivery_id: str,
         event: AstrMessageEvent | None = None,
     ) -> bool:
-        response_text = str(assistant_response or "").strip()
+        response_text = sanitize_llm_segment_control_tokens(assistant_response)
         umo = str(umo or "").strip()
         if not umo or not response_text:
             return False
@@ -985,7 +1241,7 @@ class FinalResponsePersistenceMixin:
         content: str,
         delivery_id: str = "",
     ) -> bool:
-        response_text = str(content or "").strip()[:2000]
+        response_text = sanitize_llm_segment_control_tokens(content)[:2000]
         session_id = _single_line(getattr(event, "unified_msg_origin", ""), 200)
         if not response_text or not session_id:
             return False
@@ -1180,9 +1436,12 @@ class FinalResponsePersistenceMixin:
         response_text: str,
         now: float,
         delivery_id: str = "",
+        llm_segments: tuple[str, ...] = (),
     ) -> set[str]:
         visible_text = _single_line(
-            _strip_internal_message_blocks(response_text),
+            _strip_internal_message_blocks(
+                sanitize_llm_segment_control_tokens(response_text)
+            ),
             500,
         )
         if not visible_text:
@@ -1264,6 +1523,7 @@ class FinalResponsePersistenceMixin:
                 talking_to_bot=talking_to_bot,
                 ts=now,
                 delivery_id=delivery_id,
+                llm_segments=llm_segments,
             )
             if isinstance(recorded, dict):
                 updated_sections.add("groups")
@@ -1292,6 +1552,7 @@ class FinalResponsePersistenceMixin:
         *,
         response_text: str,
         delivery_id: str,
+        llm_segments: tuple[str, ...] = (),
     ) -> tuple[bool, set[str]]:
         """Commit all local continuity for one confirmed delivery exactly once."""
         if not response_text:
@@ -1312,6 +1573,7 @@ class FinalResponsePersistenceMixin:
                     response_text=response_text,
                     now=now,
                     delivery_id=delivery_id,
+                    llm_segments=llm_segments,
                 )
                 sections = private_sections | group_sections
                 if sections:
@@ -1341,6 +1603,7 @@ class FinalResponsePersistenceMixin:
         *,
         chain: list[Any] | tuple[Any, ...] | None = None,
         fallback_text: str = "",
+        llm_segments: tuple[str, ...] = (),
         force: bool = False,
     ) -> bool:
         if event is None or not bool(
@@ -1365,6 +1628,7 @@ class FinalResponsePersistenceMixin:
             delivered_chain,
             fallback_text=fallback_text,
         )
+        response_text = sanitize_llm_segment_control_tokens(response_text)
         if not response_text:
             return False
 
@@ -1378,6 +1642,7 @@ class FinalResponsePersistenceMixin:
             event,
             response_text=response_text,
             delivery_id=delivery_id,
+            llm_segments=llm_segments,
         )
         if duplicate:
             setattr(event, "_private_companion_delivery_persisted", True)

--- a/group_observation.py
+++ b/group_observation.py
@@ -123,6 +123,7 @@ from .conversation_prompt_section import prompt_section
 from .group_prompt_context import (
     build_group_prompt_context,
 )
+from .segmented_message import sanitize_llm_segment_control_tokens
 from .planning import (
     build_daily_plan_prompt,
     build_detail_enhancement_prompt,
@@ -846,8 +847,9 @@ class GroupObservationMixin:
         ts: float | None = None,
         message_id: Any = "",
         delivery_id: Any = "",
+        llm_segments: Any = None,
     ) -> dict[str, Any] | None:
-        cleaned = _single_line(text, 500)
+        cleaned = _single_line(sanitize_llm_segment_control_tokens(text), 500)
         if not cleaned:
             return None
         allowed_kinds = {
@@ -876,6 +878,22 @@ class GroupObservationMixin:
             record["message_id"] = clean_message_id
         if clean_delivery_id:
             record["delivery_id"] = clean_delivery_id
+        if isinstance(llm_segments, (list, tuple)):
+            clean_segments: list[str] = []
+            remaining = 500
+            for raw_segment in llm_segments:
+                segment = _single_line(
+                    sanitize_llm_segment_control_tokens(raw_segment),
+                    remaining,
+                )
+                if not segment:
+                    continue
+                clean_segments.append(segment)
+                remaining = max(0, remaining - len(segment))
+                if remaining <= 0:
+                    break
+            if len(clean_segments) >= 2:
+                record["llm_segments"] = clean_segments
         recent.append(record)
         self._trim_group_history_lists(group)
         return record
@@ -3006,6 +3024,10 @@ class GroupObservationMixin:
                 20000,
             ),
             include_history=history_injection_enabled,
+            render_llm_segments=bool(
+                _persona_value(self, "enable_segmented_proactive_reply", False)
+                and _persona_value(self, "enable_llm_controlled_segmenting", False)
+            ),
             include_current_text=False,
             bot_id=str(getattr(self, "_effective_plugin_persona_id", lambda: "bot")() or "bot"),
             bot_name=str(_persona_value(self, "bot_name", "Bot") or "Bot"),

--- a/group_prompt_context.py
+++ b/group_prompt_context.py
@@ -13,6 +13,7 @@ from .conversation_prompt_section import (
     render_prompt_sections,
     xml_element,
 )
+from .segmented_message import sanitize_llm_segment_control_tokens
 
 GROUP_CONTEXT_KEY = "group.context"
 GROUP_HISTORY_INJECTED_ATTR = "_private_companion_group_history_injected"
@@ -213,6 +214,16 @@ def _message_time_attrs(
 
 
 def _message_element(item: Mapping[str, Any]) -> XmlElement:
+    segments = item.get("segments")
+    segment_children = (
+        tuple(
+            xml_element("seg", text=segment)
+            for segment in segments
+            if _clean_text(segment)
+        )
+        if isinstance(segments, (list, tuple))
+        else ()
+    )
     return xml_element(
         "message",
         attrs={
@@ -224,7 +235,8 @@ def _message_element(item: Mapping[str, Any]) -> XmlElement:
             "name": item.get("name") or "群成员",
             "role": item.get("role") or "user",
         },
-        text=item.get("content") or "",
+        text=None if len(segment_children) >= 2 else item.get("content") or "",
+        children=segment_children if len(segment_children) >= 2 else (),
     )
 
 
@@ -316,6 +328,7 @@ def _fit_timeline_to_budget(
             if middle == len(original_text)
             else original_text[: max(0, middle - 3)].rstrip() + ("..." if middle else "")
         )
+        candidate.pop("segments", None)
         if content_chars([candidate]) <= budget:
             best = candidate
             low = middle + 1
@@ -334,6 +347,7 @@ def build_group_prompt_context(
     limit: int = 20,
     max_chars: int = 4000,
     include_history: bool = True,
+    render_llm_segments: bool = True,
     include_current_text: bool = True,
     bot_id: str = "bot",
     bot_name: str = "Bot",
@@ -481,7 +495,10 @@ def build_group_prompt_context(
 
     member_count = len(member_records)
     for index, item in enumerate(bot_records):
-        text = _clean_text(item.get("text"), limit=2000)
+        text = _clean_text(
+            sanitize_llm_segment_control_tokens(item.get("text")),
+            limit=2000,
+        )
         if not text:
             continue
         timestamp = _safe_timestamp(item.get("ts"))
@@ -497,6 +514,18 @@ def build_group_prompt_context(
             "role": "assistant",
             "content": text,
         }
+        raw_segments = item.get("llm_segments")
+        if render_llm_segments and isinstance(raw_segments, (list, tuple)):
+            segments = [
+                _clean_text(
+                    sanitize_llm_segment_control_tokens(segment),
+                    limit=2000,
+                )
+                for segment in raw_segments
+            ]
+            segments = [segment for segment in segments if segment]
+            if len(segments) >= 2:
+                event["segments"] = segments
         timeline_with_sort.append((timestamp, member_count + index, event))
 
     timeline_with_sort.sort(key=lambda entry: (entry[0], entry[1]))

--- a/main.py
+++ b/main.py
@@ -322,7 +322,9 @@ from .segmented_message import (
     has_fenced_llm_segment_marker,
     LLM_SEGMENT_MARKER,
     normalize_component_strategy,
+    parse_llm_segment_control,
     plan_component_chunks,
+    sanitize_llm_segment_control_tokens,
     split_llm_controlled_text,
     strip_llm_segment_marker_lines,
 )
@@ -9328,10 +9330,7 @@ class PrivateCompanionPlugin(
             )
             if not bool(runtime_persona_setting(self, 'enable_tts_enhancement', False)):
                 cleaned = re.sub(r"</?t{2,}s\b[^>]*>", "", cleaned, flags=re.IGNORECASE).strip()
-            if bool(runtime_persona_setting(self, "enable_segmented_proactive_reply", False)) and bool(
-                runtime_persona_setting(self, "enable_llm_controlled_segmenting", False)
-            ):
-                cleaned = self._strip_llm_segment_marker_lines(cleaned)
+            cleaned = sanitize_llm_segment_control_tokens(cleaned)
             if cleaned != original:
                 changed = True
                 try:
@@ -9380,10 +9379,7 @@ class PrivateCompanionPlugin(
             )
             if not bool(runtime_persona_setting(self, 'enable_tts_enhancement', False)):
                 cleaned = re.sub(r"</?t{2,}s\b[^>]*>", "", cleaned, flags=re.IGNORECASE).strip()
-            if bool(runtime_persona_setting(self, "enable_segmented_proactive_reply", False)) and bool(
-                runtime_persona_setting(self, "enable_llm_controlled_segmenting", False)
-            ):
-                cleaned = self._strip_llm_segment_marker_lines(cleaned)
+            cleaned = sanitize_llm_segment_control_tokens(cleaned)
             if cleaned:
                 cleaned_chain.append(Plain(cleaned) if cleaned != original else component)
             if cleaned != original:
@@ -10602,10 +10598,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         )
         if not bool(runtime_persona_setting(self, 'enable_tts_enhancement', False)):
             cleaned = re.sub(r"</?t{2,}s\b[^>]*>", "", cleaned, flags=re.IGNORECASE).strip()
-        if bool(runtime_persona_setting(self, "enable_segmented_proactive_reply", False)) and bool(
-            runtime_persona_setting(self, "enable_llm_controlled_segmenting", False)
-        ):
-            cleaned = self._strip_llm_segment_marker_lines(cleaned)
+        cleaned = sanitize_llm_segment_control_tokens(cleaned)
         return cleaned
 
     @staticmethod
@@ -10670,15 +10663,28 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             return False
 
     @staticmethod
-    def _llm_controlled_segmenting_prompt() -> str:
-        """Compact instruction for the user-facing conversation model only."""
+    def _default_llm_controlled_segmenting_prompt() -> str:
         return (
-            "你可以使用标记将回复内容拆分成多个消息发送；"
-            "方便你进行表达、短句拆分发送，以及实现连续发送多句的效果；"
-            "日常对话、聊天 等需要短句输出的情景鼓励经常使用；"
+            "你可以自行决定是否把你的本轮回复作为多条消息发送；"
+            "日常对话、聊天 等需要短句输出的情景建议使用拆分；"
             "长文、教程、代码 等连续性较高的表述尽量少用分段。"
-            f"\n使用方法：需要分段时必须完整输出 {LLM_SEGMENT_MARKER}，并让它单独占一行，不能添加引号，也不能把它放进代码块。"
-            f"\n示例：第一段内容\n{LLM_SEGMENT_MARKER}\n第二段内容（仅在确有必要时使用）。"
+            "\n使用方法：每个消息边界都必须使用下面的完整标记： {{split_marker}}，并让它单独占一行，不能添加引号，也不能把它放进代码块。"
+            "\n示例：第一段内容\n{{split_marker}}\n第二段内容。"
+            "\n只有上述方法可以实现发送多条消息，换行和连续换行都不会作为多条消息发送。（仅在确有必要时使用）。"
+        )
+
+    def _llm_controlled_segmenting_prompt(self) -> str:
+        """Resolve the active persona's user-facing segmentation instruction."""
+        custom = str(
+            runtime_persona_setting(self, "llm_controlled_segmenting_prompt", "")
+            or ""
+        ).strip()[:4000]
+        template = custom or PrivateCompanionPlugin._default_llm_controlled_segmenting_prompt()
+        return re.sub(
+            r"\{\{\s*split_marker\s*\}\}",
+            lambda _match: LLM_SEGMENT_MARKER,
+            template,
+            flags=re.IGNORECASE,
         )
 
     @filter.on_llm_request(priority=-253000)
@@ -10703,7 +10709,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         # entities, making exact-copy behavior less reliable for some models.
         content = (
             '<private_companion_context><section title="回复分段控制"><![CDATA['
-            + self._llm_controlled_segmenting_prompt()
+            + self._llm_controlled_segmenting_prompt().replace("]]>", "]]]]><![CDATA[>")
             + "]]></section></private_companion_context>"
         )
         placement = "prompt" if self._append_turn_prompt_fragment_by_position(
@@ -10752,15 +10758,19 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         umo: str = "",
     ) -> list[list[str]]:
         """Plan LLM and plugin boundaries across every text buffer in a chain."""
-        normalized_buffers = [str(text or "").strip() for text in texts]
-        if not normalized_buffers:
+        raw_buffers = [str(text or "").strip() for text in texts]
+        if not raw_buffers:
             return []
         if not bool(runtime_persona_setting(self, "enable_segmented_proactive_reply", False)):
-            return [[text] if text else [] for text in normalized_buffers]
+            return [
+                [cleaned] if (cleaned := sanitize_llm_segment_control_tokens(text)) else []
+                for text in raw_buffers
+            ]
         if not bool(runtime_persona_setting(self, "enable_llm_controlled_segmenting", False)):
             return [
-                self._split_proactive_text(text, event=event, umo=umo) if text else []
-                for text in normalized_buffers
+                self._split_proactive_text(cleaned, event=event, umo=umo) if cleaned else []
+                for text in raw_buffers
+                for cleaned in [sanitize_llm_segment_control_tokens(text)]
             ]
         plugin_rules_enabled = bool(
             runtime_persona_setting(self, "enable_segmented_plugin_rules", True)
@@ -10778,32 +10788,80 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
 
         parsed_buffers: list[list[str]] = []
         controlled_buffers: list[bool] = []
-        for normalized in normalized_buffers:
-            segments, controlled = split_llm_controlled_text(normalized)
-            parsed_buffers.append(segments if controlled else ([normalized] if normalized else []))
-            controlled_buffers.append(controlled)
+        parse_results = []
+        for raw_text in raw_buffers:
+            parsed = parse_llm_segment_control(raw_text)
+            parse_results.append(parsed)
+            parsed_buffers.append(
+                list(parsed.segments)
+                if parsed.controlled
+                else ([parsed.sanitized_text] if parsed.sanitized_text else [])
+            )
+            controlled_buffers.append(parsed.controlled)
 
-        def split_uncontrolled_buffer(text: str) -> list[str]:
+        if event is not None:
+            setattr(
+                event,
+                "_private_companion_llm_segment_diagnostics",
+                {
+                    "exact": sum(item.exact_boundary_count for item in parse_results),
+                    "recovered": sum(item.recovered_boundary_count for item in parse_results),
+                    "cleaned_only": sum(item.cleaned_only_count for item in parse_results),
+                },
+            )
+            for attr_name in (
+                "_private_companion_llm_history_segments",
+                "_private_companion_llm_planned_chunk_texts",
+                "_private_companion_llm_planned_segment_ids",
+            ):
+                try:
+                    delattr(event, attr_name)
+                except AttributeError:
+                    pass
+            if len(parse_results) == 1 and parse_results[0].controlled:
+                history_segments = [
+                    cleaned
+                    for segment in parse_results[0].segments
+                    if (cleaned := apply_common_transforms(segment))
+                ]
+                if len(history_segments) >= 2:
+                    setattr(
+                        event,
+                        "_private_companion_llm_history_segments",
+                        tuple(history_segments),
+                    )
+
+        def split_uncontrolled_buffer(text: str, *, suppress_plugin_rules: bool = False) -> list[str]:
             if not text:
                 return []
-            if has_fenced_llm_segment_marker(text):
+            if suppress_plugin_rules:
                 transformed = apply_common_transforms(text)
                 return [transformed] if transformed else []
             return self._split_proactive_text(text, event=event, umo=umo)
 
         if not any(controlled_buffers):
             if plugin_rules_enabled:
-                return [split_uncontrolled_buffer(text) for text in normalized_buffers]
+                return [
+                    split_uncontrolled_buffer(
+                        parsed.sanitized_text,
+                        suppress_plugin_rules=parsed.suppress_plugin_rule_split,
+                    )
+                    for parsed in parse_results
+                ]
             return [
-                [transformed] if (transformed := apply_common_transforms(text)) else []
-                for text in normalized_buffers
+                [transformed]
+                if (transformed := apply_common_transforms(parsed.sanitized_text))
+                else []
+                for parsed in parse_results
             ]
 
         llm_count = sum(len(segments) for segments in parsed_buffers)
         if event is not None:
             setattr(event, "_private_companion_llm_segment_count", llm_count)
-        if not plugin_rules_enabled:
-            return [
+        if not plugin_rules_enabled or any(
+            item.suppress_plugin_rule_split for item in parse_results
+        ):
+            planned = [
                 [
                     cleaned
                     for segment in segments
@@ -10811,6 +10869,13 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                 ]
                 for segments in parsed_buffers
             ]
+            if event is not None and len(planned) == 1 and len(planned[0]) >= 2:
+                setattr(
+                    event,
+                    "_private_companion_llm_planned_segment_ids",
+                    tuple(range(len(planned[0]))),
+                )
+            return planned
 
         max_segments = max(
             1,
@@ -10822,7 +10887,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             ),
         )
         if llm_count >= max_segments:
-            return [
+            planned = [
                 [
                     cleaned
                     for segment in segments
@@ -10830,6 +10895,13 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                 ]
                 for segments in parsed_buffers
             ]
+            if event is not None and len(planned) == 1 and len(planned[0]) >= 2:
+                setattr(
+                    event,
+                    "_private_companion_llm_planned_segment_ids",
+                    tuple(range(len(planned[0]))),
+                )
+            return planned
 
         result: list[list[list[str] | str]] = [list(segments) for segments in parsed_buffers]
         rule_processed: set[tuple[int, int]] = set()
@@ -10864,15 +10936,17 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             remaining -= additions
 
         flattened_buffers: list[list[str]] = []
+        flattened_ids_by_buffer: list[list[int]] = []
         for buffer_index, segments in enumerate(result):
             flattened: list[str] = []
+            flattened_ids: list[int] = []
             for segment_index, item in enumerate(segments):
                 if isinstance(item, list):
-                    flattened.extend(
-                        str(part or "").strip()
-                        for part in item
-                        if str(part or "").strip()
-                    )
+                    for part in item:
+                        clean_part = str(part or "").strip()
+                        if clean_part:
+                            flattened.append(clean_part)
+                            flattened_ids.append(segment_index)
                     continue
                 transformed = (
                     str(item or "").strip()
@@ -10881,7 +10955,19 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                 )
                 if transformed:
                     flattened.append(transformed)
+                    flattened_ids.append(segment_index)
             flattened_buffers.append(flattened)
+            flattened_ids_by_buffer.append(flattened_ids)
+        if (
+            event is not None
+            and len(flattened_buffers) == 1
+            and len(set(flattened_ids_by_buffer[0])) >= 2
+        ):
+            setattr(
+                event,
+                "_private_companion_llm_planned_segment_ids",
+                tuple(flattened_ids_by_buffer[0]),
+            )
         return flattened_buffers
 
     def _segment_llm_reply_chain(self, event: AstrMessageEvent, chain: list[Any]) -> tuple[list[list[Any]], bool, str]:
@@ -10950,13 +11036,44 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         )
         if not full_text:
             return [], False, ""
-        if bool(runtime_persona_setting(self, "enable_segmented_proactive_reply", False)) and bool(
-            runtime_persona_setting(self, "enable_llm_controlled_segmenting", False)
-        ):
-            full_text = self._strip_llm_segment_marker_lines(full_text)
-        if not changed:
-            return [chain], False, full_text
-        return self._clean_segmented_reply_chunks(event, chunks), True, full_text
+        full_text = sanitize_llm_segment_control_tokens(full_text)
+        final_chunks = self._clean_segmented_reply_chunks(event, chunks) if changed else [chain]
+        history_segments = getattr(
+            event,
+            "_private_companion_llm_history_segments",
+            (),
+        )
+        if isinstance(history_segments, tuple) and len(history_segments) >= 2:
+            planned_texts = [
+                self._plain_result_body_text(chunk)
+                for chunk in final_chunks
+            ]
+            planned_ids = getattr(
+                event,
+                "_private_companion_llm_planned_segment_ids",
+                (),
+            )
+            if (
+                planned_texts
+                and all(planned_texts)
+                and isinstance(planned_ids, tuple)
+                and len(planned_ids) == len(planned_texts)
+            ):
+                setattr(
+                    event,
+                    "_private_companion_llm_planned_chunk_texts",
+                    tuple(planned_texts),
+                )
+            else:
+                for attr_name in (
+                    "_private_companion_llm_history_segments",
+                    "_private_companion_llm_planned_segment_ids",
+                ):
+                    try:
+                        delattr(event, attr_name)
+                    except AttributeError:
+                        pass
+        return final_chunks, changed, full_text
 
     async def _send_segmented_remainder_chain(
         self,
@@ -13125,7 +13242,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
 
     @staticmethod
     def _strip_private_companion_prompt_artifacts(text: Any) -> str:
-        cleaned = str(text or "")
+        cleaned = sanitize_llm_segment_control_tokens(text)
         if not cleaned or "private_companion_" not in cleaned:
             return cleaned
         cleaned = re.sub(

--- a/page_api.py
+++ b/page_api.py
@@ -22604,6 +22604,7 @@ class PrivateCompanionPageApi(
         segmented_setting_keys = (
             "enable_segmented_proactive_reply",
             "enable_llm_controlled_segmenting",
+            "llm_controlled_segmenting_prompt",
             "enable_segmented_plugin_rules",
             "segmented_proactive_scope",
             "segmented_proactive_chat_scope",
@@ -25545,6 +25546,7 @@ class PrivateCompanionPageApi(
             "group_image_max_images",
             "enable_segmented_proactive_reply",
             "enable_llm_controlled_segmenting",
+            "llm_controlled_segmenting_prompt",
             "enable_segmented_plugin_rules",
             "segmented_proactive_scope",
             "segmented_proactive_chat_scope",

--- a/pages/companion-panel/app.js
+++ b/pages/companion-panel/app.js
@@ -2067,6 +2067,7 @@ const configLabels = {
   private_image_vision_cache_max_items: "图片转述缓存上限",
   enable_segmented_proactive_reply: "分段发送",
   enable_llm_controlled_segmenting: "LLM 自主分段",
+  llm_controlled_segmenting_prompt: "自主分段提示词",
   enable_segmented_plugin_rules: "插件规则分段",
   segmented_proactive_scope: "分段作用范围",
   segmented_proactive_chat_scope: "分段会话范围",
@@ -2880,7 +2881,8 @@ const configDescriptions = {
   enable_private_image_vision_cache: "开启后，同一张图片或表情包会按内容哈希复用上次视觉摘要，避免重复调用识图模型；会保留压缩预览图用于管理，不保留原始大图，也不会缓存最终聊天回复。",
   private_image_vision_cache_max_items: "最多保留多少条图片视觉摘要缓存。达到上限后会清理最久未命中的旧缓存，0 表示不限制。",
   segmented_proactive_threshold: "纯文本短于或等于该字数时才考虑分段；太长的内容保持一整条，避免读起来散。",
-  enable_llm_controlled_segmenting: "允许直接回复使用的 LLM 通过单独一行 <<PRIVATE_COMPANION_SPLIT>> 控制消息边界。默认输出一条消息；长文、说明、教程、代码、列表和引用尽量不要主动分段。",
+  enable_llm_controlled_segmenting: "允许直接回复使用的 LLM 在适合时自主安排消息边界。",
+  llm_controlled_segmenting_prompt: "留空使用默认提示词。可使用 {{split_marker}} 表示消息分隔标记，发送给模型前会自动替换。",
   enable_segmented_plugin_rules: "按标点、换行和分段词执行插件规则分段。默认开启；总开关保持升级前的值，因此旧版行为不会改变。关闭后仍可只使用 LLM 自主分段。",
   segmented_proactive_scope: "插件主动只影响插件主动消息；全部纯文本回复还会处理普通模型回复和插件生成的非命令文本。回复引用固定跟随第一段，语音、图片、@、平台表情与附件按各自位置策略编排。",
   segmented_proactive_chat_scope: "控制分段在哪类会话生效：全部、仅私聊或仅群聊。不匹配的会话会保持整条发送。",
@@ -3336,7 +3338,7 @@ const featureSettingGroups = {
   enable_daily_diary: ["daily_diary_time", "daily_diary_form", "daily_diary_length", "daily_diary_creativity", "daily_diary_custom_direction", "daily_diary_generate_share_seed", "max_diary_entries"],
   enable_rest_reply_simulation: ["rest_reply_mode", "rest_reply_probability", "rest_reply_llm_threshold", "rest_reply_active_windows", "rest_reply_awake_grace_minutes", "enable_rest_backlog_reply", "rest_backlog_max_messages", "REST_WAKEUP_PROVIDER_ID"],
   enable_busy_reply_gate: ["busy_reply_min_delay_seconds", "busy_reply_max_delay_seconds", "busy_reply_proactive_resume_buffer_minutes"],
-  enable_segmented_proactive_reply: ["enable_llm_controlled_segmenting", "enable_segmented_plugin_rules", "enable_segmented_proactive_chat_profiles", "segmented_proactive_private_enabled", "segmented_proactive_private_scope", "segmented_proactive_private_threshold", "segmented_proactive_private_min_segment_chars", "segmented_proactive_private_max_segments", "segmented_proactive_private_send_as_forward", "segmented_proactive_private_interval_method", "segmented_proactive_private_interval_min", "segmented_proactive_private_interval_max", "segmented_proactive_private_log_base", "segmented_proactive_group_enabled", "segmented_proactive_group_scope", "segmented_proactive_group_threshold", "segmented_proactive_group_min_segment_chars", "segmented_proactive_group_max_segments", "segmented_proactive_group_send_as_forward", "segmented_proactive_group_interval_method", "segmented_proactive_group_interval_min", "segmented_proactive_group_interval_max", "segmented_proactive_group_log_base", "segmented_proactive_scope", "segmented_proactive_chat_scope", "segmented_proactive_threshold", "segmented_proactive_min_segment_chars", "segmented_proactive_max_segments", "segmented_proactive_send_as_forward", "segmented_proactive_voice_strategy", "segmented_proactive_image_strategy", "segmented_proactive_at_strategy", "segmented_proactive_face_strategy", "segmented_proactive_component_order", "reaction_expression_delivery_mode", "segmented_proactive_other_strategy", "segmented_proactive_split_mode", "enable_qq_official_segmented_reply", "segmented_proactive_match_width_variants", "segmented_proactive_regex", "segmented_proactive_split_words", "enable_segmented_proactive_content_cleanup", "segmented_proactive_content_cleanup_scope", "segmented_proactive_content_cleanup_rule", "segmented_proactive_content_cleanup_words", "enable_segmented_proactive_content_replacement", "segmented_proactive_content_replacements", "segmented_proactive_interval_method", "segmented_proactive_interval_min", "segmented_proactive_interval_max", "segmented_proactive_log_base"],
+  enable_segmented_proactive_reply: ["enable_llm_controlled_segmenting", "llm_controlled_segmenting_prompt", "enable_segmented_plugin_rules", "enable_segmented_proactive_chat_profiles", "segmented_proactive_private_enabled", "segmented_proactive_private_scope", "segmented_proactive_private_threshold", "segmented_proactive_private_min_segment_chars", "segmented_proactive_private_max_segments", "segmented_proactive_private_send_as_forward", "segmented_proactive_private_interval_method", "segmented_proactive_private_interval_min", "segmented_proactive_private_interval_max", "segmented_proactive_private_log_base", "segmented_proactive_group_enabled", "segmented_proactive_group_scope", "segmented_proactive_group_threshold", "segmented_proactive_group_min_segment_chars", "segmented_proactive_group_max_segments", "segmented_proactive_group_send_as_forward", "segmented_proactive_group_interval_method", "segmented_proactive_group_interval_min", "segmented_proactive_group_interval_max", "segmented_proactive_group_log_base", "segmented_proactive_scope", "segmented_proactive_chat_scope", "segmented_proactive_threshold", "segmented_proactive_min_segment_chars", "segmented_proactive_max_segments", "segmented_proactive_send_as_forward", "segmented_proactive_voice_strategy", "segmented_proactive_image_strategy", "segmented_proactive_at_strategy", "segmented_proactive_face_strategy", "segmented_proactive_component_order", "reaction_expression_delivery_mode", "segmented_proactive_other_strategy", "segmented_proactive_split_mode", "enable_qq_official_segmented_reply", "segmented_proactive_match_width_variants", "segmented_proactive_regex", "segmented_proactive_split_words", "enable_segmented_proactive_content_cleanup", "segmented_proactive_content_cleanup_scope", "segmented_proactive_content_cleanup_rule", "segmented_proactive_content_cleanup_words", "enable_segmented_proactive_content_replacement", "segmented_proactive_content_replacements", "segmented_proactive_interval_method", "segmented_proactive_interval_min", "segmented_proactive_interval_max", "segmented_proactive_log_base"],
   inject_passive_states: ["humanized_state_intensity", "enable_passive_state_delta_injection", "enable_passive_state_continuity_anchor"],
   enable_passive_state_delta_injection: ["enable_passive_state_continuity_anchor"],
   enable_health_state: ["humanized_state_intensity"],
@@ -4040,8 +4042,8 @@ const featureSettingSections = {
   enable_segmented_proactive_reply: [
     {
       title: "分段管线",
-      note: "总开关关闭时两种分段都停用；LLM 自主分段使用单独一行控制标记，插件规则分段继续使用下方规则。",
-      keys: ["enable_llm_controlled_segmenting", "enable_segmented_plugin_rules"],
+      note: "总开关关闭时两种分段都停用；LLM 自主分段可使用自定义提示词，插件规则分段继续使用下方规则。",
+      keys: ["enable_llm_controlled_segmenting", "llm_controlled_segmenting_prompt", "enable_segmented_plugin_rules"],
     },
     {
       title: "模块作用范围",
@@ -4436,6 +4438,7 @@ const featureSettingTypes = {
   enable_segmented_proactive_chat_profiles: { type: "checkbox" },
   segmented_proactive_private_enabled: { type: "checkbox" },
   enable_llm_controlled_segmenting: { type: "checkbox" },
+  llm_controlled_segmenting_prompt: { type: "textarea", rows: 3, maxLength: 4000 },
   enable_segmented_plugin_rules: { type: "checkbox" },
   segmented_proactive_private_scope: { type: "select", options: [["proactive_only", "仅插件主动"], ["all_llm", "全部纯文本回复"]] },
   segmented_proactive_private_threshold: { type: "number", min: 20, max: 1024, step: 2 },
@@ -26795,6 +26798,7 @@ function updateSegmentedConfigVisibility(root = document) {
     segmented_proactive_min_segment_chars: !independentProfiles,
     segmented_proactive_max_segments: !independentProfiles,
     enable_llm_controlled_segmenting: true,
+    llm_controlled_segmenting_prompt: toBool(values.enable_llm_controlled_segmenting),
     enable_segmented_plugin_rules: true,
     segmented_proactive_send_as_forward: !independentProfiles,
     segmented_proactive_interval_method: !independentProfiles,
@@ -26856,7 +26860,7 @@ function bindSegmentedPreview(root = document) {
       });
     });
   });
-  const controls = scope.querySelectorAll('[name^="segmented_proactive_"], [name="reaction_expression_delivery_mode"], [name="enable_segmented_proactive_reply"], [name="enable_llm_controlled_segmenting"], [name="enable_segmented_plugin_rules"], [name="enable_segmented_proactive_content_cleanup"], [name="enable_segmented_proactive_content_replacement"], [data-feature-param^="segmented_proactive_"], [data-feature-param="reaction_expression_delivery_mode"], [data-feature-param="enable_llm_controlled_segmenting"], [data-feature-param="enable_segmented_plugin_rules"], [data-feature-param="enable_segmented_proactive_content_cleanup"], [data-feature-param="enable_segmented_proactive_content_replacement"], [data-feature-detail-toggle="enable_segmented_proactive_reply"]');
+  const controls = scope.querySelectorAll('[name^="segmented_proactive_"], [name="reaction_expression_delivery_mode"], [name="enable_segmented_proactive_reply"], [name="enable_llm_controlled_segmenting"], [name="llm_controlled_segmenting_prompt"], [name="enable_segmented_plugin_rules"], [name="enable_segmented_proactive_content_cleanup"], [name="enable_segmented_proactive_content_replacement"], [data-feature-param^="segmented_proactive_"], [data-feature-param="reaction_expression_delivery_mode"], [data-feature-param="enable_llm_controlled_segmenting"], [data-feature-param="llm_controlled_segmenting_prompt"], [data-feature-param="enable_segmented_plugin_rules"], [data-feature-param="enable_segmented_proactive_content_cleanup"], [data-feature-param="enable_segmented_proactive_content_replacement"], [data-feature-detail-toggle="enable_segmented_proactive_reply"]');
   controls.forEach((control) => {
     if (control.dataset.segmentedConfigBound) return;
     control.dataset.segmentedConfigBound = "1";

--- a/pages/陪伴面板/app.js
+++ b/pages/陪伴面板/app.js
@@ -2067,6 +2067,7 @@ const configLabels = {
   private_image_vision_cache_max_items: "图片转述缓存上限",
   enable_segmented_proactive_reply: "分段发送",
   enable_llm_controlled_segmenting: "LLM 自主分段",
+  llm_controlled_segmenting_prompt: "自主分段提示词",
   enable_segmented_plugin_rules: "插件规则分段",
   segmented_proactive_scope: "分段作用范围",
   segmented_proactive_chat_scope: "分段会话范围",
@@ -2880,7 +2881,8 @@ const configDescriptions = {
   enable_private_image_vision_cache: "开启后，同一张图片或表情包会按内容哈希复用上次视觉摘要，避免重复调用识图模型；会保留压缩预览图用于管理，不保留原始大图，也不会缓存最终聊天回复。",
   private_image_vision_cache_max_items: "最多保留多少条图片视觉摘要缓存。达到上限后会清理最久未命中的旧缓存，0 表示不限制。",
   segmented_proactive_threshold: "纯文本短于或等于该字数时才考虑分段；太长的内容保持一整条，避免读起来散。",
-  enable_llm_controlled_segmenting: "允许直接回复使用的 LLM 通过单独一行 <<PRIVATE_COMPANION_SPLIT>> 控制消息边界。默认输出一条消息；长文、说明、教程、代码、列表和引用尽量不要主动分段。",
+  enable_llm_controlled_segmenting: "允许直接回复使用的 LLM 在适合时自主安排消息边界。",
+  llm_controlled_segmenting_prompt: "留空使用默认提示词。可使用 {{split_marker}} 表示消息分隔标记，发送给模型前会自动替换。",
   enable_segmented_plugin_rules: "按标点、换行和分段词执行插件规则分段。默认开启；总开关保持升级前的值，因此旧版行为不会改变。关闭后仍可只使用 LLM 自主分段。",
   segmented_proactive_scope: "插件主动只影响插件主动消息；全部纯文本回复还会处理普通模型回复和插件生成的非命令文本。回复引用固定跟随第一段，语音、图片、@、平台表情与附件按各自位置策略编排。",
   segmented_proactive_chat_scope: "控制分段在哪类会话生效：全部、仅私聊或仅群聊。不匹配的会话会保持整条发送。",
@@ -3336,7 +3338,7 @@ const featureSettingGroups = {
   enable_daily_diary: ["daily_diary_time", "daily_diary_form", "daily_diary_length", "daily_diary_creativity", "daily_diary_custom_direction", "daily_diary_generate_share_seed", "max_diary_entries"],
   enable_rest_reply_simulation: ["rest_reply_mode", "rest_reply_probability", "rest_reply_llm_threshold", "rest_reply_active_windows", "rest_reply_awake_grace_minutes", "enable_rest_backlog_reply", "rest_backlog_max_messages", "REST_WAKEUP_PROVIDER_ID"],
   enable_busy_reply_gate: ["busy_reply_min_delay_seconds", "busy_reply_max_delay_seconds", "busy_reply_proactive_resume_buffer_minutes"],
-  enable_segmented_proactive_reply: ["enable_llm_controlled_segmenting", "enable_segmented_plugin_rules", "enable_segmented_proactive_chat_profiles", "segmented_proactive_private_enabled", "segmented_proactive_private_scope", "segmented_proactive_private_threshold", "segmented_proactive_private_min_segment_chars", "segmented_proactive_private_max_segments", "segmented_proactive_private_send_as_forward", "segmented_proactive_private_interval_method", "segmented_proactive_private_interval_min", "segmented_proactive_private_interval_max", "segmented_proactive_private_log_base", "segmented_proactive_group_enabled", "segmented_proactive_group_scope", "segmented_proactive_group_threshold", "segmented_proactive_group_min_segment_chars", "segmented_proactive_group_max_segments", "segmented_proactive_group_send_as_forward", "segmented_proactive_group_interval_method", "segmented_proactive_group_interval_min", "segmented_proactive_group_interval_max", "segmented_proactive_group_log_base", "segmented_proactive_scope", "segmented_proactive_chat_scope", "segmented_proactive_threshold", "segmented_proactive_min_segment_chars", "segmented_proactive_max_segments", "segmented_proactive_send_as_forward", "segmented_proactive_voice_strategy", "segmented_proactive_image_strategy", "segmented_proactive_at_strategy", "segmented_proactive_face_strategy", "segmented_proactive_component_order", "reaction_expression_delivery_mode", "segmented_proactive_other_strategy", "segmented_proactive_split_mode", "enable_qq_official_segmented_reply", "segmented_proactive_match_width_variants", "segmented_proactive_regex", "segmented_proactive_split_words", "enable_segmented_proactive_content_cleanup", "segmented_proactive_content_cleanup_scope", "segmented_proactive_content_cleanup_rule", "segmented_proactive_content_cleanup_words", "enable_segmented_proactive_content_replacement", "segmented_proactive_content_replacements", "segmented_proactive_interval_method", "segmented_proactive_interval_min", "segmented_proactive_interval_max", "segmented_proactive_log_base"],
+  enable_segmented_proactive_reply: ["enable_llm_controlled_segmenting", "llm_controlled_segmenting_prompt", "enable_segmented_plugin_rules", "enable_segmented_proactive_chat_profiles", "segmented_proactive_private_enabled", "segmented_proactive_private_scope", "segmented_proactive_private_threshold", "segmented_proactive_private_min_segment_chars", "segmented_proactive_private_max_segments", "segmented_proactive_private_send_as_forward", "segmented_proactive_private_interval_method", "segmented_proactive_private_interval_min", "segmented_proactive_private_interval_max", "segmented_proactive_private_log_base", "segmented_proactive_group_enabled", "segmented_proactive_group_scope", "segmented_proactive_group_threshold", "segmented_proactive_group_min_segment_chars", "segmented_proactive_group_max_segments", "segmented_proactive_group_send_as_forward", "segmented_proactive_group_interval_method", "segmented_proactive_group_interval_min", "segmented_proactive_group_interval_max", "segmented_proactive_group_log_base", "segmented_proactive_scope", "segmented_proactive_chat_scope", "segmented_proactive_threshold", "segmented_proactive_min_segment_chars", "segmented_proactive_max_segments", "segmented_proactive_send_as_forward", "segmented_proactive_voice_strategy", "segmented_proactive_image_strategy", "segmented_proactive_at_strategy", "segmented_proactive_face_strategy", "segmented_proactive_component_order", "reaction_expression_delivery_mode", "segmented_proactive_other_strategy", "segmented_proactive_split_mode", "enable_qq_official_segmented_reply", "segmented_proactive_match_width_variants", "segmented_proactive_regex", "segmented_proactive_split_words", "enable_segmented_proactive_content_cleanup", "segmented_proactive_content_cleanup_scope", "segmented_proactive_content_cleanup_rule", "segmented_proactive_content_cleanup_words", "enable_segmented_proactive_content_replacement", "segmented_proactive_content_replacements", "segmented_proactive_interval_method", "segmented_proactive_interval_min", "segmented_proactive_interval_max", "segmented_proactive_log_base"],
   inject_passive_states: ["humanized_state_intensity", "enable_passive_state_delta_injection", "enable_passive_state_continuity_anchor"],
   enable_passive_state_delta_injection: ["enable_passive_state_continuity_anchor"],
   enable_health_state: ["humanized_state_intensity"],
@@ -4040,8 +4042,8 @@ const featureSettingSections = {
   enable_segmented_proactive_reply: [
     {
       title: "分段管线",
-      note: "总开关关闭时两种分段都停用；LLM 自主分段使用单独一行控制标记，插件规则分段继续使用下方规则。",
-      keys: ["enable_llm_controlled_segmenting", "enable_segmented_plugin_rules"],
+      note: "总开关关闭时两种分段都停用；LLM 自主分段可使用自定义提示词，插件规则分段继续使用下方规则。",
+      keys: ["enable_llm_controlled_segmenting", "llm_controlled_segmenting_prompt", "enable_segmented_plugin_rules"],
     },
     {
       title: "模块作用范围",
@@ -4436,6 +4438,7 @@ const featureSettingTypes = {
   enable_segmented_proactive_chat_profiles: { type: "checkbox" },
   segmented_proactive_private_enabled: { type: "checkbox" },
   enable_llm_controlled_segmenting: { type: "checkbox" },
+  llm_controlled_segmenting_prompt: { type: "textarea", rows: 3, maxLength: 4000 },
   enable_segmented_plugin_rules: { type: "checkbox" },
   segmented_proactive_private_scope: { type: "select", options: [["proactive_only", "仅插件主动"], ["all_llm", "全部纯文本回复"]] },
   segmented_proactive_private_threshold: { type: "number", min: 20, max: 1024, step: 2 },
@@ -26795,6 +26798,7 @@ function updateSegmentedConfigVisibility(root = document) {
     segmented_proactive_min_segment_chars: !independentProfiles,
     segmented_proactive_max_segments: !independentProfiles,
     enable_llm_controlled_segmenting: true,
+    llm_controlled_segmenting_prompt: toBool(values.enable_llm_controlled_segmenting),
     enable_segmented_plugin_rules: true,
     segmented_proactive_send_as_forward: !independentProfiles,
     segmented_proactive_interval_method: !independentProfiles,
@@ -26856,7 +26860,7 @@ function bindSegmentedPreview(root = document) {
       });
     });
   });
-  const controls = scope.querySelectorAll('[name^="segmented_proactive_"], [name="reaction_expression_delivery_mode"], [name="enable_segmented_proactive_reply"], [name="enable_llm_controlled_segmenting"], [name="enable_segmented_plugin_rules"], [name="enable_segmented_proactive_content_cleanup"], [name="enable_segmented_proactive_content_replacement"], [data-feature-param^="segmented_proactive_"], [data-feature-param="reaction_expression_delivery_mode"], [data-feature-param="enable_llm_controlled_segmenting"], [data-feature-param="enable_segmented_plugin_rules"], [data-feature-param="enable_segmented_proactive_content_cleanup"], [data-feature-param="enable_segmented_proactive_content_replacement"], [data-feature-detail-toggle="enable_segmented_proactive_reply"]');
+  const controls = scope.querySelectorAll('[name^="segmented_proactive_"], [name="reaction_expression_delivery_mode"], [name="enable_segmented_proactive_reply"], [name="enable_llm_controlled_segmenting"], [name="llm_controlled_segmenting_prompt"], [name="enable_segmented_plugin_rules"], [name="enable_segmented_proactive_content_cleanup"], [name="enable_segmented_proactive_content_replacement"], [data-feature-param^="segmented_proactive_"], [data-feature-param="reaction_expression_delivery_mode"], [data-feature-param="enable_llm_controlled_segmenting"], [data-feature-param="llm_controlled_segmenting_prompt"], [data-feature-param="enable_segmented_plugin_rules"], [data-feature-param="enable_segmented_proactive_content_cleanup"], [data-feature-param="enable_segmented_proactive_content_replacement"], [data-feature-detail-toggle="enable_segmented_proactive_reply"]');
   controls.forEach((control) => {
     if (control.dataset.segmentedConfigBound) return;
     control.dataset.segmentedConfigBound = "1";

--- a/plugin_bootstrap.py
+++ b/plugin_bootstrap.py
@@ -969,6 +969,12 @@ def _initialize_proactive_and_reaction_config(self: Any, c: Any) -> None:
         "enable_llm_controlled_segmenting",
         False,
     )
+    self.llm_controlled_segmenting_prompt = self._cfg_str(
+        c,
+        "llm_controlled_segmenting_prompt",
+        "",
+        "",
+    )[:4000]
     self.enable_segmented_plugin_rules = self._cfg_bool(
         c,
         "enable_segmented_plugin_rules",

--- a/private_image.py
+++ b/private_image.py
@@ -41,6 +41,7 @@ from .segmented_message import (
     component_order_from_owner,
     component_strategies_from_owner,
     plan_component_chunks,
+    sanitize_llm_segment_control_tokens,
 )
 
 
@@ -5383,7 +5384,12 @@ class PrivateImageMixin:
             cleaned = re.sub(r"</?(?:pc[_-]?tts|t{2,}s)\b[^>]*>", "", str(reply or ""), flags=re.IGNORECASE).strip()
         # This text is persisted into AstrBot's user-visible conversation
         # history; remove plugin-only markers before it reaches that store.
-        return _single_line(_strip_outbound_control_blocks(cleaned or reply), 1200)
+        return _single_line(
+            sanitize_llm_segment_control_tokens(
+                _strip_outbound_control_blocks(cleaned or reply)
+            ),
+            1200,
+        )
 
     async def _archive_private_image_turn_to_conversation(
         self,

--- a/proactive_message.py
+++ b/proactive_message.py
@@ -164,6 +164,7 @@ from .segmented_message import (
     component_order_from_owner,
     component_strategies_from_owner,
     plan_component_chunks,
+    sanitize_llm_segment_control_tokens,
     split_llm_controlled_text,
 )
 from .token_budget import _looks_like_upstream_llm_error_response
@@ -3391,9 +3392,10 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
         instruction = str(prompt_getter() or "").strip()
         if not instruction:
             return ""
+        safe_instruction = instruction.replace("]]>", "]]]]><![CDATA[>")
         return (
             '<private_companion_context><section title="回复分段控制"><![CDATA['
-            f"{instruction}"
+            f"{safe_instruction}"
             "]]></section></private_companion_context>"
         )
 
@@ -15123,11 +15125,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
         comp = Plain(text)
         full_source = str(full_text or "")
         marker_cleaner = getattr(self, "_strip_llm_segment_marker_lines", None)
-        if (
-            callable(marker_cleaner)
-            and bool(runtime_persona_setting(self, "enable_segmented_proactive_reply", False))
-            and bool(runtime_persona_setting(self, "enable_llm_controlled_segmenting", False))
-        ):
+        if callable(marker_cleaner):
             full_source = marker_cleaner(full_source)
         clean_full = _single_line(full_source, max(1200, len(full_source) + 32))
         if clean_full:
@@ -15843,11 +15841,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
             )
             return False
         marker_cleaner = getattr(self, "_strip_llm_segment_marker_lines", None)
-        if (
-            callable(marker_cleaner)
-            and bool(runtime_persona_setting(self, "enable_segmented_proactive_reply", False))
-            and bool(runtime_persona_setting(self, "enable_llm_controlled_segmenting", False))
-        ):
+        if callable(marker_cleaner):
             cleaned_chain: list[Any] = []
             for component in chain or []:
                 if not isinstance(component, Plain):
@@ -16992,7 +16986,9 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
         photo_subject_owner: str = "",
     ) -> str:
         original_is_receipt = self._is_proactive_delivery_receipt_text(text)
-        message_text = self._visible_text_without_tts_reading(text, limit=1000)
+        message_text = sanitize_llm_segment_control_tokens(
+            self._visible_text_without_tts_reading(text, limit=1000)
+        )
         attachment_notes: list[str] = []
         history_image_count = 0
         history_record_count = 0
@@ -17062,7 +17058,9 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
         umo = str(umo or user.get("umo") or "").strip()
         if not umo or not assistant_response:
             return False
-        visible_assistant_response = _strip_outbound_control_blocks(assistant_response)
+        visible_assistant_response = sanitize_llm_segment_control_tokens(
+            _strip_outbound_control_blocks(assistant_response)
+        )
         if not visible_assistant_response:
             return False
         for attempt in range(4):

--- a/segmented_message.py
+++ b/segmented_message.py
@@ -3,12 +3,55 @@ from __future__ import annotations
 
 import json
 import re
+from dataclasses import dataclass
 from typing import Any, Callable, Mapping
 
 from .persona_config import runtime_persona_setting
 
 
 LLM_SEGMENT_MARKER = "<<PRIVATE_COMPANION_SPLIT>>"
+LLM_SEGMENT_PLACEHOLDER = "{{split_marker}}"
+
+_ESCAPED_LLM_SEGMENT_MARKER_PATTERN = re.compile(
+    r"(?:&lt;|&#0*60;){2}\s*PRIVATE_COMPANION_SPLIT\s*(?:&gt;|&#0*62;){2}",
+    flags=re.IGNORECASE,
+)
+_MARKDOWN_ESCAPED_LLM_SEGMENT_MARKER_PATTERN = re.compile(
+    r"\\<\\<\s*PRIVATE\s*_\s*COMPANION\s*_\s*SPLIT\s*\\>\\>",
+    flags=re.IGNORECASE,
+)
+_PLACEHOLDER_PATTERN = re.compile(
+    r"\{\{\s*split_marker\s*\}\}",
+    flags=re.IGNORECASE,
+)
+_SPACED_LLM_SEGMENT_MARKER_PATTERN = re.compile(
+    r"<<\s*PRIVATE\s*_\s*COMPANION\s*_\s*SPLIT\s*>>",
+    flags=re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class LlmSegmentParseResult:
+    """One scan of an LLM reply's reserved segmentation protocol."""
+
+    segments: tuple[str, ...]
+    sanitized_text: str
+    boundary_kinds: tuple[str, ...]
+    exact_boundary_count: int = 0
+    recovered_boundary_count: int = 0
+    cleaned_only_count: int = 0
+    fenced_token_count: int = 0
+    quoted_token_count: int = 0
+    escaped_token_count: int = 0
+    placeholder_token_count: int = 0
+
+    @property
+    def controlled(self) -> bool:
+        return len(self.segments) >= 2 and bool(self.boundary_kinds)
+
+    @property
+    def suppress_plugin_rule_split(self) -> bool:
+        return self.fenced_token_count > 0
 
 
 def _next_markdown_fence_state(
@@ -34,24 +77,8 @@ def strip_llm_segment_marker_lines(
     *,
     marker: str = LLM_SEGMENT_MARKER,
 ) -> str:
-    """Remove active marker lines without altering fenced code examples."""
-    normalized = str(text or "")
-    marker = str(marker or LLM_SEGMENT_MARKER).strip()
-    if not normalized or not marker:
-        return normalized.strip()
-    kept_lines: list[str] = []
-    fence_state: tuple[str, int] | None = None
-    for raw_line in normalized.splitlines():
-        line = raw_line.strip()
-        next_fence_state = _next_markdown_fence_state(line, fence_state)
-        if next_fence_state != fence_state:
-            fence_state = next_fence_state
-            kept_lines.append(raw_line)
-            continue
-        if fence_state is None and line == marker and not raw_line.lstrip().startswith(">"):
-            continue
-        kept_lines.append(raw_line)
-    return "\n".join(kept_lines).strip()
+    """Compatibility wrapper that removes every reserved control token."""
+    return sanitize_llm_segment_control_tokens(text, marker=marker)
 
 
 def has_fenced_llm_segment_marker(
@@ -83,34 +110,166 @@ def split_llm_controlled_text(text: Any, *, marker: str = LLM_SEGMENT_MARKER) ->
     ignored so examples or quoted instructions do not accidentally create
     outbound message boundaries.
     """
-    normalized = str(text or "").strip()
-    if not normalized:
+    result = parse_llm_segment_control(text, marker=marker)
+    if not result.sanitized_text:
         return [], False
+    if not result.controlled:
+        return [result.sanitized_text], False
+    return list(result.segments), True
+
+
+def _replace_reserved_tokens(value: str, *, marker: str) -> tuple[str, dict[str, int]]:
+    counts = {"escaped": 0, "placeholder": 0, "marker": 0}
+
+    def replace(pattern: re.Pattern[str], key: str, source: str) -> str:
+        def repl(_match: re.Match[str]) -> str:
+            counts[key] += 1
+            return " "
+
+        return pattern.sub(repl, source)
+
+    cleaned = replace(_ESCAPED_LLM_SEGMENT_MARKER_PATTERN, "escaped", value)
+    cleaned = replace(
+        _MARKDOWN_ESCAPED_LLM_SEGMENT_MARKER_PATTERN,
+        "escaped",
+        cleaned,
+    )
+    cleaned = replace(_PLACEHOLDER_PATTERN, "placeholder", cleaned)
+    marker_pattern = (
+        _SPACED_LLM_SEGMENT_MARKER_PATTERN
+        if marker == LLM_SEGMENT_MARKER
+        else re.compile(re.escape(marker), flags=re.IGNORECASE)
+    )
+    cleaned = replace(marker_pattern, "marker", cleaned)
+    cleaned = re.sub(r"[ \t]{2,}", " ", cleaned)
+    return cleaned, counts
+
+
+def parse_llm_segment_control(
+    text: Any,
+    *,
+    marker: str = LLM_SEGMENT_MARKER,
+) -> LlmSegmentParseResult:
+    """Parse high-confidence boundaries while removing all reserved tokens.
+
+    An exact standalone marker is a boundary. A marker attached to text on only
+    one side of its line is recovered as a boundary. Fully inline, quoted,
+    fenced, escaped and placeholder forms are cleanup-only.
+    """
+
+    normalized = str(text or "").replace("\r\n", "\n").replace("\r", "\n")
     marker = str(marker or LLM_SEGMENT_MARKER).strip()
-    if not marker:
-        return [normalized], False
+    if not normalized or not marker:
+        cleaned = normalized.strip()
+        return LlmSegmentParseResult(
+            segments=(cleaned,) if cleaned else (),
+            sanitized_text=cleaned,
+            boundary_kinds=(),
+        )
+
     segments: list[str] = []
+    boundary_kinds: list[str] = []
     current: list[str] = []
+    pending_boundary: str | None = None
+    exact_count = 0
+    recovered_count = 0
+    cleaned_only_count = 0
+    fenced_count = 0
+    quoted_count = 0
+    escaped_count = 0
+    placeholder_count = 0
     fence_state: tuple[str, int] | None = None
-    found = False
-    for raw_line in normalized.splitlines():
-        line = raw_line.strip()
-        fence_state = _next_markdown_fence_state(line, fence_state)
-        is_marker = fence_state is None and line == marker and not raw_line.lstrip().startswith(">")
-        if is_marker:
-            found = True
-            body = "\n".join(current).strip()
-            if body:
-                segments.append(body)
-            current = []
-            continue
-        current.append(raw_line)
-    body = "\n".join(current).strip()
-    if body:
+
+    def append_current() -> bool:
+        nonlocal pending_boundary, exact_count, recovered_count
+        body = "\n".join(current).strip()
+        current.clear()
+        if not body:
+            return False
+        if segments and pending_boundary:
+            boundary_kinds.append(pending_boundary)
+            if pending_boundary == "exact":
+                exact_count += 1
+            else:
+                recovered_count += 1
         segments.append(body)
-    if not found or len(segments) < 2:
-        return [normalized], False
-    return segments, True
+        pending_boundary = None
+        return True
+
+    for raw_line in normalized.split("\n"):
+        stripped = raw_line.strip()
+        next_fence_state = _next_markdown_fence_state(stripped, fence_state)
+        fence_transition = next_fence_state != fence_state
+        inside_fence = fence_state is not None or (
+            fence_transition and next_fence_state is not None
+        )
+        quoted = raw_line.lstrip().startswith(">")
+
+        if not inside_fence and not quoted and raw_line.count(marker) == 1:
+            left, right = raw_line.split(marker, 1)
+            left_has_text = bool(left.strip())
+            right_has_text = bool(right.strip())
+            if not (left_has_text and right_has_text):
+                if left_has_text:
+                    current.append(left.rstrip())
+                boundary_kind = "exact" if not left_has_text and not right_has_text else "recovered"
+                if append_current():
+                    pending_boundary = boundary_kind
+                else:
+                    cleaned_only_count += 1
+                if right_has_text:
+                    current.append(right.lstrip())
+                fence_state = next_fence_state
+                continue
+
+        cleaned, counts = _replace_reserved_tokens(raw_line, marker=marker)
+        token_count = counts["escaped"] + counts["placeholder"] + counts["marker"]
+        escaped_count += counts["escaped"]
+        placeholder_count += counts["placeholder"]
+        cleaned_only_count += token_count
+        if inside_fence:
+            fenced_count += token_count
+        if quoted:
+            quoted_count += token_count
+            if token_count and not cleaned.lstrip("> ").strip():
+                cleaned = ""
+        current.append(cleaned.rstrip())
+        fence_state = next_fence_state
+
+    appended_final = append_current()
+    if not appended_final and pending_boundary:
+        cleaned_only_count += 1
+        pending_boundary = None
+    controlled = len(segments) >= 2 and len(boundary_kinds) == len(segments) - 1
+    if not controlled:
+        cleaned_only_count += exact_count + recovered_count
+        exact_count = 0
+        recovered_count = 0
+        boundary_kinds = []
+
+    sanitized = "\n".join(segments).strip()
+    sanitized = re.sub(r"\n{3,}", "\n\n", sanitized)
+    return LlmSegmentParseResult(
+        segments=tuple(segments) if controlled else ((sanitized,) if sanitized else ()),
+        sanitized_text=sanitized,
+        boundary_kinds=tuple(boundary_kinds),
+        exact_boundary_count=exact_count,
+        recovered_boundary_count=recovered_count,
+        cleaned_only_count=cleaned_only_count,
+        fenced_token_count=fenced_count,
+        quoted_token_count=quoted_count,
+        escaped_token_count=escaped_count,
+        placeholder_token_count=placeholder_count,
+    )
+
+
+def sanitize_llm_segment_control_tokens(
+    text: Any,
+    *,
+    marker: str = LLM_SEGMENT_MARKER,
+) -> str:
+    """Remove reserved segmentation tokens without making send boundaries."""
+    return parse_llm_segment_control(text, marker=marker).sanitized_text
 
 
 COMPONENT_STRATEGIES = frozenset({"inline", "separate", "previous", "next"})

--- a/tests/test_final_response_persistence.py
+++ b/tests/test_final_response_persistence.py
@@ -222,6 +222,15 @@ class FinalResponsePersistenceTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn('<pc_history_media images="1" />', archived)
         self.assertNotIn("随消息发送了一张图片", archived)
 
+    def test_proactive_archive_removes_segment_control_tokens(self):
+        harness = _Harness()
+
+        archived = harness._build_proactive_archive_assistant_text(
+            text="第一段<<PRIVATE_COMPANION_SPLIT>>第二段",
+        )
+
+        self.assertEqual("第一段 第二段", archived)
+
     def test_private_image_history_text_hides_internal_media_marker(self):
         harness = PrivateImageMixin.__new__(PrivateImageMixin)
 
@@ -401,6 +410,53 @@ class FinalResponsePersistenceTests(unittest.IsolatedAsyncioTestCase):
         archived = harness.conversation_manager.history[-1]["content"]
         self.assertIn("主动发送的图片说明", archived)
         self.assertNotIn("pc_history_media", archived)
+
+    async def test_proactive_persistence_sinks_remove_segment_control_tokens(self):
+        captured: list[str] = []
+
+        async def livingmemory_handler(_event, response):
+            captured.append(response.completion_text)
+
+        handler = SimpleNamespace(
+            handler=livingmemory_handler,
+            handler_name="handle_memory_reflection",
+            handler_module_path=LIVING_MODULE,
+        )
+        plugins = {
+            LIVING_MODULE: SimpleNamespace(
+                name="LivingMemory", activated=True, reserved=False
+            )
+        }
+        harness = _Harness()
+        leaked = "第一段<<PRIVATE_COMPANION_SPLIT>>第二段"
+
+        with patch(
+            "astrbot_plugin_private_companion.final_response_persistence.star_handlers_registry",
+            _Registry([handler]),
+        ), patch(
+            "astrbot_plugin_private_companion.final_response_persistence.star_map",
+            plugins,
+        ):
+            self.assertTrue(
+                await harness._archive_proactive_message_to_conversation(
+                    user={"umo": UMO},
+                    user_prompt="主动承接",
+                    assistant_response=leaked,
+                )
+            )
+            self.assertTrue(
+                await harness._record_final_assistant_in_livingmemory(
+                    umo=UMO,
+                    assistant_response=leaked,
+                    delivery_id="proactive-marker-cleanup",
+                )
+            )
+
+        self.assertEqual(
+            "第一段 第二段",
+            harness.conversation_manager.history[-1]["content"],
+        )
+        self.assertEqual(["第一段 第二段"], captured)
 
     async def test_missing_memory_plugins_does_not_block_official_history(self):
         harness = _Harness()
@@ -613,6 +669,136 @@ class FinalResponsePersistenceTests(unittest.IsolatedAsyncioTestCase):
         plugin._finalize_passive_delivered_response.assert_awaited_once()
         call = plugin._finalize_passive_delivered_response.await_args
         self.assertEqual("第一段\n第二段", call.kwargs["fallback_text"])
+
+    async def test_confirmed_segment_plan_rebuilds_llm_segments_only_when_complete(self):
+        plugin = PrivateCompanionPlugin.__new__(PrivateCompanionPlugin)
+        event = _SendTrackerEvent()
+        event._private_companion_llm_planned_chunk_texts = (
+            "第一段",
+            "第二段。",
+            "第三句。",
+        )
+        event._private_companion_llm_planned_segment_ids = (0, 1, 1)
+        coordinator = plugin._final_response_persistence_coordinator()
+        confirmed = [
+            [Plain("第一段")],
+            [Plain("第二段。")],
+            [Plain("第三句。")],
+        ]
+
+        self.assertEqual(
+            ("第一段", "第二段。第三句。"),
+            coordinator._confirmed_llm_history_segments(event, confirmed),
+        )
+        self.assertEqual(
+            (),
+            coordinator._confirmed_llm_history_segments(event, confirmed[:-1]),
+        )
+
+    async def test_send_tracker_persists_logical_segments_from_normal_sends(self):
+        plugin = PrivateCompanionPlugin.__new__(PrivateCompanionPlugin)
+        plugin._finalize_passive_delivered_response = AsyncMock(return_value=True)
+        event = _SendTrackerEvent()
+        event._has_send_oper = False
+        run_context = SimpleNamespace(
+            messages=[Message(role="assistant", content=[TextPart(text="原始回复")])]
+        )
+
+        plugin._begin_final_response_persistence(event)
+        await plugin._prepare_final_response_after_agent(
+            event,
+            run_context,
+            LLMResponse(role="assistant", completion_text="第一段第二段。第三句。"),
+        )
+        event._private_companion_llm_planned_chunk_texts = (
+            "第一段",
+            "第二段。",
+            "第三句。",
+        )
+        event._private_companion_llm_planned_segment_ids = (0, 1, 1)
+
+        for text in event._private_companion_llm_planned_chunk_texts:
+            await event.send(SimpleNamespace(chain=[Plain(text)]))
+        await plugin.persist_confirmed_passive_reply(event)
+
+        call = plugin._finalize_passive_delivered_response.await_args
+        self.assertEqual(("第一段", "第二段。第三句。"), call.kwargs["llm_segments"])
+        deliveries = event._private_companion_delivery_ledger.confirmed_deliveries
+        self.assertEqual([(0,), (1,), (1,)], [item.logical_segment_ids for item in deliveries])
+        self.assertEqual([(0,), (1,), (2,)], [item.logical_segment_indices for item in deliveries])
+
+    async def test_send_tracker_maps_combined_forward_chain_to_logical_segments(self):
+        plugin = PrivateCompanionPlugin.__new__(PrivateCompanionPlugin)
+        plugin._finalize_passive_delivered_response = AsyncMock(return_value=True)
+        event = _SendTrackerEvent()
+        event._has_send_oper = False
+        run_context = SimpleNamespace(
+            messages=[Message(role="assistant", content=[TextPart(text="原始回复")])]
+        )
+
+        plugin._begin_final_response_persistence(event)
+        await plugin._prepare_final_response_after_agent(
+            event,
+            run_context,
+            LLMResponse(role="assistant", completion_text="第一段第二段。第三句。"),
+        )
+        event._private_companion_llm_planned_chunk_texts = (
+            "第一段",
+            "第二段。",
+            "第三句。",
+        )
+        event._private_companion_llm_planned_segment_ids = (0, 1, 1)
+
+        # A OneBot merged-forward send is confirmed through the common
+        # proactive primitive as one chain containing several Plain nodes.
+        plugin._confirm_outbound_delivery(
+            "",
+            [Plain("第一段"), Plain("第二段。"), Plain("第三句。")],
+        )
+        await plugin.persist_confirmed_passive_reply(event)
+
+        call = plugin._finalize_passive_delivered_response.await_args
+        self.assertEqual(("第一段", "第二段。第三句。"), call.kwargs["llm_segments"])
+        delivery = event._private_companion_delivery_ledger.confirmed_deliveries[0]
+        self.assertEqual((0, 1, 1), delivery.logical_segment_ids)
+        self.assertEqual((0, 1, 2), delivery.logical_segment_indices)
+
+    async def test_partial_send_failure_records_only_confirmed_logical_segments(self):
+        plugin = PrivateCompanionPlugin.__new__(PrivateCompanionPlugin)
+        plugin._finalize_passive_delivered_response = AsyncMock(return_value=True)
+        event = _SendTrackerEvent()
+        event._has_send_oper = False
+        run_context = SimpleNamespace(
+            messages=[Message(role="assistant", content=[TextPart(text="原始回复")])]
+        )
+
+        plugin._begin_final_response_persistence(event)
+        await plugin._prepare_final_response_after_agent(
+            event,
+            run_context,
+            LLMResponse(role="assistant", completion_text="第一段第二段第三段"),
+        )
+        event._private_companion_llm_planned_chunk_texts = (
+            "第一段",
+            "第二段",
+            "第三段",
+        )
+        event._private_companion_llm_planned_segment_ids = (0, 1, 2)
+
+        await event.send(SimpleNamespace(chain=[Plain("第一段")]))
+        await event.send(SimpleNamespace(chain=[Plain("第二段")]))
+        event.send_error = RuntimeError("第三段发送失败")
+        with self.assertRaisesRegex(RuntimeError, "第三段发送失败"):
+            await event.send(SimpleNamespace(chain=[Plain("第三段")]))
+        await plugin.persist_confirmed_passive_reply(event)
+
+        call = plugin._finalize_passive_delivered_response.await_args
+        self.assertEqual("第一段\n第二段", call.kwargs["fallback_text"])
+        self.assertEqual(("第一段", "第二段"), call.kwargs["llm_segments"])
+        self.assertEqual(
+            ["第一段", "第二段"],
+            [item.chain[0].text for item in event._private_companion_delivery_ledger.confirmed_deliveries],
+        )
 
     async def test_direct_send_that_stops_event_uses_fallback_finalizer(self):
         plugin = PrivateCompanionPlugin.__new__(PrivateCompanionPlugin)

--- a/tests/test_group_bot_history_delivery_e2e.py
+++ b/tests/test_group_bot_history_delivery_e2e.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+import unittest
+from types import SimpleNamespace
+
+from astrbot.api.message_components import Plain
+
+from astrbot_plugin_private_companion.final_response_persistence import (
+    FinalResponsePersistenceMixin,
+)
+from astrbot_plugin_private_companion.group_observation import GroupObservationMixin
+
+
+class _Event:
+    def __init__(self, results: list[object]) -> None:
+        self.unified_msg_origin = "default:GroupMessage:group-a"
+        self._has_send_oper = True
+        self._private_companion_persistence_managed = True
+        self._private_companion_llm_planned_chunk_texts = (
+            "第一段",
+            "第二段",
+            "第三句",
+        )
+        self._private_companion_llm_planned_segment_ids = (0, 1, 1)
+        self._private_companion_official_assistant_message = object()
+        self.private_companion_group_scene = {"talking_to": "group"}
+        self._results = iter(results)
+        self.sent: list[object] = []
+
+    def get_result(self):
+        return SimpleNamespace(chain=[Plain("候选回复")])
+
+    def get_sender_id(self) -> str:
+        return "user-a"
+
+    def is_private_chat(self) -> bool:
+        return False
+
+    def is_stopped(self) -> bool:
+        return False
+
+    async def send(self, message):
+        self.sent.append(message)
+        return next(self._results)
+
+
+class _Harness(FinalResponsePersistenceMixin, GroupObservationMixin):
+    max_group_recent_messages = 8
+
+    def __init__(self) -> None:
+        self._data_lock = asyncio.Lock()
+        self.group = {"group_id": "group-a"}
+        self.saved_sections: set[str] = set()
+
+    @staticmethod
+    def _extract_group_id_from_event(_event) -> str:
+        return "group-a"
+
+    def _get_group(self, _group_id: str) -> dict:
+        return self.group
+
+    @staticmethod
+    def _feature_enabled_or_temp_unlocked(_key: str) -> bool:
+        return True
+
+    def _save_data_sync(self, *, sections=None) -> None:
+        self.saved_sections.update(sections or ())
+
+    @staticmethod
+    def _event_message_id(_event) -> str:
+        return "message-group-1"
+
+    @staticmethod
+    def _stage_delivered_assistant_for_official_history(**_kwargs) -> bool:
+        return False
+
+    async def _append_delivered_assistant_to_conversation(self, **_kwargs) -> bool:
+        return False
+
+    async def _record_final_assistant_in_livingmemory(self, **_kwargs) -> bool:
+        return False
+
+
+class GroupBotHistoryDeliveryE2ETests(unittest.IsolatedAsyncioTestCase):
+    async def test_successful_segmented_send_persists_group_segment_metadata(self) -> None:
+        harness = _Harness()
+        event = _Event([True, True, True])
+        harness._capture_final_outbound_delivery(event)
+        harness._final_response_persistence_coordinator().mark_final_response_ready(event)
+
+        await event.send(SimpleNamespace(chain=[Plain("第一段")]))
+        await event.send(SimpleNamespace(chain=[Plain("第二段")]))
+        await event.send(SimpleNamespace(chain=[Plain("第三句")]))
+        self.assertTrue(await harness._persist_final_outbound_delivery(event))
+
+        record = harness.group["recent_bot_replies"][-1]
+        self.assertEqual("第一段 第二段 第三句", record["text"])
+        self.assertEqual(["第一段", "第二段第三句"], record["llm_segments"])
+        self.assertEqual("default:GroupMessage:group-a", event.unified_msg_origin)
+        self.assertEqual({"groups"}, harness.saved_sections)
+
+    async def test_partial_segmented_send_persists_only_confirmed_logical_content(self) -> None:
+        harness = _Harness()
+        event = _Event([True, False, True])
+        harness._capture_final_outbound_delivery(event)
+        harness._final_response_persistence_coordinator().mark_final_response_ready(event)
+
+        await event.send(SimpleNamespace(chain=[Plain("第一段")]))
+        self.assertFalse(await event.send(SimpleNamespace(chain=[Plain("第二段")])))
+        await event.send(SimpleNamespace(chain=[Plain("第三句")]))
+        self.assertTrue(await harness._persist_final_outbound_delivery(event))
+
+        record = harness.group["recent_bot_replies"][-1]
+        self.assertEqual("第一段 第三句", record["text"])
+        self.assertEqual(["第一段", "第三句"], record["llm_segments"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_group_bot_history_lifecycle.py
+++ b/tests/test_group_bot_history_lifecycle.py
@@ -137,6 +137,24 @@ class GroupBotHistoryLifecycleTests(unittest.IsolatedAsyncioTestCase):
             record,
         )
 
+    def test_bot_record_keeps_llm_segments_inside_one_history_turn(self) -> None:
+        harness = _HistoryHarness()
+        group: dict = {}
+
+        record = harness._record_group_bot_reply(
+            group,
+            text="第一段 第二段",
+            kind="passive_reply",
+            llm_segments=[
+                "第一段",
+                "第二段<<PRIVATE_COMPANION_SPLIT>>",
+            ],
+        )
+
+        self.assertEqual(1, len(group["recent_bot_replies"]))
+        self.assertEqual(["第一段", "第二段"], record["llm_segments"])
+        self.assertNotIn("PRIVATE_COMPANION_SPLIT", str(record))
+
     def test_air_guard_filter_is_a_pure_time_window_view(self) -> None:
         harness = _HistoryHarness()
         group = {

--- a/tests/test_group_prompt_context.py
+++ b/tests/test_group_prompt_context.py
@@ -123,6 +123,38 @@ class GroupPromptContextTests(unittest.TestCase):
         self.assertEqual("明确 @ Bot", scene.get("trigger"))
         self.assertEqual("明确 @ Bot", scene.get("reason"))
 
+    def test_renders_llm_segments_inside_one_assistant_message(self) -> None:
+        kwargs = dict(
+            current_message={"ts": 100, "sender_id": "1", "text": "继续"},
+            recent_messages=[],
+            recent_bot_replies=[
+                {
+                    "ts": 95,
+                    "text": "第一段 第二段",
+                    "llm_segments": ["第一段", "第二段"],
+                }
+            ],
+            fromtimestamp=_fromtimestamp,
+            limit=20,
+            max_chars=4000,
+            bot_id="璃",
+            bot_name="璃",
+        )
+
+        group = _rendered_group(build_group_prompt_context(**kwargs))
+        messages = group.findall("./history/message")
+        self.assertEqual(1, len(messages))
+        self.assertEqual("assistant", messages[0].get("role"))
+        self.assertEqual(["第一段", "第二段"], [seg.text for seg in messages[0].findall("./seg")])
+
+        flat_group = _rendered_group(
+            build_group_prompt_context(**kwargs, render_llm_segments=False)
+        )
+        flat_message = flat_group.find("./history/message")
+        self.assertIsNotNone(flat_message)
+        self.assertEqual("第一段 第二段", flat_message.text)
+        self.assertEqual([], flat_message.findall("./seg"))
+
     def test_formats_same_day_and_cross_day_times_in_configured_timezone(self) -> None:
         context = build_group_prompt_context(
             current_message={
@@ -366,6 +398,26 @@ class GroupPromptContextTests(unittest.TestCase):
             len(_timeline_wire_text(history, **_history_wire_kwargs(history_attrs))),
             20,
         )
+
+    def test_truncated_message_drops_nested_segments_to_enforce_budget(self) -> None:
+        context = build_group_prompt_context(
+            current_message={"ts": 500, "sender_id": "1", "text": "当前"},
+            recent_messages=[],
+            recent_bot_replies=[
+                {
+                    "ts": 95,
+                    "text": "第一段第二段第三段",
+                    "llm_segments": ["第一段", "第二段第三段"],
+                }
+            ],
+            fromtimestamp=_fromtimestamp,
+            max_chars=6,
+        )
+
+        message = _rendered_group(context).find("./history/message")
+        self.assertIsNotNone(message)
+        self.assertEqual([], message.findall("./seg"))
+        self.assertLessEqual(len(message.text or ""), 6)
 
     def test_builder_does_not_mutate_source_records(self) -> None:
         current = {"ts": 100, "sender_id": "opaque-current", "text": "当前"}

--- a/tests/test_llm_controlled_segmenting.py
+++ b/tests/test_llm_controlled_segmenting.py
@@ -12,6 +12,8 @@ from astrbot_plugin_private_companion.proactive_message import ProactiveMessageM
 from astrbot_plugin_private_companion.segmented_message import (
     has_fenced_llm_segment_marker,
     LLM_SEGMENT_MARKER,
+    parse_llm_segment_control,
+    sanitize_llm_segment_control_tokens,
     split_llm_controlled_text,
     strip_llm_segment_marker_lines,
 )
@@ -73,24 +75,42 @@ class LlmControlledSegmentingTests(unittest.TestCase):
     def test_marker_is_strict_and_standalone(self) -> None:
         marker = LLM_SEGMENT_MARKER
         self.assertEqual((['a', 'b'], True), split_llm_controlled_text(f"a\n{marker}\nb"))
-        self.assertEqual(([f"a {marker} b"], False), split_llm_controlled_text(f"a {marker} b"))
+        self.assertEqual((["a b"], False), split_llm_controlled_text(f"a {marker} b"))
         self.assertEqual((["a\n[]\nb"], False), split_llm_controlled_text("a\n[]\nb"))
         self.assertEqual(
-            ([f"a\n```\n{marker}\n```\nb"], False),
+            (["a\n```\n\n```\nb"], False),
             split_llm_controlled_text(f"a\n```\n{marker}\n```\nb"),
         )
         four_tick_fence = f"a\n````text\n```\n{marker}\nstill code\n````\nb"
         self.assertEqual(
-            ([four_tick_fence], False),
+            ([four_tick_fence.replace(marker, "")], False),
             split_llm_controlled_text(four_tick_fence),
         )
         self.assertTrue(has_fenced_llm_segment_marker(four_tick_fence))
 
     def test_prompt_names_only_the_real_control_marker(self) -> None:
-        prompt = PrivateCompanionPlugin._llm_controlled_segmenting_prompt()
+        prompt = PrivateCompanionPlugin._llm_controlled_segmenting_prompt(_Harness())
         self.assertEqual(2, prompt.count(LLM_SEGMENT_MARKER))
         self.assertNotIn("[]", prompt)
         self.assertNotIn("[[]]", prompt)
+
+    def test_custom_prompt_replaces_placeholder_and_empty_uses_default(self) -> None:
+        harness = _Harness()
+        harness.persona_values["llm_controlled_segmenting_prompt"] = (
+            "短句之间使用 {{ split_marker }}，不要用空行代替。"
+        )
+        custom = PrivateCompanionPlugin._llm_controlled_segmenting_prompt(harness)
+        self.assertEqual(
+            f"短句之间使用 {LLM_SEGMENT_MARKER}，不要用空行代替。",
+            custom,
+        )
+        harness.persona_values["llm_controlled_segmenting_prompt"] = ""
+        self.assertEqual(
+            2,
+            PrivateCompanionPlugin._llm_controlled_segmenting_prompt(harness).count(
+                LLM_SEGMENT_MARKER
+            ),
+        )
 
     def test_plugin_rules_do_not_split_a_fenced_marker_example(self) -> None:
         harness = _Harness()
@@ -100,7 +120,7 @@ class LlmControlledSegmentingTests(unittest.TestCase):
             "still code\n````\nafter"
         )
         self.assertEqual(
-            [text],
+            [text.replace(LLM_SEGMENT_MARKER, "")],
             PrivateCompanionPlugin._split_llm_controlled_text_for_event(
                 harness,
                 _Event(),
@@ -108,18 +128,40 @@ class LlmControlledSegmentingTests(unittest.TestCase):
             ),
         )
 
-    def test_marker_cleanup_preserves_fenced_and_quoted_examples(self) -> None:
+    def test_marker_cleanup_removes_fenced_and_quoted_examples(self) -> None:
         marker = LLM_SEGMENT_MARKER
         source = f"a\n{marker}\n```text\n{marker}\n```\n> {marker}\nb"
-        self.assertEqual(
-            f"a\n```text\n{marker}\n```\n> {marker}\nb",
-            strip_llm_segment_marker_lines(source),
-        )
+        self.assertEqual("a\n```text\n\n```\n\nb", strip_llm_segment_marker_lines(source))
         four_tick_fence = f"a\n````text\n```\n{marker}\nstill code\n````\nb"
         self.assertEqual(
-            four_tick_fence,
+            four_tick_fence.replace(marker, ""),
             strip_llm_segment_marker_lines(four_tick_fence),
         )
+
+    def test_recovers_only_one_sided_newline_errors(self) -> None:
+        marker = LLM_SEGMENT_MARKER
+        for source in (f"a{marker}\nb", f"a\n{marker}b"):
+            with self.subTest(source=source):
+                parsed = parse_llm_segment_control(source)
+                self.assertTrue(parsed.controlled)
+                self.assertEqual(("a", "b"), parsed.segments)
+                self.assertEqual(1, parsed.recovered_boundary_count)
+
+        inline = parse_llm_segment_control(f"a{marker}b")
+        self.assertFalse(inline.controlled)
+        self.assertEqual("a b", inline.sanitized_text)
+        self.assertEqual(1, inline.cleaned_only_count)
+
+    def test_cleanup_removes_reserved_variants_and_is_idempotent(self) -> None:
+        source = (
+            "a {{ split_marker }} b "
+            "&lt;&lt;PRIVATE_COMPANION_SPLIT&gt;&gt; c "
+            "<< PRIVATE _ COMPANION _ SPLIT >> d "
+            r"\<\<PRIVATE_COMPANION_SPLIT\>\> e"
+        )
+        cleaned = sanitize_llm_segment_control_tokens(source)
+        self.assertEqual("a b c d e", cleaned)
+        self.assertEqual(cleaned, sanitize_llm_segment_control_tokens(cleaned))
 
     def test_legacy_persona_migration_adds_new_defaults(self) -> None:
         from astrbot_plugin_private_companion.persona_config import (
@@ -151,6 +193,10 @@ class LlmControlledSegmentingTests(unittest.TestCase):
         self.assertEqual("短段。", segments[0])
         self.assertEqual("这是最长的一段。", segments[1])
         self.assertEqual("再一段。", segments[2])
+        self.assertEqual(
+            (0, 1, 1),
+            event._private_companion_llm_planned_segment_ids,
+        )
 
     def test_llm_segments_are_not_limited_when_over_plugin_budget(self) -> None:
         harness = _Harness()
@@ -206,7 +252,7 @@ class LlmControlledSegmentingTests(unittest.TestCase):
         splitter = PrivateCompanionPlugin._split_llm_controlled_text_for_event
         event = _Event()
         text = f"一\n{LLM_SEGMENT_MARKER}\n二。三。"
-        self.assertEqual([text], splitter(harness, event, text))
+        self.assertEqual(["一\n二。三。"], splitter(harness, event, text))
 
     def test_llm_segments_still_use_shared_content_replacement(self) -> None:
         harness = _Harness()
@@ -220,14 +266,21 @@ class LlmControlledSegmentingTests(unittest.TestCase):
 
     def test_native_proactive_generation_receives_the_marker_contract(self) -> None:
         harness = _Harness()
-        harness._llm_controlled_segmenting_prompt = (
-            PrivateCompanionPlugin._llm_controlled_segmenting_prompt
+        harness._llm_controlled_segmenting_prompt = lambda: (
+            PrivateCompanionPlugin._llm_controlled_segmenting_prompt(harness)
         )
         hint = harness._proactive_llm_segmenting_instruction(
             umo="default:FriendMessage:1",
         )
         self.assertIn(LLM_SEGMENT_MARKER, hint)
         self.assertIn("<![CDATA[", hint)
+
+        harness._llm_controlled_segmenting_prompt = lambda: "前半]]>后半"
+        escaped_hint = harness._proactive_llm_segmenting_instruction(
+            umo="default:FriendMessage:1",
+        )
+        self.assertIn("前半]]]]><![CDATA[>后半", escaped_hint)
+        self.assertNotIn("<![CDATA[前半]]>后半]]>", escaped_hint)
 
         harness.enable_llm_controlled_segmenting = False
         self.assertEqual(

--- a/tests/test_overall_debug_regressions.py
+++ b/tests/test_overall_debug_regressions.py
@@ -146,6 +146,24 @@ class OverallDebugRegressionTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual([], result.chain)
 
+    async def test_final_outbound_guard_removes_malformed_segment_marker_when_disabled(self) -> None:
+        plugin = PrivateCompanionPlugin.__new__(PrivateCompanionPlugin)
+        plugin.enabled = True
+        plugin.enable_tts_enhancement = False
+        plugin.enable_segmented_proactive_reply = False
+        plugin.enable_llm_controlled_segmenting = False
+        result = SimpleNamespace(
+            chain=[Plain("第一段<<PRIVATE_COMPANION_SPLIT>>第二段")]
+        )
+        event = SimpleNamespace(
+            unified_msg_origin=UMO,
+            get_result=lambda: result,
+        )
+
+        await plugin.final_strip_outbound_control_blocks_before_send(event)
+
+        self.assertEqual("第一段 第二段", result.chain[0].text)
+
     def test_segmented_reply_never_keeps_history_media_marker_as_a_bubble(self) -> None:
         plugin = PrivateCompanionPlugin.__new__(PrivateCompanionPlugin)
         plugin.enable_tts_enhancement = False

--- a/tests/test_persona_config.py
+++ b/tests/test_persona_config.py
@@ -29,10 +29,10 @@ class PersonaConfigTests(unittest.TestCase):
         cls.schema = load_schema(ROOT / "_conf_schema.json")
         cls.manifest = build_scope_manifest(cls.schema)
 
-    def test_manifest_covers_canonical_grouped_928_leaves(self) -> None:
+    def test_manifest_covers_canonical_grouped_932_leaves(self) -> None:
         self.assertEqual(4, PERSONA_SETTINGS_SCHEMA_VERSION)
         leaves = discover_grouped_schema_leaves(self.schema)
-        self.assertEqual(len(leaves), 928)
+        self.assertEqual(len(leaves), 932)
         self.assertEqual(set(leaves), set(self.manifest))
         required_fields = {
             "scope",
@@ -53,6 +53,38 @@ class PersonaConfigTests(unittest.TestCase):
         self.assertEqual(self.manifest["bot_name"]["scope"], "persona")
         self.assertTrue(self.manifest["bot_name"]["identity"])
         self.assertFalse(self.manifest["bot_name"]["inherit_primary"])
+        prompt_entry = self.manifest["llm_controlled_segmenting_prompt"]
+        self.assertEqual("persona", prompt_entry["scope"])
+        self.assertTrue(prompt_entry["cloneable"])
+        self.assertEqual("", prompt_entry["default"])
+
+    def test_segmenting_prompt_distinguishes_follow_empty_and_custom(self) -> None:
+        primary = {"llm_controlled_segmenting_prompt": "主人格提示"}
+        self.assertEqual(
+            "",
+            default_persona_settings(
+                self.schema,
+                manifest=self.manifest,
+            )["llm_controlled_segmenting_prompt"],
+        )
+        self.assertEqual(
+            "主人格提示",
+            resolve_persona_setting(
+                "llm_controlled_segmenting_prompt",
+                {},
+                primary,
+                manifest=self.manifest,
+            ),
+        )
+        self.assertEqual(
+            "",
+            resolve_persona_setting(
+                "llm_controlled_segmenting_prompt",
+                {"llm_controlled_segmenting_prompt": ""},
+                primary,
+                manifest=self.manifest,
+            ),
+        )
         self.assertEqual(self.manifest["storage_backend"]["scope"], "common")
         self.assertEqual(self.manifest["plugin_specific_persona_id"]["scope"], "common")
         self.assertFalse(self.manifest["plugin_specific_persona_id"]["cloneable"])

--- a/tests/test_segmented_config_save.py
+++ b/tests/test_segmented_config_save.py
@@ -47,6 +47,11 @@ class SegmentedConfigSaveTests(unittest.TestCase):
             self.assertIn('if (matched === ",")', script)
             self.assertIn('dashRun.length >= 2 && nextIsAsciiDigit(end, true)', script)
             self.assertIn('enable_segmented_proactive_chat_profiles: { type: "checkbox" }', script)
+            self.assertIn(
+                'llm_controlled_segmenting_prompt: { type: "textarea", rows: 3, maxLength: 4000 }',
+                script,
+            )
+            self.assertIn("{{split_marker}} 表示消息分隔标记", script)
             self.assertIn('segmented_proactive_private_scope: { type: "select"', script)
             self.assertIn('segmented_proactive_group_scope: { type: "select"', script)
             self.assertIn("function segmentedComponentOrderEditorHtml", script)
@@ -105,6 +110,7 @@ class SegmentedConfigSaveTests(unittest.TestCase):
             "legacy_compat_config": {
                 "enable_segmented_proactive_reply": True,
                 "enable_llm_controlled_segmenting": True,
+                "llm_controlled_segmenting_prompt": "短句之间使用 {{split_marker}}。",
                 "enable_segmented_plugin_rules": False,
                 "segmented_proactive_scope": "all_llm",
                 "segmented_proactive_chat_scope": "private",
@@ -156,6 +162,7 @@ class SegmentedConfigSaveTests(unittest.TestCase):
         expected = {
             "enable_segmented_proactive_reply": True,
             "enable_llm_controlled_segmenting": True,
+            "llm_controlled_segmenting_prompt": "短句之间使用 {{split_marker}}。",
             "enable_segmented_plugin_rules": False,
             "enable_segmented_proactive_chat_profiles": True,
             "segmented_proactive_private_enabled": True,

--- a/tts_tool_sanitizer.py
+++ b/tts_tool_sanitizer.py
@@ -15,6 +15,7 @@ from .helpers import (
     _strip_outbound_control_blocks,
 )
 from .persona_config import runtime_persona_setting
+from .segmented_message import sanitize_llm_segment_control_tokens
 
 
 class TtsToolSanitizerMixin:
@@ -171,7 +172,9 @@ class TtsToolSanitizerMixin:
         # Tool payloads can bypass the normal decorating-result chain. Apply
         # the same outbound control cleanup here so internal sentinels (such
         # as the photo-delivery marker) are never sent as visible text.
-        cleaned_outbound = _strip_outbound_control_blocks(text)
+        cleaned_outbound = sanitize_llm_segment_control_tokens(
+            _strip_outbound_control_blocks(text)
+        )
         if cleaned_outbound != text:
             logger.info(
                 "[PrivateCompanion] 已清理工具直发文本中的内部控制标记: before=%s after=%s",


### PR DESCRIPTION
## 概述

新增分段发送中的 LLM 自主分段自定义提示词
修复其在发送、历史回写和异常输出下的边界问题。

## 主要改动

- 新增“自主分段提示词”配置：
  - 留空时使用内置提示词；
  - 支持 `{{split_marker}}` 占位符，运行时替换为实际分段标记；
  - 配置按人格生效，缺失时继续跟随主人格。
- 优化 LLM 分段标记解析：
  - 正常的独立标记产生发送边界；
  - 可容忍部分轻微格式错误；
  - 引用、代码块、转义、HTML 形式及内联标记不会误触发分段。
- 无论分段是否启用，均会清理回复、工具发送、被动/主动记录及历史中的分段控制标记，避免残留标记进入后续上下文并误导模型。
- 群聊 Bot 历史仍保持为单个 assistant 回合；仅 LLM 明确自主分段的内容以 `<seg>` 保留逻辑段落，插件规则二次拆分不会污染历史结构。
- 补齐合并转发、部分发送成功、延迟回调等场景的送达确认，只有实际确认送达的内容会写入历史。
- WebUI 两份陪伴面板同步增加配置项，并将自主分段提示词输入框调整为紧凑高度。

## 兼容性

- 人格配置版本保持 v4，不触发 schema 版本升级。
- LLM 自主分段默认关闭，既有插件规则分段行为不变。
- 非直接回复用户的 LLM 调用和工具提示词格式未改动。

## 测试

- 相关测试：`124 passed, 1 deselected`
- Python 编译、WebUI JavaScript 语法检查及双面板镜像一致性检查通过。