### PR TITLE
refactor: add module-tagged logging with Chinese labels

### DIFF
--- a/astrbot_knowledge.py
+++ b/astrbot_knowledge.py
@@ -8,12 +8,14 @@ import unicodedata
 from pathlib import Path
 from typing import Any
 
-from astrbot.api import logger
 from astrbot.core.utils.astrbot_path import get_astrbot_data_path
 
 from .helpers import _single_line
 from .persona_config import runtime_persona_setting
 from .reference_assets import normalize_reference_asset
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 class AstrBotKnowledgeMixin:
@@ -69,7 +71,7 @@ class AstrBotKnowledgeMixin:
             ).fetchall()
             conn.close()
         except Exception as exc:
-            logger.warning(f"[PrivateCompanion] 读取 AstrBot 知识库列表失败: {exc}")
+            logger.warning(f"读取 AstrBot 知识库列表失败: {exc}")
             return []
 
         docs_by_kb: dict[str, list[dict[str, Any]]] = {}
@@ -415,7 +417,7 @@ class AstrBotKnowledgeMixin:
             rows = conn.execute("select text, metadata from documents order by id asc").fetchall()
             conn.close()
         except Exception as exc:
-            logger.warning(f"[PrivateCompanion] 读取 AstrBot 知识库片段失败 {kb_id}: {exc}")
+            logger.warning(f"读取 AstrBot 知识库片段失败 {kb_id}: {exc}")
             return []
 
         chunks: list[dict[str, Any]] = []

--- a/atrelay.py
+++ b/atrelay.py
@@ -31,7 +31,7 @@ from typing import Any
 from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlunparse
 from xml.etree import ElementTree as ET
 
-from astrbot.api import AstrBotConfig, logger
+from astrbot.api import AstrBotConfig
 from astrbot.api.event import AstrMessageEvent, MessageChain, filter
 try:
     from astrbot.api.message_components import At, Image, Plain, Record, Reply
@@ -117,6 +117,9 @@ from .planning import (
     normalize_story_plan,
     pick_detail_segment,
 )
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 DEFAULT_AI_DAILY_NEWS_SOURCE = "B站 AI早报|bilibili:285286947"
@@ -430,7 +433,7 @@ class AtRelayMixin:
             return {}
         chosen = candidates[0]
         logger.info(
-            "[PrivateCompanion] 跨群转述按收话人活跃群自动选群: recipient=%s user=%s group=%s candidates=%s",
+            "跨群转述按收话人活跃群自动选群: recipient=%s user=%s group=%s candidates=%s",
             recipient,
             user_id,
             chosen.get("group_id"),
@@ -614,7 +617,7 @@ class AtRelayMixin:
                 task="atrelay_rewrite",
             )
         except Exception as exc:
-            logger.info("[PrivateCompanion] 转述正文 LLM 转译失败: %s", _single_line(exc, 120))
+            logger.info("转述正文 LLM 转译失败: %s", _single_line(exc, 120))
             return original
         cleaned = self._clean_atrelay_llm_text(rewritten)
         if not cleaned:
@@ -632,12 +635,12 @@ class AtRelayMixin:
             recipient_name=recipient_name,
         ):
             logger.info(
-                "[PrivateCompanion] 转述正文 LLM 转译疑似扩写污染,使用原文: before=%s after=%s",
+                "转述正文 LLM 转译疑似扩写污染,使用原文: before=%s after=%s",
                 _single_line(original, 80),
                 _single_line(cleaned, 120),
             )
             return original
-        logger.info("[PrivateCompanion] 转述正文已 LLM 转译: before=%s after=%s", _single_line(original, 80), _single_line(cleaned, 120))
+        logger.info("转述正文已 LLM 转译: before=%s after=%s", _single_line(original, 80), _single_line(cleaned, 120))
         return cleaned
 
     @filter.on_llm_response()
@@ -687,7 +690,7 @@ class AtRelayMixin:
         )
         if should_compact:
             logger.info(
-                "[PrivateCompanion] 转述工具回执已收敛: before=%s after=%s",
+                "转述工具回执已收敛: before=%s after=%s",
                 _single_line(compact, 160),
                 final_reply,
             )
@@ -937,7 +940,7 @@ class AtRelayMixin:
         if len(cached_matches) == 1:
             match = cached_matches[0]
             logger.info(
-                "[PrivateCompanion] 跨群转述群名命中本地缓存: hint=%s group=%s source=%s",
+                "跨群转述群名命中本地缓存: hint=%s group=%s source=%s",
                 hint,
                 match.get("group_id"),
                 match.get("source"),
@@ -1099,7 +1102,7 @@ class AtRelayMixin:
         allowed = bool(requester_id and callable(checker) and checker(requester_id))
         if not allowed:
             logger.info(
-                "[PrivateCompanion] relay authorization denied: sender=%s umo=%s",
+                "relay authorization denied: sender=%s umo=%s",
                 requester_id or "-",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120),
             )
@@ -1128,7 +1131,7 @@ class AtRelayMixin:
         blacklist_getter = getattr(self, "_configured_group_blacklist_ids", None)
         blacklist = set(blacklist_getter()) if callable(blacklist_getter) else set()
         if target in blacklist:
-            logger.info("[PrivateCompanion] relay group denied by blacklist: group=%s", target)
+            logger.info("relay group denied by blacklist: group=%s", target)
             return "发送失败：目标群不在允许转述范围内"
         whitelist_getter = getattr(self, "_configured_group_ids", None)
         allowed = set(whitelist_getter()) if callable(whitelist_getter) else set()
@@ -1142,10 +1145,10 @@ class AtRelayMixin:
             if current_group:
                 allowed.add(current_group)
         if not allowed:
-            logger.warning("[PrivateCompanion] relay group allow-set empty; compatibility pass: group=%s", target)
+            logger.warning("relay group allow-set empty; compatibility pass: group=%s", target)
             return ""
         if target not in allowed:
-            logger.info("[PrivateCompanion] relay group denied: group=%s", target)
+            logger.info("relay group denied: group=%s", target)
             return "发送失败：目标群不在允许转述范围内"
         return ""
 
@@ -1399,7 +1402,7 @@ class AtRelayMixin:
                 continue
             duplicate = self._atrelay_duplicate_guard("group", group_id, text, sender_id)
             if duplicate:
-                logger.info("[PrivateCompanion] 延迟转述重复拦截: group=%s user=%s", group_id, sender_id)
+                logger.info("延迟转述重复拦截: group=%s user=%s", group_id, sender_id)
                 continue
             try:
                 await self.context.send_message(target_umo, MessageChain([At(qq=sender_id), Plain(" "), Plain(text)]))
@@ -1413,5 +1416,5 @@ class AtRelayMixin:
                 )
                 self._save_data_sync(sections={"groups", "recent_atrelay_contexts", "atrelay_send_log"})
             except Exception as exc:
-                logger.warning("[PrivateCompanion] 延迟转述发送失败: group=%s user=%s err=%s", group_id, sender_id, _single_line(exc, 160))
+                logger.warning("延迟转述发送失败: group=%s user=%s err=%s", group_id, sender_id, _single_line(exc, 160))
 

--- a/balance_awareness.py
+++ b/balance_awareness.py
@@ -11,10 +11,12 @@ import re
 from typing import Any
 from urllib.parse import urlparse
 
-from astrbot.api import logger
 
 from .helpers import _now_ts, _safe_float, _single_line
 from .persona_config import runtime_persona_setting
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 class BalanceAwarenessMixin:
@@ -614,7 +616,7 @@ class BalanceAwarenessMixin:
                     schedule_save(sections={"balance_awareness"}, delay=0.5)
                 if auto_unsupported:
                     logger.warning(
-                        "[PrivateCompanion] 当前 Provider 不支持余额查询,已延长探测间隔: "
+                        "当前 Provider 不支持余额查询,已延长探测间隔: "
                         "failures=%s retry_hours=%.1f max_retry_hours=168 error=%s",
                         failures,
                         retry / 3600.0,
@@ -622,7 +624,7 @@ class BalanceAwarenessMixin:
                     )
                 else:
                     logger.warning(
-                        "[PrivateCompanion] 余额拉取失败,将在稍后重试: failures=%s error=%s",
+                        "余额拉取失败,将在稍后重试: failures=%s error=%s",
                         failures,
                         safe_error,
                     )
@@ -680,7 +682,7 @@ class BalanceAwarenessMixin:
                 schedule_save(sections=sections, delay=0.5)
             if offered:
                 logger.info(
-                    "[PrivateCompanion] 余额偏低事件已进入主动候选链: tier=%s targets=%s",
+                    "余额偏低事件已进入主动候选链: tier=%s targets=%s",
                     tier,
                     offered,
                 )

--- a/body_monitor_integration.py
+++ b/body_monitor_integration.py
@@ -672,7 +672,7 @@ class BodyMonitorIntegration:
     def _record_error(self, state: dict[str, Any], status: str, exc: Exception) -> dict[str, Any]:
         state["status"] = status
         state["last_error"] = _error_text(exc, 180) or exc.__class__.__name__
-        logger.warning("[PrivateCompanion] Body Monitor 联动失败: %s", state["last_error"])
+        logger.warning("[身体监测联动] Body Monitor 联动失败: %s", state["last_error"])
         self._save()
         return self.status_view()
 

--- a/busy_reply_gate.py
+++ b/busy_reply_gate.py
@@ -6,10 +6,12 @@ import random
 import re
 from typing import Any
 
-from astrbot.api import logger
 
 from .helpers import _safe_float, _safe_int, _single_line
 from .persona_config import runtime_persona_setting
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 class BusyReplyGateMixin:
@@ -304,7 +306,7 @@ class BusyReplyGateMixin:
         except Exception:
             pass
         logger.info(
-            "[PrivateCompanion] 繁忙回复闸门延迟本轮被动回复: session=%s delay=%.1fs private=%s schedule=%s",
+            "繁忙回复闸门延迟本轮被动回复: session=%s delay=%.1fs private=%s schedule=%s",
             _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             delay,
             is_private_chat,
@@ -314,7 +316,7 @@ class BusyReplyGateMixin:
         if is_private_chat and self._busy_reply_event_is_superseded(event):
             self._busy_reply_stop_superseded_event(event)
             logger.info(
-                "[PrivateCompanion] 繁忙等待期间收到更新私聊，已取消陈旧回复: session=%s delay=%.1fs text=%s",
+                "繁忙等待期间收到更新私聊，已取消陈旧回复: session=%s delay=%.1fs text=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                 delay,
                 _single_line(getattr(event, "message_str", ""), 100),

--- a/command_handlers.py
+++ b/command_handlers.py
@@ -12,7 +12,6 @@ from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
-from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent
 
 from .constants import DEFAULT_NATURAL_LANGUAGE_PHOTO_EXTRA_PROMPT
@@ -29,6 +28,9 @@ from .photo_reference_catalog import (
 )
 from .photo_prompt_context import PhotoPromptSection
 from .persona_config import runtime_persona_setting
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 _PHOTO_REFERENCE_SUFFIXES = {".png", ".jpg", ".jpeg", ".webp"}
@@ -1291,7 +1293,7 @@ class CommandHandlersMixin:
             event.stop_event()
         except Exception:
             pass
-        logger.info("[PrivateCompanion] 自然语言插件权限答疑已接管: text=%s", _single_line(question, 120))
+        logger.info("自然语言插件权限答疑已接管: text=%s", _single_line(question, 120))
         return True
 
     def _companion_manual_entry_tags(self, entry: dict[str, Any]) -> set[str]:
@@ -1451,7 +1453,7 @@ class CommandHandlersMixin:
             return
         ok, normalized, error = self._companion_manual_normalize_config_value(key, value)
         if not ok:
-            logger.debug("[PrivateCompanion] 答疑可执行建议被跳过: key=%s error=%s", key, _single_line(error, 120))
+            logger.debug("答疑可执行建议被跳过: key=%s error=%s", key, _single_line(error, 120))
             return
         old = self._companion_manual_current_config_value(key)
         if self._companion_manual_values_equal(old, normalized):
@@ -2162,21 +2164,21 @@ class CommandHandlersMixin:
                 for source in await current_getter(event, sender_id):
                     add(source, "随消息携带图片")
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 答疑携带图片提取失败: %s", _single_line(exc, 120))
+                logger.debug("答疑携带图片提取失败: %s", _single_line(exc, 120))
         reply_cache_getter = getattr(self, "_photo_reference_sources_from_reply_cache", None)
         if callable(reply_cache_getter):
             try:
                 for source in reply_cache_getter(event):
                     add(source, "引用撤回/缓存图片")
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 答疑引用缓存图片提取失败: %s", _single_line(exc, 120))
+                logger.debug("答疑引用缓存图片提取失败: %s", _single_line(exc, 120))
         reply_getter = getattr(self, "_photo_reference_sources_from_reply_event", None)
         if callable(reply_getter):
             try:
                 for source in await reply_getter(event):
                     add(source, "引用消息图片")
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 答疑引用图片提取失败: %s", _single_line(exc, 120))
+                logger.debug("答疑引用图片提取失败: %s", _single_line(exc, 120))
         if not sources:
             return ""
 
@@ -2200,7 +2202,7 @@ class CommandHandlersMixin:
                 limit = limit_getter(len(source_values)) if callable(limit_getter) else 1200
                 vision_text = _single_line(raw_vision, _safe_int(limit, 1200, 240, 2400))
             except Exception as exc:
-                logger.info("[PrivateCompanion] 答疑图片视觉摘要失败: %s", _single_line(exc, 120))
+                logger.info("答疑图片视觉摘要失败: %s", _single_line(exc, 120))
                 vision_text = ""
 
         lines = [
@@ -2525,7 +2527,7 @@ class CommandHandlersMixin:
                     _set_into_config(config, "semantic_message_debounce_seconds", old_semantic_seconds)
                 return False, "配置保存失败，已恢复修改前的运行配置。", old, old
         if not saved:
-            logger.debug("[PrivateCompanion] 答疑设置只更新运行态,未找到可写配置项: key=%s", key)
+            logger.debug("答疑设置只更新运行态,未找到可写配置项: key=%s", key)
             setattr(self, key, old)
             if key == "enable_message_debounce":
                 self.enable_semantic_message_debounce = old_semantic_debounce
@@ -3435,7 +3437,7 @@ class CommandHandlersMixin:
                     timeout_seconds=2.0,
                 )
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 答疑 我会牢牢记住你 上下文读取失败: %s", _single_line(exc, 120))
+                logger.debug("答疑 我会牢牢记住你 上下文读取失败: %s", _single_line(exc, 120))
         prompt = f"""
 你是 PrivateCompanion 的插件专家答疑助手。你理解插件的功能边界、模块协作、配置、运行状态和关键实现，目标是像熟悉整个项目的维护者一样回答，而不是把问题套进关键词规则。
 
@@ -3518,10 +3520,10 @@ class CommandHandlersMixin:
                 timeout=answer_timeout + 3.0,
             )
         except asyncio.TimeoutError:
-            logger.info("[PrivateCompanion] 陪伴答疑模型诊断超时,回退本地说明: question=%s", _single_line(question, 120))
+            logger.warning("陪伴答疑模型诊断超时,回退本地说明: question=%s", _single_line(question, 120))
             return ""
         except Exception as exc:
-            logger.info("[PrivateCompanion] 陪伴答疑模型诊断失败,回退本地说明: %s", _single_line(exc, 120))
+            logger.warning("陪伴答疑模型诊断失败,回退本地说明: %s", _single_line(exc, 120))
             return ""
         return self._companion_manual_clean_multiline(raw, limit=1800)
 
@@ -3655,7 +3657,7 @@ class CommandHandlersMixin:
             resolved = source_path
         if not trusted and not self._photo_reference_path_within_data_dir(resolved):
             logger.warning(
-                "[PrivateCompanion] 参考图越权本地路径已拒绝: %s",
+                "参考图越权本地路径已拒绝: %s",
                 _single_line(str(resolved), 200),
             )
             return ""
@@ -4086,12 +4088,12 @@ class CommandHandlersMixin:
                 updated = catalog
             return await self._set_photo_reference_catalog_config(updated)
         except (CatalogValidationError, KeyError, TypeError, ValueError) as exc:
-            logger.warning("[PrivateCompanion] 保存 persona 参考图失败: %s", _single_line(exc, 160))
+            logger.warning("保存 persona 参考图失败: %s", _single_line(exc, 160))
             return False
 
     async def _set_photo_reference_catalog_config(self, items: Any) -> bool:
         if bool(getattr(self, "photo_reference_catalog_read_only", False)):
-            logger.warning("[PrivateCompanion] 参考图目录当前为只读状态，拒绝覆盖原配置；请在管理页校验并保存目录")
+            logger.warning("参考图目录当前为只读状态，拒绝覆盖原配置；请在管理页校验并保存目录")
             return False
         previous = tuple(runtime_persona_setting(self, 'photo_reference_catalog', ()) or ())
         previous_version = _safe_int(runtime_persona_setting(self, 'photo_reference_catalog_version', 0), 0, 0)
@@ -4134,7 +4136,7 @@ class CommandHandlersMixin:
                 _set_into_config(self.config, "photo_reference_catalog_user_cleared", previous_user_cleared)
             except Exception:
                 pass
-            logger.warning("[PrivateCompanion] 保存规范参考图目录失败: %s", _single_line(exc, 180))
+            logger.warning("保存规范参考图目录失败: %s", _single_line(exc, 180))
             return False
 
     async def _set_photo_reference_library_config(self, items: list[Any]) -> bool:
@@ -4186,7 +4188,7 @@ class CommandHandlersMixin:
             )
             return await self._set_photo_reference_catalog_config((*kept, *loaded.references))
         except (CatalogValidationError, TypeError, ValueError) as exc:
-            logger.warning("[PrivateCompanion] 保存兼容参考图库失败: %s", _single_line(exc, 160))
+            logger.warning("保存兼容参考图库失败: %s", _single_line(exc, 160))
             return False
 
     async def _photo_reference_library_command_payload(
@@ -4424,7 +4426,7 @@ class CommandHandlersMixin:
                     try:
                         resolved = _path_text(await async_resolver(), 1000)
                     except Exception as exc:
-                        logger.info("[PrivateCompanion] 参考图查看时 URL 下载失败: %s", _single_line(exc, 120))
+                        logger.info("参考图查看时 URL 下载失败: %s", _single_line(exc, 120))
                         resolved = ""
             status = "可用" if resolved else "URL 待首次使用时下载" if re.match(r"^https?://", configured.strip(), flags=re.I) else "路径不可用或格式不支持"
             return (
@@ -5129,7 +5131,7 @@ class CommandHandlersMixin:
         if mode in {"tool_first", "off"}:
             if explicit_plugin_request:
                 logger.info(
-                    "[PrivateCompanion] 非指令生图交给主链工具处理: mode=%s user=%s text=%s",
+                    "非指令生图交给主链工具处理: mode=%s user=%s text=%s",
                     mode,
                     _single_line(user_id, 40),
                     _single_line(text, 160),
@@ -5156,7 +5158,7 @@ class CommandHandlersMixin:
             if not missing:
                 raise
             logger.warning(
-                "[PrivateCompanion] 自然语言生图参考图检测缺少可选模型依赖，已按无参考图继续: module=%s err=%s",
+                "自然语言生图参考图检测缺少可选模型依赖，已按无参考图继续: module=%s err=%s",
                 missing,
                 _single_line(exc, 160),
             )
@@ -5165,7 +5167,7 @@ class CommandHandlersMixin:
         if not intent:
             if directed:
                 logger.info(
-                    "[PrivateCompanion] 定向自然语言生图未命中意图: user=%s has_reference=%s text=%s",
+                    "定向自然语言生图未命中意图: user=%s has_reference=%s text=%s",
                     _single_line(user_id, 40),
                     has_reference,
                     _single_line(text, 180),
@@ -5177,7 +5179,7 @@ class CommandHandlersMixin:
         if group_photo_requested and intent.get("kind") != "edit":
             intent["kind"] = "selfie"
         logger.info(
-            "[PrivateCompanion] 自然语言生图命中: user=%s kind=%s has_reference=%s prompt=%s raw=%s",
+            "自然语言生图命中: user=%s kind=%s has_reference=%s prompt=%s raw=%s",
             _single_line(user_id, 40),
             _single_line(intent.get("kind"), 30),
             has_reference,
@@ -5244,7 +5246,7 @@ class CommandHandlersMixin:
                 if not missing:
                     raise
                 logger.warning(
-                    "[PrivateCompanion] 自然语言生图引用来源解析缺少可选模型依赖: module=%s err=%s",
+                    "自然语言生图引用来源解析缺少可选模型依赖: module=%s err=%s",
                     missing,
                     _single_line(exc, 160),
                 )
@@ -5260,7 +5262,7 @@ class CommandHandlersMixin:
                 event.stop_event()
                 return True
             logger.info(
-                "[PrivateCompanion] 自然语言生图引用来源解析: user=%s kind=%s saw_image=%s label=%s path=%s exists=%s",
+                "自然语言生图引用来源解析: user=%s kind=%s saw_image=%s label=%s path=%s exists=%s",
                 _single_line(user_id, 40),
                 _single_line(reference_kind, 30),
                 saw_image,
@@ -5342,7 +5344,7 @@ class CommandHandlersMixin:
             if not missing:
                 raise
             logger.warning(
-                "[PrivateCompanion] 自然语言生图后端缺少可选模型依赖: module=%s err=%s",
+                "自然语言生图后端缺少可选模型依赖: module=%s err=%s",
                 missing,
                 _single_line(exc, 160),
             )
@@ -5350,7 +5352,7 @@ class CommandHandlersMixin:
             event.stop_event()
             return True
         logger.info(
-            "[PrivateCompanion] 自然语言生图结果: user=%s backend=%s ok=%s note=%s image=%s",
+            "自然语言生图结果: user=%s backend=%s ok=%s note=%s image=%s",
             _single_line(user_id, 40),
             _single_line(backend_name, 80),
             bool(image_path),
@@ -5468,7 +5470,7 @@ class CommandHandlersMixin:
             if not missing:
                 raise
             logger.warning(
-                "[PrivateCompanion] 指令生图参考图检测缺少可选模型依赖，已按无参考图继续: module=%s err=%s",
+                "指令生图参考图检测缺少可选模型依赖，已按无参考图继续: module=%s err=%s",
                 missing,
                 _single_line(exc, 160),
             )
@@ -5552,7 +5554,7 @@ class CommandHandlersMixin:
                 if not missing:
                     raise
                 logger.warning(
-                    "[PrivateCompanion] 指令生图引用来源解析缺少可选模型依赖: module=%s err=%s",
+                    "指令生图引用来源解析缺少可选模型依赖: module=%s err=%s",
                     missing,
                     _single_line(exc, 160),
                 )
@@ -5568,7 +5570,7 @@ class CommandHandlersMixin:
                 event.stop_event()
                 return True
             logger.info(
-                "[PrivateCompanion] 指令生图引用来源解析: user=%s kind=%s saw_image=%s label=%s path=%s exists=%s",
+                "指令生图引用来源解析: user=%s kind=%s saw_image=%s label=%s path=%s exists=%s",
                 _single_line(user_id, 40),
                 _single_line(forced_kind, 30),
                 saw_image,
@@ -5654,7 +5656,7 @@ class CommandHandlersMixin:
             if not missing:
                 raise
             logger.warning(
-                "[PrivateCompanion] 指令生图后端缺少可选模型依赖: module=%s err=%s",
+                "指令生图后端缺少可选模型依赖: module=%s err=%s",
                 missing,
                 _single_line(exc, 160),
             )
@@ -5662,7 +5664,7 @@ class CommandHandlersMixin:
             event.stop_event()
             return True
         logger.info(
-            "[PrivateCompanion] 指令生图结果: user=%s action=%s backend=%s ok=%s note=%s image=%s",
+            "指令生图结果: user=%s action=%s backend=%s ok=%s note=%s image=%s",
             _single_line(user_id, 40),
             action_text,
             _single_line(backend_name, 80),
@@ -5791,7 +5793,7 @@ class CommandHandlersMixin:
                         await refresher(event, group_id, force=False)
                     except Exception as exc:
                         logger.debug(
-                            "[PrivateCompanion] 刷新群权限快照失败: group=%s error=%s",
+                            "刷新群权限快照失败: group=%s error=%s",
                             _single_line(group_id, 80),
                             _single_line(exc, 160),
                         )

--- a/config_migration.py
+++ b/config_migration.py
@@ -9,13 +9,15 @@ import re
 from pathlib import Path
 from typing import Any
 
-from astrbot.api import logger
 
 from .photo_generation_scope import (
     PHOTO_GENERATION_SCOPE_LIMIT_KEYS,
     legacy_photo_generation_scope_limits,
     normalize_photo_generation_scope_limit,
 )
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 LEGACY_PROACTIVE_ACTIONS_KEY = "enabled_proactive_actions"
 
@@ -178,7 +180,7 @@ def migrate_flat_config_into_schema_groups(
         return _migrate_flat_config_into_schema_groups(config, schema_path=schema_path, logger=logger, save=save)
     except Exception as exc:
         if logger is not None:
-            logger.warning("[PrivateCompanion] 配置分组迁移失败，已跳过且不影响插件加载: %s", _single_line(exc, 160))
+            logger.warning("配置分组迁移失败，已跳过且不影响插件加载: %s", _single_line(exc, 160))
         return 0
 
 
@@ -347,7 +349,7 @@ def _migrate_flat_config_into_schema_groups(
     if not changed:
         return 0
     if logger is not None:
-        logger.info("[PrivateCompanion] 已将旧版扁平配置迁移到新版分组配置: %s 项", len(changed))
+        logger.info("已将旧版扁平配置迁移到新版分组配置: %s 项", len(changed))
     if save:
         _save_config_after_schema_migration(config, logger=logger)
     return len(changed)
@@ -1129,7 +1131,7 @@ def _schema_group_items(schema_path: Path, *, logger: Any | None = None) -> dict
         raw = json.loads(schema_path.read_text(encoding="utf-8"))
     except Exception as exc:
         if logger is not None:
-            logger.debug("[PrivateCompanion] 读取配置 schema 用于分组迁移失败: %s", exc)
+            logger.debug("读取配置 schema 用于分组迁移失败: %s", exc)
         return mapping
     if not isinstance(raw, dict):
         return mapping
@@ -1203,7 +1205,7 @@ def _save_config_after_schema_migration(config: Any, *, logger: Any | None = Non
             if callable(close):
                 close()
             if logger is not None:
-                logger.debug("[PrivateCompanion] config migration async save skipped: no event loop")
+                logger.debug("config migration async save skipped: no event loop")
             return True
         tasks = getattr(config, "_private_companion_config_save_tasks", None)
         if not isinstance(tasks, set):
@@ -1223,7 +1225,7 @@ def _save_config_after_schema_migration(config: Any, *, logger: Any | None = Non
                 pass
             except Exception as exc:
                 if logger is not None:
-                    logger.warning("[PrivateCompanion] config migration async save failed: %s", _single_line(exc, 160))
+                    logger.warning("config migration async save failed: %s", _single_line(exc, 160))
             finally:
                 if isinstance(tasks, set):
                     tasks.discard(done_task)
@@ -1246,7 +1248,7 @@ def _save_config_after_schema_migration(config: Any, *, logger: Any | None = Non
                     if callable(close):
                         close()
                     if logger is not None:
-                        logger.debug("[PrivateCompanion] 配置分组迁移已写入运行态，当前无事件循环可异步保存")
+                        logger.debug("配置分组迁移已写入运行态，当前无事件循环可异步保存")
             return
         except TypeError:
             continue
@@ -1264,14 +1266,14 @@ def _save_config_after_schema_migration(config: Any, *, logger: Any | None = Non
                     return
                 except Exception as retry_exc:
                     if logger is not None:
-                        logger.warning("[PrivateCompanion] 重试保存配置分组迁移结果失败: %s", _single_line(retry_exc, 160))
+                        logger.warning("重试保存配置分组迁移结果失败: %s", _single_line(retry_exc, 160))
                     return
             if logger is not None:
-                logger.warning("[PrivateCompanion] 保存配置分组迁移结果失败: %s", _single_line(exc, 160))
+                logger.warning("保存配置分组迁移结果失败: %s", _single_line(exc, 160))
             return
         except Exception as exc:
             if logger is not None:
-                logger.warning("[PrivateCompanion] 保存配置分组迁移结果失败: %s", _single_line(exc, 160))
+                logger.warning("保存配置分组迁移结果失败: %s", _single_line(exc, 160))
             return
 
 
@@ -1326,7 +1328,7 @@ def _ensure_config_parent_dir(
             changed = True
         except Exception as exc:
             if logger is not None:
-                logger.debug("[PrivateCompanion] 创建配置目录失败: %s", _single_line(exc, 160))
+                logger.debug("创建配置目录失败: %s", _single_line(exc, 160))
     return changed
 
 

--- a/content_companion_bridge.py
+++ b/content_companion_bridge.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from typing import Any
 
-from astrbot.api import logger
 
 from .helpers import _single_line
 from .external_bridge_resolver import resolve_external_bridge
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 class ContentCompanionBridgeMixin:
@@ -31,7 +33,7 @@ class ContentCompanionBridgeMixin:
         try:
             value = getter()
         except Exception as exc:
-            logger.warning("[PrivateCompanion] 独立创作能力查询失败: %s", _single_line(exc, 160))
+            logger.warning("独立创作能力查询失败: %s", _single_line(exc, 160))
             return {"installed": True, "enabled": False, "available": False, "reason": "status_query_failed"}
         return dict(value) if isinstance(value, dict) else {"installed": True, "enabled": False, "available": False}
 
@@ -51,7 +53,7 @@ class ContentCompanionBridgeMixin:
             self._content_companion_delegating = True
             return await handler(self, *args, **kwargs)
         except Exception as exc:
-            logger.warning("[PrivateCompanion] 独立创作操作失败: operation=%s error=%s", operation, _single_line(exc, 160))
+            logger.warning("独立创作操作失败: operation=%s error=%s", operation, _single_line(exc, 160))
             return None
         finally:
             self._content_companion_delegating = False

--- a/core_store.py
+++ b/core_store.py
@@ -36,7 +36,7 @@ from typing import Any
 from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlunparse
 from xml.etree import ElementTree as ET
 
-from astrbot.api import AstrBotConfig, logger
+from astrbot.api import AstrBotConfig
 from astrbot.api.event import AstrMessageEvent, MessageChain, filter
 try:
     from astrbot.api.message_components import At, Image, Plain, Record, Reply
@@ -157,6 +157,9 @@ from .planning import (
     normalize_story_plan,
     pick_detail_segment,
 )
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 DEFAULT_AI_DAILY_NEWS_SOURCE = "B站 AI早报|bilibili:285286947"
@@ -666,7 +669,7 @@ class CoreStoreMixin:
             os.replace(temporary, path)
         except OSError as exc:
             logger.warning(
-                "[PrivateCompanion] 后端状态标记写入失败，不影响当前存储: %s",
+                "后端状态标记写入失败，不影响当前存储: %s",
                 _single_line(exc, 160),
             )
         finally:
@@ -706,7 +709,7 @@ class CoreStoreMixin:
             if invalid_reason:
                 sqlite_path = default_sqlite_path
                 logger.warning(
-                    "[PrivateCompanion] SQLite 数据文件路径无效，已回退默认路径: configured=%s reason=%s fallback=%s",
+                    "SQLite 数据文件路径无效，已回退默认路径: configured=%s reason=%s fallback=%s",
                     configured_sqlite_path,
                     invalid_reason,
                     default_sqlite_path,
@@ -803,7 +806,7 @@ class CoreStoreMixin:
                             next_manager.backend.save_store(deepcopy(source_data))
                         self._advance_data_save_write_generation()
                     logger.info(
-                        "[PrivateCompanion] 已从 %s 后端迁移到 %s 后端",
+                        "已从 %s 后端迁移到 %s 后端",
                         migration_source_backend,
                         backend,
                     )
@@ -834,7 +837,7 @@ class CoreStoreMixin:
                     )
                 except Exception as restore_exc:
                     logger.error(
-                        "[PrivateCompanion] Failed to restore storage switch target: %s",
+                        "Failed to restore storage switch target: %s",
                         _single_line(restore_exc, 200),
                     )
             if reload_data and previous_manager is not None:
@@ -877,14 +880,14 @@ class CoreStoreMixin:
                             await result
                         return True
                     except Exception as retry_exc:
-                        logger.warning("[PrivateCompanion] 自动保存配置重试失败: %s", _single_line(retry_exc, 120))
+                        logger.warning("自动保存配置重试失败: %s", _single_line(retry_exc, 120))
                         return False
-                logger.warning("[PrivateCompanion] 自动保存配置失败: %s", _single_line(exc, 120))
+                logger.warning("自动保存配置失败: %s", _single_line(exc, 120))
                 return False
             except Exception as exc:
-                logger.warning("[PrivateCompanion] 自动保存配置失败: %s", _single_line(exc, 120))
+                logger.warning("自动保存配置失败: %s", _single_line(exc, 120))
                 return False
-        logger.warning("[PrivateCompanion] 当前配置对象没有可用保存方法，本次修改未落盘")
+        logger.warning("当前配置对象没有可用保存方法，本次修改未落盘")
         return False
 
     def _set_runtime_bool_config(self, key: str, value: bool) -> None:
@@ -915,7 +918,7 @@ class CoreStoreMixin:
                     token = getattr(self, "_activate_persona_id", lambda _pid: None)(persona_id)
                     if token is None:
                         logger.info(
-                            "[PrivateCompanion] 跳过尚未创建独立配置的人格启动任务: persona=%s",
+                            "跳过尚未创建独立配置的人格启动任务: persona=%s",
                             _single_line(persona_id, 96),
                         )
                         continue
@@ -927,7 +930,7 @@ class CoreStoreMixin:
                             await self._maybe_settle_skill_growth()
                         except Exception as exc:
                             logger.warning(
-                                "[PrivateCompanion] 启动初始化人格失败，继续处理其他人格: persona=%s error=%s",
+                                "启动初始化人格失败，继续处理其他人格: persona=%s error=%s",
                                 _single_line(persona_id, 96),
                                 _single_line(exc, 160),
                             )
@@ -943,7 +946,7 @@ class CoreStoreMixin:
             await self._ensure_daily_diary()
             await self._maybe_settle_skill_growth()
         except Exception as e:
-            logger.warning(f"[PrivateCompanion] 启动时生成今日日志失败: {e}", exc_info=True)
+            logger.warning(f"启动时生成今日日志失败: {e}", exc_info=True)
 
     def _has_today_diary(self) -> bool:
         diaries = self.data.get("bot_diaries", [])
@@ -1385,7 +1388,7 @@ class CoreStoreMixin:
             else ""
         )
         logger.info(
-            "[PrivateCompanion] Store safety cleanup: stage=%s fields=%s%s",
+            "Store safety cleanup: stage=%s fields=%s%s",
             key,
             changed,
             suffix,
@@ -1643,12 +1646,12 @@ class CoreStoreMixin:
             recovered = max(0, int(recoverer(data) or 0))
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanion] 启动恢复夹层本地书页失败，已保留现有存储: %s",
+                "启动恢复夹层本地书页失败，已保留现有存储: %s",
                 _single_line(exc, 160),
             )
             return 0
         if recovered:
-            logger.warning("[PrivateCompanion] 已根据本地书页和删除记录校准夹层书库: changed=%s", recovered)
+            logger.warning("已根据本地书页和删除记录校准夹层书库: changed=%s", recovered)
         return recovered
 
     def _persist_startup_maintenance_sync(
@@ -1749,11 +1752,11 @@ class CoreStoreMixin:
                 compacted = self._compact_store_history_inplace(data)
                 bookshelf_recovered = self._recover_bookshelf_after_load(data)
                 if changed:
-                    logger.warning("[PrivateCompanion] 启动读取数据时清理非标准控制标签: fields=%s", changed)
+                    logger.warning("启动读取数据时清理非标准控制标签: fields=%s", changed)
                 if repeat_changed:
-                    logger.warning("[PrivateCompanion] 启动读取数据时压缩主动候选重复计数: items=%s", repeat_changed)
+                    logger.warning("启动读取数据时压缩主动候选重复计数: items=%s", repeat_changed)
                 if compacted:
-                    logger.info("[PrivateCompanion] 启动读取数据时压缩历史存储: %s", compacted)
+                    logger.info("启动读取数据时压缩历史存储: %s", compacted)
                 self._persist_startup_maintenance_sync(
                     manager,
                     before_maintenance,
@@ -1767,7 +1770,7 @@ class CoreStoreMixin:
                 return data
             except Exception as exc:
                 logger.error(
-                    "[PrivateCompanion] StoreManager 读取失败，为避免用空数据覆盖原存储，已中止加载: %s",
+                    "StoreManager 读取失败，为避免用空数据覆盖原存储，已中止加载: %s",
                     _single_line(exc, 200),
                 )
                 raise
@@ -1784,15 +1787,15 @@ class CoreStoreMixin:
             compacted = self._compact_store_history_inplace(data)
             self._recover_bookshelf_after_load(data)
             if changed:
-                logger.warning("[PrivateCompanion] 启动读取 JSON 时清理非标准控制标签: fields=%s", changed)
+                logger.warning("启动读取 JSON 时清理非标准控制标签: fields=%s", changed)
             if repeat_changed:
-                logger.warning("[PrivateCompanion] 启动读取 JSON 时压缩主动候选重复计数: items=%s", repeat_changed)
+                logger.warning("启动读取 JSON 时压缩主动候选重复计数: items=%s", repeat_changed)
             if compacted:
-                logger.info("[PrivateCompanion] 启动读取 JSON 时压缩历史存储: %s", compacted)
+                logger.info("启动读取 JSON 时压缩历史存储: %s", compacted)
             return data
         except Exception as exc:
             logger.error(
-                "[PrivateCompanion] 读取已有 JSON 数据失败，为避免覆盖原文件，已中止加载: %s",
+                "读取已有 JSON 数据失败，为避免覆盖原文件，已中止加载: %s",
                 _single_line(exc, 200),
             )
             raise
@@ -1964,7 +1967,7 @@ class CoreStoreMixin:
                         manager.export_current_to_json(mirror)
                     except Exception as exc:
                         logger.debug(
-                            "[PrivateCompanion] SQLite 快照镜像 JSON 写出失败: %s",
+                            "SQLite 快照镜像 JSON 写出失败: %s",
                             _single_line(exc, 160),
                         )
                 else:
@@ -2500,7 +2503,7 @@ class CoreStoreMixin:
                 pass
             except Exception as exc:
                 logger.debug(
-                    "[PrivateCompanion] Waiting for the default incremental writer "
+                    "Waiting for the default incremental writer "
                     "during shutdown failed: %s",
                     _single_line(exc, 160),
                 )
@@ -2945,7 +2948,7 @@ class CoreStoreMixin:
                     except Exception as exc:
                         failures += 1
                         logger.warning(
-                            "[PrivateCompanion] Delayed data save failed: %s",
+                            "Delayed data save failed: %s",
                             _single_line(exc, 160),
                         )
                         if self._save_is_stopping():
@@ -2993,7 +2996,7 @@ class CoreStoreMixin:
                     except Exception as exc:
                         failures += 1
                         logger.warning(
-                            "[PrivateCompanion] Delayed persona data save failed: "
+                            "Delayed persona data save failed: "
                             "persona=%s error=%s",
                             persona_id,
                             _single_line(exc, 160),
@@ -3219,7 +3222,7 @@ class CoreStoreMixin:
                 except Exception as exc:
                     self.data["daily_diary_postprocess_error"] = _single_line(exc, 180)
                     logger.warning(
-                        "[PrivateCompanion] 重建今日日记已保存,但梦境碎片合并失败: %s",
+                        "重建今日日记已保存,但梦境碎片合并失败: %s",
                         _single_line(exc, 180),
                     )
                 story_plan = diary.get("story_plan") if isinstance(diary, dict) else None
@@ -3240,7 +3243,7 @@ class CoreStoreMixin:
                     await outfit_generator(diary)
                 except Exception as exc:
                     logger.warning(
-                        "[PrivateCompanion] 重建今日日记已保存,但每日穿搭照片生成失败: %s",
+                        "重建今日日记已保存,但每日穿搭照片生成失败: %s",
                         _single_line(exc, 180),
                     )
         return state, plan, diary
@@ -3921,7 +3924,7 @@ class CoreStoreMixin:
                 users.pop(raw_user_id, None)
                 transport_changed = True
                 logger.info(
-                    "[PrivateCompanion] 已归一旧私聊 UMO 用户键: old=%s user=%s",
+                    "已归一旧私聊 UMO 用户键: old=%s user=%s",
                     _single_line(raw_id, 120),
                     _single_line(canonical_id, 80),
                 )
@@ -4296,7 +4299,7 @@ class CoreStoreMixin:
 
         if removed:
             logger.info(
-                "[PrivateCompanion] 已清理群聊链路遗留的私聊占位记录: count=%s ids=%s",
+                "已清理群聊链路遗留的私聊占位记录: count=%s ids=%s",
                 len(removed),
                 ",".join(removed[:12]),
             )
@@ -4598,7 +4601,7 @@ class CoreStoreMixin:
                         "dual_write": "failed",
                     })
                 logger.warning(
-                    "[PrivateCompanion] REQ-041 关系双写失败，已暂停新读切换并保留 legacy 写入: %s",
+                    "REQ-041 关系双写失败，已暂停新读切换并保留 legacy 写入: %s",
                     _single_line(exc, 160),
                 )
         if result.get("changed") or score_migration.get("changed"):
@@ -5285,7 +5288,7 @@ class CoreStoreMixin:
                 if not bool(getattr(self, "_empty_group_whitelist_warning_logged", False)):
                     self._empty_group_whitelist_warning_logged = True
                     logger.warning(
-                        "[PrivateCompanion] 群聊观察已开启但白名单为空,当前不会观察任何群；"
+                        "群聊观察已开启但白名单为空,当前不会观察任何群；"
                         "请在群聊观测页把目标群加入白名单,或改用黑名单模式: first_group=%s",
                         _single_line(group_id, 80) or "-",
                     )

--- a/creative.py
+++ b/creative.py
@@ -15,7 +15,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from astrbot.api import logger
 
 from .constants import (
     CREATIVE_MEMORY_MAX_ENTRIES,
@@ -29,6 +28,9 @@ from .constants import (
 )
 from .helpers import _now_ts, _path_text, _safe_float, _safe_int, _single_line, _text_similarity
 from .persona_config import runtime_persona_setting
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 def _persona_provider_id(owner: Any, canonical_key: str, legacy_attr: str, quick_role: str) -> str:
@@ -372,7 +374,7 @@ class CreativeMixin:
             cleaned_projects += 1
         if removed_chunks:
             logger.info(
-                "[PrivateCompanion] 已清理资料柜旧版固定兜底片段: projects=%s chunks=%s memories=%s",
+                "已清理资料柜旧版固定兜底片段: projects=%s chunks=%s memories=%s",
                 cleaned_projects,
                 removed_chunks,
                 removed_memories,
@@ -694,7 +696,7 @@ class CreativeMixin:
                     max_chars=900,
                 )
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 创作立项 我会牢牢记住你 上下文读取失败: %s", _single_line(exc, 120))
+                logger.debug("创作立项 我会牢牢记住你 上下文读取失败: %s", _single_line(exc, 120))
         prompt = f"""
  你是一个拟人化 Bot 的私人创作状态生成器。这个 Bot/角色会因为一个生活小事、日记碎片或梦境灵感,突然想开一个自己的创作项目。
 
@@ -831,7 +833,7 @@ class CreativeMixin:
                     max_chars=850,
                 )
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 创作大纲 我会牢牢记住你 上下文读取失败: %s", _single_line(exc, 120))
+                logger.debug("创作大纲 我会牢牢记住你 上下文读取失败: %s", _single_line(exc, 120))
         prompt = f"""
 你在为一个私人创作项目安排本次要写的一小段,先给出简短大纲。
 
@@ -915,7 +917,7 @@ class CreativeMixin:
                     max_chars=850,
                 )
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 创作审稿 我会牢牢记住你 上下文读取失败: %s", _single_line(exc, 120))
+                logger.debug("创作审稿 我会牢牢记住你 上下文读取失败: %s", _single_line(exc, 120))
         prompt = f"""
 你是一个严格但懂文风的审稿人。检查这段私人创作片段是否满足：贴合人格、推进作品、避免重复。
 
@@ -1003,7 +1005,7 @@ class CreativeMixin:
                     max_chars=700,
                 )
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 创作抽取 我会牢牢记住你 上下文读取失败: %s", _single_line(exc, 120))
+                logger.debug("创作抽取 我会牢牢记住你 上下文读取失败: %s", _single_line(exc, 120))
         prompt = f"""
 整理一个长期创作项目刚写出的新片段,提取对后续续写最有用的结构化信息。
 
@@ -1314,7 +1316,7 @@ class CreativeMixin:
                     max_chars=1000,
                 )
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 创作续写 我会牢牢记住你 上下文读取失败: %s", _single_line(exc, 120))
+                logger.debug("创作续写 我会牢牢记住你 上下文读取失败: %s", _single_line(exc, 120))
 
         async def _do_generate(extra_notice: str = "") -> str:
             story_time = _single_line(story_bible.get("story_time"), 60)
@@ -1477,7 +1479,7 @@ class CreativeMixin:
             del projects[:-20]
             self.data["creative_projects"] = projects
             self._save_data_sync(sections={"creative_projects"})
-        logger.info("[PrivateCompanion] 新增创作项目: %s / %s", project.get("work_type"), project.get("title"))
+        logger.info("新增创作项目: %s / %s", project.get("work_type"), project.get("title"))
         return True
 
     @staticmethod
@@ -1801,7 +1803,7 @@ class CreativeMixin:
                 await asyncio.to_thread(shutil.copy2, source, target)
             return str(target)
         except Exception as exc:
-            logger.warning("[PrivateCompanion] 创作封面保存失败: project=%s error=%s", project_id, _single_line(exc, 160))
+            logger.warning("创作封面保存失败: project=%s error=%s", project_id, _single_line(exc, 160))
             return ""
 
     async def _maybe_generate_creative_cover(self, project_id: str, *, force: bool = False) -> dict[str, Any] | None:
@@ -1881,7 +1883,7 @@ class CreativeMixin:
                         )
                     except Exception as exc:
                         logger.warning(
-                            "[PrivateCompanion] 创作封面读取人物参考图失败: project=%s error=%s",
+                            "创作封面读取人物参考图失败: project=%s error=%s",
                             project_id,
                             _single_line(exc, 160),
                         )
@@ -1951,12 +1953,12 @@ class CreativeMixin:
                     project["cover_generation_status"] = "ready"
                     project["cover_generation_error"] = ""
                     project["cover_generation_next_retry_at"] = 0
-                    logger.info("[PrivateCompanion] 创作封面已生成: project=%s backend=%s path=%s", project_id, _single_line(backend, 80), _single_line(stored_path, 180))
+                    logger.info("创作封面已生成: project=%s backend=%s path=%s", project_id, _single_line(backend, 80), _single_line(stored_path, 180))
                 else:
                     project["cover_generation_status"] = "failed"
                     project["cover_generation_error"] = _single_line(note, 220) or "生图失败"
                     project["cover_generation_next_retry_at"] = now + min(24, max(3, attempt_number * 3)) * 3600
-                    logger.info("[PrivateCompanion] 创作封面未生成: project=%s attempt=%s error=%s", project_id, attempt_number, _single_line(note, 180))
+                    logger.info("创作封面未生成: project=%s attempt=%s error=%s", project_id, attempt_number, _single_line(note, 180))
                 self._save_data_sync(sections={"creative_projects"})
                 return dict(project)
 
@@ -1995,7 +1997,7 @@ class CreativeMixin:
                     reason=f"创作生成失败: {_single_line(exc, 140)}",
                 )
                 logger.warning(
-                    "[PrivateCompanion] 创作推进失败,已保留项目并退避: project=%s failures=%s delay=%sm error=%s",
+                    "创作推进失败,已保留项目并退避: project=%s failures=%s delay=%sm error=%s",
                     _single_line(project.get("id"), 32),
                     _safe_int(project.get("advance_failure_count"), 1, 1),
                     delay_minutes,
@@ -2010,7 +2012,7 @@ class CreativeMixin:
                     reason="生成结果为空、重复或未通过质量复核",
                 )
                 logger.info(
-                    "[PrivateCompanion] 创作片段未通过质量门,本轮不写入资料柜: project=%s failures=%s delay=%sm",
+                    "创作片段未通过质量门,本轮不写入资料柜: project=%s failures=%s delay=%sm",
                     _single_line(project.get("id"), 32),
                     _safe_int(project.get("advance_failure_count"), 1, 1),
                     delay_minutes,

--- a/daily_review.py
+++ b/daily_review.py
@@ -15,13 +15,15 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 
-from astrbot.api import logger
 
 from .helpers import _redact_outbound_secrets, _safe_float, _safe_int, _single_line
 from .conversation_injection_plan import (
     PLACEMENT_DYNAMIC_SYSTEM,
     get_conversation_injection_plan,
 )
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 class DailyReviewMixin:
@@ -90,7 +92,7 @@ class DailyReviewMixin:
                 visit(group_node)
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanion] 每日巡视读取配置 Schema 失败: %s",
+                "每日巡视读取配置 Schema 失败: %s",
                 _single_line(exc, 180),
             )
         self._daily_review_schema_index_cache = index
@@ -1366,7 +1368,7 @@ class DailyReviewMixin:
                     self._save_data_sync(sections={"daily_review_last_attempt"})
                 if force:
                     raise
-                logger.warning("[PrivateCompanion] 每日终盘巡视失败，将在冷却后重试: %s", safe_error)
+                logger.warning("每日终盘巡视失败，将在冷却后重试: %s", safe_error)
                 return None
 
             async with self._data_lock:
@@ -1389,7 +1391,7 @@ class DailyReviewMixin:
                 }
                 self._save_data_sync(sections={"daily_review_reports", "daily_review_active_guidance", "daily_review_last_attempt", "daily_review_completed_day"})
             logger.info(
-                "[PrivateCompanion] 每日终盘巡视完成: date=%s score=%s findings=%s guidance=%s",
+                "每日终盘巡视完成: date=%s score=%s findings=%s guidance=%s",
                 date_key,
                 report.get("health_score"),
                 len(report.get("findings", [])),
@@ -1472,7 +1474,7 @@ class DailyReviewMixin:
                 raise
             except Exception as exc:
                 logger.warning(
-                    "[PrivateCompanion] 每日终盘巡视循环异常，将在 30 分钟后重试: %s",
+                    "每日终盘巡视循环异常，将在 30 分钟后重试: %s",
                     self._daily_review_safe_text(exc, 180),
                 )
                 await asyncio.sleep(30 * 60)

--- a/daily_state.py
+++ b/daily_state.py
@@ -34,7 +34,7 @@ from typing import Any, Iterable
 from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlunparse
 from xml.etree import ElementTree as ET
 
-from astrbot.api import AstrBotConfig, logger
+from astrbot.api import AstrBotConfig
 from astrbot.api.event import AstrMessageEvent, MessageChain, filter
 try:
     from astrbot.api.message_components import At, Image, Plain, Record, Reply
@@ -133,6 +133,9 @@ from .planning import (
     normalize_story_plan,
     pick_detail_segment,
 )
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 DEFAULT_AI_DAILY_NEWS_SOURCE = "B站 AI早报|bilibili:285286947"
@@ -653,7 +656,7 @@ class DailyStateMixin(DailyStateTickMixin):
                 await outfit_generator()
             except Exception as exc:
                 logger.warning(
-                    "[PrivateCompanion] 今日日程已保存,但每日穿搭照片生成失败: %s",
+                    "今日日程已保存,但每日穿搭照片生成失败: %s",
                     _single_line(exc, 180),
                 )
         await self._ensure_daily_news_reading(force=force)
@@ -712,7 +715,7 @@ class DailyStateMixin(DailyStateTickMixin):
             if force:
                 raise
             logger.warning(
-                "[PrivateCompanion] 生成今日日记失败,已进入30分钟冷却避免重复请求: %s",
+                "生成今日日记失败,已进入30分钟冷却避免重复请求: %s",
                 _single_line(exc, 180),
             )
             return None
@@ -734,7 +737,7 @@ class DailyStateMixin(DailyStateTickMixin):
             )
             if deleted_now and (not force or deleted_during_generation):
                 logger.info(
-                    "[PrivateCompanion] 日记生成期间该日期被手动删除，已丢弃生成结果: request_day=%s diary_day=%s force=%s",
+                    "日记生成期间该日期被手动删除，已丢弃生成结果: request_day=%s diary_day=%s force=%s",
                     request_day,
                     diary_day,
                     force,
@@ -762,12 +765,12 @@ class DailyStateMixin(DailyStateTickMixin):
                 diaries = migrated_diaries
                 self.data["bot_diaries"] = diaries
                 logger.info(
-                    "[PrivateCompanion] 已无损迁移旧字典日记存储: entries=%s",
+                    "已无损迁移旧字典日记存储: entries=%s",
                     len(diaries),
                 )
             elif not isinstance(diaries, list):
                 logger.error(
-                    "[PrivateCompanion] 日记记录结构异常，已保留原数据并放弃写入本次生成结果: storage=%s",
+                    "日记记录结构异常，已保留原数据并放弃写入本次生成结果: storage=%s",
                     type(diaries).__name__,
                 )
                 return None
@@ -819,7 +822,7 @@ class DailyStateMixin(DailyStateTickMixin):
             except Exception as exc:
                 self.data["daily_diary_postprocess_error"] = _single_line(exc, 180)
                 logger.warning(
-                    "[PrivateCompanion] 今日日记已保存,但梦境碎片合并失败: %s",
+                    "今日日记已保存,但梦境碎片合并失败: %s",
                     _single_line(exc, 180),
                 )
             dream_fragments = diary.get("dream_fragments", []) if isinstance(diary, dict) else []
@@ -853,7 +856,7 @@ class DailyStateMixin(DailyStateTickMixin):
             try:
                 await diary_recorder(diary)
             except Exception as exc:
-                logger.debug("[PrivateCompanion] Bot Personal 日记归档失败: %s", _single_line(exc, 160))
+                logger.debug("Bot Personal 日记归档失败: %s", _single_line(exc, 160))
         if memory_payload:
             try:
                 await self._memory_companion_record_dream_fragment(**memory_payload)
@@ -939,14 +942,14 @@ class DailyStateMixin(DailyStateTickMixin):
                         retry_after = ""
                 if failure_is_current:
                     logger.warning(
-                        "[PrivateCompanion] 日程细化生成失败,已标记为可重试: segment=%s retry_after=%s error=%s",
+                        "日程细化生成失败,已标记为可重试: segment=%s retry_after=%s error=%s",
                         _single_line(segment.get("key"), 80),
                         retry_after,
                         _single_line(exc, 180),
                     )
                 else:
                     logger.info(
-                        "[PrivateCompanion] 日程细化失败结果已过期,不再回写: segment=%s error=%s",
+                        "日程细化失败结果已过期,不再回写: segment=%s error=%s",
                         _single_line(segment.get("key"), 80),
                         _single_line(exc, 180),
                     )
@@ -1220,7 +1223,7 @@ class DailyStateMixin(DailyStateTickMixin):
                 occurred_at=_single_line(entry.get("occurred_at"), 80),
             )
         except Exception as exc:
-            logger.debug("[PrivateCompanion] MemoryCompanion 进食记忆写入失败: %s", _single_line(exc, 120))
+            logger.debug("MemoryCompanion 进食记忆写入失败: %s", _single_line(exc, 120))
             return
         entry["memory_recorded"] = True
         entry["memory_id"] = _single_line(memory_id, 120)
@@ -1635,7 +1638,7 @@ class DailyStateMixin(DailyStateTickMixin):
                 label = self._schedule_segment_label(segment)
             return True, f"已重新细化：{label}", detail
         except Exception as exc:
-            logger.warning("[PrivateCompanion] 聊天命令局部重生成日程细化失败: %s", exc, exc_info=True)
+            logger.warning("聊天命令局部重生成日程细化失败: %s", exc, exc_info=True)
             async with self._data_lock:
                 enhanced = self.data.setdefault("detail_enhanced_segments", {})
                 if isinstance(enhanced, dict) and key and generation_id and self._detail_generation_is_current(segment, generation_id):
@@ -2833,7 +2836,7 @@ class DailyStateMixin(DailyStateTickMixin):
         if callable(meta_leak_checker) and (
             meta_leak_checker(text) or meta_leak_checker(topic) or meta_leak_checker(motive)
         ):
-            logger.warning("[PrivateCompanion] 跳过记录疑似工具循环摘要的主动话题记忆")
+            logger.warning("跳过记录疑似工具循环摘要的主动话题记忆")
             return
         signature = self._proactive_topic_signature(text, topic, motive)
         if not signature:
@@ -5004,7 +5007,7 @@ class DailyStateMixin(DailyStateTickMixin):
                 )
             if offered:
                 logger.info(
-                    "[PrivateCompanion] 环境突变已进入即时主动候选: kind=%s targets=%s topic=%s",
+                    "环境突变已进入即时主动候选: kind=%s targets=%s topic=%s",
                     _single_line(change.get("kind"), 40),
                     offered,
                     _single_line(change.get("topic"), 80),
@@ -5068,7 +5071,7 @@ class DailyStateMixin(DailyStateTickMixin):
                         prompt = text
                         source = "screen_companion"
                 except Exception as e:
-                    logger.debug(f"[PrivateCompanion] 获取天气信息失败: {e}")
+                    logger.debug(f"获取天气信息失败: {e}")
         weather = {
             "date": today,
             "prompt": prompt,
@@ -5265,7 +5268,7 @@ class DailyStateMixin(DailyStateTickMixin):
                 metadata={"注入位置": placement, "获取成功": valid},
             )
         logger.info(
-            "[PrivateCompanion] 当前天气查询已处理: session=%s success=%s source=%s location_visible=%s",
+            "当前天气查询已处理: session=%s success=%s source=%s location_visible=%s",
             _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             valid,
             _single_line(weather.get("source"), 40) if isinstance(weather, dict) else "none",
@@ -5332,7 +5335,7 @@ class DailyStateMixin(DailyStateTickMixin):
                         summary = raw_summary
                         source = "screen_companion_api"
                 except Exception as exc:
-                    logger.debug("[PrivateCompanion] 读取屏幕昨日结构化日记失败: %s", exc)
+                    logger.debug("读取屏幕昨日结构化日记失败: %s", exc)
             if not summary:
                 diary_storage = str(getattr(plugin, "diary_storage", "") or "").strip()
                 summary = self._load_screen_diary_summary_file(target_date, diary_storage)
@@ -5381,7 +5384,7 @@ class DailyStateMixin(DailyStateTickMixin):
                 data = json.load(f)
             return data if isinstance(data, dict) else {}
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 读取屏幕日记摘要文件失败: %s", exc)
+            logger.debug("读取屏幕日记摘要文件失败: %s", exc)
             return {}
 
     def _load_screen_diary_markdown_file(self, target_date: date, diary_dir: str = "") -> str:
@@ -5393,7 +5396,7 @@ class DailyStateMixin(DailyStateTickMixin):
         try:
             return path.read_text(encoding="utf-8")[:4000]
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 读取屏幕日记正文失败: %s", exc)
+            logger.debug("读取屏幕日记正文失败: %s", exc)
             return ""
 
     def _screen_diary_activity_label(self, text: Any) -> str:
@@ -5874,17 +5877,17 @@ class DailyStateMixin(DailyStateTickMixin):
                     allow_redirects=False,
                 ) as response:
                     if response.status != 200:
-                        logger.debug("[PrivateCompanion] 和风天气地点解析请求失败: %s", response.status)
+                        logger.debug("和风天气地点解析请求失败: %s", response.status)
                         return {}
                     try:
                         payload = await response.json()
                     except TypeError:
                         payload = await response.json(content_type=None)
         except asyncio.TimeoutError:
-            logger.debug("[PrivateCompanion] 和风天气地点解析请求超时")
+            logger.warning("和风天气地点解析请求超时")
             return {}
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 和风天气地点解析失败: %s", _single_line(exc, 160))
+            logger.debug("和风天气地点解析失败: %s", _single_line(exc, 160))
             return {}
         return self._parse_qweather_location_payload(payload)
 
@@ -5933,7 +5936,7 @@ class DailyStateMixin(DailyStateTickMixin):
                 try:
                     saver(sections={"qweather_location"})
                 except Exception as exc:
-                    logger.debug("[PrivateCompanion] 保存和风天气地点缓存失败: %s", _single_line(exc, 160))
+                    logger.debug("保存和风天气地点缓存失败: %s", _single_line(exc, 160))
 
         data_lock = getattr(self, "_data_lock", None)
         if isinstance(data_lock, asyncio.Lock):
@@ -6472,7 +6475,7 @@ class DailyStateMixin(DailyStateTickMixin):
                             "source": "qweather",
                         }
                     if response.status != 200:
-                        logger.debug("[PrivateCompanion] 和风天气预警请求失败: %s", response.status)
+                        logger.debug("和风天气预警请求失败: %s", response.status)
                         return {
                             "ok": False,
                             "alerts": [],
@@ -6486,10 +6489,10 @@ class DailyStateMixin(DailyStateTickMixin):
                         # not expose a content type; allow the documented JSON.
                         payload = await response.json(content_type=None)
         except asyncio.TimeoutError:
-            logger.debug("[PrivateCompanion] 和风天气预警请求超时")
+            logger.warning("和风天气预警请求超时")
             return {"ok": False, "alerts": [], "error": "timeout", "source": "qweather"}
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 和风天气预警获取失败: %s", _single_line(exc, 160))
+            logger.debug("和风天气预警获取失败: %s", _single_line(exc, 160))
             return {"ok": False, "alerts": [], "error": "request_failed", "source": "qweather"}
         parsed = self._parse_qweather_alert_payload(payload)
         parsed["source"] = "qweather"
@@ -6571,7 +6574,7 @@ class DailyStateMixin(DailyStateTickMixin):
                 try:
                     saver(sections={"weather_alerts"})
                 except Exception as exc:
-                    logger.debug("[PrivateCompanion] 保存天气预警缓存失败: %s", _single_line(exc, 160))
+                    logger.debug("保存天气预警缓存失败: %s", _single_line(exc, 160))
         return result
 
     def _weather_alert_time_ts(self, value: Any) -> float:
@@ -7254,17 +7257,17 @@ class DailyStateMixin(DailyStateTickMixin):
                     allow_redirects=False,
                 ) as response:
                     if response.status != 200:
-                        logger.debug("[PrivateCompanion] QWeather 实时天气请求失败: %s", response.status)
+                        logger.debug("QWeather 实时天气请求失败: %s", response.status)
                         return {"prompt": "", "source": ""}
                     try:
                         payload = await response.json()
                     except TypeError:
                         payload = await response.json(content_type=None)
         except asyncio.TimeoutError:
-            logger.debug("[PrivateCompanion] QWeather 实时天气请求超时")
+            logger.warning("QWeather 实时天气请求超时")
             return {"prompt": "", "source": ""}
         except Exception as exc:
-            logger.debug("[PrivateCompanion] QWeather 实时天气获取失败: %s", _single_line(exc, 160))
+            logger.debug("QWeather 实时天气获取失败: %s", _single_line(exc, 160))
             return {"prompt": "", "source": ""}
         parsed = self._parse_qweather_weather_payload(payload)
         if parsed.get("prompt"):
@@ -7302,11 +7305,11 @@ class DailyStateMixin(DailyStateTickMixin):
             async with aiohttp.ClientSession(timeout=timeout) as session:
                 async with session.get(url) as response:
                     if response.status != 200:
-                        logger.debug(f"[PrivateCompanion] Open-Meteo 天气请求失败: {response.status}")
+                        logger.debug(f"Open-Meteo 天气请求失败: {response.status}")
                         return {"prompt": "", "source": ""}
                     weather_data = await response.json()
         except Exception as e:
-            logger.debug(f"[PrivateCompanion] Open-Meteo 天气获取失败: {e}")
+            logger.debug(f"Open-Meteo 天气获取失败: {e}")
             return {"prompt": "", "source": ""}
         try:
             if not isinstance(weather_data, dict):
@@ -7340,11 +7343,11 @@ class DailyStateMixin(DailyStateTickMixin):
             async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
                 async with session.get(url) as response:
                     if response.status != 200:
-                        logger.debug(f"[PrivateCompanion] 高德天气请求失败: {response.status}")
+                        logger.debug(f"高德天气请求失败: {response.status}")
                         return {"prompt": "", "source": ""}
                     weather_data = await response.json()
         except Exception as e:
-            logger.debug(f"[PrivateCompanion] 高德天气获取失败: {e}")
+            logger.debug(f"高德天气获取失败: {e}")
             return {"prompt": "", "source": ""}
         try:
             if not isinstance(weather_data, dict) or str(weather_data.get("status")) != "1":
@@ -7382,11 +7385,11 @@ class DailyStateMixin(DailyStateTickMixin):
             async with aiohttp.ClientSession() as session:
                 async with session.get(url) as response:
                     if response.status != 200:
-                        logger.debug(f"[PrivateCompanion] 天气请求失败: {response.status}")
+                        logger.debug(f"天气请求失败: {response.status}")
                         return {"prompt": "", "source": ""}
                     weather_data = await response.json()
         except Exception as e:
-            logger.debug(f"[PrivateCompanion] 私有天气获取失败: {e}")
+            logger.debug(f"私有天气获取失败: {e}")
             return {"prompt": "", "source": ""}
         try:
             weather_desc = weather_data.get("weather", [{}])[0].get("description", "")
@@ -9499,7 +9502,7 @@ class DailyStateMixin(DailyStateTickMixin):
             if not keep_continuous_state:
                 self.data.pop("body_cycle_state", None)
             logger.info(
-                "[PrivateCompanion] 周期策略切换，已清理不兼容旧状态: mode=%s removed=%s",
+                "周期策略切换，已清理不兼容旧状态: mode=%s removed=%s",
                 desired_mode,
                 removed,
             )
@@ -9528,7 +9531,7 @@ class DailyStateMixin(DailyStateTickMixin):
                 )
                 kept.append(condition)
                 self._record_body_cycle_episode(condition)
-                logger.info("[PrivateCompanion] 六阶段周期策略首次启用，已从月经期第 1 天开始推进")
+                logger.info("六阶段周期策略首次启用，已从月经期第 1 天开始推进")
             return kept
 
         signature = self._advanced_cycle_offset_signature(offset)
@@ -9563,7 +9566,7 @@ class DailyStateMixin(DailyStateTickMixin):
         )
         self.data["body_cycle_state"] = meta
         logger.info(
-            "[PrivateCompanion] 已应用六阶段周期起始日: offset=%s phase=%s phase_day=%s previous_mode=%s",
+            "已应用六阶段周期起始日: offset=%s phase=%s phase_day=%s previous_mode=%s",
             offset,
             phase,
             day_in_phase,
@@ -9588,7 +9591,7 @@ class DailyStateMixin(DailyStateTickMixin):
             removed_count = before_count - len(conditions)
             if removed_count:
                 self.data.pop("body_cycle_state", None)
-                logger.info("[PrivateCompanion] 生理期模拟已关闭，清理旧周期状态: removed=%s", removed_count)
+                logger.info("生理期模拟已关闭，清理旧周期状态: removed=%s", removed_count)
         else:
             conditions = self._synchronize_body_cycle_strategy(conditions, now)
             conditions = self._repair_body_cycle_conditions(conditions, now)
@@ -9603,7 +9606,7 @@ class DailyStateMixin(DailyStateTickMixin):
                 ]
                 if len(conditions) < before_count:
                     logger.info(
-                        "[PrivateCompanion] 不适模拟已关闭，清理残留经期不适状态: removed=%s",
+                        "不适模拟已关闭，清理残留经期不适状态: removed=%s",
                         before_count - len(conditions),
                     )
         active = []
@@ -9640,7 +9643,7 @@ class DailyStateMixin(DailyStateTickMixin):
             if isinstance(cond, dict) and str(cond.get("kind") or "") == "hunger" and cond.get("id") != keep_id:
                 continue
             pruned.append(cond)
-        logger.info("[PrivateCompanion] 已清理重复饥饿状态: kept=%s removed=%s", keep_id or "-", len(hunger_items) - 1)
+        logger.info("已清理重复饥饿状态: kept=%s removed=%s", keep_id or "-", len(hunger_items) - 1)
         return pruned
 
     def _repair_body_cycle_conditions(self, conditions: list[Any], now: float) -> list[dict[str, Any]]:
@@ -9763,7 +9766,7 @@ class DailyStateMixin(DailyStateTickMixin):
         kept.append(condition)
         self._record_body_cycle_episode(condition)
         logger.info(
-            "[PrivateCompanion] 已对齐六阶段周期状态: phase=%s phase_start=%s day_in_phase=%s",
+            "已对齐六阶段周期状态: phase=%s phase_start=%s day_in_phase=%s",
             expected_phase,
             self._environment_fromtimestamp(phase_start).strftime("%Y-%m-%d %H:%M"),
             day_in_phase,
@@ -10442,7 +10445,7 @@ class DailyStateMixin(DailyStateTickMixin):
                         continue
                     conv = await self.context.conversation_manager.get_conversation(umo, conv_id)
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 读取昨日对话失败: user=%s err=%s", user_id, exc)
+                logger.debug("读取昨日对话失败: user=%s err=%s", user_id, exc)
                 continue
             if not conv:
                 continue
@@ -10720,7 +10723,7 @@ class DailyStateMixin(DailyStateTickMixin):
         result = "；".join(part for part in kept if part).strip("；; ")
         if changed:
             logger.info(
-                "[PrivateCompanion] 已降级日程饮食参考: field=%s before=%s after=%s",
+                "已降级日程饮食参考: field=%s before=%s after=%s",
                 field or "-",
                 _single_line(source, 120),
                 _single_line(result, 120),
@@ -10860,22 +10863,22 @@ class DailyStateMixin(DailyStateTickMixin):
                     if _cancel_requested():
                         raise
                     logger.debug(
-                        "[PrivateCompanion] 指定人格查询被管理器取消(ID: %s),本轮使用缓存人格",
+                        "指定人格查询被管理器取消(ID: %s),本轮使用缓存人格",
                         specific_id,
                     )
                     return cached or self._get_default_persona_prompt(umo)
                 except (sqlite3.OperationalError, sqlite3.ProgrammingError) as exc:
                     logger.debug(
-                        "[PrivateCompanion] 指定人格数据库暂不可用(ID: %s),本轮使用缓存人格: %s",
+                        "指定人格数据库暂不可用(ID: %s),本轮使用缓存人格: %s",
                         specific_id,
                         _single_line(exc, 160),
                     )
                     return cached or self._get_default_persona_prompt(umo)
                 except asyncio.TimeoutError:
-                    logger.warning("[PrivateCompanion] 读取插件指定人格超时(ID: %s),本轮使用缓存人格", specific_id)
+                    logger.warning("读取插件指定人格超时(ID: %s),本轮使用缓存人格", specific_id)
                     return cached or self._get_default_persona_prompt(umo)
                 except Exception as e:
-                    logger.warning(f"[PrivateCompanion] 读取插件指定人格失败(ID: {specific_id}): {e}")
+                    logger.warning(f"读取插件指定人格失败(ID: {specific_id}): {e}")
             getter = getattr(manager, "get_default_persona_v3", None) if manager else None
             if not callable(getter):
                 return cached or self._get_default_persona_prompt(umo)
@@ -10899,16 +10902,16 @@ class DailyStateMixin(DailyStateTickMixin):
         except asyncio.CancelledError:
             if _cancel_requested():
                 raise
-            logger.debug("[PrivateCompanion] 默认人格查询被管理器取消,本轮使用缓存人格")
+            logger.debug("默认人格查询被管理器取消,本轮使用缓存人格")
         except (sqlite3.OperationalError, sqlite3.ProgrammingError) as exc:
             logger.debug(
-                "[PrivateCompanion] 默认人格数据库暂不可用,本轮使用缓存人格: %s",
+                "默认人格数据库暂不可用,本轮使用缓存人格: %s",
                 _single_line(exc, 160),
             )
         except asyncio.TimeoutError:
-            logger.warning("[PrivateCompanion] 读取 AstrBot 默认人格超时,本轮使用缓存人格")
+            logger.warning("读取 AstrBot 默认人格超时,本轮使用缓存人格")
         except Exception as e:
-            logger.warning(f"[PrivateCompanion] 读取 AstrBot 默认人格失败: {e}")
+            logger.warning(f"读取 AstrBot 默认人格失败: {e}")
         return self._get_default_persona_prompt(umo)
 
     async def _await_framework_db_query(
@@ -10986,7 +10989,7 @@ class DailyStateMixin(DailyStateTickMixin):
                             pass
                         except Exception as exc:
                             logger.warning(
-                                "[PrivateCompanion] 默认人格后台刷新失败: %s",
+                                "默认人格后台刷新失败: %s",
                                 _single_line(exc, 160),
                             )
 
@@ -12170,7 +12173,7 @@ class DailyStateMixin(DailyStateTickMixin):
                     )
                     changed = True
         if changed:
-            logger.info("[PrivateCompanion] 已清理普通休闲段的错误睡眠唤醒记录")
+            logger.info("已清理普通休闲段的错误睡眠唤醒记录")
         return changed
 
     def _invalidate_detail_after_interaction(self, *, now: float | None = None) -> None:
@@ -12998,7 +13001,7 @@ class DailyStateMixin(DailyStateTickMixin):
             state = await self._ensure_daily_state(skip_conversation_summary=True, passive_fast=True)
             self._prepared_lightweight_state_injection(state, force=True)
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 预热轻量被动注入失败: %s", _single_line(exc, 120))
+            logger.debug("预热轻量被动注入失败: %s", _single_line(exc, 120))
 
     def _user_asks_recent_bot_activity(self, text: str) -> bool:
         normalized = _single_line(text, 180)
@@ -14392,13 +14395,13 @@ class DailyStateMixin(DailyStateTickMixin):
     ) -> str:
         if bool(getattr(event, "private_companion_memo_reminder_saved", False)):
             logger.info(
-                "[PrivateCompanion] 跳过对话临时预约转写: 本轮已保存带提醒的便签 session=%s",
+                "跳过对话临时预约转写: 本轮已保存带提醒的便签 session=%s",
                 _single_line(trigger_umo, 120) or "unknown",
             )
             return "memo_reminder"
         if bool(getattr(event, "private_companion_future_task_succeeded", False)):
             logger.info(
-                "[PrivateCompanion] 跳过对话临时预约转写: 本轮 AstrBot future_task 已执行成功 session=%s",
+                "跳过对话临时预约转写: 本轮 AstrBot future_task 已执行成功 session=%s",
                 _single_line(trigger_umo, 120) or "unknown",
             )
             return "official_task"
@@ -14407,14 +14410,14 @@ class DailyStateMixin(DailyStateTickMixin):
         )
         if not future_task_result_observed and self._should_skip_timer_capture_for_official_task(resp, visible_text):
             logger.info(
-                "[PrivateCompanion] 跳过对话临时预约转写: 本轮疑似已由 AstrBot 官方定时计划处理 session=%s",
+                "跳过对话临时预约转写: 本轮疑似已由 AstrBot 官方定时计划处理 session=%s",
                 _single_line(trigger_umo, 120) or "unknown",
             )
             return "official_task"
         if _single_line(payload.get("delivery"), 32).lower() == "reality_touch":
             scheduler = getattr(self, "_schedule_reality_touch_official_reminder", None)
             if not callable(scheduler):
-                logger.warning("[PrivateCompanion] 当前实例不支持现实触及官方提醒")
+                logger.warning("当前实例不支持现实触及官方提醒")
                 return "reality_touch_unavailable"
             scheduled = await scheduler(
                 user_id,
@@ -14868,7 +14871,7 @@ class DailyStateMixin(DailyStateTickMixin):
             job = await getter(normalized_job_id)
         except Exception as exc:
             logger.debug(
-                "[PrivateCompanion] 查询官方定时任务状态失败: job=%s error=%s",
+                "查询官方定时任务状态失败: job=%s error=%s",
                 normalized_job_id,
                 _single_line(exc, 160),
             )
@@ -14931,7 +14934,7 @@ class DailyStateMixin(DailyStateTickMixin):
                 self._clear_llm_timer_internal_plan_fields(current_user)
                 self._save_data_sync(sections={"users"})
         logger.info(
-            "[PrivateCompanion] 官方临时预约开始执行: user=%s timer=%s job=%s",
+            "官方临时预约开始执行: user=%s timer=%s job=%s",
             user_id,
             metadata["timer_id"],
             metadata.get("job_id") or "-",
@@ -15209,7 +15212,7 @@ class DailyStateMixin(DailyStateTickMixin):
                     user["llm_timer_event"] = restored
                 self._save_data_sync(sections={"users"})
             logger.info(
-                "[PrivateCompanion] 对话临时预约取消%s: user=%s job=%s error=%s",
+                "对话临时预约取消%s: user=%s job=%s error=%s",
                 "完成" if ok else "失败",
                 normalized_user_id,
                 existing_job_id,
@@ -15424,7 +15427,7 @@ class DailyStateMixin(DailyStateTickMixin):
                 and _single_line(existing.get("reason"), 40) != "activity_followup"
             ):
                 logger.info(
-                    "[PrivateCompanion] 保留已有明确预约,跳过自动动作查岗: user=%s existing=%s topic=%s",
+                    "保留已有明确预约,跳过自动动作查岗: user=%s existing=%s topic=%s",
                     user_id,
                     _single_line(existing.get("reason"), 40) or "appointment",
                     _single_line(existing.get("topic"), 80) or "-",
@@ -15522,7 +15525,7 @@ class DailyStateMixin(DailyStateTickMixin):
                         user["llm_timer_event"] = timer_event
                     self._save_data_sync(sections={"users"})
             logger.warning(
-                "[PrivateCompanion] LLM 临时预约登记失败,已保留原任务: user=%s old_job=%s error=%s",
+                "LLM 临时预约登记失败,已保留原任务: user=%s old_job=%s error=%s",
                 user_id,
                 replaced_job_id or previous_running_job_id or "-",
                 error or "官方定时计划登记失败",
@@ -15543,7 +15546,7 @@ class DailyStateMixin(DailyStateTickMixin):
         if not reservation_current:
             await self._delete_official_llm_timer_job(job_id)
             logger.warning(
-                "[PrivateCompanion] LLM 临时预约预留已失效,已回收新官方任务: user=%s job=%s",
+                "LLM 临时预约预留已失效,已回收新官方任务: user=%s job=%s",
                 user_id,
                 job_id,
             )
@@ -15576,7 +15579,7 @@ class DailyStateMixin(DailyStateTickMixin):
                             current["rollback_error"] = rollback_error or "新官方任务回滚失败"
                         self._save_data_sync(sections={"users"})
                 logger.warning(
-                    "[PrivateCompanion] LLM 临时预约替换失败,新任务回滚%s: user=%s old_job=%s new_job=%s error=%s rollback_error=%s",
+                    "LLM 临时预约替换失败,新任务回滚%s: user=%s old_job=%s new_job=%s error=%s rollback_error=%s",
                     "完成" if rollback_ok else "失败",
                     user_id,
                     replaced_job_id,
@@ -15610,7 +15613,7 @@ class DailyStateMixin(DailyStateTickMixin):
             await self._delete_official_llm_timer_job(job_id)
             return
         logger.info(
-            "[PrivateCompanion] LLM 临时预约已转写到官方定时计划: user=%s time=%s reason=%s action=%s topic=%s job=%s replaced=%s error=%s replace_error=%s",
+            "LLM 临时预约已转写到官方定时计划: user=%s time=%s reason=%s action=%s topic=%s job=%s replaced=%s error=%s replace_error=%s",
             user_id,
             self._environment_fromtimestamp(scheduled_ts).strftime("%m-%d %H:%M:%S"),
             reason,
@@ -16115,7 +16118,7 @@ class DailyStateMixin(DailyStateTickMixin):
             setattr(self, "_recent_relationship_context_sanitize_logs", recent_logs)
         if now - _safe_float(recent_logs.get(log_key), 0) >= 1800:
             logger.info(
-                "[PrivateCompanion] 生成前已剔除未声明关系上下文: source=%s relations=%s",
+                "生成前已剔除未声明关系上下文: source=%s relations=%s",
                 source or "-",
                 ",".join(initial_hits[:8]),
             )
@@ -16299,7 +16302,7 @@ class DailyStateMixin(DailyStateTickMixin):
         last_logged = _safe_float(recent_logs.get(log_key), 0)
         if now - last_logged >= 1800:
             logger.info(
-                "[PrivateCompanion] 已清理日程中的未授权社交事实: field=%s before=%s after=%s",
+                "已清理日程中的未授权社交事实: field=%s before=%s after=%s",
                 field or "-",
                 _single_line(source, 120),
                 _single_line(cleaned, 120),
@@ -16636,7 +16639,7 @@ class DailyStateMixin(DailyStateTickMixin):
                     counts["qzone_integration.text_fields"] = counts.get("qzone_integration.text_fields", 0) + 1
 
         if changed:
-            logger.info("[PrivateCompanion] 已清理未声明关系的生成历史: %s", counts)
+            logger.info("已清理未声明关系的生成历史: %s", counts)
         return changed
 
     def _sanitize_runtime_social_facts_inplace(self) -> bool:
@@ -16772,7 +16775,7 @@ class DailyStateMixin(DailyStateTickMixin):
                     changed = True
 
         if changed:
-            logger.info("[PrivateCompanion] 已清理框架工具循环摘要污染记录: %s", removed_counts)
+            logger.info("已清理框架工具循环摘要污染记录: %s", removed_counts)
         return changed
 
     def _sanitize_story_plan_social_facts_inplace(self, story_plan: dict[str, Any]) -> bool:
@@ -17146,7 +17149,7 @@ class DailyStateMixin(DailyStateTickMixin):
         log_key = f"{local_day if (local_day := status.get('current_time', '')[:10]) else ''}|{original}|{replacement}"
         if getattr(self, "_deepseek_peak_last_log_key", "") != log_key:
             self._deepseek_peak_last_log_key = log_key
-            logger.info("[PrivateCompanion] DeepSeek 高价时段临时路由: %s -> %s (%s)", original, replacement, status.get("current_time"))
+            logger.info("DeepSeek 高价时段临时路由: %s -> %s (%s)", original, replacement, status.get("current_time"))
         return replacement
 
     def _task_provider(self, *provider_ids: str | None) -> str:
@@ -17965,7 +17968,7 @@ class DailyStateMixin(DailyStateTickMixin):
             for old_key, ts in list(cache.items()):
                 if _safe_float(ts, 0) < cutoff:
                     cache.pop(old_key, None)
-        logger.debug(f"[PrivateCompanion] {prefix} {user_id}: {reason_text}")
+        logger.debug(f"{prefix} {user_id}: {reason_text}")
 
     def _sync_live_user_proactive_schedule(self, user_id: str, source: dict[str, Any]) -> bool:
         """Mirror proactive-plan mutations from a tick snapshot back to the live user record."""
@@ -18119,7 +18122,7 @@ class DailyStateMixin(DailyStateTickMixin):
                         )
                     )
                 except Exception as exc:
-                    logger.debug("[PrivateCompanion] 刚聊完主动换念头失败,回退延后: %s", _single_line(exc, 120))
+                    logger.debug("刚聊完主动换念头失败,回退延后: %s", _single_line(exc, 120))
                     replaced = False
                     handled_by_replacer = False
             if not replaced:
@@ -18295,7 +18298,7 @@ class DailyStateMixin(DailyStateTickMixin):
             try:
                 await task_factory()
             except Exception as exc:
-                logger.warning("[PrivateCompanion] 主动维护任务失败,不阻塞私聊主动: %s error=%s", label, _single_line(exc, 160))
+                logger.warning("主动维护任务失败,不阻塞私聊主动: %s error=%s", label, _single_line(exc, 160))
 
     @staticmethod
     def _proactive_send_disables_segmenting(reason: str, *, friend_proactive: bool = False) -> bool:
@@ -18310,7 +18313,7 @@ class DailyStateMixin(DailyStateTickMixin):
             await self._pull_body_monitor_candidates()
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanion] Body Monitor 事件拉取失败，本轮继续执行其他主动任务: %s",
+                "Body Monitor 事件拉取失败，本轮继续执行其他主动任务: %s",
                 _single_line(exc, 160),
             )
         async with self._data_lock:

--- a/daily_state_tick.py
+++ b/daily_state_tick.py
@@ -5,7 +5,6 @@ import asyncio
 import re
 from typing import Any
 
-from astrbot.api import logger
 
 from .constants import _REASON_TEXT
 from .helpers import (
@@ -20,6 +19,9 @@ from .helpers import (
     normalize_legacy_tag_text,
 )
 from .persona_config import runtime_persona_setting
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 class DailyStateTickMixin:
@@ -174,7 +176,7 @@ class DailyStateTickMixin:
                             self._sync_live_user_proactive_schedule(user_id, current_for_quiet)
                             self._save_data_sync(sections={"users"})
                             logger.info(
-                                "[PrivateCompanion] 免打扰主动任务已一次性改期: user=%s next=%s note=%s",
+                                "免打扰主动任务已一次性改期: user=%s next=%s note=%s",
                                 user_id,
                                 int(max(0, _safe_float(current_for_quiet.get("next_proactive_at"), now) - now)),
                                 _single_line(quiet_note, 120),
@@ -204,7 +206,7 @@ class DailyStateTickMixin:
                             user["planned_proactive_delivery_state"] = current_for_guard.get("planned_proactive_delivery_state", "")
                             self._save_data_sync(sections={"users"})
                             logger.info(
-                                "[PrivateCompanion] 主动发送检查未通过且无未来调度,已兜底延后: user=%s reason=%s delay=%ss",
+                                "主动发送检查未通过且无未来调度,已兜底延后: user=%s reason=%s delay=%ss",
                                 user_id,
                                 guard_reason,
                                 int(max(0, _safe_float(current_for_guard.get("next_proactive_at"), now) - now)),
@@ -232,7 +234,7 @@ class DailyStateTickMixin:
                 model_judgement = await self._review_planned_proactive_with_model(user, now=now)
             except Exception as e:
                 logger.warning(
-                    "[PrivateCompanion] 主动模型人格判定异常,降级本地判定: user=%s error=%s",
+                    "主动模型人格判定异常,降级本地判定: user=%s error=%s",
                     user_id,
                     _single_line(e, 160),
                 )
@@ -270,7 +272,7 @@ class DailyStateTickMixin:
                                 "模型人格判定改写计划: " + _single_line(model_judgement.get("reason"), 120),
                             )
                             logger.info(
-                                "[PrivateCompanion] 模型人格判定已改写主动计划: user=%s reason=%s",
+                                "模型人格判定已改写主动计划: user=%s reason=%s",
                                 user_id,
                                 _single_line(model_judgement.get("reason"), 120),
                             )
@@ -453,7 +455,7 @@ class DailyStateTickMixin:
                 )
                 self._save_data_sync(sections={"users", "proactive_candidate_pool"})
                 logger.info(
-                    "[PrivateCompanion] 刚聊完,延后本轮普通主动: user=%s reason=%s planned=%s/%s",
+                    "刚聊完,延后本轮普通主动: user=%s reason=%s planned=%s/%s",
                     user_id,
                     _single_line(recent_chat_guard_reason, 120),
                     _single_line(current_reason, 40),
@@ -527,7 +529,7 @@ class DailyStateTickMixin:
                     self._schedule_next_proactive(current_for_duplicate_cooldown, now=_now_ts(), delay_hours=(2.0, 5.0))
                     self._save_data_sync(sections={"users", "proactive_candidate_pool", "proactive_audit_log"})
                 logger.info(
-                    "[PrivateCompanion] 活动分享去重冷却中,跳过本轮主动: user=%s remain=%.0fs note=%s",
+                    "活动分享去重冷却中,跳过本轮主动: user=%s remain=%.0fs note=%s",
                     user_id,
                     duplicate_block_remaining,
                     note,
@@ -538,7 +540,7 @@ class DailyStateTickMixin:
             fallback_action = self._fallback_action_for_unavailable(planned_action_for_send, user)
             if fallback_action != planned_action_for_send:
                 logger.info(
-                    "[PrivateCompanion] 主动发图能力不可用,发送前已降级: user=%s requested=%s fallback=%s",
+                    "主动发图能力不可用,发送前已降级: user=%s requested=%s fallback=%s",
                     user_id,
                     planned_action_for_send,
                     fallback_action,
@@ -581,7 +583,7 @@ class DailyStateTickMixin:
                     self._save_data_sync(sections={"users", "proactive_candidate_pool", "proactive_audit_log"})
             if group_share_block_reason:
                 logger.info(
-                    "[PrivateCompanion] 群聊分享主动发送前复核取消: user=%s reason=%s",
+                    "群聊分享主动发送前复核取消: user=%s reason=%s",
                     user_id,
                     group_share_block_reason,
                 )
@@ -603,7 +605,7 @@ class DailyStateTickMixin:
             )
             effective_action_for_send = _single_line(pending_send_retry.get("action"), 40) or planned_action_for_send or "message"
             logger.info(
-                "[PrivateCompanion] 复用待重发主动消息: user=%s retry=%s text=%s image=%s",
+                "复用待重发主动消息: user=%s retry=%s text=%s image=%s",
                 user_id,
                 _safe_int(pending_send_retry.get("retry_count"), 0, 0, 10),
                 _single_line(text, 100),
@@ -616,7 +618,7 @@ class DailyStateTickMixin:
                     user.pop("_proactive_photo_subject_owner", "")
                 )
             except Exception as e:
-                logger.warning("[PrivateCompanion] 主动消息生成失败: user=%s error=%s", user_id, _single_line(e, 160), exc_info=True)
+                logger.warning("主动消息生成失败: user=%s error=%s", user_id, _single_line(e, 160), exc_info=True)
                 async with self._data_lock:
                     current_after_render_failure = self._get_user(user_id)
                     current_after_render_failure["proactive_sending"] = False
@@ -738,14 +740,14 @@ class DailyStateTickMixin:
                         )
                         if review_strength == "strict":
                             logger.warning(
-                                "[PrivateCompanion] 主动消息发送前价值复核连续失败,严格模式放弃本条候选避免反复调用: count=%s error=%s",
+                                "主动消息发送前价值复核连续失败,严格模式放弃本条候选避免反复调用: count=%s error=%s",
                                 failure_count,
                                 _single_line(exc, 120),
                             )
                             review_decision = {"decision": "drop", "reason": "发送前价值复核连续失败，已放弃本条候选"}
                         else:
                             logger.warning(
-                                "[PrivateCompanion] 主动消息发送前价值复核连续失败,按%s强度放行原候选避免主动归零: count=%s error=%s",
+                                "主动消息发送前价值复核连续失败,按%s强度放行原候选避免主动归零: count=%s error=%s",
                                 review_strength or "lenient",
                                 failure_count,
                                 _single_line(exc, 120),
@@ -759,7 +761,7 @@ class DailyStateTickMixin:
                     else:
                         delay_minutes = min(240, 45 * (2 ** max(0, failure_count - 1)))
                         logger.warning(
-                            "[PrivateCompanion] 主动消息发送前价值复核失败,本轮延后重试: count=%s delay=%s error=%s",
+                            "主动消息发送前价值复核失败,本轮延后重试: count=%s delay=%s error=%s",
                             failure_count,
                             delay_minutes,
                             _single_line(exc, 120),
@@ -770,7 +772,7 @@ class DailyStateTickMixin:
                             "reason": f"发送前价值复核失败，稍后重试（第 {failure_count} 次）",
                         }
                 else:
-                    logger.debug("[PrivateCompanion] 主动消息发送前本地复核失败,按原文继续: %s", _single_line(exc, 120))
+                    logger.debug("主动消息发送前本地复核失败,按原文继续: %s", _single_line(exc, 120))
                     review_decision = {"decision": "send"}
             decision = str(review_decision.get("decision") or "send").lower() if isinstance(review_decision, dict) else "send"
             review_fallback_release = bool(
@@ -794,7 +796,7 @@ class DailyStateTickMixin:
                     self._save_data_sync(sections={"proactive_review_runtime"})
                 if release_count == 10 or release_count % 10 == 0:
                     logger.warning(
-                        "[PrivateCompanion] 主动复核模型已连续放行 %s 条原文，请检查 RESPONSE_REVIEW_PROVIDER_ID",
+                        "主动复核模型已连续放行 %s 条原文，请检查 RESPONSE_REVIEW_PROVIDER_ID",
                         release_count,
                     )
             review_model_ok = bool(
@@ -866,7 +868,7 @@ class DailyStateTickMixin:
                                 )
                             except Exception as exc:
                                 replacer_called = False
-                                logger.debug("[PrivateCompanion] 复核延后更新候选失败，回退直接排程: %s", _single_line(exc, 120))
+                                logger.debug("复核延后更新候选失败，回退直接排程: %s", _single_line(exc, 120))
                         if stale_candidate and not replacer_called:
                             self._mark_planned_candidate_status(current_for_review_defer, "cancelled", note)
                             self._clear_pending_proactive_plan(current_for_review_defer)
@@ -887,7 +889,7 @@ class DailyStateTickMixin:
                     )
                     self._save_data_sync(sections={"users", "proactive_candidate_pool", "proactive_audit_log"})
                 logger.info(
-                    "[PrivateCompanion] 主动消息发送前复核%s: user=%s delay=%s reason=%s",
+                    "主动消息发送前复核%s: user=%s delay=%s reason=%s",
                     "作废过期候选" if stale_candidate else "延后",
                     user_id,
                     delay_minutes,
@@ -901,7 +903,7 @@ class DailyStateTickMixin:
                     rewritten_text = _normalize_outbound_punctuation_flow(rewritten_text).strip()
                     original_text_before_rewrite = str(text or review_candidate_text or "").strip()
                     logger.info(
-                        "[PrivateCompanion] 主动消息发送前已润色: user=%s before=%s after=%s",
+                        "主动消息发送前已润色: user=%s before=%s after=%s",
                         user_id,
                         _single_line(original_text_before_rewrite, 100),
                         _single_line(rewritten_text, 100),
@@ -985,7 +987,7 @@ class DailyStateTickMixin:
                             "troubleshooting_test_results",
                         }
                     )
-                logger.info("[PrivateCompanion] Proactive final content gate dropped: user=%s reason=%s text=%s", user_id, note, _single_line(text, 120))
+                logger.info("Proactive final content gate dropped: user=%s reason=%s text=%s", user_id, note, _single_line(text, 120))
                 self._debug_tick_skip(user_id, note, prefix="dropped")
                 return
         outbound_validator = getattr(self, "_validate_proactive_outbound_candidate", None)
@@ -1045,7 +1047,7 @@ class DailyStateTickMixin:
                         }
                     )
                 logger.warning(
-                    "[PrivateCompanion] 主动消息发送前统一校验拦截: user=%s reason=%s text=%s",
+                    "主动消息发送前统一校验拦截: user=%s reason=%s text=%s",
                     user_id,
                     note,
                     _single_line(text, 180),
@@ -1057,7 +1059,7 @@ class DailyStateTickMixin:
                 if validated_text != text:
                     text_before_validation_rewrite = text
                     logger.warning(
-                        "[PrivateCompanion] 主动消息发送前统一校验改写: user=%s reason=%s before=%s after=%s",
+                        "主动消息发送前统一校验改写: user=%s reason=%s before=%s after=%s",
                         user_id,
                         _single_line(outbound_validation.get("reason"), 120),
                         _single_line(text, 160),
@@ -1091,7 +1093,7 @@ class DailyStateTickMixin:
                 self._schedule_next_proactive(current_for_meta_leak, now=_now_ts(), delay_hours=(1.5, 4.0))
                 self._save_data_sync(sections={"users", "proactive_candidate_pool", "proactive_audit_log"})
             logger.warning(
-                "[PrivateCompanion] 主动消息发送前硬拦截元叙述泄漏: user=%s text=%s",
+                "主动消息发送前硬拦截元叙述泄漏: user=%s text=%s",
                 user_id,
                 _single_line(text, 180),
             )
@@ -1102,7 +1104,7 @@ class DailyStateTickMixin:
             cleaned_text = placeholder_cleaner(text)
             if cleaned_text != text:
                 logger.warning(
-                    "[PrivateCompanion] 主动消息清理到孤儿 TTS 占位符: user=%s before=%s after=%s",
+                    "主动消息清理到孤儿 TTS 占位符: user=%s before=%s after=%s",
                     user_id,
                     _single_line(text, 120),
                     _single_line(cleaned_text, 120),
@@ -1146,7 +1148,7 @@ class DailyStateTickMixin:
                     )
             if duplicate_note:
                 logger.info(
-                    "[PrivateCompanion] 取消重复活动分享: user=%s duplicate=%s",
+                    "取消重复活动分享: user=%s duplicate=%s",
                     user_id,
                     _single_line(duplicate_note, 100),
                 )
@@ -1162,11 +1164,11 @@ class DailyStateTickMixin:
                     action=effective_action_for_send or planned_action_for_send or "message",
                 )
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 主动消息时间一致性复核失败: %s", _single_line(exc, 120))
+                logger.debug("主动消息时间一致性复核失败: %s", _single_line(exc, 120))
                 time_mismatch_reason = ""
         if time_mismatch_reason:
             logger.info(
-                "[PrivateCompanion] 主动消息时间不一致,已取消发送: user=%s reason=%s",
+                "主动消息时间不一致,已取消发送: user=%s reason=%s",
                 user_id,
                 _single_line(time_mismatch_reason, 160),
             )
@@ -1239,7 +1241,7 @@ class DailyStateTickMixin:
                     self._save_data_sync(sections={"users", "proactive_candidate_pool", "proactive_audit_log"})
             if similar_note:
                 logger.info(
-                    "[PrivateCompanion] 主动消息正文近似重复,已取消: user=%s reason=%s text=%s",
+                    "主动消息正文近似重复,已取消: user=%s reason=%s text=%s",
                     user_id,
                     _single_line(similar_note, 120),
                     _single_line(text, 120),
@@ -1268,7 +1270,7 @@ class DailyStateTickMixin:
                     self._save_data_sync(sections={"users", "proactive_candidate_pool", "proactive_audit_log"})
             if textual_greeting_note:
                 logger.info(
-                    "[PrivateCompanion] 主动消息正文命中重复问候,已取消: user=%s reason=%s text=%s",
+                    "主动消息正文命中重复问候,已取消: user=%s reason=%s text=%s",
                     user_id,
                     _single_line(textual_greeting_note, 120),
                     _single_line(text, 120),
@@ -1301,7 +1303,7 @@ class DailyStateTickMixin:
         if has_new_user_message:
             if is_troubleshooting_for_send:
                 logger.info(
-                    "[PrivateCompanion] 排障临时主动检测到生成期间有新消息,继续发送以验证链路: %s",
+                    "排障临时主动检测到生成期间有新消息,继续发送以验证链路: %s",
                     user_id,
                 )
                 async with self._data_lock:
@@ -1327,13 +1329,13 @@ class DailyStateTickMixin:
                     self._save_data_sync(sections={"users", "troubleshooting_test_results"})
             elif not bool(route_options_for_send.get("cancel_if_new_inbound", True)):
                 logger.info(
-                    "[PrivateCompanion] 生成期间收到新消息，但 %s 路线保留独立投递: user=%s",
+                    "生成期间收到新消息，但 %s 路线保留独立投递: user=%s",
                     route_key_for_send,
                     user_id,
                 )
             else:
                 logger.info(
-                    "[PrivateCompanion] 用户在主动消息生成期间已有新消息,%s 路线取消本次发送: %s",
+                    "用户在主动消息生成期间已有新消息,%s 路线取消本次发送: %s",
                     route_key_for_send,
                     user_id,
                 )
@@ -1364,7 +1366,7 @@ class DailyStateTickMixin:
                     self._save_data_sync(sections={"users", "proactive_candidate_pool", "proactive_audit_log"})
         if delivery_freshness_reason:
             logger.info(
-                "[PrivateCompanion] 主动候选在生成期间失效,已取消发送: user=%s reason=%s",
+                "主动候选在生成期间失效,已取消发送: user=%s reason=%s",
                 user_id,
                 _single_line(delivery_freshness_reason, 120),
             )
@@ -1419,7 +1421,7 @@ class DailyStateTickMixin:
                 )
         if recent_chat_guard_reason:
             logger.info(
-                "[PrivateCompanion] 发送前发现刚聊完,延后普通主动: user=%s reason=%s",
+                "发送前发现刚聊完,延后普通主动: user=%s reason=%s",
                 user_id,
                 _single_line(recent_chat_guard_reason, 120),
             )
@@ -1428,7 +1430,7 @@ class DailyStateTickMixin:
         if text and self._is_proactive_delivery_receipt_text(text):
             note = "主动正文是工具/执行状态回执，已取消发送"
             logger.warning(
-                "[PrivateCompanion] 主动消息发送前拦截执行回执: user=%s text=%s",
+                "主动消息发送前拦截执行回执: user=%s text=%s",
                 user_id,
                 _single_line(text, 160),
             )
@@ -1521,7 +1523,7 @@ class DailyStateTickMixin:
                 if item
             )
             logger.info(
-                "[PrivateCompanion] 准备主动发送给 %s: reason=%s(%s) action=%s quote=%s umo=%s text=%s image=%s extra=%s%s",
+                "准备主动发送给 %s: reason=%s(%s) action=%s quote=%s umo=%s text=%s image=%s extra=%s%s",
                 user_id,
                 reason,
                 reason_label,
@@ -1553,7 +1555,7 @@ class DailyStateTickMixin:
                 if outcome_note:
                     cancel_note = f"{cancel_note}：{outcome_note}"
                 logger.info(
-                    "[PrivateCompanion] 主动消息未实际投递: user=%s reason=%s action=%s",
+                    "主动消息未实际投递: user=%s reason=%s action=%s",
                     user_id,
                     reason,
                     effective_action_for_send or planned_action_for_send or "message",
@@ -1639,7 +1641,7 @@ class DailyStateTickMixin:
                 delivered_has_photo = bool(image_path) or self._proactive_components_contain_image(extra_components)
             if not delivery_complete:
                 logger.warning(
-                    "[PrivateCompanion] 主动消息仅部分投递，后续只按真实送达内容归档: user=%s reason=%s note=%s",
+                    "主动消息仅部分投递，后续只按真实送达内容归档: user=%s reason=%s note=%s",
                     user_id,
                     reason,
                     delivery_note or "部分组件被取消或发送失败",
@@ -1730,7 +1732,7 @@ class DailyStateTickMixin:
                     )
                     self._save_data_sync(sections={"users", "troubleshooting_test_results"})
             logger.info(
-                "[PrivateCompanion] 主动发送完成: user=%s reason=%s action=%s complete=%s",
+                "主动发送完成: user=%s reason=%s action=%s complete=%s",
                 user_id,
                 reason,
                 planned_action_for_send or "message",
@@ -1780,7 +1782,7 @@ class DailyStateTickMixin:
             formatter = getattr(self, "_format_send_exception", None)
             error_text = formatter(e) if callable(formatter) else (_single_line(str(e), 180) or repr(e))
             diagnostic_detail = f"{e.__class__.__name__}: {_single_line(str(e) or repr(e), 2300)}"
-            logger.warning("[PrivateCompanion] 发送给 %s 失败: %s", user_id, error_text)
+            logger.warning("发送给 %s 失败: %s", user_id, error_text)
             async with self._data_lock:
                 current_after_failure = self._get_user(user_id)
                 delivery_failure_recorder = getattr(self, "_note_private_delivery_failure", None)

--- a/desktop_pet_bridge.py
+++ b/desktop_pet_bridge.py
@@ -10,8 +10,10 @@ import urllib.error
 import urllib.request
 import uuid
 from typing import Any
+from .logging_util import get_module_logger
 
-from astrbot.api import logger
+logger = get_module_logger(__name__)
+
 
 
 def _clean_text(value: Any, limit: int = 4000) -> str:
@@ -131,7 +133,7 @@ class DesktopPetBridge:
             self._last_status = "桌宠未连接"
             self._last_error = str(exc)[:240]
             logger.debug(
-                "[PrivateCompanion] 桌宠消息镜像跳过（桌宠未运行或接口不可用）: %s",
+                "桌宠消息镜像跳过（桌宠未运行或接口不可用）: %s",
                 self._last_error,
             )
             return

--- a/event_dispatch.py
+++ b/event_dispatch.py
@@ -33,7 +33,7 @@ from typing import Any
 from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlunparse
 from xml.etree import ElementTree as ET
 
-from astrbot.api import AstrBotConfig, logger
+from astrbot.api import AstrBotConfig
 from astrbot.api.event import AstrMessageEvent, MessageChain, filter
 try:
     from astrbot.api.message_components import At, Image, Plain, Record, Reply
@@ -127,6 +127,9 @@ from .planning import (
     normalize_story_plan,
     pick_detail_segment,
 )
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 DEFAULT_AI_DAILY_NEWS_SOURCE = "B站 AI早报|bilibili:285286947"
 
@@ -823,7 +826,7 @@ class EventDispatchMixin:
             if message_id and not prior_message_id:
                 entry["echo_message_id"] = message_id
             logger.info(
-                "[PrivateCompanion] 已拦截未授权私聊拒绝回流: scope=%s mode=%s duplicate=%s",
+                "已拦截未授权私聊拒绝回流: scope=%s mode=%s duplicate=%s",
                 _single_line(scope, 240),
                 match_mode,
                 bool(matched_at),
@@ -1844,7 +1847,7 @@ class EventDispatchMixin:
                     if converted:
                         return converted
                 except Exception as exc:
-                    logger.debug("[PrivateCompanion] 撤回图片组件转换失败: %s", exc)
+                    logger.debug("撤回图片组件转换失败: %s", exc)
             return source
 
         for comp in self._event_components(event):
@@ -1898,7 +1901,7 @@ class EventDispatchMixin:
                 target.write_bytes(raw)
                 return str(target)
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 撤回图片 data url 暂存失败: %s", exc)
+                logger.debug("撤回图片 data url 暂存失败: %s", exc)
                 return ""
 
         for index, source in enumerate(raw_sources[: max(1, limit)], 1):
@@ -1915,7 +1918,7 @@ class EventDispatchMixin:
                     try:
                         downloaded = await asyncio.wait_for(downloader(text, target_dir, f"{now_ms}_{index}"), timeout=8.0)
                     except Exception as exc:
-                        logger.debug("[PrivateCompanion] 撤回图片远程暂存失败: %s", exc)
+                        logger.debug("撤回图片远程暂存失败: %s", exc)
                         downloaded = ""
                     if downloaded:
                         add_persisted(downloaded, "local")
@@ -1936,7 +1939,7 @@ class EventDispatchMixin:
                     add_persisted(str(target), "local")
                     continue
                 except Exception as exc:
-                    logger.debug("[PrivateCompanion] 撤回图片本地暂存失败: %s", exc)
+                    logger.debug("撤回图片本地暂存失败: %s", exc)
             if not re.match(r"^(?:[A-Za-z]:[\\/]|/|\\\\|file://)", text):
                 # OneBot/NapCat may expose only a platform-side image file id.
                 # Keep it as a best-effort sendable Image(file=...) reference.
@@ -2079,7 +2082,7 @@ class EventDispatchMixin:
         try:
             iterator = list(root_resolved.rglob("*"))
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 撤回图片缓存扫描失败: %s", exc)
+            logger.debug("撤回图片缓存扫描失败: %s", exc)
             return False
 
         for path in iterator:
@@ -2095,11 +2098,11 @@ class EventDispatchMixin:
                         removed_count += 1
                         removed_bytes += size
                     except Exception as exc:
-                        logger.debug("[PrivateCompanion] 撤回图片过期缓存删除失败: path=%s error=%s", path, exc)
+                        logger.debug("撤回图片过期缓存删除失败: path=%s error=%s", path, exc)
                     continue
                 files.append((mtime, size, path))
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 撤回图片缓存条目读取失败: path=%s error=%s", path, exc)
+                logger.debug("撤回图片缓存条目读取失败: path=%s error=%s", path, exc)
 
         total_bytes = sum(size for _, size, _ in files)
         if max_bytes and total_bytes > max_bytes:
@@ -2112,7 +2115,7 @@ class EventDispatchMixin:
                     removed_count += 1
                     removed_bytes += size
                 except Exception as exc:
-                    logger.debug("[PrivateCompanion] 撤回图片容量缓存删除失败: path=%s error=%s", path, exc)
+                    logger.debug("撤回图片容量缓存删除失败: path=%s error=%s", path, exc)
 
         for directory in sorted((p for p in iterator if p.is_dir()), key=lambda p: len(p.parts), reverse=True):
             try:
@@ -2120,11 +2123,11 @@ class EventDispatchMixin:
             except OSError:
                 pass
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 撤回图片空目录清理失败: path=%s error=%s", directory, exc)
+                logger.debug("撤回图片空目录清理失败: path=%s error=%s", directory, exc)
 
         if removed_count:
             logger.info(
-                "[PrivateCompanion] 已清理撤回图片缓存: files=%s size=%.1fMB ttl=%.0fs max=%.1fMB",
+                "已清理撤回图片缓存: files=%s size=%.1fMB ttl=%.0fs max=%.1fMB",
                 removed_count,
                 removed_bytes / 1024 / 1024,
                 ttl,
@@ -2284,7 +2287,7 @@ class EventDispatchMixin:
                 "cache_miss": True,
             }
             logger.info(
-                "[PrivateCompanion] 撤回消息快照未命中: scope=%s message_id=%s notice=%s",
+                "撤回消息快照未命中: scope=%s message_id=%s notice=%s",
                 _single_line(scope, 160) or "-",
                 message_id,
                 _single_line(notice_type, 40) or "-",
@@ -2410,7 +2413,7 @@ class EventDispatchMixin:
                 raw = await call_action("get_msg", message_id=value)
             except Exception as exc:
                 logger.debug(
-                    "[PrivateCompanion] 触发消息存在性检查失败: message_id=%s error=%s",
+                    "触发消息存在性检查失败: message_id=%s error=%s",
                     message_id,
                     _single_line(exc, 120),
                 )
@@ -2653,7 +2656,7 @@ class EventDispatchMixin:
                 40,
             ) or self._quote_cache_key(event)
             logger.debug(
-                "[PrivateCompanion] 当前平台不支持原生撤回，已跳过: platform=%s message_id=%s",
+                "当前平台不支持原生撤回，已跳过: platform=%s message_id=%s",
                 platform_label,
                 message_id,
             )
@@ -2669,10 +2672,10 @@ class EventDispatchMixin:
         for value in attempts:
             try:
                 await call(event, "delete_msg", message_id=value)
-                logger.info("[PrivateCompanion] 已尝试撤回消息: message_id=%s reason=%s", message_id, _single_line(reason, 80))
+                logger.info("已尝试撤回消息: message_id=%s reason=%s", message_id, _single_line(reason, 80))
                 return True
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 撤回消息失败: message_id=%s error=%s", message_id, _single_line(exc, 120))
+                logger.debug("撤回消息失败: message_id=%s error=%s", message_id, _single_line(exc, 120))
         return False
 
     def _candidate_trigger_message_id(self, candidate: dict[str, Any]) -> str:
@@ -2753,12 +2756,12 @@ class EventDispatchMixin:
         platform_supports = getattr(self, "_platform_supports", None)
         if event is not None and callable(platform_supports) and not platform_supports("reply_quote", event=event):
             logger.debug(
-                "[PrivateCompanion] 当前平台不支持指定消息引用，已降级为普通发送: platform=%s",
+                "当前平台不支持指定消息引用，已降级为普通发送: platform=%s",
                 self._quote_cache_key(event),
             )
             return None
         if Reply is None:
-            logger.debug("[PrivateCompanion] 当前 AstrBot 运行环境缺少 Reply 组件，引用触发消息已降级。")
+            logger.debug("当前 AstrBot 运行环境缺少 Reply 组件，引用触发消息已降级。")
             return None
         message_id = _single_line(message_id, 120)
         if not message_id:
@@ -2801,7 +2804,7 @@ class EventDispatchMixin:
             except Exception:
                 continue
         logger.info(
-            "[PrivateCompanion] 当前平台未能构造 Reply 引用组件，已降级为普通发送: platform=%s message_id=%s",
+            "当前平台未能构造 Reply 引用组件，已降级为普通发送: platform=%s message_id=%s",
             cache_key,
             message_id,
         )
@@ -3132,7 +3135,7 @@ class EventDispatchMixin:
             if last <= 0 or now - last > window:
                 continue
             logger.info(
-                "[PrivateCompanion] 用户消息防抖拦截: kind=%s scope=%s sender=%s msg_id=%s text=%s",
+                "用户消息防抖拦截: kind=%s scope=%s sender=%s msg_id=%s text=%s",
                 kind,
                 scope,
                 sender_id,
@@ -3261,7 +3264,7 @@ class EventDispatchMixin:
                     messages.append({"ts": now, "text": cleaned, "sender_name": _single_line(sender_name, 40)})
                 current["deadline_ts"] = now
                 logger.info(
-                    "[PrivateCompanion] 消息收口固定窗口已到,准备立刻收口: kind=%s scope=%s sender=%s count=%s text=%s",
+                    "消息收口固定窗口已到,准备立刻收口: kind=%s scope=%s sender=%s count=%s text=%s",
                     buffer_kind,
                     scope,
                     sender_id,
@@ -3280,7 +3283,7 @@ class EventDispatchMixin:
                 current["deadline_ts"] = now
                 current["max_wait_reached"] = True
                 logger.info(
-                    "[PrivateCompanion] 消息收口达到最长等待,准备立刻收口: kind=%s scope=%s sender=%s max_wait=%.1fs count=%s text=%s",
+                    "消息收口达到最长等待,准备立刻收口: kind=%s scope=%s sender=%s max_wait=%.1fs count=%s text=%s",
                     buffer_kind,
                     scope,
                     sender_id,
@@ -3313,7 +3316,7 @@ class EventDispatchMixin:
                 current["deadline_ts"] = now
                 current["max_merge_reached"] = True
                 logger.info(
-                    "[PrivateCompanion] 消息收口达到最大合并条数,准备立刻收口: kind=%s scope=%s sender=%s max=%s text=%s",
+                    "消息收口达到最大合并条数,准备立刻收口: kind=%s scope=%s sender=%s max=%s text=%s",
                     buffer_kind,
                     scope,
                     sender_id,
@@ -3321,7 +3324,7 @@ class EventDispatchMixin:
                     _single_line(cleaned, 80),
                 )
             logger.info(
-                "[PrivateCompanion] 消息收口合并补话: kind=%s mode=%s scope=%s sender=%s wait=%.1fs count=%s appended=%s text=%s",
+                "消息收口合并补话: kind=%s mode=%s scope=%s sender=%s wait=%.1fs count=%s appended=%s text=%s",
                 buffer_kind,
                 debounce_mode,
                 scope,
@@ -3349,7 +3352,7 @@ class EventDispatchMixin:
         if smart_debounce:
             buffers[key]["smart_debounce"] = dict(smart_debounce)
         logger.info(
-            "[PrivateCompanion] 消息收口创建缓冲: kind=%s mode=%s scope=%s sender=%s wait=%.1fs text=%s",
+            "消息收口创建缓冲: kind=%s mode=%s scope=%s sender=%s wait=%.1fs text=%s",
             buffer_kind,
             debounce_mode,
             scope,
@@ -3517,7 +3520,7 @@ class EventDispatchMixin:
         except Exception:
             pass
         logger.info(
-            "[PrivateCompanion] LLM 处理中收到补话，旧回复标记过期并合并等待: key=%s count=%s text=%s",
+            "LLM 处理中收到补话，旧回复标记过期并合并等待: key=%s count=%s text=%s",
             key,
             len(messages),
             _single_line(cleaned, 80),
@@ -3556,7 +3559,7 @@ class EventDispatchMixin:
         raw_rules = legacy.get("route_rules", []) if isinstance(legacy, dict) else []
         parsed, warnings = build_rules(raw_rules)
         for warning in warnings:
-            logger.warning("[PrivateCompanion] 兼容旧关键词换模规则：%s", warning)
+            logger.warning("兼容旧关键词换模规则：%s", warning)
         return parsed
 
     @staticmethod
@@ -3618,7 +3621,7 @@ class EventDispatchMixin:
                     if isinstance(caption, str) and caption.strip():
                         sources.append(("companion_image_caption", caption))
                 except Exception as exc:
-                    logger.debug("[PrivateCompanion] 模型替换读取图片转述失败：%s", _single_line(exc, 120))
+                    logger.debug("模型替换读取图片转述失败：%s", _single_line(exc, 120))
         return sources
 
     @_ON_WAITING_LLM_REQUEST(priority=110000)
@@ -3641,7 +3644,7 @@ class EventDispatchMixin:
             provider_id = str(match.rule.provider_id or "").strip()
             model = str(match.rule.model or "").strip()
             if not self._model_replacement_provider_exists(provider_id):
-                logger.warning("[PrivateCompanion] 模型替换规则目标 Provider 不存在，保留原路由：%s", provider_id)
+                logger.warning("模型替换规则目标 Provider 不存在，保留原路由：%s", provider_id)
                 provider_id = ""
         if not provider_id:
             getter = getattr(self, "_default_chat_provider_id", None)
@@ -3743,7 +3746,7 @@ class EventDispatchMixin:
                 pass
             pending["updated_ts"] = _now_ts()
             logger.info(
-                "[PrivateCompanion] 已丢弃消息收口中过期 LLM 回复: key=%s event=%s",
+                "已丢弃消息收口中过期 LLM 回复: key=%s event=%s",
                 key,
                 message_id,
             )
@@ -3851,7 +3854,7 @@ class EventDispatchMixin:
         )
         del examples[:- max(20, _safe_int(_persona_value(self, 'smart_message_debounce_examples_limit', 8), 8, 0) * 4 or 20)]
         logger.info(
-            "[PrivateCompanion] 智能防抖学习样本已记录: kind=%s scope=%s messages=%s note=%s",
+            "智能防抖学习样本已记录: kind=%s scope=%s messages=%s note=%s",
             kind,
             scope,
             len(cleaned),
@@ -4057,7 +4060,7 @@ class EventDispatchMixin:
         except Exception:
             pass
         logger.info(
-            "[PrivateCompanion] 群聊短唤醒进入补话等待: wait=%.1fs trigger=%s text=%s",
+            "群聊短唤醒进入补话等待: wait=%.1fs trigger=%s text=%s",
             wait,
             trigger,
             _single_line(cleaned, 40),
@@ -4152,7 +4155,7 @@ class EventDispatchMixin:
                 private_chat=private_chat,
             )
             logger.info(
-                "[PrivateCompanion] 智能防抖沿用等待缓冲: scope=%s sender=%s wait=%.1fs text=%s",
+                "智能防抖沿用等待缓冲: scope=%s sender=%s wait=%.1fs text=%s",
                 scope,
                 sender_id,
                 wait,
@@ -4193,7 +4196,7 @@ class EventDispatchMixin:
                 reason=suspense_reason,
             )
             logger.info(
-                "[PrivateCompanion] 智能防抖本地判定等待补话: scope=%s sender=%s elapsed=%sms reason=%s wait=%.1fs text=%s",
+                "智能防抖本地判定等待补话: scope=%s sender=%s elapsed=%sms reason=%s wait=%.1fs text=%s",
                 scope,
                 sender_id,
                 elapsed_ms,
@@ -4235,7 +4238,7 @@ class EventDispatchMixin:
                 reason=fast_complete_reason,
             )
             logger.info(
-                "[PrivateCompanion] 智能防抖本地快判放行: scope=%s sender=%s elapsed=%sms reason=%s text=%s",
+                "智能防抖本地快判放行: scope=%s sender=%s elapsed=%sms reason=%s text=%s",
                 scope,
                 sender_id,
                 elapsed_ms,
@@ -4312,8 +4315,8 @@ class EventDispatchMixin:
                 timeout=timeout_seconds,
             ) or ""
         except asyncio.TimeoutError:
-            logger.info(
-                "[PrivateCompanion] 智能防抖模型判断超时,使用启发式: scope=%s sender=%s timeout=%.1fs text=%s",
+            logger.warning(
+                "智能防抖模型判断超时,使用启发式: scope=%s sender=%s timeout=%.1fs text=%s",
                 scope,
                 sender_id,
                 timeout_seconds,
@@ -4321,7 +4324,7 @@ class EventDispatchMixin:
             )
             model_error = f"timeout>{timeout_seconds:.1f}s"
         except Exception as exc:
-            logger.info("[PrivateCompanion] 智能防抖模型判断失败,使用启发式: %s", _single_line(exc, 120))
+            logger.warning("智能防抖模型判断失败,使用启发式: %s", _single_line(exc, 120))
             model_error = _single_line(exc, 120)
         decision, confidence, reason = self._parse_smart_message_debounce_decision(raw)
         source = "model" if raw else "heuristic"
@@ -4361,7 +4364,7 @@ class EventDispatchMixin:
                 reason=reason,
             )
             logger.info(
-                "[PrivateCompanion] 智能防抖判定放行: scope=%s sender=%s elapsed=%sms source=%s confidence=%.2f reason=%s text=%s",
+                "智能防抖判定放行: scope=%s sender=%s elapsed=%sms source=%s confidence=%.2f reason=%s text=%s",
                 scope,
                 sender_id,
                 elapsed_ms,
@@ -4405,7 +4408,7 @@ class EventDispatchMixin:
             reason=reason,
         )
         logger.info(
-            "[PrivateCompanion] 智能防抖判定等待补话: scope=%s sender=%s elapsed=%sms source=%s wait=%.1fs remaining=%.1fs confidence=%.2f reason=%s text=%s",
+            "智能防抖判定等待补话: scope=%s sender=%s elapsed=%sms source=%s wait=%.1fs remaining=%.1fs confidence=%.2f reason=%s text=%s",
             scope,
             sender_id,
             elapsed_ms,
@@ -4528,7 +4531,7 @@ Bot 近期回复：
         try:
             raw = await self._llm_call(prompt, max_tokens=8, provider_id=provider_id, task="group_air_reply_guard")
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 群聊读空气判断失败: %s", _single_line(exc, 120))
+            logger.debug("群聊读空气判断失败: %s", _single_line(exc, 120))
             return {"block": False, "reason": "judge_failed"}
         answer = str(raw or "").strip().upper()
         if answer.startswith("SILENCE") or answer.startswith("NO") or answer.startswith("否") or answer.startswith("沉默"):
@@ -4777,7 +4780,7 @@ Bot 近期回复：
                 self._save_data_sync(sections={"groups"})
         if refreshed:
             logger.info(
-                "[PrivateCompanion] Bot 回复已确认发送，群聊续接窗口从实际回复时间重新计时: group=%s sender=%s window=%.1fs",
+                "Bot 回复已确认发送，群聊续接窗口从实际回复时间重新计时: group=%s sender=%s window=%.1fs",
                 group_id,
                 sender_id,
                 expires_in,
@@ -5070,7 +5073,7 @@ Bot 近期回复：
                 24,
             )
             logger.info(
-                "[PrivateCompanion] 群聊 @ 休息用户提醒: group=%s sender=%s target=%s until=%s",
+                "群聊 @ 休息用户提醒: group=%s sender=%s target=%s until=%s",
                 self._extract_group_id_from_event(event),
                 sender_id,
                 target_id,
@@ -5411,7 +5414,7 @@ Bot 近期回复：
             if candidate:
                 normalized = candidate
             else:
-                logger.warning("[PrivateCompanion] 主动分段内容替换会清空整条文本，已保留原文")
+                logger.warning("主动分段内容替换会清空整条文本，已保留原文")
         threshold = max(20, _safe_int(setting("threshold", 500), 500, 20, 1024))
         min_segment_chars = max(1, _safe_int(setting("min_segment_chars", 8), 8, 1, 40))
         max_segments = max(
@@ -5462,7 +5465,7 @@ Bot 近期回复：
                 try:
                     cleanup_pattern = re.compile(setting("content_cleanup_rule", '[\\n]'))
                 except re.error as e:
-                    logger.warning("[PrivateCompanion] 主动分段内容清理正则无效,跳过清理: %s", e)
+                    logger.warning("主动分段内容清理正则无效,跳过清理: %s", e)
 
         def _protected_cleanup_chunks(value: str) -> list[tuple[str, bool]]:
             bracket_pairs = {
@@ -5900,7 +5903,7 @@ Bot 近期回复：
                 re.DOTALL | re.MULTILINE,
             )
         except re.error as e:
-            logger.warning("[PrivateCompanion] 主动分段正则无效,使用默认规则: %s", e)
+            logger.warning("主动分段正则无效,使用默认规则: %s", e)
             raw_segments = re.findall(r".*?[。？！~…\n]+|.+$", protected_normalized, re.DOTALL | re.MULTILINE)
 
         segments = []

--- a/final_response_persistence.py
+++ b/final_response_persistence.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass, field, is_dataclass, replace
 from functools import wraps
 from typing import Any, Awaitable, Callable
 
-from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent
 from astrbot.api.message_components import Image, Plain, Record
 from astrbot.core.agent.message import AssistantMessageSegment, TextPart
@@ -29,6 +28,9 @@ from .helpers import (
 from .llm_tool_actions import PHOTO_TOOL_SILENT_SENTINEL
 from .persona_config import runtime_persona_setting
 from .segmented_message import sanitize_llm_segment_control_tokens
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 _DELIVERY_TASK_LABELS = frozenset({"segmented_llm_remainder"})
@@ -233,7 +235,7 @@ class FinalResponsePersistenceCoordinator:
     def install_send_tracking(self, event: AstrMessageEvent) -> None:
         if not bool(getattr(event, "_private_companion_persistence_managed", False)):
             logger.info(
-                "[PrivateCompanion][SendTracking] _private_companion_persistence_managed not set, calling begin_passive: event=%s",
+                "[SendTracking] _private_companion_persistence_managed not set, calling begin_passive: event=%s",
                 id(event),
             )
             self.begin_passive(event)
@@ -263,7 +265,7 @@ class FinalResponsePersistenceCoordinator:
                                 text = str(getattr(component, "text", "") or "")
                                 if PHOTO_TOOL_SILENT_SENTINEL in text:
                                     logger.info(
-                                        "[PrivateCompanion][SendTracking] tracked_send STRIPPING chain: event=%s text_len=%d",
+                                        "[SendTracking] tracked_send STRIPPING chain: event=%s text_len=%d",
                                         id(event),
                                         len(text),
                                     )
@@ -273,7 +275,7 @@ class FinalResponsePersistenceCoordinator:
                                         pass
                     elif isinstance(message, str) and PHOTO_TOOL_SILENT_SENTINEL in message:
                         logger.info(
-                            "[PrivateCompanion][SendTracking] tracked_send STRIPPING str: event=%s text_len=%d",
+                            "[SendTracking] tracked_send STRIPPING str: event=%s text_len=%d",
                             id(event),
                             len(message),
                         )
@@ -287,7 +289,7 @@ class FinalResponsePersistenceCoordinator:
                 setattr(event, "_private_companion_original_send", original_send)
                 event.send = tracked_send
                 logger.info(
-                    "[PrivateCompanion][SendTracking] send wrapper installed: event=%s",
+                    "[SendTracking] send wrapper installed: event=%s",
                     id(event),
                 )
 
@@ -318,7 +320,7 @@ class FinalResponsePersistenceCoordinator:
                                         text = str(getattr(component, "text", "") or "")
                                         if PHOTO_TOOL_SILENT_SENTINEL in text:
                                             logger.info(
-                                                "[PrivateCompanion][SendTracking] tracked_send_streaming STRIPPING chain: event=%s text_len=%d",
+                                                "[SendTracking] tracked_send_streaming STRIPPING chain: event=%s text_len=%d",
                                                 id(event),
                                                 len(text),
                                             )
@@ -333,7 +335,7 @@ class FinalResponsePersistenceCoordinator:
                                 content = str(getattr(message, "content", "") or "")
                                 if PHOTO_TOOL_SILENT_SENTINEL in content:
                                     logger.info(
-                                        "[PrivateCompanion][SendTracking] tracked_send_streaming STRIPPING content: event=%s text_len=%d",
+                                        "[SendTracking] tracked_send_streaming STRIPPING content: event=%s text_len=%d",
                                         id(event),
                                         len(content),
                                     )
@@ -360,7 +362,7 @@ class FinalResponsePersistenceCoordinator:
                 ledger.original_send_streaming = original_streaming
                 event.send_streaming = tracked_send_streaming
                 logger.info(
-                    "[PrivateCompanion][SendTracking] send_streaming wrapper installed: event=%s",
+                    "[SendTracking] send_streaming wrapper installed: event=%s",
                     id(event),
                 )
 
@@ -1054,13 +1056,13 @@ class FinalResponsePersistenceMixin:
                 message._no_save = False
             except Exception as exc:
                 logger.warning(
-                    "[PrivateCompanion] 纯媒体回复恢复 AstrBot 核心保存失败: session=%s error=%s",
+                    "纯媒体回复恢复 AstrBot 核心保存失败: session=%s error=%s",
                     _single_line(getattr(event, "unified_msg_origin", ""), 140),
                     _single_line(exc, 160),
                 )
                 return False
             logger.info(
-                "[PrivateCompanion] 纯媒体回复已保留转码前正文供 AstrBot 核心保存: %s",
+                "纯媒体回复已保留转码前正文供 AstrBot 核心保存: %s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 140),
             )
             return True
@@ -1079,13 +1081,13 @@ class FinalResponsePersistenceMixin:
             message._no_save = False
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanion] 实际回复暂存到 AstrBot 会话上下文失败: session=%s error=%s",
+                "实际回复暂存到 AstrBot 会话上下文失败: session=%s error=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 140),
                 _single_line(exc, 160),
             )
             return False
         logger.info(
-            "[PrivateCompanion] 已将实际发送回复交给 AstrBot 核心保存: %s",
+            "已将实际发送回复交给 AstrBot 核心保存: %s",
             _single_line(getattr(event, "unified_msg_origin", ""), 140),
         )
         return True
@@ -1136,14 +1138,14 @@ class FinalResponsePersistenceMixin:
             )
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanion] 实际回复写入 AstrBot 会话历史失败: session=%s error=%s",
+                "实际回复写入 AstrBot 会话历史失败: session=%s error=%s",
                 _single_line(umo, 140),
                 _single_line(exc, 160),
             )
             return False
         if written:
             logger.info(
-                "[PrivateCompanion] 已将实际发送回复写入 AstrBot 会话历史: %s",
+                "已将实际发送回复写入 AstrBot 会话历史: %s",
                 _single_line(umo, 140),
             )
         return written
@@ -1216,7 +1218,7 @@ class FinalResponsePersistenceMixin:
                 delivered = True
             except Exception as exc:
                 logger.warning(
-                    "[PrivateCompanion] LivingMemory 最终回复写入失败: session=%s handler=%s error=%s",
+                    "LivingMemory 最终回复写入失败: session=%s handler=%s error=%s",
                     _single_line(umo, 140),
                     _single_line(getattr(handler, "handler_name", ""), 80),
                     _single_line(exc, 160),
@@ -1229,7 +1231,7 @@ class FinalResponsePersistenceMixin:
                 )[:-384]:
                     recorded.pop(old_key, None)
             logger.info(
-                "[PrivateCompanion] 已将实际发送回复交给 LivingMemory 记录: %s",
+                "已将实际发送回复交给 LivingMemory 记录: %s",
                 _single_line(umo, 140),
             )
         return delivered
@@ -1291,7 +1293,7 @@ class FinalResponsePersistenceMixin:
             ):
                 return False
             logger.debug(
-                "[PrivateCompanion] MemoryCompanion 实际回复写入失败: %s",
+                "MemoryCompanion 实际回复写入失败: %s",
                 _single_line(exc, 120),
             )
             return False
@@ -1592,7 +1594,7 @@ class FinalResponsePersistenceMixin:
                 return record()
         except Exception as exc:
             logger.debug(
-                "[PrivateCompanion] Confirmed delivery state commit failed: %s",
+                "Confirmed delivery state commit failed: %s",
                 _single_line(exc, 120),
             )
             return False, set()

--- a/forward_message.py
+++ b/forward_message.py
@@ -11,7 +11,6 @@ from datetime import datetime
 from typing import Any
 from urllib.parse import urlparse
 
-from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent
 try:
     from astrbot.api.message_components import Plain
@@ -25,6 +24,9 @@ from .conversation_injection_plan import (
 )
 from .helpers import _group_link_message_context, _safe_float, _safe_int, _single_line, _strip_internal_message_blocks
 from .persona_config import runtime_persona_setting
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 class ForwardMessageMixin:
     """Forward-message parsing and prompt-context helpers."""
@@ -488,24 +490,24 @@ class ForwardMessageMixin:
                 continue
             if raw:
                 logger.info(
-                    "[PrivateCompanion] 合并消息平台接口返回: action=%s args=%s shape=%s",
+                    "合并消息平台接口返回: action=%s args=%s shape=%s",
                     action,
                     ",".join(kwargs.keys()),
                     self._forward_payload_shape(raw),
                 )
                 return raw
         if last_error:
-            logger.info("[PrivateCompanion] 合并消息平台接口全部失败: id=%s error=%s", _single_line(safe_id, 80), last_error)
+            logger.info("合并消息平台接口全部失败: id=%s error=%s", _single_line(safe_id, 80), last_error)
         return None
 
     async def _extract_forward_from_reply(self, event: AstrMessageEvent, reply_seg: Any) -> tuple[str, dict[str, Any]]:
         message_id = self._extract_reply_message_id(reply_seg)
         if not message_id:
-            logger.info("[PrivateCompanion] 引用合并消息读取跳过: Reply 段没有 message_id")
+            logger.info("引用合并消息读取跳过: Reply 段没有 message_id")
             return "", {}
         recalled_message_id = await self._should_cancel_reply_for_missing_or_recalled_trigger(event, message_id)
         if recalled_message_id:
-            logger.info("[PrivateCompanion] 引用合并消息读取跳过: 被引用消息已撤回或不可见 message_id=%s", recalled_message_id)
+            logger.info("引用合并消息读取跳过: 被引用消息已撤回或不可见 message_id=%s", recalled_message_id)
             return "", {}
         message_obj = None
         try:
@@ -516,7 +518,7 @@ class ForwardMessageMixin:
             except Exception:
                 message_obj = None
         if not message_obj:
-            logger.info("[PrivateCompanion] 引用合并消息读取失败: get_msg 无返回 message_id=%s", message_id)
+            logger.info("引用合并消息读取失败: get_msg 无返回 message_id=%s", message_id)
             return "", {}
         raw_message = message_obj.get("message") if isinstance(message_obj, dict) else message_obj
         try:
@@ -528,14 +530,14 @@ class ForwardMessageMixin:
         forward_payload = self._extract_forward_payload_from_message_obj(raw_message)
         if forward_id or forward_payload:
             logger.info(
-                "[PrivateCompanion] 引用合并消息已解析: message_id=%s id=%s inline=%s",
+                "引用合并消息已解析: message_id=%s id=%s inline=%s",
                 message_id,
                 _single_line(forward_id, 40) or "inline",
                 bool(forward_payload),
             )
         else:
             logger.info(
-                "[PrivateCompanion] 引用消息未解析到合并转发: message_id=%s shape=%s",
+                "引用消息未解析到合并转发: message_id=%s shape=%s",
                 message_id,
                 self._forward_payload_shape(raw_message),
             )
@@ -547,7 +549,7 @@ class ForwardMessageMixin:
             return []
         recalled_message_id = await self._should_cancel_reply_for_missing_or_recalled_trigger(event, message_id)
         if recalled_message_id:
-            logger.info("[PrivateCompanion] 引用图片读取跳过: 被引用消息已撤回或不可见 message_id=%s", recalled_message_id)
+            logger.info("引用图片读取跳过: 被引用消息已撤回或不可见 message_id=%s", recalled_message_id)
             return []
         message_obj = None
         try:
@@ -556,7 +558,7 @@ class ForwardMessageMixin:
             try:
                 message_obj = await self._call_platform_action(event, "get_msg", message_id=message_id)
             except Exception as exc:
-                logger.info("[PrivateCompanion] 引用图片读取失败: message_id=%s error=%s", message_id, _single_line(exc, 120))
+                logger.info("引用图片读取失败: message_id=%s error=%s", message_id, _single_line(exc, 120))
                 return []
         if isinstance(message_obj, dict):
             raw_message = message_obj.get("message") or message_obj.get("raw_message") or message_obj.get("content")
@@ -564,7 +566,7 @@ class ForwardMessageMixin:
             raw_message = message_obj
         sources = self._extract_image_sources_from_message_obj(raw_message)
         if sources:
-            logger.info("[PrivateCompanion] 引用消息图片已解析: message_id=%s images=%s", message_id, len(sources))
+            logger.info("引用消息图片已解析: message_id=%s images=%s", message_id, len(sources))
         return sources[:5]
 
     async def _find_reply_image_sources_for_event(self, event: AstrMessageEvent) -> list[str]:
@@ -573,7 +575,7 @@ class ForwardMessageMixin:
             sources = self._extract_image_sources_from_message_obj(row.get("raw_message"))
             if sources:
                 logger.info(
-                    "[PrivateCompanion] 引用链图片已解析: depth=%s message_id=%s images=%s",
+                    "引用链图片已解析: depth=%s message_id=%s images=%s",
                     _safe_int(row.get("depth"), 1, 1),
                     _single_line(row.get("message_id"), 120),
                     len(sources),
@@ -709,7 +711,7 @@ class ForwardMessageMixin:
             messages = self._extract_messages_from_forward_data(raw)
             if raw and not messages:
                 logger.info(
-                    "[PrivateCompanion] 合并消息接口返回未解析出节点: id=%s shape=%s",
+                    "合并消息接口返回未解析出节点: id=%s shape=%s",
                     _single_line(forward_id, 80),
                     self._forward_payload_shape(raw),
                 )
@@ -873,12 +875,12 @@ class ForwardMessageMixin:
         forward_id, payload = await self._find_forward_descriptor_for_event(event)
         if not (forward_id or payload):
             if should_log_probe:
-                logger.info("[PrivateCompanion] 合并消息请求未找到描述符: text=%s", message_text or "(empty)")
+                logger.info("合并消息请求未找到描述符: text=%s", message_text or "(empty)")
             setattr(event, "_private_companion_forward_context", "")
             return ""
         if should_log_probe:
             logger.info(
-                "[PrivateCompanion] 合并消息请求命中描述符: id=%s inline=%s text=%s",
+                "合并消息请求命中描述符: id=%s inline=%s text=%s",
                 _single_line(forward_id, 40) or "inline",
                 bool(payload),
                 message_text or "(empty)",
@@ -886,7 +888,7 @@ class ForwardMessageMixin:
         try:
             rows, image_urls, nested_count = await self._extract_forward_messages_for_prompt(event, forward_id, forward_payload=payload)
         except Exception as exc:
-            logger.info("[PrivateCompanion] 合并消息读取失败: %s", exc)
+            logger.info("合并消息读取失败: %s", exc)
             setattr(event, "_private_companion_forward_context", "")
             return ""
         preview = " | ".join(
@@ -894,7 +896,7 @@ class ForwardMessageMixin:
             for index, row in enumerate(rows[:5])
         )
         logger.info(
-            "[PrivateCompanion] 合并消息解析结果: id=%s messages=%s images=%s nested=%s preview=%s",
+            "合并消息解析结果: id=%s messages=%s images=%s nested=%s preview=%s",
             _single_line(forward_id, 40) or "inline",
             len(rows),
             len(image_urls),
@@ -924,7 +926,7 @@ class ForwardMessageMixin:
                 setattr(event, "_private_companion_forward_context_body", context_body)
                 setattr(event, "_private_companion_forward_context_title", "本轮合并消息转述")
                 logger.info(
-                    "[PrivateCompanion] 已注入合并消息转述: messages=%s images=%s provider=%s",
+                    "已注入合并消息转述: messages=%s images=%s provider=%s",
                     len(rows),
                     len(image_urls),
                     self._task_provider(
@@ -981,20 +983,20 @@ class ForwardMessageMixin:
         setattr(event, "_private_companion_forward_context", context)
         setattr(event, "_private_companion_forward_context_body", context_body)
         setattr(event, "_private_companion_forward_context_title", "本轮合并消息")
-        logger.info("[PrivateCompanion] 已注入合并消息上下文: id=%s messages=%s images=%s", _single_line(forward_id, 40) or "inline", len(rows), len(image_urls))
+        logger.info("已注入合并消息上下文: id=%s messages=%s images=%s", _single_line(forward_id, 40) or "inline", len(rows), len(image_urls))
         return context if include_heading else context_body
 
     async def _transcribe_forward_message_images(self, event: AstrMessageEvent, image_sources: list[str]) -> str:
         if not runtime_persona_setting(self, "forward_message_image_vision", True):
-            logger.info("[PrivateCompanion] 合并/引用图片视觉跳过: forward_message_image_vision=false")
+            logger.info("合并/引用图片视觉跳过: forward_message_image_vision=false")
             return ""
         limit = max(0, _safe_int(runtime_persona_setting(self, "forward_message_image_limit", 4), 4, 0))
         if limit <= 0:
-            logger.info("[PrivateCompanion] 合并/引用图片视觉跳过: forward_message_image_limit=%s", limit)
+            logger.info("合并/引用图片视觉跳过: forward_message_image_limit=%s", limit)
             return ""
         original_sources = [str(item).strip() for item in (image_sources or []) if str(item or "").strip()][:limit]
         if not original_sources:
-            logger.info("[PrivateCompanion] 合并/引用图片视觉跳过: 未抽取到图片源")
+            logger.info("合并/引用图片视觉跳过: 未抽取到图片源")
             return ""
         sources = await self._prepare_private_image_sources_for_model(
             original_sources,
@@ -1002,7 +1004,7 @@ class ForwardMessageMixin:
         )
         if not sources:
             logger.info(
-                "[PrivateCompanion] 合并/引用图片视觉跳过: 图片源无法转为模型可读源 original=%s",
+                "合并/引用图片视觉跳过: 图片源无法转为模型可读源 original=%s",
                 len(original_sources),
             )
             return ""
@@ -1012,7 +1014,7 @@ class ForwardMessageMixin:
         image_urls = [url for _, url in image_items]
         if not image_urls:
             logger.info(
-                "[PrivateCompanion] 合并/引用图片视觉跳过: 已准备图片但无模型可用 URL sources=%s prepared=%s",
+                "合并/引用图片视觉跳过: 已准备图片但无模型可用 URL sources=%s prepared=%s",
                 len(original_sources),
                 len(sources),
             )
@@ -1083,7 +1085,7 @@ class ForwardMessageMixin:
             )
             if cached_text:
                 logger.info(
-                    "[PrivateCompanion] 合并消息图片视觉命中缓存: provider=%s images=%s preview=%s",
+                    "合并消息图片视觉命中缓存: provider=%s images=%s preview=%s",
                     provider_id,
                     len(image_urls),
                     _single_line(cached_text, 220),
@@ -1168,7 +1170,7 @@ class ForwardMessageMixin:
                         task="forward_message_image_vision",
                     )
                     logger.info(
-                        "[PrivateCompanion] 合并消息图片视觉返回空摘要,已尝试下一个 provider: provider=%s source=%s",
+                        "合并消息图片视觉返回空摘要,已尝试下一个 provider: provider=%s source=%s",
                         provider_id,
                         provider_source,
                     )
@@ -1185,7 +1187,7 @@ class ForwardMessageMixin:
                 )
                 self._clear_private_image_provider_failure(provider_id, provider_source)
                 logger.info(
-                    "[PrivateCompanion] 合并消息图片视觉完成: provider=%s source=%s images=%s chars=%s preview=%s",
+                    "合并消息图片视觉完成: provider=%s source=%s images=%s chars=%s preview=%s",
                     provider_id,
                     provider_source,
                     len(image_urls),
@@ -1215,8 +1217,8 @@ class ForwardMessageMixin:
                     error=f"timeout after {timeout:.1f}s",
                     budget_exempt=True,
                 )
-                logger.info(
-                    "[PrivateCompanion] 合并消息图片视觉超时,本轮尝试下一个 provider；不会禁用后续图片调用: provider=%s source=%s timeout=%.1fs timeout_source=%s",
+                logger.warning(
+                    "合并消息图片视觉超时,本轮尝试下一个 provider；不会禁用后续图片调用: provider=%s source=%s timeout=%.1fs timeout_source=%s",
                     provider_id,
                     provider_source,
                     timeout,
@@ -1236,8 +1238,8 @@ class ForwardMessageMixin:
                 )
                 self._mark_private_image_provider_failure(provider_id, provider_source, exc, task="forward_message_image_vision")
                 continue
-        logger.info(
-            "[PrivateCompanion] 合并消息图片视觉失败: 所有候选 provider 均不可用或失败 attempts=%s skipped=%s images=%s",
+        logger.warning(
+            "合并消息图片视觉失败: 所有候选 provider 均不可用或失败 attempts=%s skipped=%s images=%s",
             attempts,
             ",".join(skipped_providers[:8]) or "-",
             len(image_urls),
@@ -1637,7 +1639,7 @@ class ForwardMessageMixin:
             seen.add(message_id)
             recalled_message_id = await self._should_cancel_reply_for_missing_or_recalled_trigger(event, message_id)
             if recalled_message_id:
-                logger.info("[PrivateCompanion] 引用链读取跳过: 被引用消息已撤回或不可见 message_id=%s", recalled_message_id)
+                logger.info("引用链读取跳过: 被引用消息已撤回或不可见 message_id=%s", recalled_message_id)
                 continue
             message_obj = await self._get_message_obj_by_id(event, message_id)
             if not message_obj:
@@ -1783,7 +1785,7 @@ class ForwardMessageMixin:
                 continue
             recalled_message_id = await self._should_cancel_reply_for_missing_or_recalled_trigger(event, message_id)
             if recalled_message_id:
-                logger.info("[PrivateCompanion] 引用原消息读取跳过: 被引用消息已撤回或不可见 message_id=%s", recalled_message_id)
+                logger.info("引用原消息读取跳过: 被引用消息已撤回或不可见 message_id=%s", recalled_message_id)
                 return message_id, None
             message_obj = None
             try:
@@ -1976,7 +1978,7 @@ class ForwardMessageMixin:
             return ""
         recalled_message_id = await self._should_cancel_reply_for_missing_or_recalled_trigger(event, message_id)
         if recalled_message_id:
-            logger.info("[PrivateCompanion] 引用卡片上下文跳过: 被引用消息已撤回或不可见 message_id=%s", recalled_message_id)
+            logger.info("引用卡片上下文跳过: 被引用消息已撤回或不可见 message_id=%s", recalled_message_id)
             return ""
         info = self._extract_reply_rich_card_info(raw_message)
         texts = [item for item in info.get("texts", []) if item]
@@ -2027,13 +2029,13 @@ class ForwardMessageMixin:
             lines.append("引用卡片中的图片：")
             lines.append(image_vision_text)
             logger.info(
-                "[PrivateCompanion] 引用卡片图片视觉摘要完成: message_id=%s images=%s preview=%s",
+                "引用卡片图片视觉摘要完成: message_id=%s images=%s preview=%s",
                 message_id or "-",
                 len(images),
                 _single_line(image_vision_text, 240),
             )
         logger.info(
-            "[PrivateCompanion] 已注入引用卡片上下文: message_id=%s texts=%s links=%s images=%s vision=%s preview=%s vision_preview=%s",
+            "已注入引用卡片上下文: message_id=%s texts=%s links=%s images=%s vision=%s preview=%s vision_preview=%s",
             message_id or "-",
             len(texts),
             len(links),
@@ -2129,10 +2131,10 @@ class ForwardMessageMixin:
             or (existing_plan is not None and existing_plan.contains_marker(marker))
         ):
             if should_log_probe:
-                logger.info("[PrivateCompanion] 合并消息请求注入跳过: 已存在 marker text=%s", message_text or "(empty)")
+                logger.info("合并消息请求注入跳过: 已存在 marker text=%s", message_text or "(empty)")
             return
         if should_log_probe:
-            logger.info("[PrivateCompanion] 合并消息请求开始注入检查: text=%s", message_text or "(empty)")
+            logger.info("合并消息请求开始注入检查: text=%s", message_text or "(empty)")
         context = await self._format_forward_message_context_for_prompt(
             event,
             req,
@@ -2248,5 +2250,5 @@ class ForwardMessageMixin:
                     metadata={"注入位置": placement},
                 )
         elif should_log_probe:
-            logger.info("[PrivateCompanion] 合并消息请求未生成上下文: text=%s", message_text or "(empty)")
+            logger.info("合并消息请求未生成上下文: text=%s", message_text or "(empty)")
 

--- a/game_integration.py
+++ b/game_integration.py
@@ -11,8 +11,10 @@ import unicodedata
 from contextlib import asynccontextmanager
 from copy import deepcopy
 from typing import Any, AsyncIterator
+from .logging_util import get_module_logger
 
-from astrbot.api import logger
+logger = get_module_logger(__name__)
+
 
 
 GAME_EVENT_TYPES = frozenset({"round_finished", "rematch_requested"})
@@ -715,7 +717,7 @@ class GameIntegrationMixin:
                 value = resolver(user_snapshot, umo=self._game_clean_text(event.get("session_id"), 200))
                 persona = str(await value if inspect.isawaitable(value) else value or "")
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 游戏余韵读取人格失败: %s", self._game_clean_text(exc, 120))
+                logger.debug("游戏余韵读取人格失败: %s", self._game_clean_text(exc, 120))
         if not persona:
             getter = getattr(self, "_get_default_persona_prompt", None)
             if callable(getter):
@@ -819,7 +821,7 @@ class GameIntegrationMixin:
             parsed = self._game_json_object(raw)
             assessment = self._game_normalize_assessment(parsed, fallback) if parsed else fallback
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 游戏余韵模型判断失败: %s", self._game_clean_text(exc, 120))
+            logger.debug("游戏余韵模型判断失败: %s", self._game_clean_text(exc, 120))
             assessment = fallback
         if cache_key:
             try:
@@ -980,7 +982,7 @@ class GameIntegrationMixin:
                 event["occurred_at"] = min(event["occurred_at"], now)
             event_id = self._game_clean_text(event.get("event_id"), 180)
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 游戏事件归一化失败: %s", self._game_clean_text(exc, 120))
+            logger.debug("游戏事件归一化失败: %s", self._game_clean_text(exc, 120))
             return {"ok": False, "reason": "invalid_game_event"}
 
         return await self._game_run_in_persona(
@@ -1036,7 +1038,7 @@ class GameIntegrationMixin:
                         self._save_data_sync(sections={"users"})
                     except Exception as exc:
                         persisted = False
-                        logger.warning("[PrivateCompanion] 游戏旧事件回执保存失败: %s", self._game_clean_text(exc, 120))
+                        logger.warning("游戏旧事件回执保存失败: %s", self._game_clean_text(exc, 120))
                     return self._game_public_result(previous, stale=True, persisted=persisted)
 
             streak_result, streak_count = self._game_afterglow_streak(previous, event, now=now)
@@ -1171,10 +1173,10 @@ class GameIntegrationMixin:
                     self._save_data_sync(sections={"users"})
                 except Exception as exc:
                     persisted = False
-                    logger.warning("[PrivateCompanion] 游戏余韵保存失败: %s", self._game_clean_text(exc, 120))
+                    logger.warning("游戏余韵保存失败: %s", self._game_clean_text(exc, 120))
 
             logger.info(
-                "[PrivateCompanion] 游戏余韵已结算: user=%s scope=%s game=%s result=%s streak=%s competition=%s companionship=%s",
+                "游戏余韵已结算: user=%s scope=%s game=%s result=%s streak=%s competition=%s companionship=%s",
                 event["user_id"],
                 descriptor["scope_key"],
                 event["game"],

--- a/group_member_safety.py
+++ b/group_member_safety.py
@@ -8,11 +8,13 @@ import time
 from copy import deepcopy
 from typing import Any
 
-from astrbot.api import logger
 
 from .helpers import _safe_float, _safe_int, _single_line, _strip_group_member_safety_markers
 from .persona_config import runtime_persona_setting
 from .conversation_injection_plan import PLACEMENT_TOOL_CONTRACT, get_conversation_injection_plan
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 class GroupMemberSafetyMixin:
@@ -730,7 +732,7 @@ evidence.target 只能是 bot、group_member、third_party、unclear；evidence.
                 task="group_member_safety",
             )
         except Exception as exc:
-            logger.warning("[PrivateCompanion] 群成员风控判定失败: %s", _single_line(exc, 160))
+            logger.warning("群成员风控判定失败: %s", _single_line(exc, 160))
             return {"malicious": False, "reason": "判定模型调用失败", "source": "judge_failed"}
         payload = self._group_member_safety_parse_json(raw)
         malicious_raw = payload.get("malicious", False)

--- a/group_observation.py
+++ b/group_observation.py
@@ -31,7 +31,7 @@ from typing import Any
 from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlunparse
 from xml.etree import ElementTree as ET
 
-from astrbot.api import AstrBotConfig, logger
+from astrbot.api import AstrBotConfig
 from astrbot.api.event import AstrMessageEvent, MessageChain, filter
 try:
     from astrbot.api.message_components import At, Image, Plain, Record, Reply
@@ -136,6 +136,9 @@ from .planning import (
     normalize_story_plan,
     pick_detail_segment,
 )
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 def build_group_episode_cache_prompts(
@@ -670,7 +673,7 @@ class GroupObservationMixin:
         try:
             raw_members = await getter(event, group_id, force_refresh=force)
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 群权限身份刷新失败: group=%s error=%s", group_id, _single_line(exc, 160))
+            logger.debug("群权限身份刷新失败: group=%s error=%s", group_id, _single_line(exc, 160))
             return False
         if not isinstance(raw_members, list) or not raw_members:
             return False
@@ -1213,7 +1216,7 @@ class GroupObservationMixin:
 
         if blocked_by_guard:
             logger.info(
-                "[PrivateCompanion] 群聊防注入已阻断学习链路: group=%s sender=%s score=%s reasons=%s text=%s",
+                "群聊防注入已阻断学习链路: group=%s sender=%s score=%s reasons=%s text=%s",
                 group.get("group_id") or group_id or "",
                 sender_id,
                 _safe_int(injection_guard.get("score"), 0, 0),
@@ -2675,7 +2678,7 @@ class GroupObservationMixin:
         try:
             provider, provider_id = await provider_getter()
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 群黑话嵌入模型解析失败: %s", _single_line(exc, 120))
+            logger.debug("群黑话嵌入模型解析失败: %s", _single_line(exc, 120))
             return ""
         if provider is None or not provider_id:
             return ""
@@ -2741,7 +2744,7 @@ class GroupObservationMixin:
                 if score >= 0.68:
                     ranked.append((score, term, meaning_text))
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 群黑话向量软召回失败: %s", _single_line(exc, 120))
+            logger.debug("群黑话向量软召回失败: %s", _single_line(exc, 120))
             return ""
         if not ranked:
             return ""
@@ -4055,7 +4058,7 @@ class GroupObservationMixin:
                     timeout_seconds=1.2,
                 )
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 群聊插话 我会牢牢记住你 上下文读取失败: %s", _single_line(exc, 120))
+                logger.debug("群聊插话 我会牢牢记住你 上下文读取失败: %s", _single_line(exc, 120))
         prompt = f"""
 你在一个群聊里,系统认为现在也许可以非常轻地接一句,但你必须先判断这句会不会显得硬插话。
 只输出 JSON,不要解释,不要 Markdown。
@@ -4102,7 +4105,7 @@ class GroupObservationMixin:
         if not should_reply or not reply:
             if skip_reason:
                 logger.debug(
-                    "[PrivateCompanion] 群聊主动插话模型决定不发言: group=%s reason=%s raw=%s",
+                    "群聊主动插话模型决定不发言: group=%s reason=%s raw=%s",
                     group.get("group_id") or "",
                     _single_line(skip_reason, 80),
                     _single_line(generated, 120),
@@ -4137,7 +4140,7 @@ class GroupObservationMixin:
             "topic_signature": self._group_topic_signature(text),
         }
         logger.info(
-            "[PrivateCompanion] 群聊主动插话已发送: group=%s reason=%s trigger=%s reply=%s",
+            "群聊主动插话已发送: group=%s reason=%s trigger=%s reply=%s",
             group.get("group_id") or "",
             _single_line(reason, 80),
             _single_line(text, 80),
@@ -4501,7 +4504,7 @@ class GroupObservationMixin:
             current["group_slang_last_error"] = ""
             current["group_slang_running_at"] = 0
             if removed_uncertain:
-                logger.info("[PrivateCompanion] 已清理低置信度群黑话释义: group=%s removed=%s", group_id, removed_uncertain)
+                logger.info("已清理低置信度群黑话释义: group=%s removed=%s", group_id, removed_uncertain)
             self._save_data_sync(sections={"groups"})
 
     async def _try_acquire_group_background_task(
@@ -4542,7 +4545,7 @@ class GroupObservationMixin:
                 current[running_key] = 0
                 self._save_data_sync(sections={"groups"})
             logger.debug(
-                "[PrivateCompanion] 群黑话释义 JSON 解析失败,已跳过本轮刷新: group=%s",
+                "群黑话释义 JSON 解析失败,已跳过本轮刷新: group=%s",
                 group_id,
             )
             return
@@ -4558,7 +4561,7 @@ class GroupObservationMixin:
             current[running_key] = 0
             self._save_data_sync(sections={"groups"})
         logger.warning(
-            "[PrivateCompanion] 群聊后台整理失败,已进入短冷却避免重复请求: group=%s task=%s retry=%ss error=%s",
+            "群聊后台整理失败,已进入短冷却避免重复请求: group=%s task=%s retry=%ss error=%s",
             group_id,
             task,
             int(delay),
@@ -4629,7 +4632,7 @@ class GroupObservationMixin:
         except Exception as exc:
             results = []
             self._last_web_search_error = _single_line(exc, 240)
-            logger.debug("[PrivateCompanion] 群黑话联网参考搜索失败: group=%s term=%s err=%s", group_id, term, _single_line(exc, 120))
+            logger.debug("群黑话联网参考搜索失败: group=%s term=%s err=%s", group_id, term, _single_line(exc, 120))
         error_text = _single_line(getattr(self, "_last_web_search_error", ""), 240)
         if error_text and not results:
             async with self._data_lock:
@@ -4650,7 +4653,7 @@ class GroupObservationMixin:
                     web_state["updated_at"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
                 self._save_data_sync(sections={"groups"})
             logger.info(
-                "[PrivateCompanion] 群黑话联网参考单词搜索失败并冷却: group=%s term=%s error=%s",
+                "群黑话联网参考单词搜索失败并冷却: group=%s term=%s error=%s",
                 group_id,
                 term,
                 error_text,
@@ -4688,5 +4691,5 @@ class GroupObservationMixin:
                 web_state["updated_at"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
             self._save_data_sync(sections={"groups"})
         if lines:
-            logger.info("[PrivateCompanion] 群黑话联网参考已收集: group=%s term=%s", group_id, term)
+            logger.info("群黑话联网参考已收集: group=%s term=%s", group_id, term)
         return "\n".join(lines)[:1800]

--- a/group_wakeup.py
+++ b/group_wakeup.py
@@ -31,7 +31,7 @@ from typing import Any
 from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlunparse
 from xml.etree import ElementTree as ET
 
-from astrbot.api import AstrBotConfig, logger
+from astrbot.api import AstrBotConfig
 from astrbot.api.event import AstrMessageEvent, MessageChain, filter
 try:
     from astrbot.api.message_components import At, Image, Plain, Record, Reply
@@ -116,6 +116,9 @@ from .planning import (
     normalize_story_plan,
     pick_detail_segment,
 )
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 DEFAULT_AI_DAILY_NEWS_SOURCE = "B站 AI早报|bilibili:285286947"
 

--- a/image_companion_bridge.py
+++ b/image_companion_bridge.py
@@ -9,10 +9,12 @@ from __future__ import annotations
 
 from typing import Any
 
-from astrbot.api import logger
 
 from .helpers import _single_line
 from .external_bridge_resolver import resolve_external_bridge
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 class ImageCompanionBridgeMixin:
@@ -52,7 +54,7 @@ class ImageCompanionBridgeMixin:
             status = getter(self)
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanion] 独立生图能力查询失败: error=%s",
+                "独立生图能力查询失败: error=%s",
                 _single_line(exc, 160),
             )
             return {
@@ -89,7 +91,7 @@ class ImageCompanionBridgeMixin:
             state = getter(self, force_refresh=force_refresh)
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanion] 独立生图负载查询失败: error=%s",
+                "独立生图负载查询失败: error=%s",
                 _single_line(exc, 160),
             )
             return {"enabled": False, "available": False, "busy": False, "reason": "负载状态查询失败"}
@@ -104,7 +106,7 @@ class ImageCompanionBridgeMixin:
             result = await maintainer(self)
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanion] 独立生图后台维护失败: error=%s",
+                "独立生图后台维护失败: error=%s",
                 _single_line(exc, 160),
             )
             return {}
@@ -129,7 +131,7 @@ class ImageCompanionBridgeMixin:
             response = await generator(self, dict(request))
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanion] 独立生图插件调用异常: workflow=%s error=%s",
+                "独立生图插件调用异常: workflow=%s error=%s",
                 _single_line(request.get("workflow_kind"), 40),
                 _single_line(exc, 160),
             )

--- a/integration_status.py
+++ b/integration_status.py
@@ -31,7 +31,7 @@ from typing import Any
 from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlunparse
 from xml.etree import ElementTree as ET
 
-from astrbot.api import AstrBotConfig, logger
+from astrbot.api import AstrBotConfig
 from .conversation_prompt_section import prompt_section
 from .persona_config import runtime_persona_setting
 from astrbot.api.event import AstrMessageEvent, MessageChain, filter
@@ -120,6 +120,9 @@ from .planning import (
     normalize_story_plan,
     pick_detail_segment,
 )
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 DEFAULT_AI_DAILY_NEWS_SOURCE = "B站 AI早报|bilibili:285286947"
@@ -274,7 +277,7 @@ class IntegrationStatusMixin:
                 setattr(service_mod, "PLUGIN_PAGE_ASSET_TOKEN_TTL_SECONDS", target_ttl_seconds)
                 changed.append(f"service_ttl={current}->{target_ttl_seconds}")
         except Exception as exc:
-            logger.debug("[PrivateCompanion] AstrBot 插件页 token TTL 兼容补丁跳过: %s", _single_line(exc, 120))
+            logger.debug("AstrBot 插件页 token TTL 兼容补丁跳过: %s", _single_line(exc, 120))
 
         try:
             from astrbot.dashboard.routes import plugin as legacy_route_mod
@@ -284,7 +287,7 @@ class IntegrationStatusMixin:
                 setattr(legacy_route_mod, "_PLUGIN_PAGE_ASSET_TOKEN_TTL_SECONDS", target_ttl_seconds)
                 changed.append(f"legacy_ttl={current}->{target_ttl_seconds}")
         except Exception as exc:
-            logger.debug("[PrivateCompanion] AstrBot 旧插件页 token TTL 兼容补丁跳过: %s", _single_line(exc, 120))
+            logger.debug("AstrBot 旧插件页 token TTL 兼容补丁跳过: %s", _single_line(exc, 120))
 
         try:
             from astrbot.dashboard.plugin_page_auth import PluginPageAuth
@@ -317,7 +320,7 @@ class IntegrationStatusMixin:
                 PluginPageAuth.is_scope_valid = classmethod(_is_scope_valid)
                 changed.append("private_companion_page_alias_scope")
         except Exception as exc:
-            logger.debug("[PrivateCompanion] AstrBot 插件页别名鉴权兼容补丁跳过: %s", _single_line(exc, 120))
+            logger.debug("AstrBot 插件页别名鉴权兼容补丁跳过: %s", _single_line(exc, 120))
 
         # A hot-reload can leave a StarMetadata object whose root_dir_name still
         # points at a temporary/old checkout.  The page and README routers use
@@ -360,7 +363,7 @@ class IntegrationStatusMixin:
                 service_mod.PluginPageService.get_plugin_root_dir = _get_plugin_root_with_fallback
                 changed.append("page_root_fallback")
         except Exception as exc:
-            logger.debug("[PrivateCompanion] AstrBot 新插件页目录兼容补丁跳过: %s", _single_line(exc, 120))
+            logger.debug("AstrBot 新插件页目录兼容补丁跳过: %s", _single_line(exc, 120))
 
         try:
             from astrbot.dashboard.routes import plugin as legacy_route_mod
@@ -451,7 +454,7 @@ class IntegrationStatusMixin:
                     setattr(legacy_route_mod.PluginRoute, method_name, _read_document_with_fallback)
                 changed.append("legacy_readme_root_fallback")
         except Exception as exc:
-            logger.debug("[PrivateCompanion] AstrBot 旧插件页目录兼容补丁跳过: %s", _single_line(exc, 120))
+            logger.debug("AstrBot 旧插件页目录兼容补丁跳过: %s", _single_line(exc, 120))
 
         try:
             from astrbot.dashboard.services import plugin_service as service_mod
@@ -496,10 +499,10 @@ class IntegrationStatusMixin:
                 service_mod.PluginService.resolve_plugin_logo_url = _resolve_logo_url_with_fallback
                 changed.append("logo_root_fallback")
         except Exception as exc:
-            logger.debug("[PrivateCompanion] AstrBot README目录兼容补丁跳过: %s", _single_line(exc, 120))
+            logger.debug("AstrBot README目录兼容补丁跳过: %s", _single_line(exc, 120))
 
         if changed:
-            logger.info("[PrivateCompanion] AstrBot 插件页入口兼容已应用: %s", ", ".join(changed))
+            logger.info("AstrBot 插件页入口兼容已应用: %s", ", ".join(changed))
 
     def _register_page_api_if_available(self) -> None:
         try:
@@ -507,17 +510,17 @@ class IntegrationStatusMixin:
 
             self.page_api = PrivateCompanionPageApi(self)
         except Exception as e:
-            logger.warning(f"[PrivateCompanion] 插件拓展页面 API 初始化失败: {e}", exc_info=True)
+            logger.warning(f"插件拓展页面 API 初始化失败: {e}", exc_info=True)
             return
 
         if hasattr(self.context, "register_web_api"):
             try:
                 self.page_api.register_routes()
-                logger.info("[PrivateCompanion] 插件拓展页面 API 已注册")
+                logger.info("插件拓展页面 API 已注册")
             except Exception as e:
-                logger.warning(f"[PrivateCompanion] 插件拓展页面 API 注册失败: {e}", exc_info=True)
+                logger.warning(f"插件拓展页面 API 注册失败: {e}", exc_info=True)
         else:
-            logger.debug("[PrivateCompanion] 当前 AstrBot 版本未提供 register_web_api,跳过插件拓展页面 API 注册")
+            logger.debug("当前 AstrBot 版本未提供 register_web_api,跳过插件拓展页面 API 注册")
 
         try:
             from .standalone_webui import StandaloneWebUIServer
@@ -525,7 +528,7 @@ class IntegrationStatusMixin:
             self.standalone_webui = StandaloneWebUIServer(self, self.page_api)
         except Exception as e:
             self.standalone_webui = None
-            logger.warning(f"[PrivateCompanion] 独立陪伴 WebUI 初始化失败: {e}", exc_info=True)
+            logger.warning(f"独立陪伴 WebUI 初始化失败: {e}", exc_info=True)
 
     def _patch_livingmemory_processor_compat(self) -> None:
         """Work around LivingMemory versions whose MemoryProcessor lacks config."""
@@ -542,9 +545,9 @@ class IntegrationStatusMixin:
             return
         try:
             setattr(processor_cls, "config", {"atom_enabled": True})
-            logger.info("[PrivateCompanion] 已为 LivingMemory MemoryProcessor 添加 config 兼容兜底")
+            logger.info("已为 LivingMemory MemoryProcessor 添加 config 兼容兜底")
         except Exception as exc:
-            logger.debug("[PrivateCompanion] LivingMemory 兼容补丁应用失败: %s", _single_line(exc, 120))
+            logger.debug("LivingMemory 兼容补丁应用失败: %s", _single_line(exc, 120))
 
     def _integrated_plugin_installed(self, *names: str) -> bool:
         roots = [
@@ -582,12 +585,12 @@ class IntegrationStatusMixin:
         for key, plugin_names, message in rules:
             if self._integrated_plugin_installed(*plugin_names):
                 state = "开启" if bool(getattr(self, key, False)) else "关闭"
-                logger.info("[PrivateCompanion] %s", message % state)
+                logger.info("%s", message % state)
         if self._integrated_plugin_installed("astrbot_plugin_proactive_chat"):
             enabled = bool(runtime_persona_setting(self, 'enable_proactive_chat_integration', True))
             review_mode = str(runtime_persona_setting(self, 'proactive_chat_bridge_review_mode', "local") or "local")
             logger.info(
-                "[PrivateCompanion] 已检测到 Proactive Chat，私聊主动发送联动%s（复核模式=%s）；不会修改对方调度配置。",
+                "已检测到 Proactive Chat，私聊主动发送联动%s（复核模式=%s）；不会修改对方调度配置。",
                 "开启" if enabled else "关闭",
                 review_mode,
             )

--- a/llm_tool_actions.py
+++ b/llm_tool_actions.py
@@ -16,7 +16,6 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 
-from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent
 from astrbot.api.event import MessageChain
 from astrbot.core.platform.message_session import MessageSession
@@ -76,6 +75,9 @@ from .reaction_expression import (
     reserve_reaction_expression_intent,
 )
 from .reaction_asset_library import ReactionAssetLibrary, get_reaction_asset_library
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 PHOTO_TOOL_SILENT_SENTINEL = "[[PC_PHOTO_SENT_NO_FOLLOWUP]]"
@@ -419,7 +421,7 @@ class LlmToolActionsMixin:
         )
         if asset is None:
             logger.debug(
-                "[PrivateCompanion] Q6 自有反应图未命中: status=%s",
+                "Q6 自有反应图未命中: status=%s",
                 status,
             )
             return None
@@ -1293,7 +1295,7 @@ class LlmToolActionsMixin:
             except Exception:
                 pass
             logger.warning(
-                "[PrivateCompanion] 当前媒体扩展名规范化失败: file=%s error=%s",
+                "当前媒体扩展名规范化失败: file=%s error=%s",
                 path.name,
                 _single_line(exc, 160),
             )
@@ -1901,7 +1903,7 @@ class LlmToolActionsMixin:
             return cleaned
         if inventory_query:
             logger.warning(
-                "[PrivateCompanion] 资料柜查询未形成可信正文，已按本地真实库存回答: attempted=%s status=%s inventory_complete=%s session=%s",
+                "资料柜查询未形成可信正文，已按本地真实库存回答: attempted=%s status=%s inventory_complete=%s session=%s",
                 bool(getattr(event, "private_companion_creative_work_tool_attempted", False)),
                 _single_line(getattr(event, "private_companion_creative_work_tool_status", ""), 24) or "none",
                 inventory_complete,
@@ -1911,7 +1913,7 @@ class LlmToolActionsMixin:
         if bool(getattr(event, "private_companion_creative_work_tool_attempted", False)):
             return "我这次没能实际读取到对应的创作原文，先不凭印象乱讲。你可以再告诉我准确标题或第几部分，我读到后再认真和你说。"
         logger.warning(
-            "[PrivateCompanion] 指定创作问答未实际调用读取工具，已阻止凭片段作答: session=%s",
+            "指定创作问答未实际调用读取工具，已阻止凭片段作答: session=%s",
             _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
         )
         return "我这次还没能实际读取到对应的创作原文，先不凭印象乱讲。你可以再告诉我准确标题或第几部分，我读到后再认真和你说。"
@@ -2221,7 +2223,7 @@ class LlmToolActionsMixin:
             return raw, None
         setattr(event, "_private_companion_plaintext_tool_checked", True)
         logger.warning(
-            "[PrivateCompanion] 检测到模型将工具调用写入普通正文，已阻止外发: session=%s tools=%s",
+            "检测到模型将工具调用写入普通正文，已阻止外发: session=%s tools=%s",
             _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             ",".join(call.get("name", "") for call in calls),
         )
@@ -2273,7 +2275,7 @@ class LlmToolActionsMixin:
                 result = {"status": "error", "sent": False, "message": "生图工具返回无法解析"}
         except Exception as exc:
             logger.error(
-                "[PrivateCompanion] 明文生图工具调用恢复失败: session=%s error=%s",
+                "明文生图工具调用恢复失败: session=%s error=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                 _single_line(exc, 160),
                 exc_info=True,
@@ -2285,7 +2287,7 @@ class LlmToolActionsMixin:
         if sent:
             setattr(event, "_private_companion_plaintext_photo_sent", True)
             logger.info(
-                "[PrivateCompanion] 已恢复并执行明文生图工具调用: session=%s",
+                "已恢复并执行明文生图工具调用: session=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             )
             return cleaned, recovery
@@ -2345,7 +2347,7 @@ class LlmToolActionsMixin:
             else:
                 return False
         except Exception as exc:
-            logger.warning("[PrivateCompanion] 便签请求移除 future_task 失败: %s", _single_line(exc, 160))
+            logger.warning("便签请求移除 future_task 失败: %s", _single_line(exc, 160))
             return False
         return True
 
@@ -2407,7 +2409,7 @@ class LlmToolActionsMixin:
                 removed.append(name)
             except Exception as exc:
                 logger.debug(
-                    "[PrivateCompanion] 裁剪实验性表情工具失败: tool=%s error=%s",
+                    "裁剪实验性表情工具失败: tool=%s error=%s",
                     name,
                     _single_line(exc, 160),
                 )
@@ -2492,7 +2494,7 @@ class LlmToolActionsMixin:
         allowed = bool(is_private and requester_id and self._is_private_companion_owner_user_id(requester_id))
         if not allowed:
             logger.info(
-                "[PrivateCompanion] 便签管理权限未通过: private=%s sender=%s umo=%s",
+                "便签管理权限未通过: private=%s sender=%s umo=%s",
                 is_private,
                 requester_id or "-",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120),
@@ -2992,13 +2994,13 @@ class LlmToolActionsMixin:
                     setattr(event, "private_companion_memo_reminder_saved", True)
                 except Exception as exc:
                     logger.warning(
-                        "[PrivateCompanion] 便签提醒已保存但无法写入本轮去重标记: user=%s error=%s",
+                        "便签提醒已保存但无法写入本轮去重标记: user=%s error=%s",
                         requester_id,
                         _single_line(exc, 160),
                     )
                 else:
                     logger.info(
-                        "[PrivateCompanion] 便签提醒已保存,本轮将抑制重复临时定时: user=%s note=%s action=%s",
+                        "便签提醒已保存,本轮将抑制重复临时定时: user=%s note=%s action=%s",
                         requester_id,
                         _single_line(affected.get("id"), 64) or "-",
                         action_key,
@@ -3024,7 +3026,7 @@ class LlmToolActionsMixin:
         except ValueError as exc:
             return json.dumps({"status": "invalid", "saved": False, "message": str(exc)}, ensure_ascii=False)
         except Exception as exc:
-            logger.error("[PrivateCompanion] 聊天便签操作失败: %s", _single_line(exc, 160), exc_info=True)
+            logger.error("聊天便签操作失败: %s", _single_line(exc, 160), exc_info=True)
             return json.dumps({"status": "error", "saved": False, "message": f"便签操作失败: {_single_line(exc, 120)}"}, ensure_ascii=False)
 
     async def _note_photo_tool_quota_attempt(
@@ -3492,7 +3494,7 @@ class LlmToolActionsMixin:
                         ]
                 except Exception as exc:
                     logger.info(
-                        "[PrivateCompanion] 合影关系网角色参考图解析失败，继续检查本轮图片: %s",
+                        "合影关系网角色参考图解析失败，继续检查本轮图片: %s",
                         _single_line(exc, 160),
                     )
             has_named_role_reference = bool(role_reference_candidates)
@@ -3556,7 +3558,7 @@ class LlmToolActionsMixin:
                     stable = await resolver(source, stem=f"tool_{index + 1}", event=event, trusted=False)
                 except Exception as exc:
                     logger.info(
-                        "[PrivateCompanion] tool reference %s rejected: %s",
+                        "tool reference %s rejected: %s",
                         index + 1,
                         _single_line(exc, 160),
                     )
@@ -3570,18 +3572,18 @@ class LlmToolActionsMixin:
                     )
                 except Exception as exc:
                     logger.info(
-                        "[PrivateCompanion] current-event reference %s could not be persisted: %s",
+                        "current-event reference %s could not be persisted: %s",
                         index + 1,
                         _single_line(exc, 160),
                     )
                 if stable:
                     logger.info(
-                        "[PrivateCompanion] accepted model reference after exact current-event source verification: index=%s",
+                        "accepted model reference after exact current-event source verification: index=%s",
                         index + 1,
                     )
             if not stable:
                 logger.warning(
-                    "[PrivateCompanion] model-controlled image reference rejected: source=%s",
+                    "model-controlled image reference rejected: source=%s",
                     _single_line(source, 200),
                 )
                 return public_receipt(
@@ -3719,7 +3721,7 @@ class LlmToolActionsMixin:
                 )
             except Exception as exc:
                 logger.debug(
-                    "[PrivateCompanion] tool 生图读取提示词格式失败，保留原始提示词: %s",
+                    "tool 生图读取提示词格式失败，保留原始提示词: %s",
                     _single_line(exc, 160),
                 )
                 prompt_format_mode = "traditional"
@@ -3794,7 +3796,7 @@ class LlmToolActionsMixin:
                 "本次工具调用没有生成或发送图片。"
             )
             logger.warning(
-                "[PrivateCompanion] pc_generate_photo 在外层工具超时前主动结束: session=%s timeout=%.1fs budget=%.1fs",
+                "pc_generate_photo 在外层工具超时前主动结束: session=%s timeout=%.1fs budget=%.1fs",
                 session_key,
                 outer_timeout,
                 generation_timeout,
@@ -3947,7 +3949,7 @@ class LlmToolActionsMixin:
                 except Exception:
                     pass
                 logger.info(
-                    "[PrivateCompanion] pc_generate_photo 成图已交由主动发送链统一投递: session=%s kind=%s",
+                    "pc_generate_photo 成图已交由主动发送链统一投递: session=%s kind=%s",
                     session_key,
                     intent_kind,
                 )
@@ -3965,7 +3967,7 @@ class LlmToolActionsMixin:
                         "message": f"图片发送失败：{_single_line(exc, 180) or '未知错误'}",
                     }
                     logger.warning(
-                        "[PrivateCompanion] pc_generate_photo 图片投递异常: session=%s err=%s",
+                        "pc_generate_photo 图片投递异常: session=%s err=%s",
                         session_key,
                         _single_line(exc, 180),
                     )
@@ -4130,7 +4132,7 @@ class LlmToolActionsMixin:
             if policy_refusal:
                 public_error = "图片服务拒绝了这次画面描述，本次没有生成或发送图片。"
                 logger.warning(
-                    "[PrivateCompanion] pc_generate_photo 被图片服务策略拒绝: backend=%s error=%s",
+                    "pc_generate_photo 被图片服务策略拒绝: backend=%s error=%s",
                     _single_line(backend_name, 80),
                     note_text,
                 )
@@ -4503,7 +4505,7 @@ class LlmToolActionsMixin:
                         digits,
                     )
             logger.info(
-                "[PrivateCompanion][ReactionExpression] %s",
+                "[ReactionExpression] %s",
                 json.dumps(payload, ensure_ascii=False, separators=(",", ":")),
             )
         except Exception:
@@ -5254,7 +5256,7 @@ class LlmToolActionsMixin:
                 ):
                     return provider, configured
             logger.warning(
-                "[PrivateCompanion] Embedding Provider 不可用，回退本地语义与关键词: provider_id=%s",
+                "Embedding Provider 不可用，回退本地语义与关键词: provider_id=%s",
                 configured,
             )
             return None, configured
@@ -5374,7 +5376,7 @@ class LlmToolActionsMixin:
                 payload = await wait_result(get_embeddings(cleaned))
             except Exception as exc:
                 logger.debug(
-                    "[PrivateCompanion] 批量表情向量请求失败，回退逐条生成: error_type=%s",
+                    "批量表情向量请求失败，回退逐条生成: error_type=%s",
                     type(exc).__name__,
                 )
                 return await asyncio.gather(
@@ -5390,7 +5392,7 @@ class LlmToolActionsMixin:
                     payload = await wait_result(get_batch(cleaned))
                 except Exception as exc:
                     logger.debug(
-                        "[PrivateCompanion] 批量表情向量请求失败，回退逐条生成: error_type=%s",
+                        "批量表情向量请求失败，回退逐条生成: error_type=%s",
                         type(exc).__name__,
                     )
                     return await asyncio.gather(
@@ -5398,7 +5400,7 @@ class LlmToolActionsMixin:
                     )
             except Exception as exc:
                 logger.debug(
-                    "[PrivateCompanion] 批量表情向量请求失败，回退逐条生成: error_type=%s",
+                    "批量表情向量请求失败，回退逐条生成: error_type=%s",
                     type(exc).__name__,
                 )
                 return await asyncio.gather(
@@ -5435,13 +5437,13 @@ class LlmToolActionsMixin:
                 try:
                     vector = await self._reaction_embedding_vector(provider, library.embedding_text(item))
                 except Exception as exc:
-                    logger.debug("[PrivateCompanion] 表情向量补齐失败: provider=%s error_type=%s", provider_id, type(exc).__name__)
+                    logger.debug("表情向量补齐失败: provider=%s error_type=%s", provider_id, type(exc).__name__)
                     continue
                 if vector:
                     updates.append({"id": item.get("id"), "text_hash": text_hash, "vector": vector})
             if updates:
                 await asyncio.to_thread(library.upsert_embeddings, provider_id, updates)
-                logger.info("[PrivateCompanion] 已补齐表情语义向量: provider=%s count=%s", provider_id, len(updates))
+                logger.info("已补齐表情语义向量: provider=%s count=%s", provider_id, len(updates))
         finally:
             inflight = getattr(self, "_reaction_embedding_backfill_inflight", set())
             inflight.discard(provider_id)
@@ -6766,7 +6768,7 @@ class LlmToolActionsMixin:
                     )
             except Exception as exc:
                 logger.debug(
-                    "[PrivateCompanion] 表情查询向量生成失败，回退关键词: provider=%s error_type=%s",
+                    "表情查询向量生成失败，回退关键词: provider=%s error_type=%s",
                     embedding_provider_id or "<auto>",
                     type(exc).__name__,
                 )
@@ -6829,7 +6831,7 @@ class LlmToolActionsMixin:
             except Exception as exc:
                 lookup_error_type = type(exc).__name__
                 logger.warning(
-                    "[PrivateCompanion] 自有表情包素材库检索失败: error_type=%s",
+                    "自有表情包素材库检索失败: error_type=%s",
                     lookup_error_type,
                 )
                 lookup = {
@@ -8072,7 +8074,7 @@ class LlmToolActionsMixin:
         forbidden_message = "只有配置的主要用户可以查询 Bot 与其他人的互动。" if owner_only else "只有配置的主要用户或 AstrBot 全局管理员可以查询 Bot 与其他人的互动。"
         if not is_private or not allowed:
             logger.info(
-                "[PrivateCompanion] 跨用户互动查询权限未通过: sender=%s owner=%s admin=%s owner_only=%s umo=%s",
+                "跨用户互动查询权限未通过: sender=%s owner=%s admin=%s owner_only=%s umo=%s",
                 requester_id or "-",
                 owner_allowed,
                 admin_allowed,
@@ -8227,7 +8229,7 @@ class LlmToolActionsMixin:
         allowed = owner_allowed or admin_allowed
         if not allowed:
             logger.info(
-                "[PrivateCompanion] 关系网查询权限未通过: private=%s sender=%s owner=%s admin=%s umo=%s",
+                "关系网查询权限未通过: private=%s sender=%s owner=%s admin=%s umo=%s",
                 is_private,
                 requester_id or "-",
                 owner_allowed,
@@ -8290,10 +8292,10 @@ class LlmToolActionsMixin:
                     existing_ids.add(uid)
 
         if not matches:
-            logger.info("[PrivateCompanion] 关系网查询未命中: keyword=%s", keyword)
+            logger.info("关系网查询未命中: keyword=%s", keyword)
             return json.dumps({"status": "not_found", "keyword": keyword, "message": "关系网里没有确认匹配对象"}, ensure_ascii=False)
         status = "success" if len(matches) == 1 else "ambiguous"
-        logger.info("[PrivateCompanion] 关系网查询命中: keyword=%s count=%s", keyword, len(matches))
+        logger.info("关系网查询命中: keyword=%s count=%s", keyword, len(matches))
         return json.dumps(
             {
                 "status": status,
@@ -8440,14 +8442,14 @@ class LlmToolActionsMixin:
                         session_id=str(getattr(session, "session_id", "") or ""),
                     )
                     await platform.send_by_session(session_obj, MessageChain(chain))
-                    logger.info("[PrivateCompanion] 转述已通过精确平台发送: umo=%s", _single_line(umo, 160))
+                    logger.info("转述已通过精确平台发送: umo=%s", _single_line(umo, 160))
                     return True, "", umo
                 except Exception as exc:
                     errors.append(f"{umo}: 精确发送失败 {self._format_send_exception(exc)}")
                 try:
                     result = await self.context.send_message(umo, MessageChain(chain))
                     if result is not False:
-                        logger.info("[PrivateCompanion] 转述已通过 AstrBot 核心发送: umo=%s", _single_line(umo, 160))
+                        logger.info("转述已通过 AstrBot 核心发送: umo=%s", _single_line(umo, 160))
                         return True, "", umo
                     errors.append(f"{umo}: 核心发送返回 False")
                 except Exception as exc:
@@ -8771,7 +8773,7 @@ class LlmToolActionsMixin:
         )
         if not ok:
             logger.warning(
-                "[PrivateCompanion] 跨群转述发送失败: group=%s at=%s error=%s",
+                "跨群转述发送失败: group=%s at=%s error=%s",
                 target_group,
                 at_qq or at_user or "-",
                 _single_line(error, 240),
@@ -8780,7 +8782,7 @@ class LlmToolActionsMixin:
         self._note_atrelay_send("group", target_group, text, at_qq or at_user, event=event)
         self._save_data_sync(sections={"recent_atrelay_contexts", "atrelay_send_log"})
         logger.info(
-            "[PrivateCompanion] 跨群转述发送完成: group=%s at=%s umo=%s",
+            "跨群转述发送完成: group=%s at=%s umo=%s",
             target_group,
             at_qq or at_user or "-",
             _single_line(used_umo, 160),
@@ -8835,7 +8837,7 @@ class LlmToolActionsMixin:
         )
         if not ok:
             logger.warning(
-                "[PrivateCompanion] 私聊转述发送失败: user=%s error=%s",
+                "私聊转述发送失败: user=%s error=%s",
                 target_user,
                 _single_line(error, 240),
             )
@@ -8852,7 +8854,7 @@ class LlmToolActionsMixin:
             )
         self._save_data_sync(sections={"pending_atrelay_receipts", "recent_atrelay_contexts", "atrelay_send_log"})
         logger.info(
-            "[PrivateCompanion] 私聊转述发送完成: user=%s umo=%s",
+            "私聊转述发送完成: user=%s umo=%s",
             target_user,
             _single_line(used_umo, 160),
         )

--- a/logging_util.py
+++ b/logging_util.py
@@ -1,0 +1,150 @@
+"""Module-tagged logging helpers for the private companion plugin.
+
+Each module obtains its logger with ``logger = get_module_logger(__name__)``.
+The returned proxy prefixes every message with a Chinese module label, e.g.
+``[空间动态]``, so a log line can be attributed to its source module at a
+glance and filtered by grep, in addition to the ``[source_file:line]``
+metadata added by the AstrBot logging pipeline. Messages still flow through
+the AstrBot plugin logger, so the per-plugin log level and the
+``[astrbot_plugin_private_companion]`` tag remain effective.
+"""
+
+from __future__ import annotations
+
+from astrbot.api import logger as _plugin_logger
+
+_PACKAGE_PREFIXES = (
+    "data.plugins.astrbot_plugin_private_companion.",
+    "astrbot_plugin_private_companion.",
+)
+
+# Chinese labels keyed by module path (last segment). Modules without an
+# entry fall back to their raw module name so new modules keep working.
+_MODULE_LABELS = {
+    "astrbot_knowledge": "知识库",
+    "atrelay": "@中继",
+    "balance_awareness": "余额感知",
+    "busy_reply_gate": "忙碌回复门控",
+    "command_handlers": "指令处理",
+    "config_migration": "配置迁移",
+    "content_companion_bridge": "内容陪伴桥接",
+    "core_store": "核心存储",
+    "creative": "创作系统",
+    "daily_review": "每日回顾",
+    "daily_state": "日程状态",
+    "daily_state_tick": "日程状态心跳",
+    "desktop_pet_bridge": "桌宠桥接",
+    "event_dispatch": "事件分发",
+    "final_response_persistence": "回复持久化",
+    "forward_message": "转发消息",
+    "game_integration": "游戏联动",
+    "group_member_safety": "群成员安全",
+    "group_observation": "群聊观察",
+    "group_wakeup": "群聊唤醒",
+    "image_companion_bridge": "图像陪伴桥接",
+    "integration_status": "集成状态",
+    "llm_tool_actions": "LLM工具动作",
+    "logging_util": "日志工具",
+    "main": "主链",
+    "memory_companion_adapter": "记忆陪伴适配",
+    "message_pipeline": "消息管线",
+    "nai_image_bridge": "NAI生图桥接",
+    "news_exploration": "新闻探索",
+    "page_api": "面板接口",
+    "page_api_qzone": "面板接口·空间",
+    "page_api_users_groups": "面板接口·用户群组",
+    "passive_state_pipeline": "被动状态管线",
+    "place_cognitive_map": "地点认知地图",
+    "plugin_bootstrap": "插件引导",
+    "private_image": "私聊图片",
+    "proactive": "主动调度",
+    "proactive_chat_runtime_bridge": "主动聊天桥接",
+    "proactive_engine": "主动引擎",
+    "proactive_message": "主动消息",
+    "qzone_auth": "空间登录",
+    "qzone_comments": "空间评论",
+    "qzone_feed": "空间动态",
+    "qzone_media": "空间媒体",
+    "qzone_publish": "空间发布",
+    "qzone_runtime": "空间运行时",
+    "qzone_schedule": "空间调度",
+    "reality_companion_bridge": "现实陪伴桥接",
+    "sqlite_backend": "存储·SQLite后端",
+    "json_backend": "存储·JSON后端",
+    "migration": "存储·迁移",
+    "store_manager": "存储·管理器",
+    "token_budget": "Token预算",
+    "tts_enhancement": "TTS增强",
+    "tts_tool_sanitizer": "TTS工具清洗",
+    "user_memory": "用户记忆",
+    "user_rest_gate": "休息门控",
+    "worldbook": "世界书",
+}
+
+
+def _module_tag(module_name: str | None) -> str:
+    """Derive the log tag for a module from its ``__name__``.
+
+    The relative module path is looked up in ``_MODULE_LABELS`` (full path
+    first, then the last path segment) and replaced with its Chinese label.
+    Modules without an entry keep their raw module name.
+
+    Args:
+        module_name: The ``__name__`` of the calling module.
+
+    Returns:
+        The dotted module path relative to the plugin package, replaced by
+        its Chinese label when one is mapped. Modules outside the plugin
+        package (for example under a test loader) are reduced to their last
+        path component first.
+    """
+    if not module_name:
+        return "未知"
+    for prefix in _PACKAGE_PREFIXES:
+        if module_name.startswith(prefix):
+            module_name = module_name[len(prefix) :] or "root"
+    tag = module_name.rpartition(".")[2] or module_name
+    return _MODULE_LABELS.get(module_name) or _MODULE_LABELS.get(tag, tag)
+
+
+class _ModuleLogger:
+    """Logger proxy that prefixes messages with the source module tag.
+
+    Level methods accept the same positional and keyword arguments as the
+    standard ``logging`` methods, including lazy ``%``-style formatting and
+    ``exc_info``. No ``__slots__`` is defined so tests can patch individual
+    methods (e.g. ``mock.patch.object(logger, "info")``).
+    """
+
+    def __init__(self, tag: str) -> None:
+        self._prefix = f"[{tag}] "
+
+    def _format(self, msg: object) -> str:
+        return f"{self._prefix}{msg}"
+
+    def debug(self, msg: object, *args: object, **kwargs: object) -> None:
+        _plugin_logger.debug(self._format(msg), *args, **kwargs)
+
+    def info(self, msg: object, *args: object, **kwargs: object) -> None:
+        _plugin_logger.info(self._format(msg), *args, **kwargs)
+
+    def warning(self, msg: object, *args: object, **kwargs: object) -> None:
+        _plugin_logger.warning(self._format(msg), *args, **kwargs)
+
+    def error(self, msg: object, *args: object, **kwargs: object) -> None:
+        _plugin_logger.error(self._format(msg), *args, **kwargs)
+
+    def exception(self, msg: object, *args: object, **kwargs: object) -> None:
+        _plugin_logger.exception(self._format(msg), *args, **kwargs)
+
+
+def get_module_logger(module_name: str | None = None) -> _ModuleLogger:
+    """Get the module-tagged logger for the calling module.
+
+    Args:
+        module_name: Pass ``__name__`` from the calling module.
+
+    Returns:
+        A logger proxy prefixing messages with the module tag.
+    """
+    return _ModuleLogger(_module_tag(module_name))

--- a/main.py
+++ b/main.py
@@ -32,7 +32,7 @@ from typing import Any
 from urllib.parse import parse_qsl, quote, unquote, urlencode, urlparse, urlunparse
 from xml.etree import ElementTree as ET
 
-from astrbot.api import AstrBotConfig, logger
+from astrbot.api import AstrBotConfig
 from astrbot.api.event import AstrMessageEvent, MessageChain, filter
 try:
     from astrbot.api.message_components import (
@@ -390,7 +390,7 @@ except ModuleNotFoundError as exc:
             return {"reviewed": False, "counted": False, "blocked": False, "reason": "module_missing"}
 
     logger.error(
-        "[PrivateCompanion] 发布包缺少 group_member_safety.py，群成员风控已停用；插件其余功能继续加载。"
+        "发布包缺少 group_member_safety.py，群成员风控已停用；插件其余功能继续加载。"
         "请重新安装包含该文件的完整版本。"
     )
 from .event_dispatch import EventDispatchMixin
@@ -408,7 +408,7 @@ except ModuleNotFoundError as exc:
         def _format_self_timeline_context_for_reply(self, *args: Any, **kwargs: Any) -> str:
             return ""
 
-    logger.warning("[PrivateCompanion] self_timeline.py 缺失，已跳过 Bot 自身时间线注入能力。请重新安装完整版本。")
+    logger.warning("self_timeline.py 缺失，已跳过 Bot 自身时间线注入能力。请重新安装完整版本。")
 from .core_store import CoreStoreMixin
 from .platform_compat import PlatformCompatibilityMixin
 from .integration_status import IntegrationStatusMixin
@@ -456,6 +456,9 @@ from .planning import (
     normalize_story_plan,
     pick_detail_segment,
 )
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 _private_companion_plugin: Any | None = None
 
@@ -2174,7 +2177,7 @@ class PrivateCompanionPlugin(
                 if backup is not None:
                     result.setdefault("backups", {})[pid] = str(backup)
                 logger.warning(
-                    "[PrivateCompanion] 人格配置迁移降级: persona=%s error=%s",
+                    "人格配置迁移降级: persona=%s error=%s",
                     pid,
                     _single_line(exc, 180),
                 )
@@ -2375,7 +2378,7 @@ class PrivateCompanionPlugin(
         try:
             shutil.copy2(path, backup)
             logger.error(
-                "[PrivateCompanion] 已隔离损坏人格 profile: source=%s backup=%s reason=%s",
+                "已隔离损坏人格 profile: source=%s backup=%s reason=%s",
                 path,
                 backup,
                 _single_line(reason, 160),
@@ -2383,7 +2386,7 @@ class PrivateCompanionPlugin(
             return backup
         except Exception as exc:
             logger.error(
-                "[PrivateCompanion] 人格 profile 备份失败: source=%s error=%s",
+                "人格 profile 备份失败: source=%s error=%s",
                 path,
                 _single_line(exc, 160),
             )
@@ -2432,7 +2435,7 @@ class PrivateCompanionPlugin(
             if legacy_path.is_file():
                 self._backup_corrupt_persona_profile_sync(legacy_path, reason=str(exc))
             profile_errors[pid] = str(exc)
-            logger.warning("[PrivateCompanion] 人格资料读取失败 persona=%s error=%s", pid, _single_line(exc, 160))
+            logger.warning("人格资料读取失败 persona=%s error=%s", pid, _single_line(exc, 160))
         if loaded is not None:
             profile = loaded
         else:
@@ -2459,7 +2462,7 @@ class PrivateCompanionPlugin(
                 self._save_persona_profile_sync(pid, profile)
             except Exception as exc:
                 logger.warning(
-                    "[PrivateCompanion] 旧人格身份配置初始化落盘失败: persona=%s error=%s",
+                    "旧人格身份配置初始化落盘失败: persona=%s error=%s",
                     pid,
                     _single_line(exc, 160),
                 )
@@ -2687,7 +2690,7 @@ class PrivateCompanionPlugin(
                 except Exception as exc:
                     rebuild_error = _single_line(exc, 180)
                     logger.warning(
-                        "[PrivateCompanion] 当前人格资料已重置，但今日数据重建失败: persona=%s error=%s",
+                        "当前人格资料已重置，但今日数据重建失败: persona=%s error=%s",
                         pid or "single",
                         rebuild_error,
                         exc_info=True,
@@ -2893,7 +2896,7 @@ class PrivateCompanionPlugin(
         self._legacy_persona_routing_status = status
         if status["ignored"]:
             logger.warning(
-                "[PrivateCompanion] 已停用插件窗口人格路由，AstrBot 为唯一权威: count=%s backup=%s error=%s",
+                "已停用插件窗口人格路由，AstrBot 为唯一权威: count=%s backup=%s error=%s",
                 len(merged),
                 status["backup_path"] or "-",
                 file_error or "-",
@@ -3250,7 +3253,7 @@ class PrivateCompanionPlugin(
         if now - float(log_marks.get(record_id) or 0) >= 300:
             log_marks[record_id] = now
             logger.warning(
-                "[PrivateCompanion] 人格路由告警 code=%s reason=%s umo=%s astrbot=%s plugin=%s action=%s",
+                "人格路由告警 code=%s reason=%s umo=%s astrbot=%s plugin=%s action=%s",
                 code,
                 reason,
                 window or "-",
@@ -3968,7 +3971,7 @@ class PrivateCompanionPlugin(
         )
         if task is None:
             logger.warning(
-                "[PrivateCompanion] 人格配置已保存，但主动调度即时唤醒未启动: persona=%s",
+                "人格配置已保存，但主动调度即时唤醒未启动: persona=%s",
                 pid,
             )
 
@@ -4326,7 +4329,7 @@ class PrivateCompanionPlugin(
                     "dual_write": "failed",
                 })
             logger.warning(
-                "[PrivateCompanion] REQ-041 身份双写失败，已暂停新读切换并保留 legacy 写入: %s",
+                "REQ-041 身份双写失败，已暂停新读切换并保留 legacy 写入: %s",
                 _single_line(exc, 160),
             )
             return {"status": "failed", "code": "identity_dual_write_failed"}
@@ -4366,7 +4369,7 @@ class PrivateCompanionPlugin(
                     "dual_write": "failed",
                 })
             logger.warning(
-                "[PrivateCompanion] REQ-041 关系快照双写失败，已暂停新读切换并保留 legacy 写入: %s",
+                "REQ-041 关系快照双写失败，已暂停新读切换并保留 legacy 写入: %s",
                 _single_line(exc, 160),
             )
             return {"status": "failed", "code": "relationship_snapshot_dual_write_failed"}
@@ -4835,7 +4838,7 @@ class PrivateCompanionPlugin(
                     denial_cache.pop(cache_key, None)
             if denial_cache_key in denial_cache:
                 logger.debug(
-                    "[PrivateCompanion] 已忽略重复的未授权私聊拒绝: sender=%s message_id=%s",
+                    "已忽略重复的未授权私聊拒绝: sender=%s message_id=%s",
                     sender_id or "-",
                     message_id,
                 )
@@ -4867,7 +4870,7 @@ class PrivateCompanionPlugin(
             raise
         if reply_result is False:
             release_reply_reservations()
-            logger.debug("[PrivateCompanion] 未授权私聊拒绝未发送，已释放回流与消息去重占位")
+            logger.debug("未授权私聊拒绝未发送，已释放回流与消息去重占位")
             return
         echo_confirm = getattr(self, "_confirm_req036_denial_echo", None)
         if callable(echo_confirm) and echo_entry is not None:
@@ -5337,11 +5340,11 @@ class PrivateCompanionPlugin(
                 failed.append(f"{path.name}:{_single_line(exc, 80)}")
         if applied:
             logger.info(
-                "[PrivateCompanion] 插件自有 SQLite WAL 优化已应用: files=%s",
+                "插件自有 SQLite WAL 优化已应用: files=%s",
                 "，".join(applied),
             )
         if failed:
-            logger.warning("[PrivateCompanion] SQLite WAL 并发优化部分失败: %s", "；".join(failed))
+            logger.warning("SQLite WAL 并发优化部分失败: %s", "；".join(failed))
 
     def _repair_private_companion_handler_bindings(self) -> None:
         """热更新后强制把残留 handler 重新绑定到当前插件实例。"""
@@ -5364,9 +5367,9 @@ class PrivateCompanionPlugin(
                 handler.handler = functools.partial(current_func, self)
                 repaired += 1
             if repaired:
-                logger.info("[PrivateCompanion] 已修复热更新残留回调绑定: handlers=%s", repaired)
+                logger.info("已修复热更新残留回调绑定: handlers=%s", repaired)
         except Exception as exc:
-            logger.warning("[PrivateCompanion] 修复热更新残留回调绑定失败: %s", _single_line(exc, 160))
+            logger.warning("修复热更新残留回调绑定失败: %s", _single_line(exc, 160))
 
     def _req041_migration_source_files(self) -> list[Path]:
         # Once a migration has a verified backup, its manifest is the authority
@@ -6078,7 +6081,7 @@ class PrivateCompanionPlugin(
             status = getattr(self, "req041_migration_status", None)
             if self._req041_group_remote_cleanup_required():
                 logger.warning(
-                    "[PrivateCompanion] 群聊删除因远端分域不可用而保留: group=%s state=%s code=%s memory_bound=%s scoped_required=%s",
+                    "群聊删除因远端分域不可用而保留: group=%s state=%s code=%s memory_bound=%s scoped_required=%s",
                     clean_group,
                     _single_line((status or {}).get("state"), 32),
                     _single_line((status or {}).get("code"), 96),
@@ -6087,7 +6090,7 @@ class PrivateCompanionPlugin(
                 )
                 return {"ok": False, "state": "degraded", "code": "scoped_group_erase_unavailable"}
             logger.info(
-                "[PrivateCompanion] MemoryCompanion 从未绑定，群聊删除仅清理本地分域: group=%s",
+                "MemoryCompanion 从未绑定，群聊删除仅清理本地分域: group=%s",
                 clean_group,
             )
             return {"ok": True, "state": "not_required", "code": "scoped_group_erase_not_required"}
@@ -7003,7 +7006,7 @@ class PrivateCompanionPlugin(
             if isinstance(status, dict):
                 status.update({"state": "degraded", "code": "group_affinity_settlement_failed"})
             logger.warning(
-                "[PrivateCompanion] REQ-041 群好感度结算失败，已保持事件可重放: %s",
+                "REQ-041 群好感度结算失败，已保持事件可重放: %s",
                 _single_line(exc, 160),
             )
 
@@ -7016,7 +7019,7 @@ class PrivateCompanionPlugin(
             try:
                 await asyncio.to_thread(router.finish, chain_id)
             except Exception as exc:
-                logger.debug("[PrivateCompanion] REQ-041 读链清理失败: %s", _single_line(exc, 120))
+                logger.debug("REQ-041 读链清理失败: %s", _single_line(exc, 120))
             try:
                 setattr(event, "req041_read_chain_id", "")
             except Exception:
@@ -7197,7 +7200,7 @@ class PrivateCompanionPlugin(
                         "code": _single_line(backfill_exc, 120) or "s4_backfill_failed",
                     }
                     logger.warning(
-                        "[PrivateCompanion] REQ-041 S4 Shadow 回填失败，继续使用 legacy 路径: %s",
+                        "REQ-041 S4 Shadow 回填失败，继续使用 legacy 路径: %s",
                         _single_line(backfill_exc, 160),
                     )
 
@@ -7403,7 +7406,7 @@ class PrivateCompanionPlugin(
                 "phase": status.get("phase", "S0") if status else "S0",
             }
             logger.warning(
-                "[PrivateCompanion] REQ-041 自动迁移启动失败，继续使用官方 legacy 路径: %s",
+                "REQ-041 自动迁移启动失败，继续使用官方 legacy 路径: %s",
                 _single_line(exc, 160),
             )
 
@@ -7527,7 +7530,7 @@ class PrivateCompanionPlugin(
         self._repair_private_companion_handler_bindings()
         if getattr(self, "_legacy_enabled_config_disabled", False):
             logger.warning(
-                "[PrivateCompanion] 检测到旧版配置 enabled=false；该字段已废弃并被忽略。"
+                "检测到旧版配置 enabled=false；该字段已废弃并被忽略。"
                 "如需停用插件，请在 AstrBot 官方插件管理页关闭本插件。"
             )
         self._log_registered_command_handlers()
@@ -7556,7 +7559,7 @@ class PrivateCompanionPlugin(
                 if cleaned_habit_users:
                     changed = True
                     logger.info(
-                        "[PrivateCompanion] 已清理旧版低质量用户习惯记录: users=%s",
+                        "已清理旧版低质量用户习惯记录: users=%s",
                         cleaned_habit_users,
                     )
             if runtime_persona_setting(self, 'default_enable_configured_targets', True):
@@ -7564,7 +7567,7 @@ class PrivateCompanionPlugin(
                 changed = True
             recovered_troubleshooting = self._recover_stale_troubleshooting_proactive_plans()
             if recovered_troubleshooting:
-                logger.info("[PrivateCompanion] 已恢复未完成的排障临时主动任务: %s", recovered_troubleshooting)
+                logger.info("已恢复未完成的排障临时主动任务: %s", recovered_troubleshooting)
             if self._prime_enabled_user_schedules():
                 changed = True
             if recovered_troubleshooting:
@@ -7591,7 +7594,7 @@ class PrivateCompanionPlugin(
         )
         if self._task is None or self._task.done():
             self._task = asyncio.create_task(self._scheduler_loop())
-            logger.info("[PrivateCompanion] 主动消息循环已启动")
+            logger.info("主动消息循环已启动")
         self._create_startup_background_task(
             "mobile_location_watch",
             self._mobile_location_watch_loop,
@@ -7623,7 +7626,7 @@ class PrivateCompanionPlugin(
                 await standalone_webui.start()
             except Exception as exc:
                 logger.warning(
-                    "[PrivateCompanion] 独立陪伴 WebUI 启动失败: %s",
+                    "独立陪伴 WebUI 启动失败: %s",
                     _single_line(exc, 160),
                     exc_info=True,
                 )
@@ -7646,7 +7649,7 @@ class PrivateCompanionPlugin(
                 return
             if error is not None:
                 logger.warning(
-                    "[PrivateCompanion] startup background task failed: task=%s error=%s",
+                    "startup background task failed: task=%s error=%s",
                     _single_line(label, 100) or "startup",
                     _single_line(error, 180),
                     exc_info=(type(error), error, error.__traceback__),
@@ -7689,7 +7692,7 @@ class PrivateCompanionPlugin(
             if callable(closer):
                 closer()
             logger.debug(
-                "[PrivateCompanion] 插件已进入终止流程，跳过创建后台任务: task=%s",
+                "插件已进入终止流程，跳过创建后台任务: task=%s",
                 _single_line(label, 100) or "background",
             )
             return None
@@ -7700,7 +7703,7 @@ class PrivateCompanionPlugin(
             if callable(closer):
                 closer()
             logger.warning(
-                "[PrivateCompanion] 后台任务无法启动：当前没有运行中的事件循环 task=%s",
+                "后台任务无法启动：当前没有运行中的事件循环 task=%s",
                 _single_line(label, 100) or "background",
             )
             return None
@@ -7723,7 +7726,7 @@ class PrivateCompanionPlugin(
                 return
             if error is not None:
                 logger.warning(
-                    "[PrivateCompanion] 后台任务异常结束: task=%s error=%s",
+                    "后台任务异常结束: task=%s error=%s",
                     _single_line(task_label, 100) or "background",
                     _single_line(error, 180),
                     exc_info=(type(error), error, error.__traceback__),
@@ -7765,7 +7768,7 @@ class PrivateCompanionPlugin(
                     }
                 )
                 logger.warning(
-                    "[PrivateCompanion] 终止后台任务超时,继续卸载: tasks=%s",
+                    "终止后台任务超时,继续卸载: tasks=%s",
                     "，".join(labels),
                 )
         registry.clear()
@@ -7787,14 +7790,14 @@ class PrivateCompanionPlugin(
                 if handler_name in expected:
                     found.add(handler_name)
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 指令注册诊断失败: %s", _single_line(exc, 120))
+            logger.debug("指令注册诊断失败: %s", _single_line(exc, 120))
             return
         registered = [expected[name] for name in expected if name in found]
         missing = [expected[name] for name in expected if name not in found]
         if registered:
-            logger.info("[PrivateCompanion] AstrBot 指令已注册: %s", "；".join(registered))
+            logger.info("AstrBot 指令已注册: %s", "；".join(registered))
         if missing:
-            logger.warning("[PrivateCompanion] AstrBot 指令注册诊断未找到: %s", "；".join(missing))
+            logger.warning("AstrBot 指令注册诊断未找到: %s", "；".join(missing))
 
     def _run_startup_data_maintenance_locked(self) -> bool:
         changed = False
@@ -7806,10 +7809,10 @@ class PrivateCompanionPlugin(
                 if callable(func) and func():
                     changed = True
             except Exception as exc:
-                logger.warning("[PrivateCompanion] 启动后台维护步骤失败: %s error=%s", label, _single_line(exc, 160))
+                logger.warning("启动后台维护步骤失败: %s error=%s", label, _single_line(exc, 160))
             elapsed_ms = int((time.perf_counter() - started) * 1000)
             if elapsed_ms > 1200:
-                logger.warning("[PrivateCompanion] 启动后台维护步骤耗时较高: step=%s elapsed=%sms", label, elapsed_ms)
+                logger.warning("启动后台维护步骤耗时较高: step=%s elapsed=%sms", label, elapsed_ms)
 
         run_step("legacy_prompt_trace_cleanup", self._cleanup_legacy_proactive_prompt_traces)
         run_step("framework_meta_leak_cleanup", self._cleanup_framework_meta_leak_records)
@@ -7857,29 +7860,29 @@ class PrivateCompanionPlugin(
                         self._startup_photo_reference_catalog_migration_pending = False
                         self.photo_reference_catalog_read_only = False
                         logger.info(
-                            "[PrivateCompanion] 参考图目录迁移完成: version=%s references=%s",
+                            "参考图目录迁移完成: version=%s references=%s",
                             CATALOG_VERSION,
                             len(runtime_persona_setting(self, 'photo_reference_catalog', ()) or ()),
                         )
                     else:
-                        logger.error("[PrivateCompanion] 参考图目录已保存，但迁移版本号保存失败；下次启动会安全重试")
+                        logger.error("参考图目录已保存，但迁移版本号保存失败；下次启动会安全重试")
                 elif not catalog_saved:
-                    logger.error("[PrivateCompanion] 参考图目录迁移保存失败，当前进程继续使用只读内存投影")
+                    logger.error("参考图目录迁移保存失败，当前进程继续使用只读内存投影")
                 else:
-                    logger.error("[PrivateCompanion] 参考图目录已保存，但迁移版本号无法写入；当前进程继续使用只读内存投影")
+                    logger.error("参考图目录已保存，但迁移版本号无法写入；当前进程继续使用只读内存投影")
                 elapsed_ms = int((time.perf_counter() - config_started) * 1000)
                 if elapsed_ms > 1200:
-                    logger.warning("[PrivateCompanion] 启动后台配置保存耗时较高: elapsed=%sms", elapsed_ms)
+                    logger.warning("启动后台配置保存耗时较高: elapsed=%sms", elapsed_ms)
             elif _safe_int(getattr(self, "_startup_config_migration_changes", 0), 0, 0) > 0:
                 config_started = time.perf_counter()
                 await self._save_config_if_possible()
                 elapsed_ms = int((time.perf_counter() - config_started) * 1000)
                 if elapsed_ms > 1200:
-                    logger.warning("[PrivateCompanion] 启动后台配置保存耗时较高: elapsed=%sms", elapsed_ms)
+                    logger.warning("启动后台配置保存耗时较高: elapsed=%sms", elapsed_ms)
             try:
                 await asyncio.wait_for(self._apply_sqlite_wal_optimizations(), timeout=20)
             except asyncio.TimeoutError:
-                logger.warning("[PrivateCompanion] SQLite WAL 后台优化超时,已跳过本轮启动优化")
+                logger.warning("SQLite WAL 后台优化超时,已跳过本轮启动优化")
             await self._image_companion_maintenance()
             if self._nai_image_selected():
                 await self._nai_image_maintenance()
@@ -7890,11 +7893,11 @@ class PrivateCompanionPlugin(
                     self._save_data_sync(full_scope="startup_maintenance")
             elapsed_ms = int((time.perf_counter() - started) * 1000)
             if elapsed_ms > 1200:
-                logger.info("[PrivateCompanion] 启动后台维护完成: elapsed=%sms", elapsed_ms)
+                logger.info("启动后台维护完成: elapsed=%sms", elapsed_ms)
         except asyncio.CancelledError:
             raise
         except Exception as exc:
-            logger.warning("[PrivateCompanion] 启动后台维护失败: %s", _single_line(exc, 160), exc_info=True)
+            logger.warning("启动后台维护失败: %s", _single_line(exc, 160), exc_info=True)
 
     async def terminate(self):
         global _private_companion_plugin
@@ -7905,7 +7908,7 @@ class PrivateCompanionPlugin(
                 await standalone_webui.stop()
             except Exception as exc:
                 logger.warning(
-                    "[PrivateCompanion] 独立陪伴 WebUI 停止失败: %s",
+                    "独立陪伴 WebUI 停止失败: %s",
                     _single_line(exc, 160),
                 )
         cleanup_delivery_caches = getattr(self, "_cleanup_framework_delivery_caches", None)
@@ -7928,7 +7931,7 @@ class PrivateCompanionPlugin(
                 await runtime_bridge.stop()
             except Exception as exc:
                 logger.warning(
-                    "[PrivateCompanion] 终止 Proactive Chat 深度联动失败: %s",
+                    "终止 Proactive Chat 深度联动失败: %s",
                     _single_line(exc, 160),
                 )
 
@@ -7938,7 +7941,7 @@ class PrivateCompanionPlugin(
             task.cancel()
             done, pending = await asyncio.wait({task}, timeout=timeout)
             if pending:
-                logger.warning("[PrivateCompanion] 终止后台任务超时,继续卸载: task=%s", label)
+                logger.warning("终止后台任务超时,继续卸载: task=%s", label)
                 return
             for finished in done:
                 try:
@@ -7946,7 +7949,7 @@ class PrivateCompanionPlugin(
                 except asyncio.CancelledError:
                     pass
                 except Exception as exc:
-                    logger.debug("[PrivateCompanion] 终止后台任务时收到异常: task=%s error=%s", label, _single_line(exc, 160))
+                    logger.debug("终止后台任务时收到异常: task=%s error=%s", label, _single_line(exc, 160))
 
         if self._task:
             await cancel_task(self._task, "proactive_scheduler")
@@ -7979,14 +7982,14 @@ class PrivateCompanionPlugin(
             await asyncio.wait_for(self._flush_scheduled_data_save(), timeout=3.0)
         except asyncio.TimeoutError:
             logger.warning(
-                "[PrivateCompanion] Scheduled persistence did not drain before "
+                "Scheduled persistence did not drain before "
                 "shutdown; final persistence will continue in the background"
             )
         except asyncio.CancelledError:
             pass
         except Exception as exc:
             logger.debug(
-                "[PrivateCompanion] Waiting for scheduled persistence during "
+                "Waiting for scheduled persistence during "
                 "shutdown failed: %s",
                 _single_line(exc, 160),
             )
@@ -7996,9 +7999,9 @@ class PrivateCompanionPlugin(
             try:
                 await asyncio.wait_for(close_image_download_session(), timeout=3.0)
             except asyncio.TimeoutError:
-                logger.warning("[PrivateCompanion] 终止时关闭在线图片下载会话超时")
+                logger.warning("终止时关闭在线图片下载会话超时")
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 终止时关闭在线图片下载会话失败: %s", _single_line(exc, 160))
+                logger.debug("终止时关闭在线图片下载会话失败: %s", _single_line(exc, 160))
         final_save_task = asyncio.create_task(self._save_data_on_terminate())
         self._termination_save_task = final_save_task
 
@@ -8013,7 +8016,7 @@ class PrivateCompanionPlugin(
                 return
             if error is not None:
                 logger.warning(
-                    "[PrivateCompanion] Final shutdown persistence failed: %s",
+                    "Final shutdown persistence failed: %s",
                     _single_line(error, 160),
                 )
 
@@ -8022,7 +8025,7 @@ class PrivateCompanionPlugin(
             await asyncio.wait_for(asyncio.shield(final_save_task), timeout=3.0)
         except asyncio.TimeoutError:
             logger.warning(
-                "[PrivateCompanion] Final shutdown persistence timed out; the "
+                "Final shutdown persistence timed out; the "
                 "shielded task will continue in the background"
             )
         if _private_companion_plugin is self:
@@ -8053,7 +8056,7 @@ class PrivateCompanionPlugin(
                     pass
                 except Exception as exc:
                     logger.debug(
-                        "[PrivateCompanion] Waiting for the default JSON writer "
+                        "Waiting for the default JSON writer "
                         "during shutdown failed: %s",
                         _single_line(exc, 160),
                     )
@@ -8082,7 +8085,7 @@ class PrivateCompanionPlugin(
                         pass
                     except Exception as exc:
                         logger.debug(
-                            "[PrivateCompanion] Waiting for a persona writer during "
+                            "Waiting for a persona writer during "
                             "shutdown failed: persona=%s error=%s",
                             persona_id,
                             _single_line(exc, 160),
@@ -8113,7 +8116,7 @@ class PrivateCompanionPlugin(
                 disable(event)
         except Exception as exc:
             logger.debug(
-                "[PrivateCompanion] TTS 流式预判失败，保留默认流式行为: session=%s error=%s",
+                "TTS 流式预判失败，保留默认流式行为: session=%s error=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                 _single_line(exc, 160),
             )
@@ -8127,7 +8130,7 @@ class PrivateCompanionPlugin(
         if self._is_onebot_poke_notice_event(event):
             # OneBot 把戳一戳同时映射为消息事件。它由专用插件处理，不能参与
             # 陪伴的活动、繁忙闸门或撤回缓存链路。
-            logger.debug("[PrivateCompanion] 放行 OneBot 戳一戳 notice 给专用插件")
+            logger.debug("放行 OneBot 戳一戳 notice 给专用插件")
             return
         self._qzone_note_event_bot(event)
         if not self.enabled:
@@ -8161,12 +8164,12 @@ class PrivateCompanionPlugin(
                 if recall_user_id:
                     self._stop_passive_input_status_loop(recall_user_id)
                     logger.info(
-                        "[PrivateCompanion] 用户撤回消息，已停止私聊输入状态: user=%s message_id=%s",
+                        "用户撤回消息，已停止私聊输入状态: user=%s message_id=%s",
                         recall_user_id,
                         message_id,
                     )
             logger.info(
-                "[PrivateCompanion] 已记录消息撤回: notice=%s scope=%s message_id=%s",
+                "已记录消息撤回: notice=%s scope=%s message_id=%s",
                 notice_type,
                 scope or "-",
                 message_id,
@@ -8194,7 +8197,7 @@ class PrivateCompanionPlugin(
             return
         ok = await self._try_delete_message(event, message_id, reason=f"forbidden:{hit}")
         logger.info(
-            "[PrivateCompanion] 违禁词撤回检查命中: scope=%s self=%s group=%s ok=%s word=%s message_id=%s",
+            "违禁词撤回检查命中: scope=%s self=%s group=%s ok=%s word=%s message_id=%s",
             scope,
             is_self,
             is_group,
@@ -8246,7 +8249,7 @@ class PrivateCompanionPlugin(
             event.set_result(self._build_result_from_chain([]))
             event.stop_event()
             logger.info(
-                "[PrivateCompanion] 已跳过 Proactive Chat 改写后的重复文本分支: session=%s attempt=%s",
+                "已跳过 Proactive Chat 改写后的重复文本分支: session=%s attempt=%s",
                 _single_line(session_id, 120),
                 attempt_id,
             )
@@ -8277,7 +8280,7 @@ class PrivateCompanionPlugin(
             if token:
                 await self._cancel_proactive_chat_bridge(session_id, token=token)
             logger.info(
-                "[PrivateCompanion] 已拦截 Proactive Chat 主动候选: session=%s decision=%s reason=%s",
+                "已拦截 Proactive Chat 主动候选: session=%s decision=%s reason=%s",
                 _single_line(session_id, 120),
                 _single_line(review.get("decision"), 24) or "drop",
                 _single_line(review.get("reason"), 160),
@@ -8311,7 +8314,7 @@ class PrivateCompanionPlugin(
         if bool(bridge_context.get("tts_sent")) and not should_replace_full_attempt:
             setattr(event, "_private_companion_skip_tts_enhancement", "proactive_chat_prebuilt_tts")
         logger.info(
-            "[PrivateCompanion] 已接入 Proactive Chat 发送前链路: session=%s segment=%s/%s upstream_tts=%s text=%s",
+            "已接入 Proactive Chat 发送前链路: session=%s segment=%s/%s upstream_tts=%s text=%s",
             _single_line(session_id, 120),
             segment_index + 1,
             segment_count,
@@ -8375,7 +8378,7 @@ class PrivateCompanionPlugin(
             or not bool(getattr(event, "_private_companion_member_safety_hidden_marker_expected", False))
         ):
             logger.warning(
-                "[PrivateCompanion] 已清理未授权的群成员风控隐性标签，未计数: session=%s",
+                "已清理未授权的群成员风控隐性标签，未计数: session=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             )
             return
@@ -8402,7 +8405,7 @@ class PrivateCompanionPlugin(
             source="reply_hidden_marker",
         )
         logger.info(
-            "[PrivateCompanion] 已消费群成员风控隐性标签: group=%s sender=%s counted=%s blocked=%s reason=%s",
+            "已消费群成员风控隐性标签: group=%s sender=%s counted=%s blocked=%s reason=%s",
             group_id,
             sender_id,
             bool(recorded.get("counted")),
@@ -8428,7 +8431,7 @@ class PrivateCompanionPlugin(
                 except (AttributeError, TypeError):
                     pass
             logger.debug(
-                "[PrivateCompanion] 本轮已有真实生图，跳过追加表情附件: session=%s",
+                "本轮已有真实生图，跳过追加表情附件: session=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             )
             return
@@ -8558,7 +8561,7 @@ class PrivateCompanionPlugin(
                 reason="attachment_component_failed",
             )
             logger.warning(
-                "[PrivateCompanion] 表情图片附件构建失败: error_type=%s",
+                "表情图片附件构建失败: error_type=%s",
                 type(exc).__name__,
             )
             return
@@ -8667,7 +8670,7 @@ class PrivateCompanionPlugin(
                 return _OneBotReactionImage(image_path)
             except Exception as exc:
                 logger.warning(
-                    "[PrivateCompanion] QQ表情格式组件构建失败,回退普通图片: error_type=%s",
+                    "QQ表情格式组件构建失败,回退普通图片: error_type=%s",
                     type(exc).__name__,
                 )
         try:
@@ -8698,7 +8701,7 @@ class PrivateCompanionPlugin(
             return send_result is not False
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanion] 表情图片单独投递失败: mode=%s error_type=%s",
+                "表情图片单独投递失败: mode=%s error_type=%s",
                 self._reaction_expression_delivery_mode(),
                 type(exc).__name__,
             )
@@ -8969,7 +8972,7 @@ class PrivateCompanionPlugin(
         )
         if recorded.get("recorded"):
             logger.info(
-                "[PrivateCompanion] 已同步 Proactive Chat 最终发送状态: session=%s text=%s",
+                "已同步 Proactive Chat 最终发送状态: session=%s text=%s",
                 _single_line(session_id, 120),
                 _single_line(source_text, 160),
             )
@@ -8997,7 +9000,7 @@ class PrivateCompanionPlugin(
             setattr(event, "_private_companion_outbound_text_candidate", candidate)
             return
         logger.warning(
-            "[PrivateCompanion] 发送前拦截短时间重复正文: scope=%s sender=%s previous=%s text=%s",
+            "发送前拦截短时间重复正文: scope=%s sender=%s previous=%s text=%s",
             candidate.get("scope") or "unknown",
             candidate.get("sender_id") or "-",
             duplicate_state,
@@ -9151,7 +9154,7 @@ class PrivateCompanionPlugin(
         except Exception as exc:
             pending["completed"] = False
             logger.warning(
-                "[PrivateCompanion] 表情正文分段补发失败: session=%s error=%s",
+                "表情正文分段补发失败: session=%s error=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120)
                 or "unknown",
                 _single_line(exc, 160),
@@ -9280,13 +9283,13 @@ class PrivateCompanionPlugin(
         result = restore_astrbot_group_history(event, run_context)
         if result.get("failed"):
             logger.error(
-                "[PrivateCompanion] AstrBot 群聊历史恢复失败，已阻止本轮覆盖旧会话: session=%s reason=%s",
+                "AstrBot 群聊历史恢复失败，已阻止本轮覆盖旧会话: session=%s reason=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 140) or "unknown",
                 _single_line(result.get("reason"), 80) or "unknown",
             )
         elif result.get("restored"):
             logger.debug(
-                "[PrivateCompanion] 已在核心保存前恢复 AstrBot 群聊历史: session=%s messages=%s",
+                "已在核心保存前恢复 AstrBot 群聊历史: session=%s messages=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 140) or "unknown",
                 result.get("history_messages", 0),
             )
@@ -9362,7 +9365,7 @@ class PrivateCompanionPlugin(
                     pass
         if changed:
             logger.warning(
-                "[PrivateCompanion] 发送前已清理内部控制标签: session=%s",
+                "发送前已清理内部控制标签: session=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             )
 
@@ -9414,7 +9417,7 @@ class PrivateCompanionPlugin(
         except Exception:
             event.set_result(self._build_result_from_chain(cleaned_chain))
         logger.warning(
-            "[PrivateCompanion] 最终发送前已清理内部控制标签: session=%s",
+            "最终发送前已清理内部控制标签: session=%s",
             _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
         )
 
@@ -9455,7 +9458,7 @@ class PrivateCompanionPlugin(
         except Exception:
             event.set_result(self._build_result_from_chain(cleaned_chain))
         logger.warning(
-            "[PrivateCompanion] 发送前终检已移除明文工具调用: session=%s tools=%s",
+            "发送前终检已移除明文工具调用: session=%s tools=%s",
             _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             ",".join(leaked_names),
         )
@@ -9472,7 +9475,7 @@ class PrivateCompanionPlugin(
         if not recalled_message_id:
             return
         logger.info(
-            "[PrivateCompanion] 触发消息已撤回或发送前不可见，取消本次发送: session=%s message_id=%s",
+            "触发消息已撤回或发送前不可见，取消本次发送: session=%s message_id=%s",
             _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             recalled_message_id,
         )
@@ -9512,7 +9515,7 @@ class PrivateCompanionPlugin(
         if not hit:
             return
         logger.warning(
-            "[PrivateCompanion] 待发送消息命中违禁词，已拦截发送: word=%s session=%s",
+            "待发送消息命中违禁词，已拦截发送: word=%s session=%s",
             _single_line(hit, 40),
             _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
         )
@@ -9552,7 +9555,7 @@ class PrivateCompanionPlugin(
             flags=re.IGNORECASE,
         ):
             logger.warning(
-                "[PrivateCompanion] 已拦截插件日志来源位置外发: session=%s text=%s",
+                "已拦截插件日志来源位置外发: session=%s text=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                 _single_line(text, 180),
             )
@@ -9624,7 +9627,7 @@ class PrivateCompanionPlugin(
                     if rewritten:
                         final_reply = rewritten
                 logger.info(
-                    "[PrivateCompanion] 工具发送回执已改为自然短句: before=%s after=%s",
+                    "工具发送回执已改为自然短句: before=%s after=%s",
                     _single_line(text, 120),
                     final_reply,
                 )
@@ -9635,13 +9638,13 @@ class PrivateCompanionPlugin(
             )
             if not companion_receipt:
                 logger.debug(
-                    "[PrivateCompanion] 放行非陪伴插件工具回执: session=%s text=%s",
+                    "放行非陪伴插件工具回执: session=%s text=%s",
                     _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                     _single_line(text, 120),
                 )
                 return
             logger.warning(
-                "[PrivateCompanion] 已拦截孤立工具发送回执外发: session=%s text=%s",
+                "已拦截孤立工具发送回执外发: session=%s text=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                 _single_line(text, 120),
             )
@@ -9686,7 +9689,7 @@ class PrivateCompanionPlugin(
         if not marker_kind:
             return
         logger.warning(
-            "[PrivateCompanion] 已拦截框架异常文本外发: kind=%s session=%s",
+            "已拦截框架异常文本外发: kind=%s session=%s",
             marker_kind,
             _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
         )
@@ -9718,7 +9721,7 @@ class PrivateCompanionPlugin(
             replacement = ""
         setattr(event, "_private_companion_response_review_guard_active", False)
         logger.error(
-            "[PrivateCompanion] 发送前拦截到回复复核内部判断: session=%s reason=%s before=%s after=%s",
+            "发送前拦截到回复复核内部判断: session=%s reason=%s before=%s after=%s",
             _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             reason,
             _single_line(outbound, 180),
@@ -9796,14 +9799,14 @@ class PrivateCompanionPlugin(
             review = await self._review_group_question_wakeup_reply_before_send(event, reply_text=reply_text)
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanion] 群聊答疑回复发送前复核失败,默认放行: %s",
+                "群聊答疑回复发送前复核失败,默认放行: %s",
                 _single_line(exc, 160),
             )
             return
         if str(review.get("decision") or "") != "drop":
             return
         logger.info(
-            "[PrivateCompanion] 已拦截群聊答疑碰瓷回复: group=%s reason=%s text=%s",
+            "已拦截群聊答疑碰瓷回复: group=%s reason=%s text=%s",
             group_id,
             _single_line(review.get("reason"), 120),
             _single_line(reply_text, 160),
@@ -9833,7 +9836,7 @@ class PrivateCompanionPlugin(
             self._passive_response_review_enabled()
             and bool(getattr(event, "_private_companion_response_review_drop", False))
         ):
-            logger.info("[PrivateCompanion] 回复复核去重发送前兜底拦截")
+            logger.info("回复复核去重发送前兜底拦截")
             self._record_passive_no_reply(
                 event,
                 source="回复复核去重",
@@ -9850,7 +9853,7 @@ class PrivateCompanionPlugin(
             return
         if bool(getattr(event, "_private_companion_smart_silence_drop", False)):
             logger.info(
-                "[PrivateCompanion] 智能沉默发送前兜底拦截: reason=%s",
+                "智能沉默发送前兜底拦截: reason=%s",
                 _single_line(getattr(event, "_private_companion_smart_silence_reason", ""), 120),
             )
             self._record_passive_no_reply(
@@ -9930,12 +9933,12 @@ class PrivateCompanionPlugin(
                 recent_context=recent_context,
             )
         except Exception as exc:
-            logger.info("[PrivateCompanion] 智能沉默发送前判定失败,默认放行: %s", _single_line(exc, 120))
+            logger.warning("智能沉默发送前判定失败,默认放行: %s", _single_line(exc, 120))
             return
         if str(decision.get("decision") or "") != "silent":
             return
         logger.info(
-            "[PrivateCompanion] 智能沉默已取消本轮群聊回复: group=%s reason=%s inbound=%s reply=%s",
+            "智能沉默已取消本轮群聊回复: group=%s reason=%s inbound=%s reply=%s",
             group_id or "-",
             _single_line(decision.get("reason"), 120),
             _single_line(inbound_text, 120),
@@ -10022,7 +10025,7 @@ class PrivateCompanionPlugin(
         event.set_result(empty_result)
         event.stop_event()
         logger.info(
-            "[PrivateCompanion] 已阻止图片工具成功发送后的尾随消息: session=%s components=%s visible=%s",
+            "已阻止图片工具成功发送后的尾随消息: session=%s components=%s visible=%s",
             _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             len(chain),
             had_visible_content,
@@ -10084,7 +10087,7 @@ class PrivateCompanionPlugin(
         text = "".join(str(getattr(comp, "text", "") or "") for comp in chain).strip()
         if not self._is_silent_control_reply_text(text):
             return
-        logger.info("[PrivateCompanion] 已静默吞掉群聊不回复控制语: %s", _single_line(text, 120))
+        logger.info("已静默吞掉群聊不回复控制语: %s", _single_line(text, 120))
         self._record_passive_no_reply(
             event,
             source="群聊静默",
@@ -10179,7 +10182,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             decision = "send"
             reason = reason or "复核输出不可解析，默认放行"
         logger.info(
-            "[PrivateCompanion] 群聊答疑回复发送前复核: decision=%s elapsed=%dms reason=%s trigger=%s text=%s",
+            "群聊答疑回复发送前复核: decision=%s elapsed=%dms reason=%s trigger=%s text=%s",
             decision,
             int((time.perf_counter() - started) * 1000),
             reason,
@@ -10188,7 +10191,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         )
         if recent_flow:
             logger.info(
-                "[PrivateCompanion] 群聊答疑复核已附带真实群聊上下文: group=%s lines=%s chars=%s",
+                "群聊答疑复核已附带真实群聊上下文: group=%s lines=%s chars=%s",
                 group_id or "-",
                 len([line for line in recent_flow.splitlines() if line.strip()]),
                 len(recent_flow),
@@ -10242,7 +10245,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         except Exception:
             event.set_result(self._build_result_from_chain(cleaned_chain))
         logger.info(
-            "[PrivateCompanion] 已移除私聊被动主链中的跨目标引用组件: session=%s current=%s removed=%s targets=%s",
+            "已移除私聊被动主链中的跨目标引用组件: session=%s current=%s removed=%s targets=%s",
             _single_line(getattr(event, "unified_msg_origin", ""), 120) or "-",
             ",".join(sorted(current_message_ids)) or "-",
             len(chain) - len(cleaned_chain),
@@ -10322,7 +10325,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                     provider_error = False
                 if provider_error:
                     logger.warning(
-                        "[PrivateCompanion] 分段前丢弃 Provider 错误正文: session=%s preview=%s",
+                        "分段前丢弃 Provider 错误正文: session=%s preview=%s",
                         _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                         _single_line(outbound_text, 180),
                     )
@@ -10365,7 +10368,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         )
         if is_llm_result and await self._should_defer_segmenting_to_astrbot_tts(event, result, chain):
             logger.debug(
-                "[PrivateCompanion] 当前 LLM 结果交由 AstrBot 官方 TTS 与原生分段处理: session=%s",
+                "当前 LLM 结果交由 AstrBot 官方 TTS 与原生分段处理: session=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             )
             return
@@ -10396,13 +10399,13 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             return
         llm_segment_count = max(0, _safe_int(getattr(event, "_private_companion_llm_segment_count", 0), 0, 0))
         logger.debug(
-            "[PrivateCompanion] 按分段计划整理 LLM 回复: chars=%s segments=%s llm_segments=%s",
+            "按分段计划整理 LLM 回复: chars=%s segments=%s llm_segments=%s",
             len(text),
             len(chunks),
             llm_segment_count,
         )
         logger.info(
-            "[PrivateCompanion] 已按分段计划发送 LLM 回复: segments=%s llm_segments=%s first=%s full=%s",
+            "已按分段计划发送 LLM 回复: segments=%s llm_segments=%s first=%s full=%s",
             len(chunks),
             llm_segment_count,
             _single_line(self._segmented_chunk_log_text(chunks[0]), 120),
@@ -10451,7 +10454,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                     },
                 )
                 logger.info(
-                    "[PrivateCompanion] 表情正文启用有序分段: session=%s segments=%s",
+                    "表情正文启用有序分段: session=%s segments=%s",
                     _single_line(getattr(event, "unified_msg_origin", ""), 120)
                     or "unknown",
                     len(chunks),
@@ -10668,7 +10671,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                 cleaned_chunks.append(cleaned_chunk)
         if removed_internal_control:
             logger.warning(
-                "[PrivateCompanion] 分段前已移除内部控制标记: session=%s",
+                "分段前已移除内部控制标记: session=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             )
         return cleaned_chunks
@@ -11199,7 +11202,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                                 signals={"stop_reason": drift_reason, "segments_expected": total + 1, "segments_sent": sent_index},
                             )
                         logger.info(
-                            "[PrivateCompanion] 分段剩余组件疑似上下文割裂，停止发送: source=%s reason=%s sent=%s/%s prev=%s next=%s",
+                            "分段剩余组件疑似上下文割裂，停止发送: source=%s reason=%s sent=%s/%s prev=%s next=%s",
                             source or "unknown",
                             drift_reason,
                             max(0, sent_index - 1),
@@ -11221,7 +11224,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                                 signals={"stop_reason": "trigger_recalled", "segments_expected": total + 1, "segments_sent": sent_index},
                             )
                         logger.info(
-                            "[PrivateCompanion] 触发消息已撤回或发送前不可见，停止发送分段剩余组件: source=%s message_id=%s sent=%s/%s",
+                            "触发消息已撤回或发送前不可见，停止发送分段剩余组件: source=%s message_id=%s sent=%s/%s",
                             source or "unknown",
                             recalled_message_id,
                             max(0, sent_index - 1),
@@ -11238,7 +11241,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                             try:
                                 if normalized_segment and provider_error_checker(normalized_segment):
                                     logger.warning(
-                                        "[PrivateCompanion] 分段剩余组件命中 Provider 错误正文，停止补发: source=%s preview=%s",
+                                        "分段剩余组件命中 Provider 错误正文，停止补发: source=%s preview=%s",
                                         source or "unknown",
                                         _single_line(normalized_segment, 180),
                                     )
@@ -11285,7 +11288,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                             )
                     if leaked_tools:
                         logger.warning(
-                            "[PrivateCompanion] 分段组件发送前已移除明文工具调用: tools=%s",
+                            "分段组件发送前已移除明文工具调用: tools=%s",
                             ",".join(leaked_tools),
                         )
                     outbound_chunk = sanitized_chunk
@@ -11299,7 +11302,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                                 outcome="incomplete",
                                 signals={"stop_reason": "forbidden_recall", "segments_expected": total + 1, "segments_sent": sent_index},
                             )
-                        logger.warning("[PrivateCompanion] 分段剩余组件命中违禁词，停止发送: word=%s", _single_line(hit, 40))
+                        logger.warning("分段剩余组件命中违禁词，停止发送: word=%s", _single_line(hit, 40))
                         return
                     delivery_path = await self._send_segmented_remainder_chain(
                         event,
@@ -11313,7 +11316,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                             signals={"segments_expected": total + 1, "segments_sent": sent_index + 1},
                         )
                     logger.info(
-                        "[PrivateCompanion] 分段 LLM 剩余组件已发送: source=%s delivery=%s index=%s/%s preview=%s",
+                        "分段 LLM 剩余组件已发送: source=%s delivery=%s index=%s/%s preview=%s",
                         source or "unknown",
                         delivery_path,
                         sent_index,
@@ -11342,7 +11345,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                                 signals={"segments_expected": total + 1, "segments_sent": sent_index},
                             )
                         logger.warning(
-                            "[PrivateCompanion] 主动分段 LLM 剩余组件发送失败: source=%s error=%s",
+                            "主动分段 LLM 剩余组件发送失败: source=%s error=%s",
                             source or "unknown",
                             _single_line(exc, 160),
                             exc_info=True,
@@ -11358,7 +11361,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                                 signals={"segments_expected": total + 1, "segments_sent": sent_index + 1},
                             )
                         logger.info(
-                            "[PrivateCompanion] 分段 LLM 剩余组件已发送: source=%s index=%s/%s preview=%s",
+                            "分段 LLM 剩余组件已发送: source=%s index=%s/%s preview=%s",
                             source or "unknown",
                             sent_index,
                             total,
@@ -11373,7 +11376,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                                 signals={"segments_expected": total + 1, "segments_sent": sent_index},
                             )
                         logger.warning(
-                            "[PrivateCompanion] 分段 LLM 剩余组件发送失败: source=%s error=%s",
+                            "分段 LLM 剩余组件发送失败: source=%s error=%s",
                             source or "unknown",
                             _single_line(exc, 160),
                             exc_info=True,
@@ -11400,7 +11403,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             segment, leaked_calls = self._strip_plaintext_tool_call_envelopes(segment)
             if leaked_calls:
                 logger.warning(
-                    "[PrivateCompanion] 分段文本发送前已移除明文工具调用: tools=%s",
+                    "分段文本发送前已移除明文工具调用: tools=%s",
                     ",".join(str(item.get("name") or "") for item in leaked_calls),
                 )
             if not segment:
@@ -11415,7 +11418,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                 )
                 if drift_reason:
                     logger.info(
-                        "[PrivateCompanion] 分段剩余片段疑似上下文割裂，停止发送: source=%s reason=%s sent=%s/%s prev=%s next=%s",
+                        "分段剩余片段疑似上下文割裂，停止发送: source=%s reason=%s sent=%s/%s prev=%s next=%s",
                         source or "unknown",
                         drift_reason,
                         max(0, sent_index - 1),
@@ -11431,7 +11434,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                 recalled_message_id = await self._should_cancel_reply_for_missing_or_recalled_trigger(event)
                 if recalled_message_id:
                     logger.info(
-                        "[PrivateCompanion] 触发消息已撤回或发送前不可见，停止发送分段剩余片段: source=%s message_id=%s sent=%s/%s",
+                        "触发消息已撤回或发送前不可见，停止发送分段剩余片段: source=%s message_id=%s sent=%s/%s",
                         source or "unknown",
                         recalled_message_id,
                         max(0, sent_index - 1),
@@ -11457,7 +11460,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                             if chain:
                                 hit = self._forbidden_recall_hit(self._chain_text_for_forbidden_recall(chain))
                                 if hit:
-                                    logger.warning("[PrivateCompanion] 分段 TTS 剩余片段命中违禁词，停止发送: word=%s", _single_line(hit, 40))
+                                    logger.warning("分段 TTS 剩余片段命中违禁词，停止发送: word=%s", _single_line(hit, 40))
                                     return
                                 try:
                                     await event.send(event.chain_result(chain))
@@ -11468,11 +11471,11 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                     outbound = re.sub(r"</?(?:pc[_-]?tts|t{2,}s)\b[^>]*>", "", normalized_segment, flags=re.IGNORECASE).strip() or segment
                     hit = self._forbidden_recall_hit(outbound)
                     if hit:
-                        logger.warning("[PrivateCompanion] 分段剩余片段命中违禁词，停止发送: word=%s", _single_line(hit, 40))
+                        logger.warning("分段剩余片段命中违禁词，停止发送: word=%s", _single_line(hit, 40))
                         return
                     await event.send(event.plain_result(outbound))
                 logger.info(
-                    "[PrivateCompanion] 分段 LLM 剩余片段已发送: source=%s index=%s/%s preview=%s",
+                    "分段 LLM 剩余片段已发送: source=%s index=%s/%s preview=%s",
                     source or "unknown",
                     sent_index,
                     total,
@@ -11483,7 +11486,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                 raise
             except Exception as exc:
                 logger.warning(
-                    "[PrivateCompanion] 分段 LLM 剩余片段发送失败: source=%s error=%s",
+                    "分段 LLM 剩余片段发送失败: source=%s error=%s",
                     source or "unknown",
                     _single_line(exc, 160),
                     exc_info=True,
@@ -11501,7 +11504,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         try:
             result = event.get_result()
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 群聊补引用读取结果失败: %s", _single_line(exc, 120))
+            logger.debug("群聊补引用读取结果失败: %s", _single_line(exc, 120))
             return
         if result is None:
             return
@@ -11513,7 +11516,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         try:
             chain = list(getattr(result, "chain", []) or [])
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 群聊补引用读取消息链失败: %s", _single_line(exc, 120))
+            logger.debug("群聊补引用读取消息链失败: %s", _single_line(exc, 120))
             return
         if not chain:
             return
@@ -11530,7 +11533,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                 )
             except Exception as exc:
                 logger.debug(
-                    "[PrivateCompanion] 群聊引用检查官方 TTS 状态失败: %s",
+                    "群聊引用检查官方 TTS 状态失败: %s",
                     _single_line(exc, 120),
                 )
                 official_tts_owns_result = False
@@ -11601,7 +11604,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             except Exception:
                 event.set_result(self._build_result_from_chain(primary_chunk))
             logger.info(
-                "[PrivateCompanion] 纯语音回复已移除孤立消息引用: session=%s removed=%s",
+                "纯语音回复已移除孤立消息引用: session=%s removed=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120)
                 or "unknown",
                 removed_count,
@@ -11627,14 +11630,14 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                     text_or_chain=flatten_component_chunks(delivery_chunks),
                 )
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 群聊补引用计算引用目标失败: %s", _single_line(exc, 120))
+                logger.debug("群聊补引用计算引用目标失败: %s", _single_line(exc, 120))
                 return
             if not quote_message_id:
                 return
             try:
                 reply = self._make_reply_component(quote_message_id, event=event)
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 群聊补引用构建消息链失败: %s", _single_line(exc, 120))
+                logger.debug("群聊补引用构建消息链失败: %s", _single_line(exc, 120))
                 return
             if reply is None:
                 return
@@ -13218,7 +13221,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             plan.render_into(req, prefer_extra_user_content=True)
             return True
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 指定位置 prompt 注入失败,回退 system_prompt: %s", _single_line(exc, 120))
+            logger.debug("指定位置 prompt 注入失败,回退 system_prompt: %s", _single_line(exc, 120))
             return False
 
     def _materialize_conversation_system_block(
@@ -13412,7 +13415,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         except Exception:
             return
         logger.info(
-            "[PrivateCompanion] 已清理请求历史里的插件动态注入残留: session=%s contexts_changed=%s",
+            "已清理请求历史里的插件动态注入残留: session=%s contexts_changed=%s",
             _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             changed,
         )
@@ -13479,7 +13482,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         except Exception:
             return
         logger.info(
-            "[PrivateCompanion] 已清理请求历史里的残留反应协议标签: session=%s contexts_changed=%s",
+            "已清理请求历史里的残留反应协议标签: session=%s contexts_changed=%s",
             _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             changed,
         )
@@ -13573,7 +13576,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         except Exception:
             return
         logger.warning(
-            "[PrivateCompanion] 已修复不完整工具调用历史: session=%s groups=%s messages=%s contexts=%s->%s",
+            "已修复不完整工具调用历史: session=%s groups=%s messages=%s contexts=%s->%s",
             _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             removed_groups,
             removed_messages,
@@ -13621,7 +13624,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             setattr(req, "_private_companion_turn_prompt_placement", "extra_user_content_parts")
             return True
         except Exception as exc:
-            logger.debug("[PrivateCompanion] extra_user_content_parts 注入失败,回退 prompt: %s", _single_line(exc, 120))
+            logger.debug("extra_user_content_parts 注入失败,回退 prompt: %s", _single_line(exc, 120))
             return False
 
     def _render_turn_prompt_fragments(self, req: ProviderRequest, *, prefer_extra_user_content: bool = False) -> bool:
@@ -13758,8 +13761,8 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         except asyncio.TimeoutError:
             elapsed_ms = int((time.time() - started) * 1000)
             metadata.update({"耗时ms": elapsed_ms, "状态": "超时"})
-            logger.info(
-                "[PrivateCompanion] 请求上下文收集超时: key=%s source=%s timeout=%.2fs",
+            logger.warning(
+                "请求上下文收集超时: key=%s source=%s timeout=%.2fs",
                 key or "-",
                 source or "-",
                 timeout,
@@ -13777,7 +13780,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             elapsed_ms = int((time.time() - started) * 1000)
             metadata.update({"耗时ms": elapsed_ms, "状态": "失败", "错误": _single_line(exc, 120)})
             logger.debug(
-                "[PrivateCompanion] 请求上下文收集失败: key=%s source=%s error=%s",
+                "请求上下文收集失败: key=%s source=%s error=%s",
                 key or "-",
                 source or "-",
                 _single_line(exc, 120),
@@ -13802,7 +13805,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             if isinstance(result, dict):
                 collected.append(result)
             elif isinstance(result, Exception):
-                logger.debug("[PrivateCompanion] 请求上下文并行收集出现未捕获异常: %s", _single_line(result, 120))
+                logger.debug("请求上下文并行收集出现未捕获异常: %s", _single_line(result, 120))
         return collected
 
     def _add_collected_prompt_contexts(self, prompt_surface: PromptSurface, collected: list[dict[str, Any]]) -> None:
@@ -14354,7 +14357,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             self._mark_memo_request_tool_boundary(event, req)
             if self._remove_future_task_for_memo_request(req, message_text):
                 logger.debug(
-                    "[PrivateCompanion] 明确便签请求已从初始工具集移除 future_task: session=%s",
+                    "明确便签请求已从初始工具集移除 future_task: session=%s",
                     _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                 )
         if (
@@ -14440,7 +14443,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                     referenced_media_edit_request = bool(await finder(event))
                 except Exception as exc:
                     logger.debug(
-                        "[PrivateCompanion] 引用图片编辑意图确认失败: session=%s error=%s",
+                        "引用图片编辑意图确认失败: session=%s error=%s",
                         _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                         _single_line(exc, 160),
                     )
@@ -14559,7 +14562,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         self._finalize_passive_reply_tool_boundary(event)
         if self._finalize_memo_request_tool_boundary(event):
             logger.info(
-                "[PrivateCompanion] 明确便签请求已从最终工具集移除 future_task,避免重复提醒: session=%s",
+                "明确便签请求已从最终工具集移除 future_task,避免重复提醒: session=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             )
 
@@ -14580,13 +14583,13 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         await self._record_official_llm_timer_tool_result(event, tool, tool_result)
         if self._record_future_task_result(event, tool, tool_args, tool_result):
             logger.info(
-                "[PrivateCompanion] 已记录本轮 future_task 成功: action=%s session=%s",
+                "已记录本轮 future_task 成功: action=%s session=%s",
                 _single_line((tool_args or {}).get("action"), 20) or "unknown",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             )
         if self._record_creative_work_tool_result(event, tool, tool_args, tool_result):
             logger.info(
-                "[PrivateCompanion] 已记录本轮创作读取工具结果: action=%s status=%s inventory_complete=%s session=%s",
+                "已记录本轮创作读取工具结果: action=%s status=%s inventory_complete=%s session=%s",
                 _single_line((tool_args or {}).get("action") if isinstance(tool_args, dict) else "", 20) or "get",
                 _single_line(getattr(event, "private_companion_creative_work_tool_status", ""), 24) or "unknown",
                 bool(getattr(event, "private_companion_bookshelf_inventory_complete", False)),
@@ -15141,7 +15144,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             )
         except Exception as exc:
             logger.debug(
-                "[PrivateCompanion] 群聊读取经期互动边界失败，已跳过: group=%s error=%s",
+                "群聊读取经期互动边界失败，已跳过: group=%s error=%s",
                 _single_line(group_id, 40) or "-",
                 _single_line(exc, 120),
             )
@@ -15600,7 +15603,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         }
         self._save_data_sync(sections={"pending_atrelay_requests"})
         logger.info(
-            "[PrivateCompanion] 转述请求等待补群: user=%s target=%s text=%s reason=%s",
+            "转述请求等待补群: user=%s target=%s text=%s reason=%s",
             uid,
             _single_line(payload.get("recipient_hint"), 80),
             _single_line(payload.get("message"), 80),
@@ -15709,7 +15712,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         pending.pop(uid, None)
         self._save_data_sync(sections={"pending_atrelay_requests"})
         logger.info(
-            "[PrivateCompanion] 已用补充群名续发转述: user=%s group=%s status=%s target=%s",
+            "已用补充群名续发转述: user=%s group=%s status=%s target=%s",
             uid,
             _single_line(group_result.get("group_id"), 40),
             _single_line(result.get("status"), 40),
@@ -15738,7 +15741,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             )
             self._store_pending_atrelay_request(pending_user_id, payload, _single_line(result.get("message"), 120))
         logger.info(
-            "[PrivateCompanion] 明确转述请求已本地直通: status=%s destination=%s target=%s text=%s",
+            "明确转述请求已本地直通: status=%s destination=%s target=%s text=%s",
             status or "-",
             _single_line(payload.get("destination"), 20),
             _single_line(payload.get("recipient_hint"), 40),
@@ -15785,14 +15788,14 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         try:
             message_id, raw_message = await self._reply_raw_message_for_event(event)
         except Exception as exc:
-            logger.info("[PrivateCompanion] 私聊引用关系网问题预读取失败: %s", _single_line(exc, 120))
+            logger.info("私聊引用关系网问题预读取失败: %s", _single_line(exc, 120))
             return ""
         if raw_message is None:
             return ""
         try:
             info = self._extract_reply_rich_card_info(raw_message)
         except Exception as exc:
-            logger.info("[PrivateCompanion] 私聊引用关系网问题解析失败: message_id=%s error=%s", message_id or "-", _single_line(exc, 120))
+            logger.info("私聊引用关系网问题解析失败: message_id=%s error=%s", message_id or "-", _single_line(exc, 120))
             return ""
         texts = [_single_line(item, 120) for item in info.get("texts", []) if _single_line(item, 120)]
         if not texts:
@@ -15801,7 +15804,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         if not self._text_looks_like_relation_lookup_question(quoted_text):
             return ""
         logger.info(
-            "[PrivateCompanion] 私聊纯引用关系网问题已补触发文本: message_id=%s text=%s",
+            "私聊纯引用关系网问题已补触发文本: message_id=%s text=%s",
             message_id or "-",
             _single_line(quoted_text, 120),
         )
@@ -15975,7 +15978,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         except Exception:
             return
         logger.info(
-            "[PrivateCompanion] 私聊超长上下文已启用轻量护栏: session=%s contexts=%s->%s approx_tokens=%s",
+            "私聊超长上下文已启用轻量护栏: session=%s contexts=%s->%s approx_tokens=%s",
             _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             len(contexts),
             len(trimmed),
@@ -16019,7 +16022,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         except Exception:
             return
         logger.info(
-            "[PrivateCompanion] 已按新会话边界裁剪 AstrBot 上下文: session=%s contexts=%s->%s boundary_index=%s",
+            "已按新会话边界裁剪 AstrBot 上下文: session=%s contexts=%s->%s boundary_index=%s",
             _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             len(contexts),
             len(trimmed),
@@ -16245,7 +16248,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         user["rest_reply_backlog_updated_at"] = now
         self._schedule_data_save(sections={"users"})
         logger.info(
-            "[PrivateCompanion] 已记录休息中未回复私聊: user=%s count=%s reason=%s text=%s",
+            "已记录休息中未回复私聊: user=%s count=%s reason=%s text=%s",
             user_id,
             len(user["rest_reply_backlog"]),
             _single_line(reason, 80),
@@ -16318,7 +16321,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
     def _stop_reply_for_rest_gate(self, event: AstrMessageEvent, reason: str) -> None:
         self._record_rest_reply_backlog(event, reason)
         logger.info(
-            "[PrivateCompanion] 睡眠/休息回复闸门拦截本轮被动回复: session=%s reason=%s",
+            "睡眠/休息回复闸门拦截本轮被动回复: session=%s reason=%s",
             _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             _single_line(reason, 120),
         )
@@ -16338,7 +16341,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
 
     def _stop_private_reply_after_user_rest_signal(self, event: AstrMessageEvent, user_id: str, text: str) -> None:
         logger.info(
-            "[PrivateCompanion] 用户明确勿扰/不用回复,已前置拦截本轮私聊回复: user=%s text=%s",
+            "用户明确勿扰/不用回复,已前置拦截本轮私聊回复: user=%s text=%s",
             _single_line(user_id, 80),
             _single_line(text, 120),
         )
@@ -16393,7 +16396,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             return True
         group_id = _single_line(item.get("group_id"), 80) or self._extract_group_id_from_event(event)
         logger.info(
-            "[PrivateCompanion] 本群 LLM 回复已被单独关闭,拦截本轮回复: group=%s source=%s",
+            "本群 LLM 回复已被单独关闭,拦截本轮回复: group=%s source=%s",
             group_id or "-",
             _single_line(source, 40),
         )
@@ -16534,7 +16537,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             except Exception:
                 pass
         logger.info(
-            "[PrivateCompanion] 已记录被动未回复: source=%s reason=%s count=%s session=%s inbound=%s",
+            "已记录被动未回复: source=%s reason=%s count=%s session=%s inbound=%s",
             source_text,
             reason_text,
             target.get("count"),
@@ -16617,7 +16620,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             )
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanion] 回复拦截转发无法启动: %s",
+                "回复拦截转发无法启动: %s",
                 _single_line(exc, 160),
             )
 
@@ -16625,10 +16628,10 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         try:
             safe_text = _redact_outbound_secrets(text, self)
             await self.context.send_message(target_umo, MessageChain([Plain(safe_text)]))
-            logger.info("[PrivateCompanion] 已转发回复拦截情况: target=%s", _single_line(target_umo, 120))
+            logger.info("已转发回复拦截情况: target=%s", _single_line(target_umo, 120))
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanion] 回复拦截转发失败: target=%s error=%s",
+                "回复拦截转发失败: target=%s error=%s",
                 _single_line(target_umo, 120),
                 _single_line(exc, 180),
             )
@@ -16662,7 +16665,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         _, changed = self._redact_outbound_chain_secrets(chain)
         if changed:
             logger.error(
-                "[PrivateCompanion] 发送前检测到敏感凭据并已脱敏: session=%s",
+                "发送前检测到敏感凭据并已脱敏: session=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             )
 
@@ -16828,7 +16831,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             if not self._private_passive_profile_available(user_id, user):
                 return
             if self._is_recent_poke_echo(user, text):
-                logger.info("[PrivateCompanion] 主动专用模式忽略 poke 回流事件: user=%s", user_id)
+                logger.info("主动专用模式忽略 poke 回流事件: user=%s", user_id)
                 return
             if self._is_duplicate_inbound_message(event, scope=f"private:{user_id}", sender_id=user_id, text=text):
                 self._schedule_data_save(sections={"inbound_debounce_stats"})
@@ -16846,7 +16849,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                 user_id=user_id,
                 trigger_umo=str(getattr(event, "unified_msg_origin", "") or ""),
             ):
-                logger.info("[PrivateCompanion] 用户已在当前问候时段自然来聊,已请求取消冲突问候候选: %s", user_id)
+                logger.info("用户已在当前问候时段自然来聊,已请求取消冲突问候候选: %s", user_id)
                 if not self._simulation_active(user) and _safe_float(user.get("next_proactive_at"), 0) <= 0:
                     self._schedule_next_proactive(user, now=received_ts)
             if text:
@@ -16896,7 +16899,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                 save_sections.add("food_menu")
             self._schedule_data_save(sections=save_sections)
         logger.info(
-            "[PrivateCompanion] 主动消息专用模式已跳过私聊被动增强: user=%s text=%s",
+            "主动消息专用模式已跳过私聊被动增强: user=%s text=%s",
             user_id,
             _single_line(text, 80) or "非文本消息",
         )
@@ -17099,7 +17102,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                     )
             if self._tool_set_has_named_tool(getattr(req, "func_tool", None), "send_message_to_user"):
                 logger.info(
-                    "[PrivateCompanion] 已约束被动回复的 send_message_to_user 仅用于媒体投递: session=%s",
+                    "已约束被动回复的 send_message_to_user 仅用于媒体投递: session=%s",
                     umo,
                 )
         return []
@@ -17333,7 +17336,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                     if hint:
                         projection["relationship_violation_hint"] = hint
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 统一表达决策生成失败，使用日常保守默认值: %s", _single_line(exc, 120))
+            logger.debug("统一表达决策生成失败，使用日常保守默认值: %s", _single_line(exc, 120))
             projection = build_expression_decision({}).to_dict()
         try:
             setattr(req, "_private_companion_expression_decision", projection)
@@ -17380,7 +17383,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                 removed.append(name)
             except Exception as exc:
                 logger.warning(
-                    "[PrivateCompanion] 移除敏感屏幕工具失败: tool=%s session=%s error=%s",
+                    "移除敏感屏幕工具失败: tool=%s session=%s error=%s",
                     name,
                     _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                     _single_line(exc, 160),
@@ -17391,7 +17394,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             except Exception:
                 pass
             logger.info(
-                "[PrivateCompanion] 已移除非主人私聊场景的敏感屏幕工具: session=%s sender=%s tools=%s",
+                "已移除非主人私聊场景的敏感屏幕工具: session=%s sender=%s tools=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                 self._safe_event_sender_id(event) or "-",
                 ",".join(removed),
@@ -17456,7 +17459,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             )
             setattr(event, "private_companion_p5_status", self.p5_source_observer_status())
         except Exception:
-            logger.debug("[PrivateCompanion] P5 request carrier attach failed")
+            logger.debug("P5 request carrier attach failed")
 
     @filter.on_llm_request(priority=-21000)
     @_multi_persona_event_context
@@ -17491,7 +17494,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         except Exception:
             return
         logger.info(
-            "[PrivateCompanion] Cleaned malformed DeepSeek tool history: groups=%s assistants=%s tool_results=%s orphans=%s",
+            "Cleaned malformed DeepSeek tool history: groups=%s assistants=%s tool_results=%s orphans=%s",
             stats.get("removed_groups", 0),
             stats.get("removed_assistants", 0),
             stats.get("removed_tool_results", 0),
@@ -17566,7 +17569,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         try:
             remove_tool("AIsearch")
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 移除不兼容 AIsearch 工具失败: %s", _single_line(exc, 160))
+            logger.debug("移除不兼容 AIsearch 工具失败: %s", _single_line(exc, 160))
             return
         settings = self._llm_request_provider_settings_for_event(event)
         provider_label = " / ".join(self._llm_request_provider_identity_parts(event, req)[:3]) or "unknown"
@@ -17579,7 +17582,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         if log_key not in logged:
             logged.add(log_key)
             logger.warning(
-                "[PrivateCompanion] 已移除本轮 Gemini 不兼容的 AIsearch 搜索工具，避免请求 400: provider=%s websearch_provider=%s session=%s",
+                "已移除本轮 Gemini 不兼容的 AIsearch 搜索工具，避免请求 400: provider=%s websearch_provider=%s session=%s",
                 _single_line(provider_label, 200),
                 _single_line(settings.get("websearch_provider"), 80) or "unknown",
                 umo or "unknown",
@@ -17604,7 +17607,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             plan.render_into(req)
         except Exception as exc:
             logger.error(
-                "[PrivateCompanion] 主对话注入计划最终渲染失败: session=%s error=%s",
+                "主对话注入计划最终渲染失败: session=%s error=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                 _single_line(exc, 180),
             )
@@ -17629,7 +17632,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         except Exception:
             return
         logger.info(
-            "[PrivateCompanion] 已兼容化历史图片消息: session=%s messages=%s image_blocks=%s",
+            "已兼容化历史图片消息: session=%s messages=%s image_blocks=%s",
             _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             stats.get("messages_changed", 0),
             stats.get("image_blocks_replaced", 0),
@@ -17650,7 +17653,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         replaced, dropped = self._sanitize_provider_request_gif_inputs(req)
         if replaced or dropped:
             logger.info(
-                "[PrivateCompanion] Provider 请求中的 GIF 已兼容化: converted=%s dropped=%s session=%s",
+                "Provider 请求中的 GIF 已兼容化: converted=%s dropped=%s session=%s",
                 replaced,
                 dropped,
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
@@ -17723,7 +17726,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                         return True
             except Exception as exc:
                 logger.debug(
-                    "[PrivateCompanion] pc_generate_photo 请求工具描述标注失败: %s",
+                    "pc_generate_photo 请求工具描述标注失败: %s",
                     _single_line(exc, 120),
                 )
                 return False
@@ -17736,7 +17739,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                 return True
             except Exception as exc:
                 logger.debug(
-                    "[PrivateCompanion] pc_generate_photo 兼容工具描述标注失败: %s",
+                    "pc_generate_photo 兼容工具描述标注失败: %s",
                     _single_line(exc, 120),
                 )
         return False
@@ -17757,7 +17760,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             self._annotate_photo_tool_prompt_format_for_request(req)
         except Exception as exc:
             logger.debug(
-                "[PrivateCompanion] pc_generate_photo 工具提示词格式标注失败: %s",
+                "pc_generate_photo 工具提示词格式标注失败: %s",
                 _single_line(exc, 120),
             )
 
@@ -17784,7 +17787,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             return
         result = intercept_astrbot_group_context(event, req)
         logger.info(
-            "[PrivateCompanion] 已拦截 AstrBot 群聊对话注入: session=%s history=%s icl=%s",
+            "已拦截 AstrBot 群聊对话注入: session=%s history=%s icl=%s",
             _single_line(getattr(event, "unified_msg_origin", ""), 140) or "unknown",
             result.get("history_messages", 0),
             result.get("group_icl_removed", 0),
@@ -17815,7 +17818,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             plan.freeze()
         except Exception as exc:
             logger.error(
-                "[PrivateCompanion] 主对话注入计划冻结失败: session=%s error=%s",
+                "主对话注入计划冻结失败: session=%s error=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120)
                 or "unknown",
                 _single_line(exc, 180),
@@ -17859,7 +17862,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             return
         try:
             if getter(target_provider) is None:
-                logger.warning("[PrivateCompanion] 敏感拒答替换模型不存在：%s", target_provider)
+                logger.warning("敏感拒答替换模型不存在：%s", target_provider)
                 return
         except Exception:
             return
@@ -17892,7 +17895,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                 except Exception:
                     pass
                 logger.warning(
-                    "[PrivateCompanion] 敏感拒答替换模型仍拒答，已阻断原回复: original=%s target=%s keyword=%s",
+                    "敏感拒答替换模型仍拒答，已阻断原回复: original=%s target=%s keyword=%s",
                     _single_line(current_provider, 120) or "unknown",
                     target_provider,
                     _single_line(fallback_keyword or keyword, 80),
@@ -17905,14 +17908,14 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             except Exception:
                 pass
             logger.info(
-                "[PrivateCompanion] 检测到模型敏感拒答，已改用指定对话模型: original=%s target=%s keyword=%s",
+                "检测到模型敏感拒答，已改用指定对话模型: original=%s target=%s keyword=%s",
                 _single_line(current_provider, 120) or "unknown",
                 target_provider,
                 _single_line(keyword, 80),
             )
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanion] 敏感拒答替换模型调用失败，已阻断原回复: target=%s error=%s",
+                "敏感拒答替换模型调用失败，已阻断原回复: target=%s error=%s",
                 target_provider,
                 _single_line(exc, 180),
             )
@@ -17936,7 +17939,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                 same_session_tool_call, _ = same_session_tool(event, resp)
             except Exception as exc:
                 logger.debug(
-                    "[PrivateCompanion] 同会话工具回复去重准备失败: %s",
+                    "同会话工具回复去重准备失败: %s",
                     _single_line(exc, 120),
                 )
         if same_session_tool_call:
@@ -17973,7 +17976,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             resp.completion_text = ""
             original_text = ""
             logger.info(
-                "[PrivateCompanion] 已隐藏媒体工具调用前的中间正文: tools=%s session=%s",
+                "已隐藏媒体工具调用前的中间正文: tools=%s session=%s",
                 ",".join(sorted(normalized_tool_names)),
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             )
@@ -17999,7 +18002,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                 except (AttributeError, TypeError):
                     pass
             logger.info(
-                "[PrivateCompanion] 图片已发送，已丢弃同轮尾随模型正文: session=%s chars=%s",
+                "图片已发送，已丢弃同轮尾随模型正文: session=%s chars=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                 len(recovered_text or ""),
             )
@@ -18160,7 +18163,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             original_text = ""
             recovered_text = ""
             logger.info(
-                "[PrivateCompanion] 已清除图片工具成功发送后的内部静默标记: session=%s",
+                "已清除图片工具成功发送后的内部静默标记: session=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             )
         if (
@@ -18175,7 +18178,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             original_text = ""
             recovered_text = ""
             logger.info(
-                "[PrivateCompanion] 已移除生图工具成功发送后的重复承接正文: session=%s caption=%s",
+                "已移除生图工具成功发送后的重复承接正文: session=%s caption=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                 _single_line(sent_photo_caption, 120),
             )
@@ -18204,7 +18207,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             except Exception:
                 pass
             logger.info(
-                "[PrivateCompanion] 已将同会话工具文本恢复为唯一最终回复: session=%s text=%s",
+                "已将同会话工具文本恢复为唯一最终回复: session=%s text=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                 _single_line(pending_tool_text, 160),
             )
@@ -18398,7 +18401,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                 )
                 if corrected:
                     logger.info(
-                        "[PrivateCompanion] 私聊引用图片回复疑似被历史话题污染,已按视觉摘要纠偏: user=%s before=%s after=%s",
+                        "私聊引用图片回复疑似被历史话题污染,已按视觉摘要纠偏: user=%s before=%s after=%s",
                         user_id,
                         _single_line(working_text, 120),
                         _single_line(corrected, 160),
@@ -18435,7 +18438,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             )
             if sanitized_elapsed_text != working_text:
                 logger.info(
-                    "[PrivateCompanion] 已清理重复纠正后的生硬回复: user=%s before=%s after=%s",
+                    "已清理重复纠正后的生硬回复: user=%s before=%s after=%s",
                     user_id,
                     _single_line(working_text, 120),
                     _single_line(sanitized_elapsed_text, 120),
@@ -18463,7 +18466,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                     stats["last_smart_silence_at"] = self._environment_now().strftime("%Y-%m-%d %H:%M")
                     self._save_data_sync(sections={"users"})
                 logger.info(
-                    "[PrivateCompanion] 智能沉默已取消本轮私聊回复: user=%s reason=%s inbound=%s reply=%s",
+                    "智能沉默已取消本轮私聊回复: user=%s reason=%s inbound=%s reply=%s",
                     user_id,
                     _single_line(silence_decision.get("reason"), 120),
                     _single_line(inbound_text, 120),
@@ -18500,7 +18503,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                     stats["last_duplicate_dropped_at"] = self._environment_now().strftime("%Y-%m-%d %H:%M")
                     self._save_data_sync(sections={"users"})
                 logger.info(
-                    "[PrivateCompanion] 回复复核已取消重复私聊回复: user=%s inbound=%s reply=%s",
+                    "回复复核已取消重复私聊回复: user=%s inbound=%s reply=%s",
                     user_id,
                     _single_line(inbound_text, 120),
                     _single_line(working_text, 160),
@@ -18547,7 +18550,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                     stats["last_duplicate_dropped_at"] = self._environment_now().strftime("%Y-%m-%d %H:%M")
                     self._save_data_sync(sections={"users"})
                 logger.info(
-                    "[PrivateCompanion] 发送前去重已取消重复私聊回复: user=%s reason=%s inbound=%s reply=%s",
+                    "发送前去重已取消重复私聊回复: user=%s reason=%s inbound=%s reply=%s",
                     user_id,
                     _single_line(duplicate_reason, 120),
                     _single_line(inbound_text, 120),
@@ -18767,7 +18770,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         last_at = _safe_float(cache.get(signature), 0.0)
         if last_at and now - last_at <= ttl:
             logger.info(
-                "[PrivateCompanion] 已跳过重复的每日穿搭命令发图: scope=%s image=%s age=%.1fs",
+                "已跳过重复的每日穿搭命令发图: scope=%s image=%s age=%.1fs",
                 _single_line(scope, 120),
                 _single_line(image_path, 160),
                 now - last_at,
@@ -19306,7 +19309,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                 )
             except Exception as exc:
                 logger.warning(
-                    "[PrivateCompanion] 摄像头单帧读取异常: %s",
+                    "摄像头单帧读取异常: %s",
                     _single_line(exc, 160),
                 )
                 result = {"status": "error", "message": "摄像头单帧读取失败，请稍后再试或检查设备连接。"}
@@ -19483,7 +19486,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                         await self._reply_with_optional_media(event, caption, image_path)
                     except Exception as exc:
                         logger.warning(
-                            "[PrivateCompanion] 每日穿搭命令发图异常,为避免重复发送已不再兜底补发: image=%s err=%s",
+                            "每日穿搭命令发图异常,为避免重复发送已不再兜底补发: image=%s err=%s",
                             _single_line(image_path, 160),
                             _single_line(exc, 180),
                         )
@@ -19563,7 +19566,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             return
         inbound_checker = getattr(self, "_event_is_inbound_chat_message", None)
         if callable(inbound_checker) and not inbound_checker(event):
-            logger.debug("[PrivateCompanion] 非入站聊天事件跳过私聊档案预建")
+            logger.debug("非入站聊天事件跳过私聊档案预建")
             return
         try:
             user_id = str(event.get_sender_id())
@@ -19588,7 +19591,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                 self._schedule_data_save(sections={"users"})
         if auto_profile_created:
             logger.info(
-                "[PrivateCompanion] 已建立最小用户档案: user=%s platform=%s",
+                "已建立最小用户档案: user=%s platform=%s",
                 _single_line(self._canonical_private_user_id(user_id), 80),
                 _single_line(self._platform_kind_for_event(event), 40),
             )
@@ -19625,7 +19628,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                         confirmation_reply = pending_confirmation_handler(user, feedback_text)
                     except Exception as exc:
                         logger.warning(
-                            "[PrivateCompanion] 现实触及待授权确认处理失败: %s",
+                            "现实触及待授权确认处理失败: %s",
                             _single_line(exc, 160),
                         )
                 else:
@@ -19648,7 +19651,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                     confirmation_reply = pending_confirmation_handler(user, feedback_text)
                 except Exception as exc:
                     logger.warning(
-                        "[PrivateCompanion] 现实触及待授权确认处理失败: %s",
+                        "现实触及待授权确认处理失败: %s",
                         _single_line(exc, 160),
                     )
             if confirmation_reply:
@@ -19721,7 +19724,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             return result
         except Exception as exc:
             logger.debug(
-                "[PrivateCompanion] C3 activity capture skipped: scope=%s id=%s error=%s",
+                "C3 activity capture skipped: scope=%s id=%s error=%s",
                 scope,
                 subject_id or "-",
                 _single_line(exc, 160),
@@ -19823,7 +19826,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                 self._save_data_sync(sections={"groups"})
         if blocked:
             logger.info(
-                "[PrivateCompanion] 已静默群成员消息: group=%s sender=%s",
+                "已静默群成员消息: group=%s sender=%s",
                 group_id,
                 sender_id,
             )
@@ -19956,7 +19959,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         )
         if result.get("blocked"):
             logger.warning(
-                "[PrivateCompanion] 群成员风险次数达到阈值，已静默当前消息: group=%s sender=%s",
+                "群成员风险次数达到阈值，已静默当前消息: group=%s sender=%s",
                 group_id,
                 sender_id,
             )
@@ -19984,7 +19987,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             return
         if kind == "third_party":
             logger.info(
-                "[PrivateCompanion] 群聊第三方画像查询已拦截: reason=explicit_third_party_query group_hash=%s text_hash=%s text_len=%s",
+                "群聊第三方画像查询已拦截: reason=explicit_third_party_query group_hash=%s text_hash=%s text_len=%s",
                 hashlib.sha256(str(group_id).encode("utf-8", errors="ignore")).hexdigest()[:12],
                 hashlib.sha256(str(text).encode("utf-8", errors="ignore")).hexdigest()[:12],
                 len(str(text)),

--- a/memory_companion_adapter.py
+++ b/memory_companion_adapter.py
@@ -12,7 +12,6 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 
-from astrbot.api import logger
 
 from .bot_personal_contract import (
     BOT_PERSONAL_CAPABILITY_SCHEMA_VERSION,
@@ -34,6 +33,9 @@ from .namespace_capability import negotiate_namespace_capability
 from .identity_namespace import validate_namespace_context
 from .persona_config import runtime_persona_setting
 from .conversation_prompt_section import prompt_section
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 # The v2 contract was published by the previous Memory Companion release.
@@ -145,7 +147,7 @@ class MemoryCompanionAdapterMixin:
             except Exception as exc:
                 if self._memory_companion_optional_dependency_failed(exc, where="register_emotion_producer"):
                     return None
-                logger.debug("[PrivateCompanion] emotion producer registration failed: %s", _single_line(exc, 120))
+                logger.debug("emotion producer registration failed: %s", _single_line(exc, 120))
                 continue
             if capability is not None:
                 break
@@ -188,7 +190,7 @@ class MemoryCompanionAdapterMixin:
         except Exception as exc:
             if self._memory_companion_optional_dependency_failed(exc, where="create_emotion_producer_context"):
                 return None
-            logger.debug("[PrivateCompanion] emotion producer context failed: %s", _single_line(exc, 120))
+            logger.debug("emotion producer context failed: %s", _single_line(exc, 120))
             return None
 
     def _memory_companion_emotion_delivery_context(
@@ -258,7 +260,7 @@ class MemoryCompanionAdapterMixin:
         except Exception as exc:
             if self._memory_companion_optional_dependency_failed(exc, where="create_emotion_delivery_context"):
                 return None
-            logger.debug("[PrivateCompanion] emotion delivery context failed: %s", _single_line(exc, 120))
+            logger.debug("emotion delivery context failed: %s", _single_line(exc, 120))
             return None
 
     async def _memory_companion_record_emotion_event(self, event: dict[str, Any]) -> None:
@@ -272,7 +274,7 @@ class MemoryCompanionAdapterMixin:
         except Exception as exc:
             if self._memory_companion_optional_dependency_failed(exc, where="record_emotion_event"):
                 return
-            logger.debug("[PrivateCompanion] emotion event mirror failed: %s", _single_line(exc, 120))
+            logger.debug("emotion event mirror failed: %s", _single_line(exc, 120))
 
     def _memory_companion_degraded_status(self, reason: str, **extra: Any) -> dict[str, Any]:
         status = {
@@ -335,7 +337,7 @@ class MemoryCompanionAdapterMixin:
             where=_single_line(where, 80) or "-",
         )
         logger.warning(
-            "[PrivateCompanion] 记忆插件可选模型依赖缺失，已临时降级 MemoryCompanion 桥接: module=%s where=%s err=%s",
+            "记忆插件可选模型依赖缺失，已临时降级 MemoryCompanion 桥接: module=%s where=%s err=%s",
             module,
             _single_line(where, 80) or "-",
             _single_line(exc, 160),
@@ -589,7 +591,7 @@ class MemoryCompanionAdapterMixin:
                 ),
             )
         except Exception as exc:
-            logger.debug("[PrivateCompanion] Bot Personal outbox 初始化失败: %s", _single_line(exc, 120))
+            logger.debug("Bot Personal outbox 初始化失败: %s", _single_line(exc, 120))
             return None
         try:
             setattr(self, "_bot_personal_outbox", current)
@@ -674,7 +676,7 @@ class MemoryCompanionAdapterMixin:
             }
             return result
         except Exception as exc:
-            logger.debug("[PrivateCompanion] Bot Personal 本地归档失败: %s", _single_line(exc, 160))
+            logger.debug("Bot Personal 本地归档失败: %s", _single_line(exc, 160))
             return {
                 "ok": False,
                 "state": "local_only",
@@ -697,7 +699,7 @@ class MemoryCompanionAdapterMixin:
             }
             return results
         except Exception as exc:
-            logger.debug("[PrivateCompanion] Bot Personal outbox 补投失败: %s", _single_line(exc, 160))
+            logger.debug("Bot Personal outbox 补投失败: %s", _single_line(exc, 160))
             return []
 
     async def _memory_companion_record_observed_activity(self, activity: dict[str, Any]) -> dict[str, Any]:
@@ -1147,7 +1149,7 @@ class MemoryCompanionAdapterMixin:
         except Exception as exc:
             if self._memory_companion_optional_dependency_failed(exc, where="coordination_status"):
                 return dict(self._bridge_last_status)
-            logger.debug("[PrivateCompanion] MemoryCompanion 协同状态读取失败: %s", _single_line(exc, 120))
+            logger.debug("MemoryCompanion 协同状态读取失败: %s", _single_line(exc, 120))
             return self._memory_companion_degraded_status("bridge_exception", error=_single_line(exc, 120))
         if not isinstance(status, dict):
             return self._memory_companion_degraded_status("invalid_status", status_type=type(status).__name__)
@@ -1180,7 +1182,7 @@ class MemoryCompanionAdapterMixin:
         except Exception as exc:
             if self._memory_companion_optional_dependency_failed(exc, where="token_usage"):
                 return {"available": False, "display_name": "我会牢牢记住你", "reason": f"缺少可选依赖 {self._bridge_dependency_failure_module}"}
-            logger.debug("[PrivateCompanion] 记忆插件 Token 统计读取失败: %s", _single_line(exc, 120))
+            logger.debug("记忆插件 Token 统计读取失败: %s", _single_line(exc, 120))
             return {"available": False, "display_name": "我会牢牢记住你", "reason": _single_line(exc, 120)}
         if not isinstance(usage, dict):
             return {"available": False, "display_name": "我会牢牢记住你", "reason": "记忆插件返回的 Token 统计格式无效"}
@@ -1231,11 +1233,11 @@ class MemoryCompanionAdapterMixin:
         except Exception as exc:
             if self._memory_companion_optional_dependency_failed(exc, where="should_defer"):
                 return False
-            logger.debug("[PrivateCompanion] MemoryCompanion 协同状态读取失败: %s", _single_line(exc, 120))
+            logger.debug("MemoryCompanion 协同状态读取失败: %s", _single_line(exc, 120))
             return False
         if should_defer:
             self._memory_companion_mark_deferred_section(section, event, req)
-            logger.info("[PrivateCompanion] MemoryCompanion 已接管提示词片段，跳过本地注入: section=%s", _single_line(section, 80))
+            logger.info("MemoryCompanion 已接管提示词片段，跳过本地注入: section=%s", _single_line(section, 80))
         return should_defer
 
     def _memory_companion_bot_emotional_state(self) -> tuple[str, float]:
@@ -1542,8 +1544,8 @@ class MemoryCompanionAdapterMixin:
                 timeout=timeout,
             )
         except asyncio.TimeoutError:
-            logger.info(
-                "[PrivateCompanion] MemoryCompanion 日程上下文读取超时,已跳过: kind=%s timeout=%.2fs",
+            logger.warning(
+                "MemoryCompanion 日程上下文读取超时,已跳过: kind=%s timeout=%.2fs",
                 _single_line(kind, 60),
                 max(0.2, min(6.0, _memory_companion_safe_float(getattr(self, "memory_companion_context_timeout_seconds", 1.2), 1.2, 0.2))),
             )
@@ -1551,7 +1553,7 @@ class MemoryCompanionAdapterMixin:
         except Exception as exc:
             if self._memory_companion_optional_dependency_failed(exc, where="compose_schedule_context"):
                 return ""
-            logger.debug("[PrivateCompanion] MemoryCompanion 日程上下文读取失败: %s", _single_line(exc, 120))
+            logger.debug("MemoryCompanion 日程上下文读取失败: %s", _single_line(exc, 120))
             return ""
         text = str(text or "").strip()
         if not text:
@@ -1692,8 +1694,8 @@ class MemoryCompanionAdapterMixin:
                 timeout=max(0.2, min(6.0, min(configured_timeout, _memory_companion_safe_float(timeout_seconds, configured_timeout, 0.2)))),
             )
         except asyncio.TimeoutError:
-            logger.info(
-                "[PrivateCompanion] MemoryCompanion 功能上下文读取超时,已跳过: kind=%s timeout=%.2fs",
+            logger.warning(
+                "MemoryCompanion 功能上下文读取超时,已跳过: kind=%s timeout=%.2fs",
                 _single_line(kind, 60),
                 max(0.2, min(6.0, min(_memory_companion_safe_float(getattr(self, "memory_companion_context_timeout_seconds", 1.2), 1.2, 0.2), _memory_companion_safe_float(timeout_seconds, 1.2, 0.2)))),
             )
@@ -1701,7 +1703,7 @@ class MemoryCompanionAdapterMixin:
         except Exception as exc:
             if self._memory_companion_optional_dependency_failed(exc, where=f"compose_feature_context:{kind}"):
                 return ""
-            logger.debug("[PrivateCompanion] MemoryCompanion 功能上下文读取失败: kind=%s err=%s", _single_line(kind, 60), _single_line(exc, 120))
+            logger.debug("MemoryCompanion 功能上下文读取失败: kind=%s err=%s", _single_line(kind, 60), _single_line(exc, 120))
             return ""
         text = str(text or "").strip()
         if not text:
@@ -1801,7 +1803,7 @@ class MemoryCompanionAdapterMixin:
         except Exception as exc:
             if self._memory_companion_optional_dependency_failed(exc, where="compose_private_recall"):
                 return ""
-            logger.debug("[PrivateCompanion] MemoryCompanion 私聊选择性召回失败: %s", _single_line(exc, 120))
+            logger.debug("MemoryCompanion 私聊选择性召回失败: %s", _single_line(exc, 120))
             return ""
         recalled = _single_line(recalled, 620)
         if not recalled:
@@ -2278,7 +2280,7 @@ class MemoryCompanionAdapterMixin:
                 payload = merged
             setattr(event, "private_companion_context", payload)
         except Exception as exc:
-            logger.debug("[PrivateCompanion] MemoryCompanion 上下文线索挂载失败: %s", _single_line(exc, 120))
+            logger.debug("MemoryCompanion 上下文线索挂载失败: %s", _single_line(exc, 120))
 
     def _memory_companion_attach_private_context(
         self,
@@ -2372,7 +2374,7 @@ class MemoryCompanionAdapterMixin:
         try:
             context = builder(event)
         except Exception as exc:
-            logger.debug("[PrivateCompanion] Unified Person 上下文生成失败: %s", _single_line(exc, 160))
+            logger.debug("Unified Person 上下文生成失败: %s", _single_line(exc, 160))
             return
         if not isinstance(context, dict):
             return
@@ -2492,7 +2494,7 @@ class MemoryCompanionAdapterMixin:
         except Exception as exc:
             if self._memory_companion_optional_dependency_failed(exc, where="record_proactive_message"):
                 return
-            logger.debug("[PrivateCompanion] MemoryCompanion 主动消息桥接写入失败: %s", _single_line(exc, 120))
+            logger.debug("MemoryCompanion 主动消息桥接写入失败: %s", _single_line(exc, 120))
 
     async def _memory_companion_record_image_observation(
         self,
@@ -2559,7 +2561,7 @@ class MemoryCompanionAdapterMixin:
         except Exception as exc:
             if self._memory_companion_optional_dependency_failed(exc, where="record_image_observation"):
                 return
-            logger.debug("[PrivateCompanion] MemoryCompanion 图片观察写入失败: %s", _single_line(exc, 120))
+            logger.debug("MemoryCompanion 图片观察写入失败: %s", _single_line(exc, 120))
 
     async def _memory_companion_record_photo_generation(
         self,
@@ -2690,7 +2692,7 @@ class MemoryCompanionAdapterMixin:
         except Exception as exc:
             if self._memory_companion_optional_dependency_failed(exc, where="record_photo_generation"):
                 return
-            logger.debug("[PrivateCompanion] MemoryCompanion 生图记录写入失败: %s", _single_line(exc, 120))
+            logger.debug("MemoryCompanion 生图记录写入失败: %s", _single_line(exc, 120))
 
     async def _memory_companion_record_user_habit(
         self,
@@ -2788,7 +2790,7 @@ class MemoryCompanionAdapterMixin:
         except Exception as exc:
             if self._memory_companion_optional_dependency_failed(exc, where="record_user_habit"):
                 return
-            logger.debug("[PrivateCompanion] MemoryCompanion 用户习惯写入失败: %s", _single_line(exc, 120))
+            logger.debug("MemoryCompanion 用户习惯写入失败: %s", _single_line(exc, 120))
 
     async def _memory_companion_record_daily_outfit(self, item: dict[str, Any]) -> None:
         if not isinstance(item, dict) or not _path_text(item.get("path"), 1000):
@@ -2839,7 +2841,7 @@ class MemoryCompanionAdapterMixin:
         except Exception as exc:
             if self._memory_companion_optional_dependency_failed(exc, where="record_daily_outfit"):
                 return
-            logger.debug("[PrivateCompanion] MemoryCompanion 每日穿搭写入失败: %s", _single_line(exc, 120))
+            logger.debug("MemoryCompanion 每日穿搭写入失败: %s", _single_line(exc, 120))
 
     async def _memory_companion_record_creative_progress(
         self,
@@ -2918,7 +2920,7 @@ class MemoryCompanionAdapterMixin:
         except Exception as exc:
             if self._memory_companion_optional_dependency_failed(exc, where="record_creative_progress"):
                 return
-            logger.debug("[PrivateCompanion] MemoryCompanion 创作进展写入失败: %s", _single_line(exc, 120))
+            logger.debug("MemoryCompanion 创作进展写入失败: %s", _single_line(exc, 120))
 
     def _memory_companion_now_iso(self) -> str:
         try:
@@ -3008,7 +3010,7 @@ class MemoryCompanionAdapterMixin:
         except Exception as exc:
             if self._memory_companion_optional_dependency_failed(exc, where="record_qzone_publish"):
                 return
-            logger.debug("[PrivateCompanion] MemoryCompanion QQ 空间发布写入失败: %s", _single_line(exc, 120))
+            logger.debug("MemoryCompanion QQ 空间发布写入失败: %s", _single_line(exc, 120))
 
     async def _memory_companion_apply_emotional_drift(
         self,
@@ -3044,7 +3046,7 @@ class MemoryCompanionAdapterMixin:
         except Exception as exc:
             if self._memory_companion_optional_dependency_failed(exc, where="list_emotion_events"):
                 return
-            logger.debug("[PrivateCompanion] 情绪余波拉取失败: %s", _single_line(exc, 120))
+            logger.debug("情绪余波拉取失败: %s", _single_line(exc, 120))
             return
         events = delivery.get("events", []) if isinstance(delivery, dict) else []
         if not isinstance(events, list) or not events:
@@ -3091,7 +3093,7 @@ class MemoryCompanionAdapterMixin:
         except Exception as exc:
             self._memory_companion_optional_dependency_failed(exc, where="ack_emotion_events")
             return
-        logger.debug("[PrivateCompanion] 已应用并确认记忆情绪余波: count=%s", len(applied_refs))
+        logger.debug("已应用并确认记忆情绪余波: count=%s", len(applied_refs))
 
     def _memory_companion_afterglow_condition(self, event: dict[str, Any], *, now: float) -> dict[str, Any] | None:
         event_id = _single_line(event.get("event_id"), 96)
@@ -3166,7 +3168,7 @@ class MemoryCompanionAdapterMixin:
         except Exception as exc:
             if self._memory_companion_optional_dependency_failed(exc, where="search_open_loops"):
                 return []
-            logger.debug("[PrivateCompanion] open-loop 搜索失败: %s", _single_line(exc, 120))
+            logger.debug("open-loop 搜索失败: %s", _single_line(exc, 120))
             return []
 
     async def _memory_companion_record_dream_fragment(
@@ -3214,7 +3216,7 @@ class MemoryCompanionAdapterMixin:
         except Exception as exc:
             if self._memory_companion_optional_dependency_failed(exc, where="record_dream_fragment"):
                 return
-            logger.debug("[PrivateCompanion] 梦境碎片写入失败: %s", _single_line(exc, 120))
+            logger.debug("梦境碎片写入失败: %s", _single_line(exc, 120))
 
     def _memory_companion_get_relationship_phase(self, *, session_id: str = "") -> dict[str, Any]:
         """Get current relationship phase from the memory plugin."""
@@ -3331,7 +3333,7 @@ class MemoryCompanionAdapterMixin:
             if error_code == "requester_context_required" and context_failure_reason:
                 error_code = context_failure_reason
             logger.warning(
-                "[PrivateCompanion] 用户记忆摘要读取失败: state=%s reason=%s context_creator=%s "
+                "用户记忆摘要读取失败: state=%s reason=%s context_creator=%s "
                 "capability=%s requester_context=%s bot_id=%s platform=%s session=%s",
                 state or "degraded",
                 error_code or "summary_unavailable",

--- a/message_pipeline.py
+++ b/message_pipeline.py
@@ -7,7 +7,6 @@ from copy import deepcopy
 from functools import wraps
 from typing import Any
 
-from astrbot.api import logger
 
 from .companion_interaction_expression import current_interaction_projection
 from .helpers import (
@@ -18,6 +17,9 @@ from .helpers import (
     _safe_int,
     _single_line,
 )
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 def _coalesce_event_data_saves(handler: Any) -> Any:
@@ -108,13 +110,13 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
         return
     inbound_checker = getattr(self, "_event_is_inbound_chat_message", None)
     if callable(inbound_checker) and not inbound_checker(event):
-        logger.debug("[PrivateCompanion] 非入站聊天事件跳过私聊陪伴链路")
+        logger.debug("非入站聊天事件跳过私聊陪伴链路")
         return
     received_ts = _now_ts()
     user_id = str(event.get_sender_id())
     self_id = self._event_self_id(event)
     if user_id and self_id and user_id == self_id:
-        logger.info("[PrivateCompanion] 忽略 Bot 自己的私聊回流事件: user=%s", user_id)
+        logger.info("忽略 Bot 自己的私聊回流事件: user=%s", user_id)
         return
     sender_display_name = _single_line(self._sender_display_name(event), 40)
     text = _single_line(event.message_str, 120)
@@ -142,13 +144,13 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
         self._schedule_data_save(sections={"users", "unified_person"})
     if auto_profile_created:
         logger.info(
-            "[PrivateCompanion] 已建立最小用户档案: user=%s platform=%s",
+            "已建立最小用户档案: user=%s platform=%s",
             _single_line(self._canonical_private_user_id(user_id), 80),
             _single_line(self._platform_kind_for_event(event), 40),
         )
     if self._is_onebot_poke_notice_event(event):
         # 戳一戳会以私聊空文本事件进入 AstrBot；交给专用插件处理。
-        logger.debug("[PrivateCompanion] 私聊戳一戳 notice 交给专用插件")
+        logger.debug("私聊戳一戳 notice 交给专用插件")
         return
     self._qzone_note_event_bot(event)
     if text.startswith(("陪伴", "/陪伴", "私聊陪伴", "主动陪伴")):
@@ -174,7 +176,7 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
                 source_text=text,
             )
         logger.info(
-            "[PrivateCompanion] 已有其他链路回复,跳过私聊被动接管: user=%s text=%s result=%s",
+            "已有其他链路回复,跳过私聊被动接管: user=%s text=%s result=%s",
             user_id,
             _single_line(text, 80),
             _single_line(existing_reply_preview, 120),
@@ -189,7 +191,7 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
     )
     if not private_profile_available:
         logger.info(
-            "[PrivateCompanion] 非目标/未启用私聊放行默认主链: user=%s text=%s reason=%s",
+            "非目标/未启用私聊放行默认主链: user=%s text=%s reason=%s",
             _single_line(canonical_user_id or user_id, 80),
             _single_line(text, 120),
             "not_profile",
@@ -221,7 +223,7 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
             if not missing:
                 raise
             logger.warning(
-                "[PrivateCompanion] 私聊自然语言生图前置处理缺少可选模型依赖，已降级放行普通私聊: user=%s module=%s err=%s",
+                "私聊自然语言生图前置处理缺少可选模型依赖，已降级放行普通私聊: user=%s module=%s err=%s",
                 user_id,
                 missing,
                 _single_line(exc, 160),
@@ -244,7 +246,7 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
             forward_id, forward_payload = await self._find_forward_descriptor_for_event(event)
         except Exception as exc:
             forward_id, forward_payload = "", {}
-            logger.info("[PrivateCompanion] 私聊合并消息预解析失败: user=%s error=%s", user_id, _single_line(exc, 120))
+            logger.info("私聊合并消息预解析失败: user=%s error=%s", user_id, _single_line(exc, 120))
         if forward_id or forward_payload:
             forward_only_prompt = "我转发了一段聊天记录,你看看里面在说什么。"
             text = forward_only_prompt
@@ -256,7 +258,7 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
             except Exception:
                 pass
             logger.info(
-                "[PrivateCompanion] 私聊纯合并消息已补触发文本: user=%s id=%s inline=%s",
+                "私聊纯合并消息已补触发文本: user=%s id=%s inline=%s",
                 user_id,
                 _single_line(forward_id, 40) or "inline",
                 bool(forward_payload),
@@ -286,7 +288,7 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
         except Exception:
             component_types = []
         logger.info(
-            "[PrivateCompanion] 忽略空私聊事件,避免阻止默认 LLM 空跑: user=%s components=%s",
+            "忽略空私聊事件,避免阻止默认 LLM 空跑: user=%s components=%s",
             user_id,
             ",".join([item for item in component_types if item]) or "-",
         )
@@ -314,7 +316,7 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
             if not missing:
                 raise
             logger.warning(
-                "[PrivateCompanion] 私聊引用媒体检测缺少可选模型依赖，已按普通文本继续: user=%s module=%s err=%s",
+                "私聊引用媒体检测缺少可选模型依赖，已按普通文本继续: user=%s module=%s err=%s",
                 user_id,
                 missing,
                 _single_line(exc, 160),
@@ -322,7 +324,7 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
             reference_media_with_text = False
         if reference_media_with_text:
             logger.info(
-                "[PrivateCompanion] 私聊引用媒体/合并消息附带文字,跳过文本收口等待: user=%s text=%s",
+                "私聊引用媒体/合并消息附带文字,跳过文本收口等待: user=%s text=%s",
                 user_id,
                 _single_line(text, 80),
             )
@@ -357,7 +359,7 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
         and not self._is_private_image_only_message(event, text)
     ):
         if self._is_recent_poke_echo(fast_user, text):
-            logger.info("[PrivateCompanion] 忽略 poke 回流事件,不计入用户新消息: %s", user_id)
+            logger.info("忽略 poke 回流事件,不计入用户新消息: %s", user_id)
             return
         if self._is_duplicate_inbound_message(event, scope=f"private:{user_id}", sender_id=user_id, text=text):
             self._record_passive_no_reply(
@@ -382,7 +384,7 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
             user_id=user_id,
             trigger_umo=str(getattr(event, "unified_msg_origin", "") or ""),
         ):
-            logger.info("[PrivateCompanion] 用户已在当前问候时段自然来聊,已请求取消冲突问候候选: %s", user_id)
+            logger.info("用户已在当前问候时段自然来聊,已请求取消冲突问候候选: %s", user_id)
             if not self._simulation_active(fast_user) and _safe_float(fast_user.get("next_proactive_at"), 0) <= 0:
                 self._schedule_next_proactive(fast_user, now=received_ts)
         safe_text = self._sanitize_orphan_tts_placeholders(text)
@@ -430,7 +432,7 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
             if not missing:
                 raise
             logger.warning(
-                "[PrivateCompanion] 私聊轻量链路记忆桥缺少可选模型依赖，已跳过记忆增强: user=%s module=%s err=%s",
+                "私聊轻量链路记忆桥缺少可选模型依赖，已跳过记忆增强: user=%s module=%s err=%s",
                 user_id,
                 missing,
                 _single_line(exc, 160),
@@ -502,7 +504,7 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
                 ) or {}
             except Exception as exc:
                 logger.warning(
-                    "[PrivateCompanion] 轻量私聊日历候选观察失败，已放行当前回复: user=%s error=%s",
+                    "轻量私聊日历候选观察失败，已放行当前回复: user=%s error=%s",
                     user_id,
                     _single_line(exc, 160),
                 )
@@ -541,14 +543,14 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
         )
         if not is_target_user:
             logger.info(
-                "[PrivateCompanion] 非目标/未启用私聊不记录陪伴资料: user=%s text=%s",
+                "非目标/未启用私聊不记录陪伴资料: user=%s text=%s",
                 _single_line(user_id, 80),
                 _single_line(text, 120),
             )
             return
         user = self._get_user(user_id)
         if self._is_recent_poke_echo(user, text):
-            logger.info("[PrivateCompanion] 忽略 poke 回流事件,不计入用户新消息: %s", user_id)
+            logger.info("忽略 poke 回流事件,不计入用户新消息: %s", user_id)
             return
         if self._is_duplicate_inbound_message(event, scope=f"private:{user_id}", sender_id=user_id, text=text):
             self._schedule_data_save(sections={"inbound_debounce_stats"})
@@ -596,7 +598,7 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
                 if not missing:
                     raise
                 logger.warning(
-                    "[PrivateCompanion] 私聊图文图片预处理缺少可选模型依赖，已按纯文本继续: user=%s module=%s err=%s",
+                    "私聊图文图片预处理缺少可选模型依赖，已按纯文本继续: user=%s module=%s err=%s",
                     user_id,
                     missing,
                     _single_line(exc, 160),
@@ -612,7 +614,7 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
                     if not missing:
                         raise
                     logger.warning(
-                        "[PrivateCompanion] 私聊图文视觉 provider 检测缺少可选模型依赖，已关闭本轮识图: user=%s module=%s err=%s",
+                        "私聊图文视觉 provider 检测缺少可选模型依赖，已关闭本轮识图: user=%s module=%s err=%s",
                         user_id,
                         missing,
                         _single_line(exc, 160),
@@ -646,7 +648,7 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
                         if not missing:
                             raise
                         logger.warning(
-                            "[PrivateCompanion] 私聊图文视觉摘要缺少可选模型依赖，已按无视觉摘要继续: user=%s module=%s err=%s",
+                            "私聊图文视觉摘要缺少可选模型依赖，已按无视觉摘要继续: user=%s module=%s err=%s",
                             user_id,
                             missing,
                             _single_line(exc, 160),
@@ -655,7 +657,7 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
                     if vision_text:
                         setattr(event, "private_companion_delayed_image_vision_text", vision_text)
                 logger.info(
-                    "[PrivateCompanion] 私聊文本图片混合消息已接入图片上下文: user=%s images=%s mode=%s gif=%s combo=%s vision=%s text=%s",
+                    "私聊文本图片混合消息已接入图片上下文: user=%s images=%s mode=%s gif=%s combo=%s vision=%s text=%s",
                     user_id,
                     len(usable_images),
                     image_mode,
@@ -666,7 +668,7 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
                 )
             else:
                 logger.info(
-                    "[PrivateCompanion] 私聊文本图片混合消息未解析到可用图片源: user=%s sources=%s text=%s",
+                    "私聊文本图片混合消息未解析到可用图片源: user=%s sources=%s text=%s",
                     user_id,
                     len(persisted_images),
                     _single_line(text, 80),
@@ -703,7 +705,7 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
                     buffers.pop(key, None)
                     setattr(event, "private_companion_deferred_private_image_only", False)
                     logger.info(
-                        "[PrivateCompanion] 私聊单图未解析到可用图片源,放行原始事件: user=%s sources=%s",
+                        "私聊单图未解析到可用图片源,放行原始事件: user=%s sources=%s",
                         user_id,
                         len(persisted_images),
                     )
@@ -712,7 +714,7 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
                     return
                 if not has_model_usable_image:
                     logger.info(
-                        "[PrivateCompanion] 私聊单图已保存但不可直供模型,仍进入防抖等待补充: user=%s sources=%s",
+                        "私聊单图已保存但不可直供模型,仍进入防抖等待补充: user=%s sources=%s",
                         user_id,
                         len(persisted_images),
                     )
@@ -739,7 +741,7 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
                         label="private_image_debounce_vision",
                     )
                 logger.info(
-                    "[PrivateCompanion] 私聊单图已进入防抖缓冲: user=%s images=%s mode=%s vision=%s",
+                    "私聊单图已进入防抖缓冲: user=%s images=%s mode=%s vision=%s",
                     user_id,
                     len(persisted_images),
                     image_mode,
@@ -783,7 +785,7 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
                     first_ts = _safe_float(existing_buffer.get("first_ts"), received_ts, received_ts)
                     existing_buffer["deadline_ts"] = first_ts + self._message_debounce_seconds("image")
                 logger.info(
-                    "[PrivateCompanion] 消息收口合并补话: kind=image mode=fixed scope=private:%s sender=%s wait=%.1fs count=%s text=%s",
+                    "消息收口合并补话: kind=image mode=fixed scope=private:%s sender=%s wait=%.1fs count=%s text=%s",
                     user_id,
                     user_id,
                     self._message_debounce_seconds("image"),
@@ -806,7 +808,7 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
                     if not missing:
                         raise
                     logger.warning(
-                        "[PrivateCompanion] 私聊智能收口模型缺少可选依赖，已回退固定等待: user=%s module=%s err=%s",
+                        "私聊智能收口模型缺少可选依赖，已回退固定等待: user=%s module=%s err=%s",
                         user_id,
                         missing,
                         _single_line(exc, 160),
@@ -934,7 +936,7 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
             )
             if expression_feedback:
                 logger.info(
-                    "[PrivateCompanion] 表达规则收到用户反馈: user=%s signal=%s updated=%s demoted=%s",
+                    "表达规则收到用户反馈: user=%s signal=%s updated=%s demoted=%s",
                     user_id,
                     _single_line(expression_feedback.get("signal"), 16),
                     _safe_int(expression_feedback.get("updated_rules"), 0, 0),
@@ -963,7 +965,7 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
                         ) or {}
                     except Exception as exc:
                         logger.warning(
-                            "[PrivateCompanion] 日历候选观察失败，已放行当前回复: user=%s error=%s",
+                            "日历候选观察失败，已放行当前回复: user=%s error=%s",
                             user_id,
                             _single_line(exc, 160),
                         )
@@ -1047,7 +1049,7 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
                 user_id=user_id,
                 trigger_umo=str(getattr(event, "unified_msg_origin", "") or ""),
             ):
-                logger.info("[PrivateCompanion] 用户已在当前问候时段自然来聊,已请求取消冲突问候候选: %s", user_id)
+                logger.info("用户已在当前问候时段自然来聊,已请求取消冲突问候候选: %s", user_id)
                 if not self._simulation_active(user) and _safe_float(user.get("next_proactive_at"), 0) <= 0:
                     self._schedule_next_proactive(user, now=_now_ts())
         user_is_owner = self._private_user_role(user, user_id) == "owner"
@@ -1155,7 +1157,7 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
                 if not missing:
                     raise
                 logger.warning(
-                    "[PrivateCompanion] 私聊记忆上下文挂载缺少可选模型依赖，已跳过记忆增强: user=%s module=%s err=%s",
+                    "私聊记忆上下文挂载缺少可选模型依赖，已跳过记忆增强: user=%s module=%s err=%s",
                     user_id,
                     missing,
                     _single_line(exc, 160),
@@ -1214,7 +1216,7 @@ async def handle_private_message(self: Any, event: Any, *args: Any, **kwargs: An
 
     if not is_target_user:
         logger.info(
-            "[PrivateCompanion] 非目标/未启用私聊放行默认主链: user=%s text=%s",
+            "非目标/未启用私聊放行默认主链: user=%s text=%s",
             _single_line(user_id, 80),
             _single_line(text, 120),
         )
@@ -1249,7 +1251,7 @@ async def handle_group_message(self: Any, event: Any, *args: Any, **kwargs: Any)
         return
     if self._is_onebot_poke_notice_event(event):
         # 同样避免群聊观察链将戳一戳误作空消息或普通上下文。
-        logger.debug("[PrivateCompanion] 群聊戳一戳 notice 已放行给专用插件")
+        logger.debug("群聊戳一戳 notice 已放行给专用插件")
         return
     self._qzone_note_event_bot(event)
     if not _persona_feature_enabled(self, "enable_group_companion"):
@@ -1264,7 +1266,7 @@ async def handle_group_message(self: Any, event: Any, *args: Any, **kwargs: Any)
     self_id = self._event_self_id(event)
     if sender_id and self_id and sender_id == self_id:
         logger.info(
-            "[PrivateCompanion] 已终止 Bot 自己的群聊回流事件: group=%s self=%s text=%s",
+            "已终止 Bot 自己的群聊回流事件: group=%s self=%s text=%s",
             group_id,
             self_id,
             _single_line(getattr(event, "message_str", ""), 80),
@@ -1329,7 +1331,7 @@ async def handle_group_message(self: Any, event: Any, *args: Any, **kwargs: Any)
     )
     existing_reply_preview = self._event_existing_reply_result_preview(event)
     if self._proactive_only_blocks_passive_event(event, "group_event_pipeline"):
-        logger.debug("[PrivateCompanion] 主动消息专用模式已保留群聊观察,跳过回复增强")
+        logger.debug("主动消息专用模式已保留群聊观察,跳过回复增强")
         return
     if existing_reply_preview:
         async with self._data_lock:
@@ -1352,7 +1354,7 @@ async def handle_group_message(self: Any, event: Any, *args: Any, **kwargs: Any)
             self._save_data_sync(sections={"groups"})
             group_snapshot = deepcopy(group)
         logger.info(
-            "[PrivateCompanion] 已有其他链路回复,仅记录群聊观察: group=%s sender=%s text=%s result=%s",
+            "已有其他链路回复,仅记录群聊观察: group=%s sender=%s text=%s result=%s",
             group_id,
             sender_id,
             _single_line(text, 80),
@@ -1369,7 +1371,7 @@ async def handle_group_message(self: Any, event: Any, *args: Any, **kwargs: Any)
         return
     if self._group_llm_reply_blocked(group_id):
         logger.debug(
-            "[PrivateCompanion] 本群 LLM 回复已关闭,已保留观察并跳过回复增强: group=%s text=%s",
+            "本群 LLM 回复已关闭,已保留观察并跳过回复增强: group=%s text=%s",
             group_id,
             _single_line(text, 80),
         )
@@ -1392,7 +1394,7 @@ async def handle_group_message(self: Any, event: Any, *args: Any, **kwargs: Any)
         try:
             quoted_link_payload = await self._event_reply_contains_link_payload(event)
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 群聊引用链接守卫读取失败: %s", _single_line(exc, 120))
+            logger.debug("群聊引用链接守卫读取失败: %s", _single_line(exc, 120))
         if quoted_link_payload:
             setattr(event, "private_companion_group_quoted_link_payload", True)
     current_link_payload = _group_link_message_context(text, limit=260)[1]
@@ -1493,7 +1495,7 @@ async def handle_group_message(self: Any, event: Any, *args: Any, **kwargs: Any)
                     user_id=scoped_sender_id,
                     trigger_umo=str(getattr(event, "unified_msg_origin", "") or ""),
                 ):
-                    logger.info("[PrivateCompanion] 目标用户已在群内交流,已请求取消冲突问候候选: group=%s user=%s", group_id, scoped_sender_id)
+                    logger.info("目标用户已在群内交流,已请求取消冲突问候候选: group=%s user=%s", group_id, scoped_sender_id)
                     if not self._simulation_active(target_user) and _safe_float(target_user.get("next_proactive_at"), 0) <= 0:
                         self._schedule_next_proactive(target_user, now=received_ts)
                 self._maybe_schedule_post_goodnight_group_activity(
@@ -1695,7 +1697,7 @@ async def handle_group_message(self: Any, event: Any, *args: Any, **kwargs: Any)
                 note=_single_line(image_wakeup.get("note"), 180),
             )
             logger.info(
-                "[PrivateCompanion] 群聊图片内容命中唤醒词: group=%s sender=%s word=%s strength=%s",
+                "群聊图片内容命中唤醒词: group=%s sender=%s word=%s strength=%s",
                 group_id,
                 sender_id,
                 image_wakeup.get("word"),
@@ -1764,7 +1766,7 @@ async def handle_group_message(self: Any, event: Any, *args: Any, **kwargs: Any)
                     note=_single_line(wakeup.get("note"), 180),
                 )
                 logger.info(
-                    "[PrivateCompanion] 群聊增强唤醒命中: group=%s sender=%s type=%s word=%s strength=%s fatigue=%s reason=%s detail=%s",
+                    "群聊增强唤醒命中: group=%s sender=%s type=%s word=%s strength=%s fatigue=%s reason=%s detail=%s",
                     group_id,
                     sender_id,
                     wakeup.get("type"),
@@ -1855,7 +1857,7 @@ async def handle_group_message(self: Any, event: Any, *args: Any, **kwargs: Any)
                 group_reference_media_with_text = await self._event_references_media_or_forward_with_text(event, text)
             if group_reference_media_with_text:
                 logger.info(
-                    "[PrivateCompanion] 群聊引用媒体/合并消息附带文字,跳过群聊收口等待: group=%s sender=%s text=%s",
+                    "群聊引用媒体/合并消息附带文字,跳过群聊收口等待: group=%s sender=%s text=%s",
                     group_id,
                     sender_id,
                     _single_line(text, 80),
@@ -1882,7 +1884,7 @@ async def handle_group_message(self: Any, event: Any, *args: Any, **kwargs: Any)
                 )
                 self._save_data_sync(sections={"groups"})
                 logger.info(
-                    "[PrivateCompanion] 群聊高强度消息已合并等待: group=%s sender=%s scope=%s recent_wakeups=%s floor=%s reason=%s wait=%ss text=%s",
+                    "群聊高强度消息已合并等待: group=%s sender=%s scope=%s recent_wakeups=%s floor=%s reason=%s wait=%ss text=%s",
                     group_id,
                     sender_id,
                     _persona_value(self, "group_high_intensity_merge_scope", "group"),
@@ -1926,7 +1928,7 @@ async def handle_group_message(self: Any, event: Any, *args: Any, **kwargs: Any)
                 }
                 self._save_data_sync(sections={"groups"})
                 logger.info(
-                    "[PrivateCompanion] 群聊读空气拦截回复: group=%s sender=%s reason=%s text=%s",
+                    "群聊读空气拦截回复: group=%s sender=%s reason=%s text=%s",
                     group_id,
                     sender_id,
                     air_guard.get("reason"),
@@ -2074,7 +2076,7 @@ async def handle_group_message(self: Any, event: Any, *args: Any, **kwargs: Any)
         )
     else:
         logger.info(
-            "[PrivateCompanion] 群聊高强度收口生效: group=%s recent_wakeups=%s threshold=%s merge_active=%s floor=%s reason=%s merge_scope=%s merge_wait=%ss skip=followup-refresh/general-interject repeat=enabled",
+            "群聊高强度收口生效: group=%s recent_wakeups=%s threshold=%s merge_active=%s floor=%s reason=%s merge_scope=%s merge_wait=%ss skip=followup-refresh/general-interject repeat=enabled",
             group_id,
             group_snapshot_high_intensity.get("recent_wakeups"),
             group_snapshot_high_intensity.get("threshold"),

--- a/nai_image_bridge.py
+++ b/nai_image_bridge.py
@@ -9,11 +9,13 @@ from __future__ import annotations
 
 from typing import Any
 
-from astrbot.api import logger
 
 from .helpers import _single_line
 from .external_bridge_resolver import resolve_external_bridge
 from .persona_config import runtime_persona_setting
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 class NAIImageBridgeMixin:
@@ -51,7 +53,7 @@ class NAIImageBridgeMixin:
                     return False
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanion] 查询统一 NAI 路线所有权失败，保留官方直连: error=%s",
+                "查询统一 NAI 路线所有权失败，保留官方直连: error=%s",
                 _single_line(exc, 120),
             )
         return True
@@ -71,7 +73,7 @@ class NAIImageBridgeMixin:
             status = getter(self)
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanion] NAI 生图能力查询失败: error=%s",
+                "NAI 生图能力查询失败: error=%s",
                 _single_line(exc, 160),
             )
             return {
@@ -101,7 +103,7 @@ class NAIImageBridgeMixin:
             result = await maintainer(self)
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanion] NAI 生图后台维护失败: error=%s",
+                "NAI 生图后台维护失败: error=%s",
                 _single_line(exc, 160),
             )
             return {}
@@ -126,7 +128,7 @@ class NAIImageBridgeMixin:
             response = await generator(self, dict(request))
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanion] NAI 生图插件调用异常: workflow=%s error=%s",
+                "NAI 生图插件调用异常: workflow=%s error=%s",
                 _single_line(request.get("workflow_kind"), 40),
                 _single_line(exc, 160),
             )

--- a/news_exploration.py
+++ b/news_exploration.py
@@ -32,7 +32,7 @@ from typing import Any
 from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlunparse
 from xml.etree import ElementTree as ET
 
-from astrbot.api import AstrBotConfig, logger
+from astrbot.api import AstrBotConfig
 from astrbot.api.event import AstrMessageEvent, MessageChain, filter
 try:
     from astrbot.api.message_components import At, Image, Plain, Record, Reply
@@ -136,6 +136,9 @@ from .planning import (
     normalize_story_plan,
     pick_detail_segment,
 )
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 DEFAULT_AI_DAILY_MORNING_UID = "3706929260006322"
 DEFAULT_AI_DAILY_JUYA_UID = "285286947"
@@ -555,7 +558,7 @@ class NewsExplorationMixin:
             result["cache_hit"] = True
             result["cache_key"] = key
             logger.info(
-                "[PrivateCompanion] 外界信息自我关联命中缓存: source=%s key=%s hit=%s",
+                "外界信息自我关联命中缓存: source=%s key=%s hit=%s",
                 source_type,
                 key,
                 item["hit_count"],
@@ -1174,7 +1177,7 @@ class NewsExplorationMixin:
             if isinstance(raw, list):
                 return [item for item in raw if isinstance(item, dict)]
         except Exception as e:
-            logger.debug(f"[PrivateCompanion] 读取 B 站观看日志失败: {e}")
+            logger.debug(f"读取 B 站观看日志失败: {e}")
         return []
 
     def _load_bilibili_recent_video_memories(self, *, hours: int = 72, limit: int = 12) -> list[dict[str, Any]]:
@@ -1191,7 +1194,7 @@ class NewsExplorationMixin:
             if isinstance(memories, list):
                 return [item for item in memories if isinstance(item, dict)]
         except Exception as e:
-            logger.debug(f"[PrivateCompanion] 读取 BiliBot 视频记忆失败: {e}")
+            logger.debug(f"读取 BiliBot 视频记忆失败: {e}")
         return []
 
     def _bilibili_memory_bvid(self, item: dict[str, Any]) -> str:
@@ -1331,7 +1334,7 @@ class NewsExplorationMixin:
                     extra={"bvid": bvid, "video_title": title},
                 )
             except Exception as e:
-                logger.debug(f"[PrivateCompanion] 写入 BiliBot 分享记忆失败: {e}")
+                logger.debug(f"写入 BiliBot 分享记忆失败: {e}")
         operation = _record()
         creator = getattr(self, "_create_lifecycle_background_task", None)
         try:
@@ -1351,7 +1354,7 @@ class NewsExplorationMixin:
                         pass
                     except Exception as exc:
                         logger.warning(
-                            "[PrivateCompanion] B站分享记忆后台任务失败: %s",
+                            "B站分享记忆后台任务失败: %s",
                             _single_line(exc, 160),
                         )
 
@@ -1429,7 +1432,7 @@ class NewsExplorationMixin:
                         pass
                     except Exception as exc:
                         logger.warning(
-                            "[PrivateCompanion] B站无聊刷视频后台任务失败: %s",
+                            "B站无聊刷视频后台任务失败: %s",
                             _single_line(exc, 160),
                         )
 
@@ -1437,11 +1440,11 @@ class NewsExplorationMixin:
             state["last_boredom_watch_at"] = now
             state["last_boredom_watch_status"] = "triggered"
             self._save_data_sync(sections={"bilibili_integration"})
-            logger.info("[PrivateCompanion] 已触发 B站 AI Bot 无聊刷视频联动")
+            logger.info("已触发 B站 AI Bot 无聊刷视频联动")
         except Exception as e:
             state["last_boredom_watch_status"] = f"failed:{_single_line(str(e), 80)}"
             self._save_data_sync(sections={"bilibili_integration"})
-            logger.debug(f"[PrivateCompanion] 触发 B站 AI Bot 刷视频失败: {e}")
+            logger.debug(f"触发 B站 AI Bot 刷视频失败: {e}")
 
     def _maybe_schedule_bilibili_video_share(self) -> bool:
         if not runtime_persona_setting(self, "enable_bilibili_integration", True):
@@ -1915,7 +1918,7 @@ class NewsExplorationMixin:
                         if len(items) >= max(1, runtime_persona_setting(self, "news_max_items_per_source", 5)):
                             break
         except Exception as exc:
-            logger.debug("[PrivateCompanion] B站搜索 API 兜底失败: %s", exc)
+            logger.debug("B站搜索 API 兜底失败: %s", exc)
         items.sort(key=lambda item: (_safe_float(item.get("published_ts"), 0), _safe_float(item.get("fetched_ts"), 0)), reverse=True)
         return items[: max(1, runtime_persona_setting(self, "news_max_items_per_source", 5))]
 
@@ -2077,7 +2080,7 @@ class NewsExplorationMixin:
                     content_type = resp.headers.get("Content-Type", "")
                     if _news_response_looks_binary(raw_bytes, content_type=content_type):
                         logger.debug(
-                            "[PrivateCompanion] 新闻文字版跳过非文本响应 %s content-type=%s",
+                            "新闻文字版跳过非文本响应 %s content-type=%s",
                             _single_line(safe_url, 120),
                             _single_line(content_type, 80),
                         )
@@ -2090,7 +2093,7 @@ class NewsExplorationMixin:
                     if not raw.strip():
                         return {}
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 新闻文字版抓取失败 %s: %s", _single_line(safe_url, 120), exc)
+            logger.debug("新闻文字版抓取失败 %s: %s", _single_line(safe_url, 120), exc)
             return {}
 
         text = html.unescape(raw or "")
@@ -2186,7 +2189,7 @@ class NewsExplorationMixin:
                         return {"cid": safe_cid, "available": False, "count": len(subtitles), "subtitle_url": subtitle_url}
                     subtitle_payload = await resp.json(content_type=None)
         except Exception as exc:
-            logger.debug("[PrivateCompanion] B站字幕读取失败 bvid=%s: %s", safe_bvid, exc)
+            logger.debug("B站字幕读取失败 bvid=%s: %s", safe_bvid, exc)
             return {}
 
         body = subtitle_payload.get("body") if isinstance(subtitle_payload, dict) and isinstance(subtitle_payload.get("body"), list) else []
@@ -2268,7 +2271,7 @@ class NewsExplorationMixin:
                 if context.get("title") or context.get("tags") or context.get("hot_comments"):
                     break
             except Exception as exc:
-                logger.debug("[PrivateCompanion] BiliBot 视频上下文联动失败 bvid=%s: %s", safe_bvid, exc)
+                logger.debug("BiliBot 视频上下文联动失败 bvid=%s: %s", safe_bvid, exc)
 
         try:
             import aiohttp
@@ -2329,7 +2332,7 @@ class NewsExplorationMixin:
                                             comments.append(message)
                                     context["hot_comments"] = comments[:6]
         except Exception as exc:
-            logger.debug("[PrivateCompanion] B站视频公开上下文抓取失败 bvid=%s: %s", safe_bvid, exc)
+            logger.debug("B站视频公开上下文抓取失败 bvid=%s: %s", safe_bvid, exc)
 
         parts: list[str] = []
         owner = _single_line(context.get("owner_name"), 60)
@@ -2470,7 +2473,7 @@ class NewsExplorationMixin:
                         payload = await payload
                     normalized = self._normalize_bilibili_video_payload(payload, safe_bvid)
                     if normalized.get("title"):
-                        logger.info("[PrivateCompanion] 已通过 B站插件客户端读取视频信息: %s", safe_bvid)
+                        logger.info("已通过 B站插件客户端读取视频信息: %s", safe_bvid)
                         return normalized
                 http_get = getattr(obj, "_http_get", None)
                 if callable(http_get):
@@ -2484,10 +2487,10 @@ class NewsExplorationMixin:
                     if isinstance(data, dict) and int(data.get("code") or 0) == 0:
                         normalized = self._normalize_bilibili_video_payload(data, safe_bvid)
                         if normalized.get("title"):
-                            logger.info("[PrivateCompanion] 已通过 BiliBot HTTP 客户端读取视频信息: %s", safe_bvid)
+                            logger.info("已通过 BiliBot HTTP 客户端读取视频信息: %s", safe_bvid)
                             return normalized
             except Exception as exc:
-                logger.debug("[PrivateCompanion] B站插件视频信息联动失败 bvid=%s: %s", safe_bvid, exc)
+                logger.debug("B站插件视频信息联动失败 bvid=%s: %s", safe_bvid, exc)
         return {}
 
     async def _fetch_bilibili_space_payloads_via_integration(self, mid: str) -> list[dict[str, Any]]:
@@ -2507,7 +2510,7 @@ class NewsExplorationMixin:
                         payload = await payload
                     if isinstance(payload, dict):
                         payloads.append(payload)
-                        logger.info("[PrivateCompanion] 已通过 B站插件客户端读取 UP 最新动态: mid=%s", safe_mid)
+                        logger.info("已通过 B站插件客户端读取 UP 最新动态: mid=%s", safe_mid)
                         continue
                 http_get = getattr(obj, "_http_get", None)
                 if callable(http_get):
@@ -2525,10 +2528,10 @@ class NewsExplorationMixin:
                     data = payload[0] if isinstance(payload, (list, tuple)) and payload else payload
                     if isinstance(data, dict) and int(data.get("code") or 0) == 0:
                         payloads.append(data)
-                        logger.info("[PrivateCompanion] 已通过 BiliBot HTTP 客户端读取 UP 最新动态: mid=%s", safe_mid)
+                        logger.info("已通过 BiliBot HTTP 客户端读取 UP 最新动态: mid=%s", safe_mid)
                         continue
             except Exception as exc:
-                logger.debug("[PrivateCompanion] B站插件 UP 动态联动失败 mid=%s: %s", safe_mid, exc)
+                logger.debug("B站插件 UP 动态联动失败 mid=%s: %s", safe_mid, exc)
         return payloads
 
     async def _fetch_bilibili_video_news_source(self, source: dict[str, str]) -> list[dict[str, Any]]:
@@ -2565,7 +2568,7 @@ class NewsExplorationMixin:
                         return await self._fetch_bilibili_news_search_fallback(source)
                     payload = await resp.json(content_type=None)
         except Exception as exc:
-            logger.debug("[PrivateCompanion] B站单视频新闻源抓取失败 bvid=%s: %s", bvid, exc)
+            logger.debug("B站单视频新闻源抓取失败 bvid=%s: %s", bvid, exc)
             return await self._fetch_bilibili_news_search_fallback(source)
         data = payload.get("data") if isinstance(payload, dict) else {}
         if not isinstance(data, dict):
@@ -2662,7 +2665,7 @@ class NewsExplorationMixin:
                     except Exception:
                         continue
         except Exception as exc:
-            logger.debug("[PrivateCompanion] B站新闻源抓取失败 mid=%s: %s", mid, exc)
+            logger.debug("B站新闻源抓取失败 mid=%s: %s", mid, exc)
             if not payloads:
                 return []
 
@@ -2737,12 +2740,12 @@ class NewsExplorationMixin:
                         return []
                     raw = await resp.text(errors="ignore")
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 新闻源抓取失败 %s: %s", _single_line(url, 120), exc)
+            logger.debug("新闻源抓取失败 %s: %s", _single_line(url, 120), exc)
             return []
         try:
             root = ET.fromstring(raw.encode("utf-8", errors="ignore"))
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 新闻源 XML 解析失败 %s: %s", _single_line(url, 120), exc)
+            logger.debug("新闻源 XML 解析失败 %s: %s", _single_line(url, 120), exc)
             return []
 
         source_name = _single_line(source.get("name"), 40) or "新闻源"
@@ -3298,7 +3301,7 @@ class NewsExplorationMixin:
             digest["share_skip_reason"] = "本次新闻阅读不允许主动分享，且自我关联未通过"
             _sync_digest_share_status()
             self._save_data_sync(sections={"news_integration"})
-            logger.info("[PrivateCompanion] 已完成一次新闻阅读: %s", reason)
+            logger.info("已完成一次新闻阅读: %s", reason)
             return
         users = self.data.get("users")
         accepted_any = False
@@ -3496,7 +3499,7 @@ class NewsExplorationMixin:
             digest["share_skip_reason"] = "没有可用的目标私聊用户"
         _sync_digest_share_status()
         self._save_data_sync(sections={"news_integration", "users", "proactive_candidate_pool", "external_event_pool", "external_event_self_link_cache"})
-        logger.info("[PrivateCompanion] 已完成一次新闻阅读: %s", reason)
+        logger.info("已完成一次新闻阅读: %s", reason)
 
     def _ai_daily_state(self) -> dict[str, Any]:
         state = self.data.setdefault("news_integration", {})
@@ -3710,7 +3713,7 @@ class NewsExplorationMixin:
         source_state.update(result_state)
         ai_state.update({"date": today, **result_state})
         logger.info(
-            "[PrivateCompanion] 已读取今日 %s: %s text_readable=%s text_chars=%s basis=%s",
+            "已读取今日 %s: %s text_readable=%s text_chars=%s basis=%s",
             source_name,
             _single_line(item.get("title"), 120),
             bool(item.get("article_readable") and item.get("article_text")),
@@ -3986,7 +3989,7 @@ class NewsExplorationMixin:
         except Exception:
             pass
         logger.warning(
-            "[PrivateCompanion] 网页搜索进入冷却: provider=%s reason=%s retry=%ss error=%s",
+            "网页搜索进入冷却: provider=%s reason=%s retry=%ss error=%s",
             provider,
             reason,
             int(seconds),
@@ -4143,7 +4146,7 @@ class NewsExplorationMixin:
         if cooldown > 0:
             self._last_web_search_error = f"custom_web_exploration_cooldown:{int(cooldown)}s"
             logger.info(
-                "[PrivateCompanion] 自定义主动搜索冷却中,跳过请求: retry=%ss query=%s",
+                "自定义主动搜索冷却中,跳过请求: retry=%ss query=%s",
                 int(cooldown),
                 cleaned_query,
             )
@@ -4208,13 +4211,13 @@ class NewsExplorationMixin:
             detail = "请求超时"
             self._last_web_search_error = f"custom_web_exploration:{detail}"
             self._mark_web_search_cooldown("custom_web_exploration", detail)
-            logger.warning("[PrivateCompanion] 自定义主动搜索失败: query=%s err=%s", cleaned_query, detail)
+            logger.warning("自定义主动搜索失败: query=%s err=%s", cleaned_query, detail)
             return []
         except Exception as exc:
             detail = _single_line(exc, 220) or exc.__class__.__name__
             self._last_web_search_error = f"custom_web_exploration:{detail}"
             self._mark_web_search_cooldown("custom_web_exploration", exc)
-            logger.warning("[PrivateCompanion] 自定义主动搜索失败: query=%s err=%s", cleaned_query, exc)
+            logger.warning("自定义主动搜索失败: query=%s err=%s", cleaned_query, exc)
             return []
 
         results = self._normalize_custom_web_search_results(raw_payload, cleaned_query)
@@ -4239,7 +4242,7 @@ class NewsExplorationMixin:
         if cooldown > 0:
             self._last_web_search_error = f"web_search_cooldown:{provider}:{int(cooldown)}s"
             logger.info(
-                "[PrivateCompanion] AstrBot 网页搜索冷却中,跳过请求: provider=%s retry=%ss query=%s",
+                "AstrBot 网页搜索冷却中,跳过请求: provider=%s retry=%ss query=%s",
                 provider,
                 int(cooldown),
                 cleaned_query,
@@ -4339,7 +4342,7 @@ class NewsExplorationMixin:
         except Exception as exc:
             self._last_web_search_error = _single_line(str(exc), 240)
             self._mark_web_search_cooldown(provider, exc)
-            logger.warning("[PrivateCompanion] AstrBot 网页搜索失败: provider=%s query=%s err=%s", provider, cleaned_query, exc)
+            logger.warning("AstrBot 网页搜索失败: provider=%s query=%s err=%s", provider, cleaned_query, exc)
             return []
         results: list[dict[str, Any]] = []
         for item in raw_results or []:
@@ -4430,7 +4433,7 @@ class NewsExplorationMixin:
                         return []
                     data = await resp.json(content_type=None)
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 微博热搜抓取失败: %s", exc)
+            logger.debug("微博热搜抓取失败: %s", exc)
             return []
         rows = (((data or {}).get("data") or {}).get("realtime") or []) if isinstance(data, dict) else []
         items: list[dict[str, Any]] = []
@@ -4479,7 +4482,7 @@ class NewsExplorationMixin:
                         return []
                     data = await resp.json(content_type=None)
         except Exception as exc:
-            logger.debug("[PrivateCompanion] Hacker News 热点抓取失败: %s", exc)
+            logger.debug("Hacker News 热点抓取失败: %s", exc)
             return []
         hits = data.get("hits") if isinstance(data, dict) else []
         items: list[dict[str, Any]] = []
@@ -4895,4 +4898,4 @@ class NewsExplorationMixin:
                     self._remember_external_event(digest, source_type="web_exploration", reason="web_exploration_share")
                     break
         self._save_data_sync(sections={"web_exploration", "users", "proactive_candidate_pool", "external_event_pool", "external_event_self_link_cache"})
-        logger.info("[PrivateCompanion] 已完成一次网页探索: %s", _single_line(digest.get("topic"), 80))
+        logger.info("已完成一次网页探索: %s", _single_line(digest.get("topic"), 80))

--- a/page_api.py
+++ b/page_api.py
@@ -27,7 +27,6 @@ from types import SimpleNamespace
 from typing import Any, Mapping
 from urllib.parse import quote, urlparse
 
-from astrbot.api import logger
 from astrbot.api.event import MessageChain
 from astrbot.core.utils.astrbot_path import get_astrbot_data_path
 from quart import request, send_file
@@ -134,6 +133,9 @@ from .reference_assets import (
     normalize_reference_owner_id,
 )
 from .reaction_asset_library import get_reaction_asset_library
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 PLUGIN_NAME = "astrbot_plugin_private_companion"
 PAGE_API_PREFIX = f"/{PLUGIN_NAME}/page"
@@ -410,7 +412,7 @@ class PrivateCompanionPageApi(
                 result = await asyncio.to_thread(self._build_troubleshooting_proactive_summary, data)
             except Exception as exc:
                 if cache is not None:
-                    logger.warning("[PrivateCompanionPage] 排障主动摘要刷新失败，返回最近成功缓存: %s", exc)
+                    logger.warning("排障主动摘要刷新失败，返回最近成功缓存: %s", exc)
                     return deepcopy(cache)
                 raise
             self._troubleshooting_proactive_summary_cache = deepcopy(result)
@@ -589,7 +591,7 @@ class PrivateCompanionPageApi(
             presets = preset_provider()
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanionPage] 读取生图场景预设失败，参考图目录将跳过预设关联校验: %s",
+                "读取生图场景预设失败，参考图目录将跳过预设关联校验: %s",
                 self._single_line(exc, 160),
             )
             return ()
@@ -677,7 +679,7 @@ class PrivateCompanionPageApi(
                 pass
             except Exception as exc:
                 logger.warning(
-                    "[PrivateCompanionPage] background task failed: label=%s error=%s",
+                    "background task failed: label=%s error=%s",
                     label,
                     self._single_line(exc, 160),
                 )
@@ -722,7 +724,7 @@ class PrivateCompanionPageApi(
                 raise
             except Exception as exc:
                 logger.warning(
-                    "[PrivateCompanionPage] 主动消息链路测试到点唤醒失败: user=%s error=%s",
+                    "主动消息链路测试到点唤醒失败: user=%s error=%s",
                     self._single_line(user_key, 80),
                     self._single_line(exc, 160),
                 )
@@ -1047,7 +1049,7 @@ class PrivateCompanionPageApi(
         except (ValueError, AgendaContractError) as exc:
             return self._error(str(exc))
         except Exception as exc:
-            logger.error("[PrivateCompanionPage] 确认日历候选失败: %s", self._single_line(exc, 180), exc_info=True)
+            logger.error("确认日历候选失败: %s", self._single_line(exc, 180), exc_info=True)
             return self._exception_error("确认候选失败")
 
     async def reject_calendar_candidate(self) -> dict[str, Any]:
@@ -1069,7 +1071,7 @@ class PrivateCompanionPageApi(
         except (ValueError, AgendaContractError) as exc:
             return self._error(str(exc))
         except Exception as exc:
-            logger.error("[PrivateCompanionPage] 忽略日历候选失败: %s", self._single_line(exc, 180), exc_info=True)
+            logger.error("忽略日历候选失败: %s", self._single_line(exc, 180), exc_info=True)
             return self._exception_error("忽略候选失败")
 
     async def get_calendar(self) -> dict[str, Any]:
@@ -1085,7 +1087,7 @@ class PrivateCompanionPageApi(
         except ValueError as exc:
             return self._error(str(exc))
         except Exception as exc:
-            logger.error("[PrivateCompanionPage] 获取日历失败: %s", self._single_line(exc, 180), exc_info=True)
+            logger.error("获取日历失败: %s", self._single_line(exc, 180), exc_info=True)
             return self._exception_error("获取日历失败")
 
     async def get_calendar_conflicts(self) -> dict[str, Any]:
@@ -1125,7 +1127,7 @@ class PrivateCompanionPageApi(
         except (ValueError, AgendaContractError) as exc:
             return self._error(str(exc))
         except Exception as exc:
-            logger.error("[PrivateCompanionPage] 预览日历失败: %s", self._single_line(exc, 180), exc_info=True)
+            logger.error("预览日历失败: %s", self._single_line(exc, 180), exc_info=True)
             return self._exception_error("预览日历失败")
 
     async def upsert_calendar(self) -> dict[str, Any]:
@@ -1147,7 +1149,7 @@ class PrivateCompanionPageApi(
         except (ValueError, AgendaContractError) as exc:
             return self._error(str(exc))
         except Exception as exc:
-            logger.error("[PrivateCompanionPage] 保存日历失败: %s", self._single_line(exc, 180), exc_info=True)
+            logger.error("保存日历失败: %s", self._single_line(exc, 180), exc_info=True)
             return self._exception_error("保存日历失败")
 
     async def cancel_calendar(self) -> dict[str, Any]:
@@ -1170,7 +1172,7 @@ class PrivateCompanionPageApi(
                 return self._error("未找到对应日历记录", status_code=404)
             return self._ok({"calendar_id": calendar_id, "cancelled": True})
         except Exception as exc:
-            logger.error("[PrivateCompanionPage] 取消日历失败: %s", self._single_line(exc, 180), exc_info=True)
+            logger.error("取消日历失败: %s", self._single_line(exc, 180), exc_info=True)
             return self._exception_error("取消日历失败")
 
     def route_bindings(self) -> list[tuple[str, Any, list[str], str]]:
@@ -1392,7 +1394,7 @@ class PrivateCompanionPageApi(
                 dismissed = bool(record.get("dismissed")) if isinstance(record, dict) else False
             return self._ok({"version": version, "dismissed": dismissed})
         except Exception as exc:
-            logger.debug("[PrivateCompanionPage] 读取拓展迁移提示偏好失败: %s", self._single_line(exc, 160))
+            logger.debug("读取拓展迁移提示偏好失败: %s", self._single_line(exc, 160))
             return self._ok({"version": version, "dismissed": False, "persistent": False})
 
     async def update_extension_migration_notice(self) -> dict[str, Any]:
@@ -1420,7 +1422,7 @@ class PrivateCompanionPageApi(
                 self.plugin._save_data_sync(sections={"extension_migration_notice_preferences"})
             return self._ok({"version": version, "dismissed": dismissed, "persistent": True})
         except Exception as exc:
-            logger.warning("[PrivateCompanionPage] 保存拓展迁移提示偏好失败: %s", self._single_line(exc, 160))
+            logger.warning("保存拓展迁移提示偏好失败: %s", self._single_line(exc, 160))
             return self._exception_error("保存迁移提示偏好失败")
 
     def _overview_section_value(
@@ -1439,7 +1441,7 @@ class PrivateCompanionPageApi(
             if isinstance(degraded_sections, list) and section_name not in degraded_sections:
                 degraded_sections.append(section_name)
             logger.warning(
-                "[PrivateCompanionPage] 总览区块读取失败: section=%s error=%s",
+                "总览区块读取失败: section=%s error=%s",
                 section_name,
                 self._single_line(exc, 200),
                 exc_info=True,
@@ -1573,7 +1575,7 @@ class PrivateCompanionPageApi(
             except Exception as exc:
                 degraded_sections.append("bookshelf")
                 logger.warning(
-                    "[PrivateCompanionPage] 总览区块读取失败: section=bookshelf error=%s",
+                    "总览区块读取失败: section=bookshelf error=%s",
                     self._single_line(exc, 200),
                     exc_info=True,
                 )
@@ -1692,14 +1694,14 @@ class PrivateCompanionPageApi(
             elapsed_ms = int((time.perf_counter() - start) * 1000)
             if elapsed_ms > 1200:
                 logger.warning(
-                    "[PrivateCompanionPage] 总览接口耗时较高: elapsed=%sms users=%s groups=%s",
+                    "总览接口耗时较高: elapsed=%sms users=%s groups=%s",
                     elapsed_ms,
                     len(users),
                     len(visible_groups),
                 )
             return self._ok(payload)
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 获取总览失败: {exc}", exc_info=True)
+            logger.error(f"获取总览失败: {exc}", exc_info=True)
             return self._exception_error("获取总览失败")
 
     def _companion_plugins_summary(self) -> dict[str, dict[str, bool]]:
@@ -1747,7 +1749,7 @@ class PrivateCompanionPageApi(
             content_status = content_status_getter() if callable(content_status_getter) else {}
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanionPage] 创作扩展状态读取失败: %s",
+                "创作扩展状态读取失败: %s",
                 self._single_line(exc, 160),
             )
             content_status = {}
@@ -1941,7 +1943,7 @@ class PrivateCompanionPageApi(
                     "recent": summary.get("recent", [])[:20],
                 }
             except Exception as exc:
-                logger.debug("[PrivateCompanionPage] 多人格 Token 分类读取失败 persona=%s error=%s", persona_id, exc)
+                logger.debug("多人格 Token 分类读取失败 persona=%s error=%s", persona_id, exc)
         payload["multi_persona"] = {"enabled": True, "by_persona": by_persona}
 
     def _overview_data_snapshot_locked(self, raw_data: Any) -> dict[str, Any]:
@@ -2331,7 +2333,7 @@ class PrivateCompanionPageApi(
                 }
             )
         except Exception as exc:
-            logger.warning("[PrivateCompanionPage] 读取每日穿搭图片失败: %s", self._single_line(exc, 160))
+            logger.warning("读取每日穿搭图片失败: %s", self._single_line(exc, 160))
             return self._exception_error("读取每日穿搭图片失败")
 
     def _cache_summary(self, data: dict[str, Any]) -> dict[str, Any]:
@@ -2755,7 +2757,7 @@ class PrivateCompanionPageApi(
                         budget_exempt=False,
                     )
                 logger.info(
-                    "[PrivateCompanionPage] 表情包自动识别尝试下一个视觉模型: provider=%s images=%s exception=%s error=%s",
+                    "表情包自动识别尝试下一个视觉模型: provider=%s images=%s exception=%s error=%s",
                     provider_id,
                     len(image_urls),
                     exc.__class__.__name__,
@@ -2862,7 +2864,7 @@ class PrivateCompanionPageApi(
                 self._schedule_reaction_library_analysis()
             return self._ok(data)
         except Exception as exc:
-            logger.error("[PrivateCompanionPage] 读取表情包素材库失败: %s", exc, exc_info=True)
+            logger.error("读取表情包素材库失败: %s", exc, exc_info=True)
             return self._error(str(exc))
 
     async def get_reaction_library_image_data(self) -> dict[str, Any]:
@@ -2873,7 +2875,7 @@ class PrivateCompanionPageApi(
             result = await asyncio.to_thread(self._reaction_library().get_image_data, item_id)
             return self._ok(result) if result else self._error("表情包不存在或图片文件已丢失")
         except Exception as exc:
-            logger.error("[PrivateCompanionPage] 读取表情包图片失败: %s", exc, exc_info=True)
+            logger.error("读取表情包图片失败: %s", exc, exc_info=True)
             return self._error(str(exc))
 
     async def import_reaction_library(self) -> dict[str, Any]:
@@ -2896,7 +2898,7 @@ class PrivateCompanionPageApi(
                 result["message"] += f"；{result.get('analysis_queued', 0)} 张已进入自动识别"
             return self._ok(result)
         except Exception as exc:
-            logger.error("[PrivateCompanionPage] 导入表情包失败: %s", exc, exc_info=True)
+            logger.error("导入表情包失败: %s", exc, exc_info=True)
             return self._error(str(exc))
 
     async def analyze_reaction_library(self) -> dict[str, Any]:
@@ -2915,7 +2917,7 @@ class PrivateCompanionPageApi(
             result["message"] = f"已将 {result.get('queued', 0)} 张素材加入识别队列"
             return self._ok(result)
         except Exception as exc:
-            logger.error("[PrivateCompanionPage] 表情包自动识别排队失败: %s", exc, exc_info=True)
+            logger.error("表情包自动识别排队失败: %s", exc, exc_info=True)
             return self._error(str(exc))
 
     async def update_reaction_library(self) -> dict[str, Any]:
@@ -2930,7 +2932,7 @@ class PrivateCompanionPageApi(
             result = await asyncio.to_thread(self._reaction_library().update_items, ids, changes)
             return self._ok(result)
         except Exception as exc:
-            logger.error("[PrivateCompanionPage] 更新表情包失败: %s", exc, exc_info=True)
+            logger.error("更新表情包失败: %s", exc, exc_info=True)
             return self._error(str(exc))
 
     async def delete_reaction_library(self) -> dict[str, Any]:
@@ -2943,7 +2945,7 @@ class PrivateCompanionPageApi(
         try:
             return self._ok(await asyncio.to_thread(self._reaction_library().delete_items, ids))
         except Exception as exc:
-            logger.error("[PrivateCompanionPage] 删除表情包失败: %s", exc, exc_info=True)
+            logger.error("删除表情包失败: %s", exc, exc_info=True)
             return self._error(str(exc))
 
     async def rescan_reaction_library(self) -> dict[str, Any]:
@@ -2956,7 +2958,7 @@ class PrivateCompanionPageApi(
                 result["message"] = f"已重建索引；发现 {duplicate_count} 个重复文件，未重复导入"
             return self._ok(result)
         except Exception as exc:
-            logger.error("[PrivateCompanionPage] 重建表情包索引失败: %s", exc, exc_info=True)
+            logger.error("重建表情包索引失败: %s", exc, exc_info=True)
             return self._error(str(exc))
 
     async def list_image_cache(self) -> dict[str, Any]:
@@ -3017,7 +3019,7 @@ class PrivateCompanionPageApi(
                 }
             )
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 获取图片缓存失败: {exc}", exc_info=True)
+            logger.error(f"获取图片缓存失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     async def update_image_cache_item(self) -> dict[str, Any]:
@@ -3048,7 +3050,7 @@ class PrivateCompanionPageApi(
                 updated = deepcopy(item)
             return self._ok(self._image_cache_item_summary(key, updated))
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 更新图片缓存失败: {exc}", exc_info=True)
+            logger.error(f"更新图片缓存失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     def _image_cache_preview_dir(self) -> Path:
@@ -3129,7 +3131,7 @@ class PrivateCompanionPageApi(
             return target
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanionPage] 生成图片缓存缩略图失败: key=%s error=%s",
+                "生成图片缓存缩略图失败: key=%s error=%s",
                 self._single_line(key, 80),
                 self._single_line(exc, 160),
             )
@@ -3227,7 +3229,7 @@ class PrivateCompanionPageApi(
             )
         except CatalogValidationError as exc:
             logger.warning(
-                "[PrivateCompanionPage] 已保存的参考图目录读取失败: %s",
+                "已保存的参考图目录读取失败: %s",
                 self._single_line(exc, 180),
             )
             return runtime_catalog
@@ -3238,7 +3240,7 @@ class PrivateCompanionPageApi(
             self.plugin.photo_reference_catalog_read_only = loaded.read_only
             self.plugin.photo_reference_catalog_user_cleared = False
             logger.info(
-                "[PrivateCompanionPage] 已从保存配置恢复运行时参考图目录: %s 项",
+                "已从保存配置恢复运行时参考图目录: %s 项",
                 len(loaded.references),
             )
         return loaded.references
@@ -3438,7 +3440,7 @@ class PrivateCompanionPageApi(
                 },
             })
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 获取参考图库失败: {exc}", exc_info=True)
+            logger.error(f"获取参考图库失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     @staticmethod
@@ -3466,7 +3468,7 @@ class PrivateCompanionPageApi(
                     return "图片声明类型与实际格式不一致"
                 image.load()
         except Exception as exc:
-            logger.info("[PrivateCompanionPage] 参考图库上传图片解码失败: type=%s", type(exc).__name__)
+            logger.info("参考图库上传图片解码失败: type=%s", type(exc).__name__)
             return "图片内容损坏或无法解码，请选择完整的 PNG、JPEG 或 WebP 文件"
         return ""
 
@@ -3650,7 +3652,7 @@ class PrivateCompanionPageApi(
                 )
             )
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 获取参考图预览失败: {exc}", exc_info=True)
+            logger.error(f"获取参考图预览失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     def _owned_reaction_asset_catalog(self) -> OwnedReactionAssetCatalog:
@@ -3679,7 +3681,7 @@ class PrivateCompanionPageApi(
                 }
             )
         except Exception:
-            logger.error("[PrivateCompanionPage] owned reaction asset status failed")
+            logger.error("owned reaction asset status failed")
             return self._exception_error("无法读取自有反应图素材状态")
 
     async def get_owned_reaction_asset_image_data(self) -> dict[str, Any]:
@@ -3704,7 +3706,7 @@ class PrivateCompanionPageApi(
                 )
             )
         except Exception:
-            logger.error("[PrivateCompanionPage] owned reaction asset preview failed")
+            logger.error("owned reaction asset preview failed")
             return self._exception_error("无法读取自有反应图预览")
 
     async def compile_photo_reference_metadata(self) -> dict[str, Any]:
@@ -3721,7 +3723,7 @@ class PrivateCompanionPageApi(
             result = compile_reference_metadata(intent, presets, saved=saved)
             return self._ok(result.to_dict())
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 编译参考图元数据失败: {exc}", exc_info=True)
+            logger.error(f"编译参考图元数据失败: {exc}", exc_info=True)
             return self._exception_error("编译参考图元数据失败")
 
     async def _photo_reference_selection_trial_model_runner(
@@ -3783,7 +3785,7 @@ class PrivateCompanionPageApi(
                 timeout_key="LLM_PROVIDER_ID",
             )
         except Exception as exc:
-            logger.info("[PrivateCompanionPage] 参考图试跑主模型工具判断失败: %s", exc)
+            logger.info("参考图试跑主模型工具判断失败: %s", exc)
             return {
                 "tool_name": "",
                 "arguments": {},
@@ -3830,7 +3832,7 @@ class PrivateCompanionPageApi(
                 return []
             conversation = await manager.get_conversation(umo, conversation_id)
         except Exception as exc:
-            logger.debug("[PrivateCompanionPage] 参考图试跑读取会话失败: %s", self._single_line(exc, 120))
+            logger.debug("参考图试跑读取会话失败: %s", self._single_line(exc, 120))
             return []
         raw_history = getattr(conversation, "history", "") if conversation is not None else ""
         if isinstance(raw_history, str):
@@ -3922,7 +3924,7 @@ class PrivateCompanionPageApi(
         try:
             persona_prompt, effective_persona_id = await self._roleplay_persona_prompt_for_id(persona_id, umo)
         except Exception as exc:
-            logger.debug("[PrivateCompanionPage] 参考图试跑读取人格失败: %s", self._single_line(exc, 120))
+            logger.debug("参考图试跑读取人格失败: %s", self._single_line(exc, 120))
             persona_prompt, effective_persona_id = "", persona_id
         daily_state = data.get("daily_state") if isinstance(data.get("daily_state"), Mapping) else {}
         daily_plan = data.get("daily_plan") if isinstance(data.get("daily_plan"), Mapping) else {}
@@ -3977,7 +3979,7 @@ class PrivateCompanionPageApi(
             if isinstance(selected, SelectionResult):
                 return selected
         except Exception as exc:
-            logger.info("[PrivateCompanionPage] 参考图试跑正式选图失败，使用规则兜底: %s", exc)
+            logger.info("参考图试跑正式选图失败，使用规则兜底: %s", exc)
             return SelectionResult(
                 selected=rule_selection.selected,
                 candidates=rule_selection.candidates,
@@ -4070,13 +4072,13 @@ class PrivateCompanionPageApi(
                     f"模型审批超时（超过 {review_timeout:.0f} 秒未返回），已使用本地证据合并。"
                 )
                 logger.warning(
-                    "[PrivateCompanionPage] 参考图问答模型审批超时: provider=%s timeout=%.1fs",
+                    "参考图问答模型审批超时: provider=%s timeout=%.1fs",
                     self._single_line(provider_id, 160),
                     review_timeout,
                 )
             except Exception as exc:
                 review_warning = f"模型审批失败，已使用本地证据合并：{self._single_line(exc, 180)}"
-                logger.warning("[PrivateCompanionPage] 参考图问答模型审批失败: %s", exc, exc_info=True)
+                logger.warning("参考图问答模型审批失败: %s", exc, exc_info=True)
         elif not use_model:
             review_warning = "本次请求关闭了模型审批，已使用本地证据合并。"
         elif not provider_id:
@@ -4112,7 +4114,7 @@ class PrivateCompanionPageApi(
             }
             return self._ok(result)
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 审批后编译参考图元数据失败: {exc}", exc_info=True)
+            logger.error(f"审批后编译参考图元数据失败: {exc}", exc_info=True)
             return self._exception_error("审批后编译参考图元数据失败")
 
     async def run_photo_reference_selection_trial(self) -> dict[str, Any]:
@@ -4194,7 +4196,7 @@ class PrivateCompanionPageApi(
             )
             return self._ok(report.to_dict())
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 参考图选图试跑失败: {exc}", exc_info=True)
+            logger.error(f"参考图选图试跑失败: {exc}", exc_info=True)
             return self._exception_error("参考图选图试跑失败")
 
     def _reference_asset_records(self) -> list[dict[str, Any]]:
@@ -4324,7 +4326,7 @@ class PrivateCompanionPageApi(
                     result = await result
                 return _path_text(result, 1200)
             except Exception as exc:
-                logger.info("[PrivateCompanionPage] 参考资产稳定落盘失败: type=%s", type(exc).__name__)
+                logger.info("参考资产稳定落盘失败: type=%s", type(exc).__name__)
                 return ""
         writer = getattr(self.plugin, "_photo_reference_write_data_image", None)
         if callable(writer) and (str(source).startswith("data:") or str(source).startswith("base64://")):
@@ -4435,7 +4437,7 @@ class PrivateCompanionPageApi(
         try:
             return self._ok(await self._encode_image_cache_file_data_url(path, mime, max_bytes=PHOTO_REFERENCE_PREVIEW_MAX_BYTES))
         except Exception as exc:
-            logger.info("[PrivateCompanionPage] 参考资产预览失败: type=%s", type(exc).__name__)
+            logger.info("参考资产预览失败: type=%s", type(exc).__name__)
             return self._error("参考资产预览失败")
 
     async def upload_reference_asset(self) -> dict[str, Any]:
@@ -4784,7 +4786,7 @@ class PrivateCompanionPageApi(
                 "scopes": sorted(PHOTO_REFERENCE_ASSET_SCOPES),
             })
         except Exception as exc:
-            logger.error("[PrivateCompanionPage] 获取参考资产列表失败: %s", exc, exc_info=True)
+            logger.error("获取参考资产列表失败: %s", exc, exc_info=True)
             return self._error(str(exc))
 
     async def get_photo_reference_asset_image_data(self) -> dict[str, Any]:
@@ -4811,7 +4813,7 @@ class PrivateCompanionPageApi(
                 return self._error("参考资产文件类型不受支持")
             return self._ok(await self._encode_image_cache_file_data_url(path, mime, max_bytes=PHOTO_REFERENCE_ASSET_MAX_BYTES))
         except Exception as exc:
-            logger.error("[PrivateCompanionPage] 获取参考资产预览失败: %s", exc, exc_info=True)
+            logger.error("获取参考资产预览失败: %s", exc, exc_info=True)
             return self._error(str(exc))
 
     async def upload_photo_reference_asset(self) -> dict[str, Any]:
@@ -4977,7 +4979,7 @@ class PrivateCompanionPageApi(
             response.headers["Cache-Control"] = "no-store, max-age=0"
             return response
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 获取图片缓存预览失败: {exc}", exc_info=True)
+            logger.error(f"获取图片缓存预览失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     async def get_image_cache_preview_data(self) -> dict[str, Any]:
@@ -4988,7 +4990,7 @@ class PrivateCompanionPageApi(
             _key, path = resolved
             return self._ok(await self._encode_image_cache_file_data_url(path))
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 获取图片缓存预览数据失败: {exc}", exc_info=True)
+            logger.error(f"获取图片缓存预览数据失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     async def get_image_cache_thumbnail_data(self) -> dict[str, Any]:
@@ -5002,7 +5004,7 @@ class PrivateCompanionPageApi(
                 return self._ok(await self._encode_image_cache_file_data_url(thumbnail, "image/webp"))
             return self._ok(await self._encode_image_cache_file_data_url(source))
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 获取图片缓存缩略图失败: {exc}", exc_info=True)
+            logger.error(f"获取图片缓存缩略图失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     async def delete_image_cache_item(self) -> dict[str, Any]:
@@ -5024,7 +5026,7 @@ class PrivateCompanionPageApi(
             self._remove_image_cache_preview_file(preview_path, key)
             return self._ok({"key": key, "remaining": remaining})
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 删除图片缓存失败: {exc}", exc_info=True)
+            logger.error(f"删除图片缓存失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     async def bulk_delete_image_cache_items(self) -> dict[str, Any]:
@@ -5075,7 +5077,7 @@ class PrivateCompanionPageApi(
                 }
             )
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 批量删除图片缓存失败: {exc}", exc_info=True)
+            logger.error(f"批量删除图片缓存失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     def _remove_image_cache_preview_file(self, preview_path: str, key: str = "") -> None:
@@ -5181,7 +5183,7 @@ class PrivateCompanionPageApi(
             try:
                 return self._ok(self._normalize_reality_touch_snapshot(linked_snapshotter()))
             except Exception as exc:
-                logger.error("[PrivateCompanionPage] 获取现实触及联动状态失败: %s", exc, exc_info=True)
+                logger.error("获取现实触及联动状态失败: %s", exc, exc_info=True)
                 return self._exception_error("获取现实触及联动状态失败")
         return self._error(
             "现实触及已由“我会来到你身边”管理，请先安装并启用 astrbot_plugin_reality_companion。",
@@ -5209,7 +5211,7 @@ class PrivateCompanionPageApi(
                 snapshot["message"] = self._single_line(result.get("message"), 240) or "现实触及联动操作已完成"
                 return self._ok(snapshot)
             except Exception as exc:
-                logger.error("[PrivateCompanionPage] 更新现实触及联动失败: %s", exc, exc_info=True)
+                logger.error("更新现实触及联动失败: %s", exc, exc_info=True)
                 return self._exception_error("更新现实触及联动失败")
         return self._error(
             "现实触及已由“我会来到你身边”管理，请先安装并启用 astrbot_plugin_reality_companion。",
@@ -5495,7 +5497,7 @@ class PrivateCompanionPageApi(
                 ),
                 "",
             )
-            logger.warning("[PrivateCompanionPage] 参考图目录字段校验失败: %s", self._single_line(exc, 240))
+            logger.warning("参考图目录字段校验失败: %s", self._single_line(exc, 240))
             return {
                 "success": False,
                 "error": f"参考图目录存在无效字段：{detail}" if detail else "参考图目录存在无效字段",
@@ -5508,14 +5510,14 @@ class PrivateCompanionPageApi(
                     await self._rollback_multi_persona_transition(mode_transition_snapshot)
                 except Exception as rollback_exc:
                     logger.error(
-                        "[PrivateCompanionPage] 多人格模式切换回滚失败: %s",
+                        "多人格模式切换回滚失败: %s",
                         rollback_exc,
                         exc_info=True,
                     )
                     return self._exception_error(
                         f"{exc}；多人格模式切换回滚失败: {rollback_exc}"
                     )
-            logger.error(f"[PrivateCompanionPage] 更新设置失败: {exc}", exc_info=True)
+            logger.error(f"更新设置失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     def _multi_persona_transition_snapshot(self) -> dict[str, Any]:
@@ -5662,7 +5664,7 @@ class PrivateCompanionPageApi(
             return bool(await self._save_config_if_possible())
         except Exception as exc:
             logger.error(
-                "[PrivateCompanionPage] REQ-041 配置回滚持久化失败: %s",
+                "REQ-041 配置回滚持久化失败: %s",
                 self._single_line(exc, 160),
             )
             return False
@@ -5762,7 +5764,7 @@ class PrivateCompanionPageApi(
                 overview["data"] = data
             return overview
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 切换在线生图 API 失败: {exc}", exc_info=True)
+            logger.error(f"切换在线生图 API 失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     async def export_migration_config(self) -> dict[str, Any]:
@@ -5770,14 +5772,14 @@ class PrivateCompanionPageApi(
             package = await self._build_migration_package(self._migration_export_options_from_request())
             return self._ok(package)
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 导出配置备份失败: {exc}", exc_info=True)
+            logger.error(f"导出配置备份失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     async def list_migration_backups(self) -> dict[str, Any]:
         try:
             return self._ok({"items": self._list_migration_backup_items(limit=8)})
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 读取配置备份列表失败: {exc}", exc_info=True)
+            logger.error(f"读取配置备份列表失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     async def restore_migration_backup(self) -> dict[str, Any]:
@@ -5797,7 +5799,7 @@ class PrivateCompanionPageApi(
             overview["data"] = data
             return overview
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 恢复配置备份失败: {exc}", exc_info=True)
+            logger.error(f"恢复配置备份失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     async def preview_migration_config_import(self) -> dict[str, Any]:
@@ -5812,7 +5814,7 @@ class PrivateCompanionPageApi(
             summary["message"] = "已读取备份，确认后才会写入。"
             return self._ok(summary)
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 预览配置导入失败: {exc}", exc_info=True)
+            logger.error(f"预览配置导入失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     async def apply_migration_config_import(self) -> dict[str, Any]:
@@ -5833,7 +5835,7 @@ class PrivateCompanionPageApi(
                 mode = "merge"
             return await self._apply_migration_normalized(normalized, mode=mode, conflict=conflict)
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 应用配置导入失败: {exc}", exc_info=True)
+            logger.error(f"应用配置导入失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     async def update_proactive_only_unlock(self) -> dict[str, Any]:
@@ -5858,7 +5860,7 @@ class PrivateCompanionPageApi(
                 }
             )
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 更新主动专用临时放行失败: {exc}", exc_info=True)
+            logger.error(f"更新主动专用临时放行失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     async def delete_proactive_candidate(self) -> dict[str, Any]:
@@ -5917,7 +5919,7 @@ class PrivateCompanionPageApi(
                 }
             )
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 删除主动候选失败: {exc}", exc_info=True)
+            logger.error(f"删除主动候选失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     async def prune_proactive_candidates(self) -> dict[str, Any]:
@@ -5944,7 +5946,7 @@ class PrivateCompanionPageApi(
                 }
             )
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 压缩主动候选失败: {exc}", exc_info=True)
+            logger.error(f"压缩主动候选失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     def _troubleshooting_warning_type(self, scope: str, *parts: Any) -> str:
@@ -6166,7 +6168,7 @@ class PrivateCompanionPageApi(
                 }
             )
         except Exception as exc:
-            logger.error("[PrivateCompanionPage] 更新排障警告屏蔽失败: %s", self._single_line(exc, 160), exc_info=True)
+            logger.error("更新排障警告屏蔽失败: %s", self._single_line(exc, 160), exc_info=True)
             return self._exception_error(str(exc))
 
     async def get_diagnostics(self) -> dict[str, Any]:
@@ -6194,7 +6196,7 @@ class PrivateCompanionPageApi(
                 }
             )
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 获取诊断失败: {exc}", exc_info=True)
+            logger.error(f"获取诊断失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     async def get_troubleshooting(self) -> dict[str, Any]:
@@ -6318,7 +6320,7 @@ class PrivateCompanionPageApi(
                 }
             )
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 获取排障信息失败: {exc}", exc_info=True)
+            logger.error(f"获取排障信息失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     async def get_daily_review(self) -> dict[str, Any]:
@@ -6330,7 +6332,7 @@ class PrivateCompanionPageApi(
                 payload = payload_getter()
             return self._ok(payload)
         except Exception as exc:
-            logger.error("[PrivateCompanionPage] 获取每日巡视报告失败: %s", self._single_line(exc, 180), exc_info=True)
+            logger.error("获取每日巡视报告失败: %s", self._single_line(exc, 180), exc_info=True)
             return self._error(str(exc))
 
     async def run_daily_review(self) -> dict[str, Any]:
@@ -6349,7 +6351,7 @@ class PrivateCompanionPageApi(
                 status = self.plugin._daily_review_status_payload()
             return self._ok({"report": report, **status})
         except Exception as exc:
-            logger.warning("[PrivateCompanionPage] 手动执行每日巡视失败: %s", self._single_line(exc, 180))
+            logger.warning("手动执行每日巡视失败: %s", self._single_line(exc, 180))
             return self._error(str(exc))
 
     async def update_daily_review_guidance(self) -> dict[str, Any]:
@@ -6368,7 +6370,7 @@ class PrivateCompanionPageApi(
                 status = self.plugin._daily_review_status_payload()
             return self._ok(status)
         except Exception as exc:
-            logger.error("[PrivateCompanionPage] 更新每日巡视指导失败: %s", self._single_line(exc, 180), exc_info=True)
+            logger.error("更新每日巡视指导失败: %s", self._single_line(exc, 180), exc_info=True)
             return self._error(str(exc))
 
     async def _recover_stale_troubleshooting_proactive_test(self, *, max_age_seconds: int = 120) -> int:
@@ -7055,7 +7057,7 @@ class PrivateCompanionPageApi(
         result_key = test_type
         start = time.time()
         logger.info(
-            "[PrivateCompanionPage][test:%s][type:%s] 开始执行测试",
+            "[test:%s][type:%s] 开始执行测试",
             request_id,
             test_type or "unknown",
         )
@@ -7096,14 +7098,14 @@ class PrivateCompanionPageApi(
                     limit=1600,
                 )
                 logger.warning(
-                    "[PrivateCompanionPage] 外部接口排障测试失败: type=%s err=%s",
+                    "外部接口排障测试失败: type=%s err=%s",
                     test_type,
                     self._single_line(safe_error, 160),
                 )
             else:
                 safe_error = self._safe_test_diagnostic_text(exc, 1600)
                 logger.warning(
-                    "[PrivateCompanionPage] 排障链路测试失败: %s",
+                    "排障链路测试失败: %s",
                     self._single_line(exc, 160),
                     exc_info=True,
                 )
@@ -7128,7 +7130,7 @@ class PrivateCompanionPageApi(
         )
         await self._remember_troubleshooting_test_result(result_key, result)
         logger.info(
-            "[PrivateCompanionPage][test:%s][type:%s] 测试结束: status=%s elapsed_ms=%s",
+            "[test:%s][type:%s] 测试结束: status=%s elapsed_ms=%s",
             result.get("request_id"),
             test_type,
             result.get("test_status"),
@@ -7214,7 +7216,7 @@ class PrivateCompanionPageApi(
             return True
         except OSError as exc:
             logger.warning(
-                "[PrivateCompanionPage] 清理生图 API 测试图片失败: path=%s error=%s",
+                "清理生图 API 测试图片失败: path=%s error=%s",
                 self._single_line(path, 180),
                 self._single_line(exc, 160),
             )
@@ -7752,7 +7754,7 @@ class PrivateCompanionPageApi(
             api = getter() if callable(getter) else None
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanionPage] 生图扩展发现失败: %s",
+                "生图扩展发现失败: %s",
                 self._single_line(exc, 160),
                 exc_info=True,
             )
@@ -7790,7 +7792,7 @@ class PrivateCompanionPageApi(
             value = status_getter()
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanionPage] 获取生图扩展状态失败: %s",
+                "获取生图扩展状态失败: %s",
                 self._single_line(exc, 160),
                 exc_info=True,
             )
@@ -7833,7 +7835,7 @@ class PrivateCompanionPageApi(
             return self._ok(payload)
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanionPage] 读取生图 debug 失败: %s",
+                "读取生图 debug 失败: %s",
                 self._single_line(exc, 180),
                 exc_info=True,
             )
@@ -7855,20 +7857,20 @@ class PrivateCompanionPageApi(
                 }
             )
         except Exception as exc:
-            logger.warning("[PrivateCompanionPage] 获取生图 API 状态失败: %s", self._single_line(exc, 160), exc_info=True)
+            logger.warning("获取生图 API 状态失败: %s", self._single_line(exc, 160), exc_info=True)
             return self._exception_error(str(exc))
 
     async def test_image_api_endpoint(self) -> dict[str, Any]:
         payload = await request.get_json(silent=True) or {}
         request_id = secrets.token_hex(6)
         started = time.time()
-        logger.info("[PrivateCompanionPage][test:%s][type:image_api_endpoint] 开始执行测试", request_id)
+        logger.info("[test:%s][type:image_api_endpoint] 开始执行测试", request_id)
         try:
             result = await self._run_image_api_endpoint_test(payload)
         except Exception as exc:
             endpoint = payload.get("endpoint") if isinstance(payload.get("endpoint"), dict) else {}
             safe_error = self._redact_image_api_test_text(exc, endpoint, 220)
-            logger.warning("[PrivateCompanionPage] 生图 API 单独测试失败: %s", safe_error)
+            logger.warning("生图 API 单独测试失败: %s", safe_error)
             result = {
                 "ok": False,
                 "title": "在线图片 API 单独测试",
@@ -7896,7 +7898,7 @@ class PrivateCompanionPageApi(
         result_key = self._single_line(result.get("test_key"), 80) or "image_api_endpoint"
         await self._remember_troubleshooting_test_result(result_key, result)
         logger.info(
-            "[PrivateCompanionPage][test:%s][type:image_api_endpoint] 测试结束: status=%s elapsed_ms=%s",
+            "[test:%s][type:image_api_endpoint] 测试结束: status=%s elapsed_ms=%s",
             result.get("request_id"),
             result.get("test_status"),
             result.get("elapsed_ms"),
@@ -8036,7 +8038,7 @@ class PrivateCompanionPageApi(
                 elapsed_ms = int((time.time() - started) * 1000)
                 safe_error = self._redact_image_api_test_text(exc, endpoint, 220)
                 logger.warning(
-                    "[PrivateCompanionPage] 在线图片 API 单端点测试失败: endpoint=%s error=%s",
+                    "在线图片 API 单端点测试失败: endpoint=%s error=%s",
                     self._single_line(summary["name"], 80),
                     safe_error,
                 )
@@ -8123,7 +8125,7 @@ class PrivateCompanionPageApi(
                     )
                 except Exception as exc:
                     logger.info(
-                        "[PrivateCompanionPage] 自拍排障参考图解析失败: %s",
+                        "自拍排障参考图解析失败: %s",
                         self._single_line(exc, 160),
                     )
         prompt_text = self._single_line(payload.get("prompt"), 600)
@@ -8159,7 +8161,7 @@ class PrivateCompanionPageApi(
             reference_image_path=reference_image_path,
         )
         logger.info(
-            "[PrivateCompanionPage] 图片生成排障测试开始: workflow_kind=%s prompt_chars=%s reference=%s timeout=%ss estimated=%ss prompt=%s",
+            "图片生成排障测试开始: workflow_kind=%s prompt_chars=%s reference=%s timeout=%ss estimated=%ss prompt=%s",
             self._single_line(workflow_kind, 40),
             len(str(prompt_text or "")),
             has_reference_source,
@@ -8238,7 +8240,7 @@ class PrivateCompanionPageApi(
             except Exception:
                 exists = False
         logger.info(
-            "[PrivateCompanionPage] 图片生成排障测试结束: ok=%s backend=%s elapsed=%sms path=%s exists=%s size=%s note=%s",
+            "图片生成排障测试结束: ok=%s backend=%s elapsed=%sms path=%s exists=%s size=%s note=%s",
             bool(image_path and exists),
             self._single_line(backend_name, 80),
             elapsed_ms,
@@ -8508,7 +8510,7 @@ class PrivateCompanionPageApi(
                 event = screen_plugin._create_virtual_event(umo)
             except Exception as exc:
                 logger.info(
-                    "[PrivateCompanionPage] 窥屏排障虚拟事件创建失败,将无事件调用: umo=%s error=%s",
+                    "窥屏排障虚拟事件创建失败,将无事件调用: umo=%s error=%s",
                     self._single_line(umo, 120),
                     self._single_line(exc, 120),
                 )
@@ -8530,7 +8532,7 @@ class PrivateCompanionPageApi(
         except Exception as exc:
             elapsed_ms = int((time.time() - started) * 1000)
             error = self._single_line(exc, 220)
-            logger.warning("[PrivateCompanionPage] 窥屏排障测试失败: %s", error, exc_info=True)
+            logger.warning("窥屏排障测试失败: %s", error, exc_info=True)
             return {
                 "ok": False,
                 "title": "窥屏链路测试",
@@ -8544,7 +8546,7 @@ class PrivateCompanionPageApi(
         unusable = bool(unusable_checker(context)) if callable(unusable_checker) else not bool(raw_result)
         preview = self._single_line(raw_result, 220)
         logger.info(
-            "[PrivateCompanionPage] 窥屏排障测试结束: ok=%s elapsed=%sms umo=%s preview=%s",
+            "窥屏排障测试结束: ok=%s elapsed=%sms umo=%s preview=%s",
             not unusable,
             elapsed_ms,
             self._single_line(umo, 120),
@@ -8734,7 +8736,7 @@ class PrivateCompanionPageApi(
         requested_umo = self._single_line(payload.get("umo"), 180)
         if requested_umo and requested_umo != umo:
             logger.info(
-                "[PrivateCompanionPage] TTS 排障测试忽略非主要用户目标: requested=%s owner=%s",
+                "TTS 排障测试忽略非主要用户目标: requested=%s owner=%s",
                 requested_umo,
                 umo,
             )
@@ -8823,12 +8825,12 @@ class PrivateCompanionPageApi(
             )
             if delivered:
                 logger.info(
-                    "[PrivateCompanionPage] TTS 排障测试语音投递成功: umo=%s",
+                    "TTS 排障测试语音投递成功: umo=%s",
                     self._single_line(umo, 140),
                 )
             else:
                 logger.warning(
-                    "[PrivateCompanionPage] TTS 排障测试语音投递失败: umo=%s error=%s",
+                    "TTS 排障测试语音投递失败: umo=%s error=%s",
                     self._single_line(umo, 140),
                     self._single_line(delivery_error, 180),
                 )
@@ -8925,7 +8927,7 @@ class PrivateCompanionPageApi(
             resolved_umo = self._single_line(route_resolver(target_user_id), 180) if callable(route_resolver) else ""
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanionPage] 主动消息链路测试解析当前投递会话失败: user=%s error=%s",
+                "主动消息链路测试解析当前投递会话失败: user=%s error=%s",
                 self._single_line(target_user_id, 80),
                 self._single_line(exc, 160),
             )
@@ -9147,7 +9149,7 @@ class PrivateCompanionPageApi(
         wakeup_task = self._schedule_troubleshooting_proactive_wakeup(target_user_id, scheduled_ts)
         if wakeup_task is None:
             logger.info(
-                "[PrivateCompanionPage] 主动消息链路测试未建立单独唤醒任务，将继续等待常驻主动循环: user=%s",
+                "主动消息链路测试未建立单独唤醒任务，将继续等待常驻主动循环: user=%s",
                 self._single_line(target_user_id, 80),
             )
         add_step("临时任务", "ok", f"已预约 {delay_seconds} 秒后由主动循环执行")
@@ -9190,7 +9192,7 @@ class PrivateCompanionPageApi(
                         candidates.append(self._single_line(route_resolver(resolved_user_id), 180))
                     except Exception as exc:
                         logger.warning(
-                            "[PrivateCompanionPage] TTS 排障测试解析主要用户投递会话失败: user=%s error=%s",
+                            "TTS 排障测试解析主要用户投递会话失败: user=%s error=%s",
                             self._single_line(resolved_user_id, 80),
                             self._single_line(exc, 160),
                         )
@@ -10171,7 +10173,7 @@ class PrivateCompanionPageApi(
                         raw.pop(stale_key, None)
                 self.plugin._save_data_sync(sections={"troubleshooting_test_results"})
         except Exception as exc:
-            logger.warning("[PrivateCompanionPage] 保存排障测试结果失败: %s", self._single_line(exc, 120))
+            logger.warning("保存排障测试结果失败: %s", self._single_line(exc, 120))
 
     def _troubleshooting_test_results(self, data: dict[str, Any]) -> dict[str, Any]:
         raw = data.get("troubleshooting_test_results")
@@ -11473,7 +11475,7 @@ class PrivateCompanionPageApi(
             self._attach_multi_persona_token_stats(stats)
             return self._ok(stats)
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 获取 Token 统计失败: {exc}", exc_info=True)
+            logger.error(f"获取 Token 统计失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     @_multi_persona_page_context
@@ -11485,7 +11487,7 @@ class PrivateCompanionPageApi(
                 self.plugin._save_data_sync(sections={"token_usage"})
             return self._ok(self._token_stats_payload({}, balance_state))
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 重置 Token 统计失败: {exc}", exc_info=True)
+            logger.error(f"重置 Token 统计失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     async def unlock_bookshelf(self) -> dict[str, Any]:
@@ -11503,7 +11505,7 @@ class PrivateCompanionPageApi(
                 data = deepcopy(self.plugin.data)
             return self._ok({"bookshelf": await self._bookshelf_summary(data, unlocked=True, access_token=access_token)})
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 解锁资料柜夹层失败: {exc}", exc_info=True)
+            logger.error(f"解锁资料柜夹层失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     async def get_bookshelf_session(self) -> dict[str, Any]:
@@ -11525,7 +11527,7 @@ class PrivateCompanionPageApi(
             bookshelf["access_expires_at"] = int(expires_at) if expires_at > 0 else 0
             return self._ok({"bookshelf": bookshelf})
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 恢复资料柜夹层会话失败: {exc}", exc_info=True)
+            logger.error(f"恢复资料柜夹层会话失败: {exc}", exc_info=True)
             return self._error(str(exc))
 
     def _memo_notes_payload(self, data: dict[str, Any]) -> dict[str, Any]:
@@ -11570,7 +11572,7 @@ class PrivateCompanionPageApi(
                 data = deepcopy(self.plugin.data)
             return self._ok({"memo_notes": self._memo_notes_payload(data)})
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 获取备忘便签失败: {exc}", exc_info=True)
+            logger.error(f"获取备忘便签失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     async def update_memo_note(self) -> dict[str, Any]:
@@ -11591,7 +11593,7 @@ class PrivateCompanionPageApi(
         except ValueError as exc:
             return self._exception_error(str(exc))
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 更新备忘便签失败: {exc}", exc_info=True)
+            logger.error(f"更新备忘便签失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     @staticmethod
@@ -11951,7 +11953,7 @@ class PrivateCompanionPageApi(
             response.headers["Cache-Control"] = "no-store, max-age=0"
             return response
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 读取资料柜图片失败: {exc}", exc_info=True)
+            logger.error(f"读取资料柜图片失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     async def get_bookshelf_image_data(self) -> dict[str, Any]:
@@ -11973,7 +11975,7 @@ class PrivateCompanionPageApi(
                 }
             )
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 读取资料柜图片数据失败: {exc}", exc_info=True)
+            logger.error(f"读取资料柜图片数据失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     async def _read_file_base64(self, path: Path) -> str:
@@ -12029,7 +12031,7 @@ class PrivateCompanionPageApi(
                 return {"error": "图片文件不存在"}
             return path
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 读取资料柜图片失败: {exc}", exc_info=True)
+            logger.error(f"读取资料柜图片失败: {exc}", exc_info=True)
             return {"error": str(exc)}
 
     async def delete_bookshelf_item(self) -> dict[str, Any]:
@@ -12108,7 +12110,7 @@ class PrivateCompanionPageApi(
                             self._remember_deleted_diary_day(deleted_date)
                     remaining = len(self.plugin.data.get("bot_diaries", []))
                     logger.info(
-                        "[PrivateCompanionPage] 日记删除: changed=%s date=%s entry=%s storage=%s remaining=%s",
+                        "日记删除: changed=%s date=%s entry=%s storage=%s remaining=%s",
                         changed,
                         diary_date_key,
                         diary_entry_key,
@@ -12216,7 +12218,7 @@ class PrivateCompanionPageApi(
                     self._cleanup_bookshelf_page_files(removed_pages)
                     self._cleanup_bookshelf_album_dirs(removed_album_ids)
                     logger.info(
-                        "[PrivateCompanionPage] 资料柜夹层移除: changed=%s id=%s album_id=%s title=%s removed=%s",
+                        "资料柜夹层移除: changed=%s id=%s album_id=%s title=%s removed=%s",
                         changed,
                         item_id,
                         album_id,
@@ -12232,7 +12234,7 @@ class PrivateCompanionPageApi(
                 data = deepcopy(self.plugin.data)
             return self._ok({"changed": changed, "bookshelf": await self._bookshelf_summary(data, unlocked=True, access_token=access_token)})
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 删除资料柜项目失败: {exc}", exc_info=True)
+            logger.error(f"删除资料柜项目失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     def _cleanup_bookshelf_page_files(self, pages: list[dict[str, Any]]) -> None:
@@ -12325,7 +12327,7 @@ class PrivateCompanionPageApi(
                 data = deepcopy(self.plugin.data)
             return self._ok({"bookshelf": await self._bookshelf_summary(data, unlocked=True, access_token=access_token)})
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 更新资料柜阅读进度失败: {exc}", exc_info=True)
+            logger.error(f"更新资料柜阅读进度失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     async def rate_bookshelf_item(self) -> dict[str, Any]:
@@ -12374,7 +12376,7 @@ class PrivateCompanionPageApi(
                 data = deepcopy(self.plugin.data)
             return self._ok({"bookshelf": await self._bookshelf_summary(data, unlocked=True, access_token=access_token)})
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 保存资料归档评分失败: {exc}", exc_info=True)
+            logger.error(f"保存资料归档评分失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     def _normalize_bookshelf_tag_list(self, value: Any, *, limit: int = 8) -> list[str]:
@@ -12484,7 +12486,7 @@ class PrivateCompanionPageApi(
                 data = deepcopy(self.plugin.data)
             return self._ok({"bookshelf": await self._bookshelf_summary(data, unlocked=True, access_token=access_token)})
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 保存资料归档标签失败: {exc}", exc_info=True)
+            logger.error(f"保存资料归档标签失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     def _resolve_bookshelf_data_file(self, value: Any) -> Path | None:
@@ -12629,7 +12631,7 @@ class PrivateCompanionPageApi(
                 data = deepcopy(self.plugin.data)
             return self._ok({"message": "Bot 已重新读过并更新读后感", "bookshelf": await self._bookshelf_summary(data, unlocked=True, access_token=access_token)})
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 更新资料归档批注失败: {exc}", exc_info=True)
+            logger.error(f"更新资料归档批注失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     async def import_worldbook(self) -> dict[str, Any]:
@@ -12649,7 +12651,7 @@ class PrivateCompanionPageApi(
                 data = deepcopy(self.plugin.data)
             return self._ok({"changed": changed, "worldbook": self._worldbook_summary(data)})
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 导入世界书失败: {exc}", exc_info=True)
+            logger.error(f"导入世界书失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     async def update_worldbook_member(self) -> dict[str, Any]:
@@ -12803,7 +12805,7 @@ class PrivateCompanionPageApi(
                 response["bind"] = bind_result
             return self._ok(response)
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 更新关系节点失败: {exc}", exc_info=True)
+            logger.error(f"更新关系节点失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     async def get_worldbook_member_livingmemory(self) -> dict[str, Any]:
@@ -12950,10 +12952,10 @@ class PrivateCompanionPageApi(
                 }
             )
         except sqlite3.OperationalError as exc:
-            logger.warning(f"[PrivateCompanionPage] 查询 LivingMemory 失败: {exc}")
+            logger.warning(f"查询 LivingMemory 失败: {exc}")
             return self._exception_error("LivingMemory 数据库暂时不可读")
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 查询关系节点 LivingMemory 失败: {exc}", exc_info=True)
+            logger.error(f"查询关系节点 LivingMemory 失败: {exc}", exc_info=True)
             return self._exception_error(str(exc))
 
     async def clear_worldbook_pending_observations(self) -> dict[str, Any]:
@@ -12987,7 +12989,7 @@ class PrivateCompanionPageApi(
             message = f"已清理 {cleared} 条待确认观察" if cleared else "没有待确认观察需要清理"
             return self._ok({"message": message, "cleared": cleared, "worldbook": self._worldbook_summary(data)})
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 清理待确认观察失败: {exc}", exc_info=True)
+            logger.error(f"清理待确认观察失败: {exc}", exc_info=True)
             return self._exception_error("清理待确认观察失败")
 
     async def update_worldbook_group(self) -> dict[str, Any]:
@@ -13043,7 +13045,7 @@ class PrivateCompanionPageApi(
                 data = deepcopy(self.plugin.data)
             return self._ok({"message": "已保存群资料", "worldbook": self._worldbook_summary(data)})
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 更新群资料失败: {exc}", exc_info=True)
+            logger.error(f"更新群资料失败: {exc}", exc_info=True)
             return self._exception_error("更新群资料失败")
 
     async def apply_preset(self) -> dict[str, Any]:
@@ -13071,7 +13073,7 @@ class PrivateCompanionPageApi(
                 overview["data"]["config_saved"] = config_saved
             return overview
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 应用预设失败: {exc}", exc_info=True)
+            logger.error(f"应用预设失败: {exc}", exc_info=True)
             return self._exception_error("应用预设失败")
 
     async def update_skill_growth(self) -> dict[str, Any]:
@@ -13173,7 +13175,7 @@ class PrivateCompanionPageApi(
                 self.plugin._save_data_sync(sections={"skill_growth"})
                 return self._ok({"message": "已保存技能", "skill_growth": self._skill_growth_summary(self.plugin.data)})
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 更新技能失败: {exc}", exc_info=True)
+            logger.error(f"更新技能失败: {exc}", exc_info=True)
             return self._exception_error("更新技能失败")
 
     async def update_personal_goal(self) -> dict[str, Any]:
@@ -13273,7 +13275,7 @@ class PrivateCompanionPageApi(
                 self.plugin._save_data_sync(sections={"personal_goals"})
                 return self._ok({"message": "已保存个人目标", "personal_goals": self._personal_goal_summary(self.plugin.data)})
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 更新个人目标失败: {exc}", exc_info=True)
+            logger.error(f"更新个人目标失败: {exc}", exc_info=True)
             return self._exception_error("更新个人目标失败")
 
     @staticmethod
@@ -13507,7 +13509,7 @@ class PrivateCompanionPageApi(
                 self.plugin._save_data_sync(sections={"food_menu"})
                 return self._ok({"message": "已保存候选", "food_menu": self._food_menu_summary(self.plugin.data)})
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 更新吃什么候选失败: {exc}", exc_info=True)
+            logger.error(f"更新吃什么候选失败: {exc}", exc_info=True)
             return self._exception_error("更新吃什么候选失败")
 
     async def bulk_update_food_menu(self) -> dict[str, Any]:
@@ -13602,7 +13604,7 @@ class PrivateCompanionPageApi(
                     }
                 )
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 批量更新吃什么候选失败: {exc}", exc_info=True)
+            logger.error(f"批量更新吃什么候选失败: {exc}", exc_info=True)
             return self._exception_error("批量更新吃什么候选失败")
 
     async def bulk_delete_food_menu(self) -> dict[str, Any]:
@@ -13649,7 +13651,7 @@ class PrivateCompanionPageApi(
                     }
                 )
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 批量删除吃什么候选失败: {exc}", exc_info=True)
+            logger.error(f"批量删除吃什么候选失败: {exc}", exc_info=True)
             return self._exception_error("批量删除吃什么候选失败")
 
     async def update_external_ability(self) -> dict[str, Any]:
@@ -13687,7 +13689,7 @@ class PrivateCompanionPageApi(
                 data = deepcopy(self.plugin.data)
             return self._ok({"message": "已保存外部主动能力", "external_abilities": self._external_ability_summary(data)})
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 更新外部主动能力失败: {exc}", exc_info=True)
+            logger.error(f"更新外部主动能力失败: {exc}", exc_info=True)
             return self._exception_error("更新外部主动能力失败")
 
     async def list_roleplay_personas(self) -> dict[str, Any]:
@@ -13733,7 +13735,7 @@ class PrivateCompanionPageApi(
                 response["multi_persona"]["current"] = current or default_id
             return self._ok(response)
         except Exception as exc:
-            logger.warning(f"[PrivateCompanionPage] 获取人格列表失败: {exc}", exc_info=True)
+            logger.warning(f"获取人格列表失败: {exc}", exc_info=True)
             return self._ok({"items": self._fallback_roleplay_persona_items(), "current": "", "default": ""})
 
     async def get_persona_config_state(self) -> dict[str, Any]:
@@ -13824,7 +13826,7 @@ class PrivateCompanionPageApi(
             result = await resetter(persona_id, rebuild_today=True)
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanionPage] 重置当前人格失败 persona=%s error=%s",
+                "重置当前人格失败 persona=%s error=%s",
                 persona_id or "single",
                 self._single_line(exc, 180),
                 exc_info=True,
@@ -14137,7 +14139,7 @@ class PrivateCompanionPageApi(
                 system_prompt=system_prompt,
             )
             if raw is None:
-                logger.warning("[PrivateCompanionPage] 人格草稿生成：LLM 返回 None（可能预算受限或 Provider 不可用），使用兜底草稿")
+                logger.warning("人格草稿生成：LLM 返回 None（可能预算受限或 Provider 不可用），使用兜底草稿")
                 parsed = self._fallback_roleplay_draft_result(persona_prompt, scopes, "模型调用返回空结果（可能预算受限或 Provider 不可用）")
                 draft = self._normalize_roleplay_draft_result(parsed, scopes)
                 return self._ok(
@@ -14179,7 +14181,7 @@ class PrivateCompanionPageApi(
                         parse_note = f"初次返回无法解析，已使用 {repair_provider_id} 修复为 JSON。"
                     except Exception as repair_exc:
                         logger.warning(
-                            "[PrivateCompanionPage] 人格草稿 JSON 修复失败: %s；初次错误: %s",
+                            "人格草稿 JSON 修复失败: %s；初次错误: %s",
                             self._single_line(repair_exc, 160),
                             self._single_line(parse_exc, 160),
                             exc_info=True,
@@ -14211,7 +14213,7 @@ class PrivateCompanionPageApi(
                 }
             )
         except Exception as exc:
-            logger.warning(f"[PrivateCompanionPage] 根据主回复人格生成设定草稿失败: {exc}", exc_info=True)
+            logger.warning(f"根据主回复人格生成设定草稿失败: {exc}", exc_info=True)
             return self._exception_error("生成草稿失败")
 
     async def apply_setup_guide(self) -> dict[str, Any]:
@@ -14436,7 +14438,7 @@ class PrivateCompanionPageApi(
                 data["config_saved"] = config_saved
             return overview
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 首次配置落地失败: {exc}", exc_info=True)
+            logger.error(f"首次配置落地失败: {exc}", exc_info=True)
             return self._exception_error("首次配置落地失败")
 
     def _setup_guide_fallback_daily_plan(self, reason: str = "timeout") -> dict[str, Any]:
@@ -14510,7 +14512,7 @@ class PrivateCompanionPageApi(
                     pass
                 except Exception as exc:
                     logger.warning(
-                        "[PrivateCompanionPage] 首次配置后台日程生成失败: %s",
+                        "首次配置后台日程生成失败: %s",
                         self._single_line(exc, 180),
                         exc_info=True,
                     )
@@ -14529,7 +14531,7 @@ class PrivateCompanionPageApi(
                 return fallback, "fallback_timeout", True
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanionPage] 首次配置快速日程生成失败，使用兜底日程: %s",
+                "首次配置快速日程生成失败，使用兜底日程: %s",
                 self._single_line(exc, 180),
                 exc_info=True,
             )
@@ -14586,7 +14588,7 @@ class PrivateCompanionPageApi(
                             pass
                         except Exception as exc:
                             logger.warning(
-                                "[PrivateCompanionPage] 首次配置后台日程细化失败: %s",
+                                "首次配置后台日程细化失败: %s",
                                 self._single_line(exc, 180),
                                 exc_info=True,
                             )
@@ -14603,7 +14605,7 @@ class PrivateCompanionPageApi(
                     except Exception as exc:
                         detail_error = f"当前细化失败：{self._single_line(exc, 160)}"
                         logger.warning(
-                            "[PrivateCompanionPage] 首次配置日程细化失败: %s",
+                            "首次配置日程细化失败: %s",
                             self._single_line(exc, 180),
                             exc_info=True,
                         )
@@ -14638,7 +14640,7 @@ class PrivateCompanionPageApi(
                 }
             )
         except Exception as exc:
-            logger.warning(f"[PrivateCompanionPage] 首次配置日程生成失败: {exc}", exc_info=True)
+            logger.warning(f"首次配置日程生成失败: {exc}", exc_info=True)
             return self._ok({"ok": False, "error": self._single_line(exc, 220)})
 
     async def regenerate_daily_detail_segment(self) -> dict[str, Any]:
@@ -14811,7 +14813,7 @@ class PrivateCompanionPageApi(
                 data = self._overview_data_snapshot_locked(self.plugin.data)
             return self._ok({"key": key, "detail": detail, "daily_timeline": self._daily_timeline_summary(data)})
         except Exception as exc:
-            logger.warning("[PrivateCompanionPage] 局部重生成日程细化失败: %s", exc, exc_info=True)
+            logger.warning("局部重生成日程细化失败: %s", exc, exc_info=True)
             async with self.plugin._data_lock:
                 enhanced = self.plugin.data.setdefault("detail_enhanced_segments", {})
                 if isinstance(enhanced, dict) and key and generation_id and self.plugin._detail_generation_is_current(segment, generation_id):
@@ -15016,7 +15018,7 @@ class PrivateCompanionPageApi(
                             parse_note = f"初次返回无法解析，已使用 {repair_provider_id} 修复为 JSON。"
                         except Exception as repair_exc:
                             logger.warning(
-                                "[PrivateCompanionPage] 人格标准化 JSON 修复失败: %s；初次错误: %s",
+                                "人格标准化 JSON 修复失败: %s；初次错误: %s",
                                 self._single_line(repair_exc, 160),
                                 self._single_line(parse_exc, 160),
                                 exc_info=True,
@@ -15078,7 +15080,7 @@ class PrivateCompanionPageApi(
                                 parse_note = f"{parse_note} 初稿偏短，已尝试扩写；请重点审核参考资料是否被充分吸收。".strip()
                     except Exception as expand_exc:
                         logger.warning(
-                            "[PrivateCompanionPage] 人格标准化薄稿扩写失败: %s",
+                            "人格标准化薄稿扩写失败: %s",
                             self._single_line(expand_exc, 180),
                             exc_info=True,
                         )
@@ -15104,7 +15106,7 @@ class PrivateCompanionPageApi(
                 }
             )
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 人格标准化问卷生成失败: {exc}", exc_info=True)
+            logger.error(f"人格标准化问卷生成失败: {exc}", exc_info=True)
             return self._exception_error("人格标准化问卷生成失败")
 
     async def generate_persona_style_scenarios(self) -> dict[str, Any]:
@@ -15228,7 +15230,7 @@ class PrivateCompanionPageApi(
                     }
                 except Exception as batch_exc:
                     logger.warning(
-                        "[PrivateCompanionPage] 人格风格试答第 %s 批失败: %s",
+                        "人格风格试答第 %s 批失败: %s",
                         batch_index,
                         self._single_line(batch_exc, 180),
                         exc_info=True,
@@ -15295,7 +15297,7 @@ class PrivateCompanionPageApi(
                 }
             )
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 人格风格试答生成失败: {exc}", exc_info=True)
+            logger.error(f"人格风格试答生成失败: {exc}", exc_info=True)
             return self._exception_error("人格风格试答生成失败")
 
     async def retry_persona_style_scenario(self) -> dict[str, Any]:
@@ -15350,7 +15352,7 @@ class PrivateCompanionPageApi(
                 }
             )
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 人格风格单情景重生成失败: {exc}", exc_info=True)
+            logger.error(f"人格风格单情景重生成失败: {exc}", exc_info=True)
             return self._exception_error("人格风格单情景重生成失败")
 
     async def generate_persona_style_summary(self) -> dict[str, Any]:
@@ -15403,7 +15405,7 @@ class PrivateCompanionPageApi(
                 }
             )
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 人格风格规则归纳失败: {exc}", exc_info=True)
+            logger.error(f"人格风格规则归纳失败: {exc}", exc_info=True)
             return self._exception_error("人格风格规则归纳失败")
 
     def _standardize_persona_provider_id(self) -> str:
@@ -16533,7 +16535,7 @@ class PrivateCompanionPageApi(
                 }
             )
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 获取 Provider 列表失败: {exc}", exc_info=True)
+            logger.error(f"获取 Provider 列表失败: {exc}", exc_info=True)
             return self._exception_error("获取 Provider 列表失败")
 
     async def test_provider(self) -> dict[str, Any]:
@@ -16548,7 +16550,7 @@ class PrivateCompanionPageApi(
             timeout_seconds = self._float(timeout_raw, 0.0, 5.0, 600.0)
         request_id = secrets.token_hex(6)
         start = time.time()
-        logger.info("[PrivateCompanionPage][test:%s][type:provider_connection] 开始执行测试", request_id)
+        logger.info("[test:%s][type:provider_connection] 开始执行测试", request_id)
         try:
             if key in {"EMBEDDING_PROVIDER_ID", "REACTION_EXPRESSION_EMBEDDING_PROVIDER_ID"}:
                 provider = await self._embedding_provider_for_test(provider_id)
@@ -16641,7 +16643,7 @@ class PrivateCompanionPageApi(
             test_id=diagnostic_test_id("provider"),
         )
         logger.info(
-            "[PrivateCompanionPage][test:%s][type:provider_connection] 测试结束: status=%s elapsed_ms=%s",
+            "[test:%s][type:provider_connection] 测试结束: status=%s elapsed_ms=%s",
             request_id,
             result.get("test_status"),
             result.get("elapsed_ms"),
@@ -18004,7 +18006,7 @@ class PrivateCompanionPageApi(
             }
             return self._ok({"package": pack, "group_count": len(groups), "rule_count": sum(len(item["rules"]) for item in groups)})
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 生成表达分享包失败: {exc}", exc_info=True)
+            logger.error(f"生成表达分享包失败: {exc}", exc_info=True)
             return self._exception_error("生成表达分享包失败")
 
     async def preview_expression_library_import(self) -> dict[str, Any]:
@@ -18038,7 +18040,7 @@ class PrivateCompanionPageApi(
         except ValueError as exc:
             return self._error(str(exc))
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 预览表达导入失败: {exc}", exc_info=True)
+            logger.error(f"预览表达导入失败: {exc}", exc_info=True)
             return self._exception_error("预览表达导入失败")
 
     async def apply_expression_library_import(self) -> dict[str, Any]:
@@ -18138,7 +18140,7 @@ class PrivateCompanionPageApi(
         except ValueError as exc:
             return self._error(str(exc))
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 导入表达分享包失败: {exc}", exc_info=True)
+            logger.error(f"导入表达分享包失败: {exc}", exc_info=True)
             return self._exception_error("导入表达分享包失败")
 
     def _expression_admin_scope_context(
@@ -18437,7 +18439,7 @@ class PrivateCompanionPageApi(
                             pass
             return self._ok(self._expression_library_summary(snapshot))
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 获取统一表达学习库失败: {exc}", exc_info=True)
+            logger.error(f"获取统一表达学习库失败: {exc}", exc_info=True)
             return self._exception_error("获取统一表达学习库失败")
 
     async def update_expression_library(self) -> dict[str, Any]:
@@ -18552,7 +18554,7 @@ class PrivateCompanionPageApi(
             except (ExpressionScopeError, ValueError) as exc:
                 return self._error(str(exc))
             except Exception as exc:
-                logger.error("[PrivateCompanionPage] 提升人格全局表达规则失败: %s", exc, exc_info=True)
+                logger.error("提升人格全局表达规则失败: %s", exc, exc_info=True)
                 return self._exception_error("提升人格全局表达规则失败")
         if action in {"batch_approve_rule_groups", "batch_reject_rule_groups"}:
             raw_items = payload.get("items")
@@ -18656,7 +18658,7 @@ class PrivateCompanionPageApi(
                 }
                 return self._ok(result)
             except Exception as exc:
-                logger.error(f"[PrivateCompanionPage] 批量审核表达规则失败: {exc}", exc_info=True)
+                logger.error(f"批量审核表达规则失败: {exc}", exc_info=True)
                 return self._error(str(exc))
         if action == "clear_all_pending":
             try:
@@ -18705,7 +18707,7 @@ class PrivateCompanionPageApi(
                 result["message"] = f"已清空 {cleared} 条待审核表达资料"
                 return self._ok(result)
             except Exception as exc:
-                logger.error(f"[PrivateCompanionPage] 清空统一表达待审样本失败: {exc}", exc_info=True)
+                logger.error(f"清空统一表达待审样本失败: {exc}", exc_info=True)
                 return self._exception_error("清空统一表达待审样本失败")
         if source_type not in {"private", "group", "persona"} or not source_id:
             return self._error("缺少有效的表达样本来源")
@@ -18780,7 +18782,7 @@ class PrivateCompanionPageApi(
         except ValueError as exc:
             return self._error(str(exc))
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 更新统一表达学习库失败: {exc}", exc_info=True)
+            logger.error(f"更新统一表达学习库失败: {exc}", exc_info=True)
             return self._exception_error("更新统一表达学习库失败")
 
     def _apply_expression_profile_action(self, user: dict[str, Any], payload: dict[str, Any]) -> str:
@@ -21384,7 +21386,7 @@ class PrivateCompanionPageApi(
             field_metadata = deepcopy(provider_metadata.get("items", {}) or {})
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanionPage] 读取 AstrBot TTS Provider 模板失败，将使用运行态字段: %s",
+                "读取 AstrBot TTS Provider 模板失败，将使用运行态字段: %s",
                 self._single_line(exc, 160),
             )
 
@@ -21645,7 +21647,7 @@ class PrivateCompanionPageApi(
         try:
             return self._ok(self._tts_provider_management_payload())
         except Exception as exc:
-            logger.error("[PrivateCompanionPage] 获取 TTS Provider 配置失败: %s", exc, exc_info=True)
+            logger.error("获取 TTS Provider 配置失败: %s", exc, exc_info=True)
             return self._error(self._single_line(exc, 240))
 
     async def create_tts_provider_config(self) -> dict[str, Any]:
@@ -21740,7 +21742,7 @@ class PrivateCompanionPageApi(
                 }
             )
             logger.info(
-                "[PrivateCompanionPage] 已复制语种专用 TTS Provider: language=%s source=%s clone=%s",
+                "已复制语种专用 TTS Provider: language=%s source=%s clone=%s",
                 language,
                 source_provider_id,
                 clone_id,
@@ -21748,7 +21750,7 @@ class PrivateCompanionPageApi(
             return self._ok(result)
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanionPage] 复制语种专用 TTS Provider 失败: language=%s source=%s error=%s",
+                "复制语种专用 TTS Provider 失败: language=%s source=%s error=%s",
                 language,
                 source_provider_id,
                 self._single_line(_redact_outbound_secrets(str(exc)), 240),
@@ -21781,7 +21783,7 @@ class PrivateCompanionPageApi(
             return self._ok(self._tts_provider_management_payload())
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanionPage] TTS Provider 保存失败: provider=%s error=%s",
+                "TTS Provider 保存失败: provider=%s error=%s",
                 provider_id,
                 self._single_line(_redact_outbound_secrets(str(exc)), 240),
             )
@@ -21792,7 +21794,7 @@ class PrivateCompanionPageApi(
         provider_id = self._single_line(payload.get("provider_id"), 160)
         request_id = secrets.token_hex(6)
         start = time.time()
-        logger.info("[PrivateCompanionPage][test:%s][type:tts_provider_connection] 开始执行测试", request_id)
+        logger.info("[test:%s][type:tts_provider_connection] 开始执行测试", request_id)
         try:
             manager = self._tts_provider_manager()
             config_getter = getattr(manager, "get_provider_config_by_id", None)
@@ -21864,7 +21866,7 @@ class PrivateCompanionPageApi(
             title="TTS Provider 连接测试",
         )
         logger.info(
-            "[PrivateCompanionPage][test:%s][type:tts_provider_connection] 测试结束: status=%s elapsed_ms=%s",
+            "[test:%s][type:tts_provider_connection] 测试结束: status=%s elapsed_ms=%s",
             request_id,
             result.get("test_status"),
             result.get("elapsed_ms"),
@@ -22578,7 +22580,7 @@ class PrivateCompanionPageApi(
                 )
             except CatalogValidationError as exc:
                 logger.warning(
-                    "[PrivateCompanionPage] 总览参考图目录序列化失败: %s",
+                    "总览参考图目录序列化失败: %s",
                     self._single_line(exc, 180),
                 )
                 persisted_catalog = self._config_get_raw("photo_reference_catalog", [])
@@ -23013,7 +23015,7 @@ class PrivateCompanionPageApi(
         await self._remember_personality_auto_tune_status(result)
         if changes:
             logger.info(
-                "[PrivateCompanionPage] 角色贴合校准已自主调节参数: %s",
+                "角色贴合校准已自主调节参数: %s",
                 "; ".join(f"{item['key']}={item['from']}->{item['to']}" for item in changes),
             )
         return result
@@ -23128,7 +23130,7 @@ class PrivateCompanionPageApi(
             self._save_plugin_sections(self.plugin, {"personality_iteration_auto_tune"})
         if changes:
             logger.info(
-                "[PrivateCompanionPage] 角色贴合校准已恢复用户手动参数: %s",
+                "角色贴合校准已恢复用户手动参数: %s",
                 "; ".join(f"{item['key']}={item['from']}->{item['to']}" for item in changes),
             )
         return {
@@ -24107,7 +24109,7 @@ class PrivateCompanionPageApi(
                             f"{profile_id or 'default'}: {self._single_line(rollback_exc, 160)}"
                         )
                         logger.error(
-                            "[PrivateCompanionPage] 关系配置人格资料回滚失败: persona=%s error=%s",
+                            "关系配置人格资料回滚失败: persona=%s error=%s",
                             profile_id or "default",
                             self._single_line(rollback_exc, 160),
                         )
@@ -24162,7 +24164,7 @@ class PrivateCompanionPageApi(
                                     f"{profile_id or 'default'}: {self._single_line(exc, 160)}"
                                 )
                                 logger.error(
-                                    "[PrivateCompanionPage] 配置保存失败后人格资料回滚失败: persona=%s error=%s",
+                                    "配置保存失败后人格资料回滚失败: persona=%s error=%s",
                                     profile_id or "default",
                                     self._single_line(exc, 160),
                                 )
@@ -24172,11 +24174,11 @@ class PrivateCompanionPageApi(
         except Exception as exc:
             rollback_config_saved = False
             logger.error(
-                "[PrivateCompanionPage] 关系配置回滚后旧配置重新保存失败: %s",
+                "关系配置回滚后旧配置重新保存失败: %s",
                 self._single_line(exc, 160),
             )
         if not rollback_config_saved:
-            logger.warning("[PrivateCompanionPage] 关系配置已恢复到运行态，但旧配置未能重新保存")
+            logger.warning("关系配置已恢复到运行态，但旧配置未能重新保存")
         if profile_rollback_errors:
             raise RuntimeError(
                 "配置保存失败，且人格资料回滚未完整完成: "
@@ -24361,7 +24363,7 @@ class PrivateCompanionPageApi(
             rules, warnings = build_rules(value)
             self.plugin.model_replacement_rules = rules
             for warning in warnings:
-                logger.warning("[PrivateCompanionPage] 模型替换规则：%s", self._single_line(warning, 180))
+                logger.warning("模型替换规则：%s", self._single_line(warning, 180))
             return
         if key == "enable_sensitive_model_replacement":
             self.plugin.enable_sensitive_model_replacement = self._normalize_bool_value(value)
@@ -24658,7 +24660,7 @@ class PrivateCompanionPageApi(
                     await result
             except Exception as exc:
                 logger.warning(
-                    "[PrivateCompanionPage] Body Monitor 联动运行态切换失败: enabled=%s error=%s",
+                    "Body Monitor 联动运行态切换失败: enabled=%s error=%s",
                     enabled,
                     self._single_line(exc, 160),
                 )
@@ -24682,14 +24684,14 @@ class PrivateCompanionPageApi(
                                 pass
                             except Exception as exc:
                                 logger.warning(
-                                    "[PrivateCompanionPage] Body Monitor 联动即时拉取失败: %s",
+                                    "Body Monitor 联动即时拉取失败: %s",
                                     self._single_line(exc, 160),
                                 )
 
                         task.add_done_callback(_consume_kick_result)
                 except Exception as exc:
                     logger.warning(
-                        "[PrivateCompanionPage] Body Monitor 联动即时拉取触发失败: %s",
+                        "Body Monitor 联动即时拉取触发失败: %s",
                         self._single_line(exc, 160),
                     )
 
@@ -24835,7 +24837,7 @@ class PrivateCompanionPageApi(
                     self.plugin.photo_reference_catalog_version = CATALOG_VERSION
                     self.plugin.photo_reference_catalog_read_only = loaded_catalog.read_only
                 except CatalogValidationError as exc:
-                    logger.warning("[PrivateCompanionPage] 忽略无效的运行时参考图目录同步: %s", self._single_line(exc, 180))
+                    logger.warning("忽略无效的运行时参考图目录同步: %s", self._single_line(exc, 180))
                 continue
             if key == "photo_reference_library":
                 normalized_library = self._normalize_setting_value(key, value)
@@ -25047,14 +25049,14 @@ class PrivateCompanionPageApi(
                                 await result
                             return True
                         except Exception as retry_exc:
-                            logger.warning("[PrivateCompanionPage] 配置保存重试失败(%s): %s", method_name, self._single_line(retry_exc, 160))
+                            logger.warning("配置保存重试失败(%s): %s", method_name, self._single_line(retry_exc, 160))
                             return False
-                    logger.warning("[PrivateCompanionPage] 配置保存失败(%s): %s", method_name, self._single_line(exc, 160))
+                    logger.warning("配置保存失败(%s): %s", method_name, self._single_line(exc, 160))
                     return False
                 except Exception as exc:
-                    logger.warning("[PrivateCompanionPage] 配置保存失败(%s): %s", method_name, self._single_line(exc, 160))
+                    logger.warning("配置保存失败(%s): %s", method_name, self._single_line(exc, 160))
                     return False
-        logger.warning("[PrivateCompanionPage] 当前配置对象没有可用保存方法,本次改动可能只在运行态生效")
+        logger.warning("当前配置对象没有可用保存方法,本次改动可能只在运行态生效")
         return False
 
     def _can_save_config(self) -> bool:
@@ -25917,7 +25919,7 @@ class PrivateCompanionPageApi(
             if isinstance(raw, dict):
                 visit(raw)
         except Exception as exc:
-            logger.debug("[PrivateCompanionPage] 读取配置 schema 索引失败: %s", exc)
+            logger.debug("读取配置 schema 索引失败: %s", exc)
         self._schema_key_index_cache = index
         return index
 
@@ -27053,7 +27055,7 @@ class PrivateCompanionPageApi(
                 try:
                     recoverer(data)
                 except Exception as exc:
-                    logger.debug("[PrivateCompanionPage] 夹层响应内本地书页恢复失败: %s", self._single_line(exc, 160))
+                    logger.debug("夹层响应内本地书页恢复失败: %s", self._single_line(exc, 160))
         projects = data.get("creative_projects") if isinstance(data.get("creative_projects"), list) else []
         diaries = self._bookshelf_diary_entries(data.get("bot_diaries"))
         shelf_items = data.get("bookshelf_items") if isinstance(data.get("bookshelf_items"), list) else []
@@ -27156,7 +27158,7 @@ class PrivateCompanionPageApi(
                     )
                 except Exception as exc:
                     logger.debug(
-                        "[PrivateCompanionPage] 跳过无法读取的夹层目录: album=%s error=%s",
+                        "跳过无法读取的夹层目录: album=%s error=%s",
                         album_id,
                         self._single_line(exc, 120),
                     )
@@ -28586,7 +28588,7 @@ class PrivateCompanionPageApi(
                 }
             )
         except Exception as exc:
-            logger.error("[PrivateCompanionPage] 读取创作封面数据失败: %s", exc, exc_info=True)
+            logger.error("读取创作封面数据失败: %s", exc, exc_info=True)
             return self._exception_error("读取创作封面数据失败")
 
     async def get_creative_project(self) -> dict[str, Any]:
@@ -28602,7 +28604,7 @@ class PrivateCompanionPageApi(
                 snapshot = deepcopy(project)
             return self._ok(self._creative_project_payload(snapshot))
         except Exception as exc:
-            logger.error("[PrivateCompanionPage] 获取创作项目详情失败: %s", exc, exc_info=True)
+            logger.error("获取创作项目详情失败: %s", exc, exc_info=True)
             return self._exception_error("获取创作项目详情失败")
 
     async def update_creative_project(self) -> dict[str, Any]:
@@ -28685,7 +28687,7 @@ class PrivateCompanionPageApi(
                 self.plugin._save_data_sync(sections={"creative_projects"})
             return self._ok({"project_id": project_id, "changed": bool(changed_notes), "message": "作品已更新"})
         except Exception as exc:
-            logger.error("[PrivateCompanionPage] 更新创作项目失败: %s", exc, exc_info=True)
+            logger.error("更新创作项目失败: %s", exc, exc_info=True)
             return self._exception_error("更新创作项目失败")
 
     async def update_creative_chunk(self) -> dict[str, Any]:
@@ -28708,7 +28710,7 @@ class PrivateCompanionPageApi(
                 return self._error(result.get("error") or "片段更新失败")
             return self._ok({"project_id": project_id, "chunk_index": chunk_index, "message": "片段已更新"})
         except Exception as exc:
-            logger.error("[PrivateCompanionPage] 更新创作片段失败: %s", exc, exc_info=True)
+            logger.error("更新创作片段失败: %s", exc, exc_info=True)
             return self._exception_error("更新创作片段失败")
 
     async def update_creative_outline(self) -> dict[str, Any]:
@@ -28726,7 +28728,7 @@ class PrivateCompanionPageApi(
                 return self._error(result.get("error") or "大纲更新失败")
             return self._ok({"project_id": project_id, "message": "大纲已更新"})
         except Exception as exc:
-            logger.error("[PrivateCompanionPage] 更新创作大纲失败: %s", exc, exc_info=True)
+            logger.error("更新创作大纲失败: %s", exc, exc_info=True)
             return self._exception_error("更新创作大纲失败")
 
     async def update_creative_characters(self) -> dict[str, Any]:
@@ -28753,7 +28755,7 @@ class PrivateCompanionPageApi(
                 return self._error(result.get("error") or "角色更新失败")
             return self._ok({"project_id": project_id, "message": "角色已更新"})
         except Exception as exc:
-            logger.error("[PrivateCompanionPage] 更新创作角色失败: %s", exc, exc_info=True)
+            logger.error("更新创作角色失败: %s", exc, exc_info=True)
             return self._exception_error("更新创作角色失败")
 
     async def reanalyze_creative_project(self) -> dict[str, Any]:
@@ -28798,7 +28800,7 @@ class PrivateCompanionPageApi(
                 self.plugin._save_data_sync(sections={"creative_projects"})
             return self._ok({"project_id": project_id, "review": review})
         except Exception as exc:
-            logger.error("[PrivateCompanionPage] 创作项目质量分析失败: %s", exc, exc_info=True)
+            logger.error("创作项目质量分析失败: %s", exc, exc_info=True)
             return self._exception_error("创作项目质量分析失败")
 
     async def rebuild_creative_memory(self) -> dict[str, Any]:
@@ -28815,7 +28817,7 @@ class PrivateCompanionPageApi(
                 return self._error(result.get("error") or "重建失败")
             return self._ok(result)
         except Exception as exc:
-            logger.error("[PrivateCompanionPage] 重建创作记忆失败: %s", exc, exc_info=True)
+            logger.error("重建创作记忆失败: %s", exc, exc_info=True)
             return self._exception_error("重建创作记忆失败")
 
     async def delete_creative_project(self) -> dict[str, Any]:
@@ -28834,7 +28836,7 @@ class PrivateCompanionPageApi(
                 self.plugin._save_data_sync(sections={"creative_projects"})
             return self._ok({"project_id": project_id, "removed": removed})
         except Exception as exc:
-            logger.error("[PrivateCompanionPage] 删除创作项目失败: %s", exc, exc_info=True)
+            logger.error("删除创作项目失败: %s", exc, exc_info=True)
             return self._exception_error("删除创作项目失败")
 
     def _creative_summary(self, data: dict[str, Any]) -> dict[str, Any]:
@@ -29290,7 +29292,7 @@ class PrivateCompanionPageApi(
             if getattr(self, "_together_token_usage_warning_key", "") != warning_key:
                 self._together_token_usage_warning_key = warning_key
                 logger.warning(
-                    "[PrivateCompanionPage] 一起插件 Token 统计暂不可用，已跳过该可选来源: %s",
+                    "一起插件 Token 统计暂不可用，已跳过该可选来源: %s",
                     reason,
                 )
             return {

--- a/page_api_qzone.py
+++ b/page_api_qzone.py
@@ -6,10 +6,12 @@ from copy import deepcopy
 from types import SimpleNamespace
 from typing import Any
 
-from astrbot.api import logger
 from quart import request
 
 from .qzone_recent_parser import parse_recent_feeds
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 class PrivateCompanionPageApiQzoneMixin:
@@ -90,7 +92,7 @@ class PrivateCompanionPageApiQzoneMixin:
                         posts = parse_recent_feeds(h5_payload, h5_diagnostics)
                     except Exception as exc:
                         logger.info(
-                            "[PrivateCompanionPage] QQ 空间 H5 好友动态读取失败，准备使用旧接口: %s",
+                            "QQ 空间 H5 好友动态读取失败，准备使用旧接口: %s",
                             self._single_line(exc, 120),
                         )
 
@@ -151,7 +153,7 @@ class PrivateCompanionPageApiQzoneMixin:
 
                 final_own_only = bool(posts) and all(int(getattr(post, "uin", 0) or 0) == viewer_uin for post in posts)
                 logger.info(
-                    "[PrivateCompanionPage] QQ 空间好友动态读取: source=%s page=%s token=%s "
+                    "QQ 空间好友动态读取: source=%s page=%s token=%s "
                     "h5_candidates=%s h5_parsed=%s h5_official_skipped=%s "
                     "legacy_candidates=%s legacy_parsed=%s legacy_official_skipped=%s final=%s own_only=%s",
                     source,

--- a/page_api_users_groups.py
+++ b/page_api_users_groups.py
@@ -11,7 +11,6 @@ from copy import deepcopy
 from datetime import datetime
 from typing import Any
 
-from astrbot.api import logger
 from quart import request
 
 from .helpers import _safe_int
@@ -23,6 +22,9 @@ from .relationship_ledger import (
     relationship_positive_score_cap,
 )
 from .migration_backfill import legacy_pending_reference
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 class PrivateCompanionPageApiUsersGroupsMixin:
@@ -290,7 +292,7 @@ class PrivateCompanionPageApiUsersGroupsMixin:
                 }
             })
         except Exception as exc:
-            logger.warning("[PrivateCompanionPage] 更新待确认身份状态失败: %s", exc)
+            logger.warning("更新待确认身份状态失败: %s", exc)
             return self._error("更新待确认身份状态失败")
 
     def _identity_admin_summary(
@@ -415,10 +417,10 @@ class PrivateCompanionPageApiUsersGroupsMixin:
             items.sort(key=lambda item: item.get("last_seen_ts") or 0, reverse=True)
             elapsed_ms = int((time.perf_counter() - start) * 1000)
             if elapsed_ms > 1200:
-                logger.warning("[PrivateCompanionPage] 用户列表接口耗时较高: elapsed=%sms users=%s", elapsed_ms, len(items))
+                logger.warning("用户列表接口耗时较高: elapsed=%sms users=%s", elapsed_ms, len(items))
             return self._ok({"items": items[:limit], "total": len(items)})
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 获取用户列表失败: {exc}", exc_info=True)
+            logger.error(f"获取用户列表失败: {exc}", exc_info=True)
             return self._error(str(exc))
     async def get_user(self) -> dict[str, Any]:
         user_id = str(request.args.get("user_id", "")).strip()
@@ -495,7 +497,7 @@ class PrivateCompanionPageApiUsersGroupsMixin:
             )
             return self._ok(detail)
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 获取用户详情失败: {exc}", exc_info=True)
+            logger.error(f"获取用户详情失败: {exc}", exc_info=True)
             return self._error(str(exc))
     async def link_unified_identity(self) -> dict[str, Any]:
         payload = await request.get_json(silent=True)
@@ -582,7 +584,7 @@ class PrivateCompanionPageApiUsersGroupsMixin:
                 return self._error(str(result.get("code") or "统一身份重新关联失败"))
             return self._ok({"result": result})
         except Exception as exc:
-            logger.warning("[PrivateCompanionPage] 统一身份重新关联失败: %s", exc)
+            logger.warning("统一身份重新关联失败: %s", exc)
             return self._error("统一身份重新关联失败")
 
     async def unlink_unified_identity(self) -> dict[str, Any]:
@@ -655,7 +657,7 @@ class PrivateCompanionPageApiUsersGroupsMixin:
                 safe_result["confirmation_token"] = expected_confirmation
             return self._ok({"result": safe_result})
         except Exception as exc:
-            logger.warning("[PrivateCompanionPage] 统一身份解绑失败: %s", exc)
+            logger.warning("统一身份解绑失败: %s", exc)
             return self._error("统一身份解绑失败")
 
     async def archive_unified_person(self) -> dict[str, Any]:
@@ -688,7 +690,7 @@ class PrivateCompanionPageApiUsersGroupsMixin:
                 return self._error(code)
             return self._ok({"result": self._safe_person_lifecycle_result(result, "archive")})
         except Exception as exc:
-            logger.warning("[PrivateCompanionPage] 人物归档失败: %s", exc)
+            logger.warning("人物归档失败: %s", exc)
             return self._error("人物归档失败")
 
     async def delete_unified_person(self) -> dict[str, Any]:
@@ -719,7 +721,7 @@ class PrivateCompanionPageApiUsersGroupsMixin:
                 return self._error(str(result.get("code") or "人物删除失败"))
             return self._ok({"result": safe_result})
         except Exception as exc:
-            logger.warning("[PrivateCompanionPage] 人物删除失败: %s", exc)
+            logger.warning("人物删除失败: %s", exc)
             return self._error("人物删除失败")
 
     async def preview_unified_identity_merge(self) -> dict[str, Any]:
@@ -742,7 +744,7 @@ class PrivateCompanionPageApiUsersGroupsMixin:
                 return self._error(str(result.get("code") or "统一人物合并预览失败"))
             return self._ok({"result": result})
         except Exception as exc:
-            logger.warning("[PrivateCompanionPage] 统一人物合并预览失败: %s", exc)
+            logger.warning("统一人物合并预览失败: %s", exc)
             return self._error("统一人物合并预览失败")
 
     async def update_user(self) -> dict[str, Any]:
@@ -1147,7 +1149,7 @@ class PrivateCompanionPageApiUsersGroupsMixin:
                 result["message"] = action_message
             return self._ok(result)
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 更新用户失败: {exc}", exc_info=True)
+            logger.error(f"更新用户失败: {exc}", exc_info=True)
             return self._error(str(exc))
 
     async def delete_user(self) -> dict[str, Any]:
@@ -1289,7 +1291,7 @@ class PrivateCompanionPageApiUsersGroupsMixin:
                 }
             )
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 删除用户失败: {exc}", exc_info=True)
+            logger.error(f"删除用户失败: {exc}", exc_info=True)
             return self._error(str(exc))
 
     @staticmethod
@@ -1328,10 +1330,10 @@ class PrivateCompanionPageApiUsersGroupsMixin:
             items.sort(key=lambda item: item.get("last_seen_ts") or 0, reverse=True)
             elapsed_ms = int((time.perf_counter() - start) * 1000)
             if elapsed_ms > 1200:
-                logger.warning("[PrivateCompanionPage] 群列表接口耗时较高: elapsed=%sms groups=%s", elapsed_ms, len(items))
+                logger.warning("群列表接口耗时较高: elapsed=%sms groups=%s", elapsed_ms, len(items))
             return self._ok({"items": items[:limit], "total": len(items), "shadow_total": shadow_count})
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 获取群列表失败: {exc}", exc_info=True)
+            logger.error(f"获取群列表失败: {exc}", exc_info=True)
             return self._error(str(exc))
 
     def _refresh_group_atmosphere_for_page(self, group: dict[str, Any]) -> dict[str, Any]:
@@ -1341,7 +1343,7 @@ class PrivateCompanionPageApiUsersGroupsMixin:
                 updater(group)
             except Exception as exc:
                 logger.info(
-                    "[PrivateCompanionPage] 群气氛读取时重算失败: %s",
+                    "群气氛读取时重算失败: %s",
                     self._single_line(exc, 120),
                 )
         return group
@@ -1633,7 +1635,7 @@ class PrivateCompanionPageApiUsersGroupsMixin:
                     if name:
                         found[group_id] = name
         except Exception as exc:
-            logger.info("[PrivateCompanionPage] 群列表名称刷新失败: %s", self._single_line(exc, 120))
+            logger.info("群列表名称刷新失败: %s", self._single_line(exc, 120))
         if len(found) < len(target_ids) and platform_target_ids:
             for group_id, _ in [item for item in missing if item[0] in platform_target_ids][:30]:
                 if group_id in found:
@@ -1713,7 +1715,7 @@ class PrivateCompanionPageApiUsersGroupsMixin:
             )
             return self._ok(detail)
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 获取群详情失败: {exc}", exc_info=True)
+            logger.error(f"获取群详情失败: {exc}", exc_info=True)
             return self._error(str(exc))
 
     async def get_group_member_safety(self) -> dict[str, Any]:
@@ -1736,7 +1738,7 @@ class PrivateCompanionPageApiUsersGroupsMixin:
             )
             return self._ok(summary)
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 获取成员风控失败: {exc}", exc_info=True)
+            logger.error(f"获取成员风控失败: {exc}", exc_info=True)
             return self._error(str(exc))
 
     async def update_group_member_safety(self) -> dict[str, Any]:
@@ -1767,7 +1769,7 @@ class PrivateCompanionPageApiUsersGroupsMixin:
         except ValueError as exc:
             return self._error(str(exc))
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 更新成员风控失败: {exc}", exc_info=True)
+            logger.error(f"更新成员风控失败: {exc}", exc_info=True)
             return self._error(str(exc))
 
     async def update_group(self) -> dict[str, Any]:
@@ -1871,7 +1873,7 @@ class PrivateCompanionPageApiUsersGroupsMixin:
                 snapshot = deepcopy(group)
             return self._ok(self._group_summary(group_id, snapshot))
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 更新群失败: {exc}", exc_info=True)
+            logger.error(f"更新群失败: {exc}", exc_info=True)
             return self._error(str(exc))
 
     async def delete_group(self) -> dict[str, Any]:
@@ -1988,7 +1990,7 @@ class PrivateCompanionPageApiUsersGroupsMixin:
                 }
             )
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 删除群失败: {exc}", exc_info=True)
+            logger.error(f"删除群失败: {exc}", exc_info=True)
             return self._error(str(exc))
 
     async def update_group_slang(self) -> dict[str, Any]:
@@ -2051,5 +2053,5 @@ class PrivateCompanionPageApiUsersGroupsMixin:
             detail["slang_items"] = self._group_slang_items(snapshot)
             return self._ok(detail)
         except Exception as exc:
-            logger.error(f"[PrivateCompanionPage] 更新群黑话失败: {exc}", exc_info=True)
+            logger.error(f"更新群黑话失败: {exc}", exc_info=True)
             return self._error(str(exc))

--- a/passive_state_pipeline.py
+++ b/passive_state_pipeline.py
@@ -5,7 +5,6 @@ import asyncio
 import re
 from typing import Any
 
-from astrbot.api import logger
 
 from .conversation_injection_plan import (
     PLACEMENT_STABLE_SYSTEM,
@@ -19,6 +18,9 @@ from .group_prompt_context import (
 from .helpers import _now_ts, _safe_float, _single_line
 from .persona_config import runtime_persona_setting
 from .prompt_surface import PromptSurface
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 GROUP_CONTEXT_FINAL_PRIORITY = 10_000
@@ -104,7 +106,7 @@ async def inject_humanized_state(
             feedback_recorder(event)
         except Exception as exc:
             logger.debug(
-                "[PrivateCompanion] 记录参考图效果反馈失败: %s",
+                "记录参考图效果反馈失败: %s",
                 _single_line(exc, 120),
             )
     if self._stop_group_llm_reply_if_blocked(event, source="llm_request"):
@@ -124,7 +126,7 @@ async def inject_humanized_state(
         except Exception as exc:
             # Historical cleanup must never prevent the provider request itself.
             logger.debug(
-                "[PrivateCompanion] 清理历史反应标签失败: %s",
+                "清理历史反应标签失败: %s",
                 _single_line(exc, 120),
             )
     else:
@@ -135,7 +137,7 @@ async def inject_humanized_state(
             _neutralize_stale_reaction_feedback_compat(req)
         except Exception as exc:
             logger.debug(
-                "[PrivateCompanion] 兼容清理历史反应标签失败: %s",
+                "兼容清理历史反应标签失败: %s",
                 _single_line(exc, 120),
             )
     self._append_deepseek_tool_protocol_guard(event, req)
@@ -186,7 +188,7 @@ async def inject_humanized_state(
             reason = "private_user_missing" if not isinstance(private_user, dict) else "private_user_disabled"
             log_bookshelf_secret_skip(reason, private_user if isinstance(private_user, dict) else None)
             logger.info(
-                "[PrivateCompanion] 非目标/未启用私聊跳过陪伴被动增强: user=%s reason=%s",
+                "非目标/未启用私聊跳过陪伴被动增强: user=%s reason=%s",
                 _single_line(private_user_id, 40) or "unknown",
                 reason,
             )
@@ -201,7 +203,7 @@ async def inject_humanized_state(
         except Exception:
             pass
         logger.info(
-            "[PrivateCompanion] 睡眠/休息回复闸门放行本轮被动回复: session=%s reason=%s",
+            "睡眠/休息回复闸门放行本轮被动回复: session=%s reason=%s",
             _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             _single_line(rest_reason, 120),
         )
@@ -472,7 +474,7 @@ async def inject_humanized_state(
                             )
                         except Exception as exc:
                             logger.debug(
-                                "[PrivateCompanion] 群黑话嵌入上下文生成失败: %s",
+                                "群黑话嵌入上下文生成失败: %s",
                                 _single_line(exc, 120),
                             )
                             slang_embedding_text = ""
@@ -649,7 +651,7 @@ async def inject_humanized_state(
     if lightweight_passive and isinstance(bookshelf_signal, dict) and bookshelf_signal.get("likely"):
         lightweight_passive = False
         logger.info(
-            "[PrivateCompanion] 夹层密码请求退出轻量被动链路: user=%s direct=%s context=%s access=%s text=%s",
+            "夹层密码请求退出轻量被动链路: user=%s direct=%s context=%s access=%s text=%s",
             user_id,
             ",".join(bookshelf_signal.get("direct_matches") or []) or "-",
             ",".join(bookshelf_signal.get("context_matches") or []) or "-",
@@ -1060,7 +1062,7 @@ async def inject_humanized_state(
                 include_heading=False,
             )
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 引用链上下文读取失败: %s", _single_line(exc, 120))
+            logger.debug("引用链上下文读取失败: %s", _single_line(exc, 120))
             reply_chain_context = ""
         if reply_chain_context:
             prompt_surface.add(
@@ -1111,9 +1113,9 @@ async def inject_humanized_state(
             if vision_wait_timeout > 0:
                 buffered_image_vision = _single_line(await asyncio.wait_for(asyncio.shield(vision_task), timeout=vision_wait_timeout), buffered_image_vision_limit)
         except asyncio.TimeoutError:
-            logger.info("[PrivateCompanion] 私聊图片视觉转述仍在进行,本轮先注入路径兜底: timeout=%.1fs", vision_wait_timeout)
+            logger.warning("私聊图片视觉转述仍在进行,本轮先注入路径兜底: timeout=%.1fs", vision_wait_timeout)
         except Exception as exc:
-            logger.info("[PrivateCompanion] 私聊图片视觉转述获取失败: %s", _single_line(exc, 120))
+            logger.warning("私聊图片视觉转述获取失败: %s", _single_line(exc, 120))
     buffered_images_include_gif = (
         bool(runtime_persona_setting(self, "enable_private_image_gif_enhancement", True))
         and self._private_image_sources_include_gif(buffered_images)
@@ -1242,7 +1244,7 @@ async def inject_humanized_state(
                         image_refs.append(request_ref)
             if not image_refs:
                 logger.info(
-                    "[PrivateCompanion] 私聊延迟图片无模型可读源,跳过直接挂图: user=%s images=%s",
+                    "私聊延迟图片无模型可读源,跳过直接挂图: user=%s images=%s",
                     user_id,
                     len(buffered_images),
                 )
@@ -1260,7 +1262,7 @@ async def inject_humanized_state(
                         existing.append(image_ref)
                 req.image_urls = existing
                 logger.info(
-                    "[PrivateCompanion] 私聊延迟图片已挂回视觉主模型: user=%s images=%s mounted=%s",
+                    "私聊延迟图片已挂回视觉主模型: user=%s images=%s mounted=%s",
                     user_id,
                     len(buffered_images),
                     len(image_refs),
@@ -1268,7 +1270,7 @@ async def inject_humanized_state(
                 try:
                     await self._refresh_default_persona_prompt(str(getattr(event, "unified_msg_origin", "") or ""))
                 except Exception as exc:
-                    logger.debug("[PrivateCompanion] 图片直挂刷新人格缓存失败: %s", exc)
+                    logger.debug("图片直挂刷新人格缓存失败: %s", exc)
                 direct_role_hint = self._private_image_direct_role_appearance_prompt(
                     include_heading=False,
                 )
@@ -1286,7 +1288,7 @@ async def inject_humanized_state(
             ownership_line = self._private_image_ownership_line(buffered_image_vision)
             reply_objective = self._private_image_reply_objective(ownership_line, vision_text=buffered_image_vision, user_text=inbound_text)
             logger.info(
-                "[PrivateCompanion] 私聊延迟图片已注入视觉摘要: user=%s chars=%s intent=%s ownership=%s objective=%s preview=%s",
+                "私聊延迟图片已注入视觉摘要: user=%s chars=%s intent=%s ownership=%s objective=%s preview=%s",
                 user_id,
                 len(buffered_image_vision),
                 intent_line or "无",
@@ -1365,7 +1367,7 @@ async def inject_humanized_state(
     reply_image_prompt_anchor = ""
     skip_reply_image_for_forward_context = bool(getattr(event, "private_companion_forward_context_injected", False))
     if skip_reply_image_for_forward_context:
-        logger.info("[PrivateCompanion] 本轮已注入合并消息上下文,跳过引用图片重复视觉: user=%s", user_id)
+        logger.info("本轮已注入合并消息上下文,跳过引用图片重复视觉: user=%s", user_id)
     if (
         not skip_reply_image_for_forward_context
         and not buffered_images
@@ -1393,7 +1395,7 @@ async def inject_humanized_state(
                 ownership_line = self._private_image_ownership_line(reply_image_vision)
                 reply_objective = self._private_image_reply_objective(ownership_line, vision_text=reply_image_vision, user_text=inbound_text)
                 logger.info(
-                    "[PrivateCompanion] 私聊引用图片已注入视觉摘要: user=%s images=%s intent=%s ownership=%s objective=%s preview=%s",
+                    "私聊引用图片已注入视觉摘要: user=%s images=%s intent=%s ownership=%s objective=%s preview=%s",
                     user_id,
                     len(reply_image_sources),
                     intent_line or "无",
@@ -1442,7 +1444,7 @@ async def inject_humanized_state(
                             }
                             self._save_data_sync(sections={"users"})
                     except Exception as exc:
-                        logger.debug("[PrivateCompanion] 私聊引用图片视觉反馈目标记录失败: %s", exc)
+                        logger.debug("私聊引用图片视觉反馈目标记录失败: %s", exc)
                 try:
                     setattr(event, "private_companion_reply_image_vision_text", _single_line(reply_image_vision, reply_image_limit))
                     setattr(event, "private_companion_reply_image_count", len(reply_image_sources))
@@ -1510,7 +1512,7 @@ async def inject_humanized_state(
         await self._append_conditional_tool_instructions_to_request(event, req)
         return
     if not injection:
-        logger.debug("[PrivateCompanion] 被动状态提示词片段为空,跳过状态 marker 注入")
+        logger.debug("被动状态提示词片段为空,跳过状态 marker 注入")
         log_bookshelf_secret_skip("empty_passive_injection", current_user, inbound_text)
         await self._append_conditional_tool_instructions_to_request(event, req)
         return
@@ -1602,7 +1604,7 @@ async def inject_humanized_state(
             },
         )
     logger.info(
-        "[PrivateCompanion] 已注入被动状态提示词到 %s: mode=%s state_mode=%s reason=%s placement=%s chars=%s 状态=%s；当前日程=%s",
+        "已注入被动状态提示词到 %s: mode=%s state_mode=%s reason=%s placement=%s chars=%s 状态=%s；当前日程=%s",
         _single_line(getattr(event, "unified_msg_origin", ""), 80) or "unknown_session",
         "light" if lightweight_passive else "full",
         "delta" if bool(runtime_persona_setting(self, "enable_passive_state_delta_injection", True)) else "legacy",

--- a/place_cognitive_map.py
+++ b/place_cognitive_map.py
@@ -8,10 +8,12 @@ import time
 from datetime import datetime, timezone
 from typing import Any
 
-from astrbot.api import logger
 
 from .helpers import _safe_float, _single_line
 from .scoped_domain_contract import build_scoped_domain_payload
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 _MAP_STORE_KEY = "place_cognitive_maps"
@@ -163,7 +165,7 @@ class PlaceCognitiveMapMixin:
             )
             if not isinstance(result, dict) or result.get("ok") is not True:
                 logger.debug(
-                    "[PrivateCompanion] 地点认知 scoped memory 写入被拒绝: code=%s",
+                    "地点认知 scoped memory 写入被拒绝: code=%s",
                     _single_line(result.get("code"), 120) if isinstance(result, dict) else "invalid_result",
                 )
             return
@@ -175,7 +177,7 @@ class PlaceCognitiveMapMixin:
             try:
                 await recorder(event)
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 地点认知活动归档失败: %s", _single_line(exc, 160))
+                logger.debug("地点认知活动归档失败: %s", _single_line(exc, 160))
 
         try:
             task = asyncio.create_task(_record())

--- a/plugin_bootstrap.py
+++ b/plugin_bootstrap.py
@@ -8,7 +8,6 @@ import time
 from pathlib import Path
 from typing import Any
 
-from astrbot.api import logger
 from astrbot.api.star import StarTools
 
 from .body_monitor_integration import BodyMonitorIntegration
@@ -44,6 +43,9 @@ from .migration_outbox import MigrationOutbox
 from .model_routing import DEFAULT_SENSITIVE_REPLACEMENT_KEYWORDS, build_rules, normalize_scope
 from .segmented_message import normalize_component_order, normalize_component_strategy
 from .unified_person_registry import UnifiedPersonRegistry
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 DEFAULT_AI_DAILY_MORNING_UID = "3706929260006322"
 DEFAULT_AI_DAILY_JUYA_UID = "285286947"
@@ -153,14 +155,14 @@ def _initialize_primary_persona_config(self: Any, config: Any) -> bool:
 
     if self._multi_persona_primary_id_mismatch:
         logger.warning(
-            "[PrivateCompanion] 检测到旧主人格配置不一致，继续以 plugin_specific_persona_id 为权威: "
+            "检测到旧主人格配置不一致，继续以 plugin_specific_persona_id 为权威: "
             "authoritative=%s legacy_candidate=%s",
             authoritative,
             legacy_candidate,
         )
     elif self._multi_persona_primary_requires_configuration and legacy_candidate:
         logger.warning(
-            "[PrivateCompanion] 多人格模式缺少 plugin_specific_persona_id；旧 multi_persona_primary_id "
+            "多人格模式缺少 plugin_specific_persona_id；旧 multi_persona_primary_id "
             "仅保留为待确认候选，不会静默启用: legacy_candidate=%s",
             legacy_candidate,
         )
@@ -185,7 +187,7 @@ def _validate_primary_persona_runtime(self: Any) -> bool:
     if invalid:
         self.enable_multi_persona_mode = False
         logger.warning(
-            "[PrivateCompanion] 多人格主人格已不在 AstrBot 人格列表中，运行态保持关闭等待修复: persona=%s",
+            "多人格主人格已不在 AstrBot 人格列表中，运行态保持关闭等待修复: persona=%s",
             primary,
         )
     return invalid
@@ -253,7 +255,7 @@ def initialize_plugin_entrypoint_state(
         }
     )
     if contract_issues:
-        logger.warning("[PrivateCompanion] Bot Personal contract self-check degraded: %s", ";".join(contract_issues))
+        logger.warning("Bot Personal contract self-check degraded: %s", ";".join(contract_issues))
 
 
 def initialize_plugin_config(self: Any, config: Any) -> None:
@@ -321,7 +323,7 @@ def _initialize_core_and_relationship_config(self: Any, c: Any) -> None:
     config_migration_elapsed_ms = int((time.perf_counter() - config_migration_started) * 1000)
     if config_migration_elapsed_ms > 1200:
         logger.warning(
-            "[PrivateCompanion] 启动配置迁移耗时较高: elapsed=%sms changes=%s",
+            "启动配置迁移耗时较高: elapsed=%sms changes=%s",
             config_migration_elapsed_ms,
             self._startup_config_migration_changes,
         )
@@ -619,7 +621,7 @@ def _initialize_world_and_model_config(self: Any, c: Any) -> None:
             self.model_replacement_rules, legacy_warnings = build_rules(legacy_config.get("route_rules", []))
             model_replacement_warnings.extend(f"兼容旧插件：{warning}" for warning in legacy_warnings)
     for warning in model_replacement_warnings:
-        logger.warning("[PrivateCompanion] 模型替换规则：%s", warning)
+        logger.warning("模型替换规则：%s", warning)
     self.enable_sensitive_model_replacement = self._cfg_bool(
         c,
         "enable_sensitive_model_replacement",
@@ -1316,7 +1318,7 @@ def _initialize_photo_and_expression_config(self: Any, c: Any) -> None:
     self.photo_reference_catalog_user_cleared = raw_reference_catalog_user_cleared
     self._startup_photo_reference_catalog_migration_pending = False
     for warning in loaded_reference_catalog.warnings:
-        logger.warning("[PrivateCompanion] 参考图目录加载警告: %s", warning)
+        logger.warning("参考图目录加载警告: %s", warning)
     if loaded_reference_catalog.needs_persist:
         self.photo_reference_catalog_read_only = True
         try:
@@ -1330,10 +1332,10 @@ def _initialize_photo_and_expression_config(self: Any, c: Any) -> None:
                 self._startup_photo_reference_catalog_migration_pending = True
                 self._startup_config_migration_changes += 1
             else:
-                logger.error("[PrivateCompanion] 参考图目录迁移无法写入配置，启动期间继续使用旧配置的只读内存投影")
+                logger.error("参考图目录迁移无法写入配置，启动期间继续使用旧配置的只读内存投影")
         except Exception as exc:
             logger.error(
-                "[PrivateCompanion] 参考图目录迁移失败，启动期间继续使用旧配置的只读内存投影: %s",
+                "参考图目录迁移失败，启动期间继续使用旧配置的只读内存投影: %s",
                 _single_line(exc, 180),
                 exc_info=True,
             )
@@ -2114,7 +2116,7 @@ def initialize_plugin_runtime(self: Any) -> None:
             retire_legacy_routing()
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanion] 旧人格路由停用失败，保留原数据等待下次启动重试: %s",
+                "旧人格路由停用失败，保留原数据等待下次启动重试: %s",
                 _single_line(exc, 180),
             )
     migrate_profiles = getattr(self, "_migrate_persona_profiles_sync", None)
@@ -2130,14 +2132,14 @@ def initialize_plugin_runtime(self: Any) -> None:
                 "error": _single_line(exc, 180),
             }
             logger.warning(
-                "[PrivateCompanion] 启动人格配置迁移失败: %s",
+                "启动人格配置迁移失败: %s",
                 _single_line(exc, 180),
             )
     self._body_monitor_integration = BodyMonitorIntegration(self)
     self._apply_tts_runtime_overrides()
     load_elapsed_ms = int((time.perf_counter() - startup_load_started) * 1000)
     if load_elapsed_ms > 1200:
-        logger.warning("[PrivateCompanion] 启动读取数据耗时较高: elapsed=%sms", load_elapsed_ms)
+        logger.warning("启动读取数据耗时较高: elapsed=%sms", load_elapsed_ms)
     self._proactive_chat_runtime_bridge = ProactiveChatRuntimeBridge(self)
     self.page_api = None
     self.standalone_webui = None

--- a/private_image.py
+++ b/private_image.py
@@ -18,7 +18,6 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qsl, quote, unquote, urlencode, urlparse, urlsplit, urlunparse, urlunsplit
 
-from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent
 try:
     from astrbot.api.message_components import Image, Plain
@@ -43,6 +42,9 @@ from .segmented_message import (
     plan_component_chunks,
     sanitize_llm_segment_control_tokens,
 )
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 PREPARED_IMAGE_MAX_AGE_SECONDS = 30 * 60
@@ -55,7 +57,7 @@ class _PublicOnlyRedirectHandler(urllib.request.HTTPRedirectHandler):
     def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[override]
         if not _url_host_is_public(newurl):
             logger.warning(
-                "[PrivateCompanion] remote image redirect rejected: url=%s",
+                "remote image redirect rejected: url=%s",
                 _single_line(newurl, 160),
             )
             return None
@@ -116,14 +118,14 @@ class PrivateImageMixin:
             missing = _missing_optional_model_dependency(exc)
             if missing:
                 logger.warning(
-                    "[PrivateCompanion] 私聊图片存在性检测缺少可选模型依赖，已按无图片继续: label=%s module=%s err=%s",
+                    "私聊图片存在性检测缺少可选模型依赖，已按无图片继续: label=%s module=%s err=%s",
                     _single_line(label, 40) or "-",
                     missing,
                     _single_line(exc, 160),
                 )
                 return False
             logger.warning(
-                "[PrivateCompanion] 私聊图片存在性检测失败，已按无图片继续: label=%s err=%s",
+                "私聊图片存在性检测失败，已按无图片继续: label=%s err=%s",
                 _single_line(label, 40) or "-",
                 _single_line(exc, 160),
             )
@@ -348,7 +350,7 @@ class PrivateImageMixin:
                     maybe = converter()
                     return str(await maybe if hasattr(maybe, "__await__") else maybe or "").strip()
                 except Exception as exc:
-                    logger.debug("[PrivateCompanion] 私聊图片组件转换失败: %s", exc)
+                    logger.debug("私聊图片组件转换失败: %s", exc)
             return ""
 
         for index, comp in enumerate(self._event_components(event), 1):
@@ -362,7 +364,7 @@ class PrivateImageMixin:
                 data = getattr(comp, "data", None)
                 data_keys = ",".join(sorted(str(key) for key in data.keys())) if isinstance(data, dict) else ""
                 logger.info(
-                    "[PrivateCompanion] 私聊图片组件未能解析出文件路径: class=%s data_keys=%s",
+                    "私聊图片组件未能解析出文件路径: class=%s data_keys=%s",
                     comp.__class__.__name__,
                     data_keys or "-",
                 )
@@ -371,7 +373,7 @@ class PrivateImageMixin:
             if source_path.exists() and source_path.is_file():
                 if not self._private_image_local_path_is_allowed(source_path):
                     logger.warning(
-                        "[PrivateCompanion] private image local path rejected: path=%s",
+                        "private image local path rejected: path=%s",
                         _single_line(source, 200),
                     )
                     continue
@@ -382,7 +384,7 @@ class PrivateImageMixin:
                     result.append(str(target))
                     continue
                 except Exception as exc:
-                    logger.debug("[PrivateCompanion] 私聊图片暂存失败: %s", exc)
+                    logger.debug("私聊图片暂存失败: %s", exc)
             if re.match(r"^https?://", source, flags=re.I):
                 persisted = await self._persist_private_remote_image_source(
                     source,
@@ -427,7 +429,7 @@ class PrivateImageMixin:
             return ""
         if public_hosts_only and not await asyncio.to_thread(_url_host_is_public, text):
             logger.warning(
-                "[PrivateCompanion] remote image host rejected: url=%s",
+                "remote image host rejected: url=%s",
                 _single_line(text, 160),
             )
             return ""
@@ -452,7 +454,7 @@ class PrivateImageMixin:
                     length = _safe_int(response.headers.get("Content-Length"), 0, 0)
                     max_bytes = 12 * 1024 * 1024
                     if length and length > max_bytes:
-                        logger.info("[PrivateCompanion] 私聊远程图片过大,跳过下载: size=%s url=%s", length, _single_line(text, 120))
+                        logger.info("私聊远程图片过大,跳过下载: size=%s url=%s", length, _single_line(text, 120))
                         return ""
                     chunks: list[bytes] = []
                     total = 0
@@ -462,12 +464,12 @@ class PrivateImageMixin:
                             break
                         total += len(chunk)
                         if total > max_bytes:
-                            logger.info("[PrivateCompanion] 私聊远程图片下载超过限制,已中止: url=%s", _single_line(text, 120))
+                            logger.info("私聊远程图片下载超过限制,已中止: url=%s", _single_line(text, 120))
                             return ""
                         chunks.append(chunk)
                 data = b"".join(chunks)
                 if not data:
-                    logger.info("[PrivateCompanion] 私聊远程图片响应为空,跳过: url=%s", _single_line(text, 120))
+                    logger.info("私聊远程图片响应为空,跳过: url=%s", _single_line(text, 120))
                     return ""
                 prefix = data[:16]
                 suffix = ".jpg"
@@ -480,13 +482,13 @@ class PrivateImageMixin:
                 elif prefix.startswith(b"\xff\xd8\xff") or "jpeg" in content_type or "jpg" in content_type:
                     suffix = ".jpg"
                 elif "image/" not in content_type:
-                    logger.info("[PrivateCompanion] 私聊远程图片响应不是图片,跳过: content_type=%s url=%s", content_type or "-", _single_line(text, 120))
+                    logger.info("私聊远程图片响应不是图片,跳过: content_type=%s url=%s", content_type or "-", _single_line(text, 120))
                     return ""
                 target = target_dir / f"{re.sub(r'[^0-9A-Za-z_.-]+', '_', stem)}{suffix}"
                 target.write_bytes(data)
                 return str(target)
             except Exception as exc:
-                logger.warning("[PrivateCompanion] 私聊远程图片下载失败: %s url=%s", _single_line(exc, 120), _single_line(text, 120))
+                logger.warning("私聊远程图片下载失败: %s url=%s", _single_line(exc, 120), _single_line(text, 120))
                 return ""
 
         return await asyncio.to_thread(download)
@@ -546,7 +548,7 @@ class PrivateImageMixin:
             normalized_source = str(local_path) if local_path is not None else source
             if not self._private_image_source_to_model_url(normalized_source):
                 logger.info(
-                    "[PrivateCompanion] 本地图片源不可读,已跳过: namespace=%s source=%s",
+                    "本地图片源不可读,已跳过: namespace=%s source=%s",
                     namespace,
                     _single_line(source, 160),
                 )
@@ -570,7 +572,7 @@ class PrivateImageMixin:
         except Exception:
             return removed
         if removed:
-            logger.info("[PrivateCompanion] stale prepared images removed: dir=%s removed=%s", target_dir.name, removed)
+            logger.info("stale prepared images removed: dir=%s removed=%s", target_dir.name, removed)
         return removed
 
     def _cleanup_prepared_image_sources(self, sources: list[str], *, namespace: str) -> None:
@@ -634,7 +636,7 @@ class PrivateImageMixin:
         try:
             return f"data:{mime};base64,{base64.b64encode(path.read_bytes()).decode('ascii')}"
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 私聊图片转 data url 失败: %s", exc)
+            logger.debug("私聊图片转 data url 失败: %s", exc)
             return ""
 
     def _private_image_source_cache_key(self, source: str) -> str:
@@ -655,7 +657,7 @@ class PrivateImageMixin:
             if path.exists() and path.is_file() and self._private_image_local_path_is_allowed(path):
                 return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 私聊图片缓存键生成失败: %s", exc)
+            logger.debug("私聊图片缓存键生成失败: %s", exc)
         if re.match(r"^https?://", text, flags=re.I):
             return self._private_image_normalized_url_cache_key(text)
         return ""
@@ -735,7 +737,7 @@ class PrivateImageMixin:
             if path.exists() and path.is_file() and self._private_image_local_path_is_allowed(path):
                 return path.read_bytes()
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 私聊图片缓存别名字节读取失败: %s", exc)
+            logger.debug("私聊图片缓存别名字节读取失败: %s", exc)
         return b""
 
     def _private_image_visual_cache_aliases_from_bytes(self, raw: bytes) -> list[str]:
@@ -772,7 +774,7 @@ class PrivateImageMixin:
                 aspect_bucket = max(1, min(999, int(round((width / max(1, height)) * 100))))
                 return [f"pxhash:v1:a{aspect_bucket}:ah{ahash}:dh{dhash}"]
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 私聊图片视觉指纹生成失败: %s", exc)
+            logger.debug("私聊图片视觉指纹生成失败: %s", exc)
         return []
 
     def _private_image_cache_preview_dir(self) -> Path:
@@ -834,7 +836,7 @@ class PrivateImageMixin:
                         "preview_size": int(file_size),
                     }
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 图片缓存预览生成失败: %s", exc)
+                logger.debug("图片缓存预览生成失败: %s", exc)
         return {}
 
     def _private_image_cache_aliases_for_sources(self, sources: list[str]) -> list[str]:
@@ -1075,7 +1077,7 @@ class PrivateImageMixin:
         try:
             self._save_data_sync(sections={"private_image_vision_cache"})
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 私聊图片视觉缓存保存失败: %s", exc)
+            logger.debug("私聊图片视觉缓存保存失败: %s", exc)
 
     def _invalidate_private_image_vision_cache_by_image_keys(self, image_keys: list[str], *, image_aliases: list[str] | None = None, reason: str = "") -> int:
         targets = {str(item) for item in image_keys or [] if str(item or "").strip()}
@@ -1097,11 +1099,11 @@ class PrivateImageMixin:
                     )
                 removed += 1
         if removed:
-            logger.info("[PrivateCompanion] 私聊图片视觉缓存已因负反馈失效: removed=%s reason=%s", removed, _single_line(reason, 120))
+            logger.info("私聊图片视觉缓存已因负反馈失效: removed=%s reason=%s", removed, _single_line(reason, 120))
             try:
                 self._save_data_sync(sections={"private_image_vision_cache"})
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 私聊图片视觉缓存失效保存失败: %s", exc)
+                logger.debug("私聊图片视觉缓存失效保存失败: %s", exc)
         return removed
 
     def _is_private_image_vision_negative_feedback(self, text: str) -> bool:
@@ -1132,7 +1134,7 @@ class PrivateImageMixin:
         target["negative_feedback_text"] = _single_line(text, 160)
         target["invalidated_cache_items"] = removed
         logger.info(
-            "[PrivateCompanion] 私聊图片视觉负反馈记录: user_image_keys=%s removed=%s text=%s",
+            "私聊图片视觉负反馈记录: user_image_keys=%s removed=%s text=%s",
             len(image_keys),
             removed,
             _single_line(text, 120),
@@ -1320,7 +1322,7 @@ class PrivateImageMixin:
             else:
                 self._save_data_sync(sections={"private_image_visual_provider_state"})
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 私聊图片视觉成功 provider 状态保存失败: %s", exc)
+            logger.debug("私聊图片视觉成功 provider 状态保存失败: %s", exc)
 
     def _private_image_visual_provider_candidates(self, umo: str = "") -> list[tuple[str, str, str]]:
         base = self._private_image_base_visual_provider_candidates(umo)
@@ -1442,7 +1444,7 @@ class PrivateImageMixin:
         if cooldown <= 0:
             self._private_image_provider_failure_cache().pop(key, None)
             logger.debug(
-                "[PrivateCompanion] 图片视觉 provider 本轮失败但未启用跨轮冷却: provider=%s source=%s task=%s error=%s",
+                "图片视觉 provider 本轮失败但未启用跨轮冷却: provider=%s source=%s task=%s error=%s",
                 provider_id,
                 provider_source,
                 task,
@@ -1457,7 +1459,7 @@ class PrivateImageMixin:
             "error": _single_line(exc, 180),
         }
         logger.info(
-            "[PrivateCompanion] 图片视觉 provider 临时降权: provider=%s source=%s task=%s cooldown=%ss error=%s",
+            "图片视觉 provider 临时降权: provider=%s source=%s task=%s cooldown=%ss error=%s",
             provider_id,
             provider_source,
             task,
@@ -1640,7 +1642,7 @@ class PrivateImageMixin:
                     prepared.append(str(target))
             except Exception as exc:
                 logger.debug(
-                    "[PrivateCompanion] 群聊成图审核缩放失败，使用原图: image=%s error=%s",
+                    "群聊成图审核缩放失败，使用原图: image=%s error=%s",
                     _single_line(source, 160),
                     _single_line(exc, 120),
                 )
@@ -1916,7 +1918,7 @@ class PrivateImageMixin:
                 # A transport timeout can happen after the platform accepted the
                 # message. Retrying here would send the same image twice.
                 logger.warning(
-                    "[PrivateCompanion] 图片发送返回异常，为避免平台已接收后重复发送，本轮不再重试: session=%s image=%s error=%s",
+                    "图片发送返回异常，为避免平台已接收后重复发送，本轮不再重试: session=%s image=%s error=%s",
                     _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                     _single_line(image_path, 180),
                     _single_line(send_error, 180),
@@ -1949,7 +1951,7 @@ class PrivateImageMixin:
         review = await self._review_group_generated_image_for_delivery(event, image_path)
         label = _single_line(review.get("label"), 40) or "unavailable"
         logger.info(
-            "[PrivateCompanion] 群聊成图安全审核: group=%s label=%s provider=%s",
+            "群聊成图安全审核: group=%s label=%s provider=%s",
             group_id,
             label,
             _single_line(review.get("provider_id"), 120) or "-",
@@ -2089,7 +2091,7 @@ class PrivateImageMixin:
                         break
                 else:
                     logger.warning(
-                        "[PrivateCompanion] GIF 无法转换为兼容的 PNG 帧,已跳过该视觉输入: source=%s",
+                        "GIF 无法转换为兼容的 PNG 帧,已跳过该视觉输入: source=%s",
                         _single_line(source, 120),
                     )
                 # Some Gemini-compatible gateways reject image/gif even when
@@ -2128,7 +2130,7 @@ class PrivateImageMixin:
         try:
             from PIL import Image as PILImage, ImageSequence
         except Exception:
-            logger.warning("[PrivateCompanion] Pillow 不可用,GIF 无法转换为模型兼容的 PNG 帧")
+            logger.warning("Pillow 不可用,GIF 无法转换为模型兼容的 PNG 帧")
             return []
         try:
             with PILImage.open(io.BytesIO(raw)) as image:
@@ -2154,10 +2156,10 @@ class PrivateImageMixin:
                         break
                 if not frames:
                     return []
-                logger.info("[PrivateCompanion] GIF 已转换为 PNG 帧供视觉识别: frames=%s/%s source=%s", len(frames), frame_total, _single_line(source, 120))
+                logger.info("GIF 已转换为 PNG 帧供视觉识别: frames=%s/%s source=%s", len(frames), frame_total, _single_line(source, 120))
                 return frames
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 动态 GIF 抽帧失败: %s", exc)
+            logger.debug("动态 GIF 抽帧失败: %s", exc)
         return []
 
     def _sanitize_provider_request_gif_inputs(self, req: Any) -> tuple[int, int]:
@@ -2246,7 +2248,7 @@ class PrivateImageMixin:
                 raw = path.read_bytes()
             return raw if raw.startswith((b"GIF87a", b"GIF89a")) else b""
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 动态 GIF 字节读取失败: %s", exc)
+            logger.debug("动态 GIF 字节读取失败: %s", exc)
             return b""
 
     def _private_image_sources_include_gif(self, image_sources: list[str]) -> bool:
@@ -2295,7 +2297,7 @@ class PrivateImageMixin:
             image_caption_provider_id = ""
         if selected and image_caption_provider_id and selected == image_caption_provider_id:
             logger.info(
-                "[PrivateCompanion] 私聊图片 selected_provider 是图片转述模型,不按主视觉模型直挂: provider=%s",
+                "私聊图片 selected_provider 是图片转述模型,不按主视觉模型直挂: provider=%s",
                 selected,
             )
             selected = ""
@@ -2656,7 +2658,7 @@ class PrivateImageMixin:
         else:
             corrected = f"{text} {new_line}".strip()
         logger.info(
-            "[PrivateCompanion] 图片归属自我识别因外观冲突降级: reason=%s before=%s after=%s",
+            "图片归属自我识别因外观冲突降级: reason=%s before=%s after=%s",
             _single_line(reason, 120),
             old_line or "无",
             new_line,
@@ -2943,7 +2945,7 @@ class PrivateImageMixin:
             missing = _missing_optional_model_dependency(exc)
             if missing:
                 logger.warning(
-                    "[PrivateCompanion] %s预处理缺少可选模型依赖，已跳过本轮识图: module=%s err=%s",
+                    "%s预处理缺少可选模型依赖，已跳过本轮识图: module=%s err=%s",
                     clean_log_subject,
                     missing,
                     _single_line(exc, 160),
@@ -2958,7 +2960,7 @@ class PrivateImageMixin:
             missing = _missing_optional_model_dependency(exc)
             if missing:
                 logger.warning(
-                    "[PrivateCompanion] %s模型输入构造缺少可选模型依赖，已跳过本轮识图: module=%s err=%s",
+                    "%s模型输入构造缺少可选模型依赖，已跳过本轮识图: module=%s err=%s",
                     clean_log_subject,
                     missing,
                     _single_line(exc, 160),
@@ -2982,7 +2984,7 @@ class PrivateImageMixin:
                 if hasattr(result, "__await__"):
                     await asyncio.wait_for(result, timeout=2.0)
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 图片自我识别刷新人格缓存失败: %s", exc)
+                logger.debug("图片自我识别刷新人格缓存失败: %s", exc)
         image_aliases = self._private_image_cache_aliases_for_sources([*original_sources, *sources])
         original_image_keys = self._private_image_cache_image_keys(original_sources or sources)
         if original_image_keys and not group_mode:
@@ -3100,7 +3102,7 @@ class PrivateImageMixin:
                 intent_line = self._private_image_intent_line(cached_text)
                 ownership_line = self._private_image_ownership_line(cached_text)
                 logger.info(
-                    "[PrivateCompanion] %s视觉转述命中缓存: provider=%s scope=%s images=%s intent=%s ownership=%s preview=%s",
+                    "%s视觉转述命中缓存: provider=%s scope=%s images=%s intent=%s ownership=%s preview=%s",
                     clean_log_subject,
                     provider_id,
                     scope,
@@ -3139,7 +3141,7 @@ class PrivateImageMixin:
                         budget_exempt=True,
                     )
                     logger.info(
-                        "[PrivateCompanion] %s主视觉模型预估超出 Token 上限，跳过并继续备用模型: primary=%s fallback=%s",
+                        "%s主视觉模型预估超出 Token 上限，跳过并继续备用模型: primary=%s fallback=%s",
                         clean_log_subject,
                         provider_id,
                         fallback_visual_id,
@@ -3174,7 +3176,7 @@ class PrivateImageMixin:
                     )
                     self._mark_private_image_provider_failure(provider_id, provider_source, empty_note, task=clean_task_name)
                     logger.info(
-                        "[PrivateCompanion] %s视觉转述返回不可用摘要,已尝试下一个 provider: provider=%s source=%s reason=%s preview=%s",
+                        "%s视觉转述返回不可用摘要,已尝试下一个 provider: provider=%s source=%s reason=%s preview=%s",
                         clean_log_subject,
                         provider_id,
                         provider_source,
@@ -3196,7 +3198,7 @@ class PrivateImageMixin:
                 )
                 self._clear_private_image_provider_failure(provider_id, provider_source)
                 logger.info(
-                    "[PrivateCompanion] %s视觉转述完成: provider=%s source=%s scope=%s images=%s chars=%s intent=%s ownership=%s preview=%s",
+                    "%s视觉转述完成: provider=%s source=%s scope=%s images=%s chars=%s intent=%s ownership=%s preview=%s",
                     clean_log_subject,
                     provider_id,
                     provider_source,
@@ -3245,8 +3247,8 @@ class PrivateImageMixin:
                     error=timeout_note,
                     budget_exempt=True,
                 )
-                logger.info(
-                    "[PrivateCompanion] %s视觉转述超时,本轮尝试下一个 provider；不会因此禁用后续图片调用: provider=%s source=%s timeout=%.1fs",
+                logger.warning(
+                    "%s视觉转述超时,本轮尝试下一个 provider；不会因此禁用后续图片调用: provider=%s source=%s timeout=%.1fs",
                     clean_log_subject,
                     provider_id,
                     provider_source,
@@ -3257,7 +3259,7 @@ class PrivateImageMixin:
                 missing = _missing_optional_model_dependency(exc)
                 if missing:
                     logger.warning(
-                        "[PrivateCompanion] %s视觉 provider 缺少可选模型依赖，已降级跳过该 provider: provider=%s module=%s err=%s",
+                        "%s视觉 provider 缺少可选模型依赖，已降级跳过该 provider: provider=%s module=%s err=%s",
                         clean_log_subject,
                         provider_id,
                         missing,
@@ -3279,7 +3281,7 @@ class PrivateImageMixin:
                 continue
         if group_mode:
             self._cleanup_prepared_image_sources(sources, namespace=clean_namespace)
-        logger.warning("[PrivateCompanion] %s视觉转述失败: 所有候选 provider 均不可用或失败 attempts=%s", clean_log_subject, attempts)
+        logger.warning("%s视觉转述失败: 所有候选 provider 均不可用或失败 attempts=%s", clean_log_subject, attempts)
         return ""
 
     def _group_image_sources_from_event(self, event: AstrMessageEvent) -> list[str]:
@@ -3294,7 +3296,7 @@ class PrivateImageMixin:
             for source in self._raw_private_image_sources(event):
                 add(source)
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 群聊图片原始来源提取失败: %s", _single_line(exc, 120))
+            logger.debug("群聊图片原始来源提取失败: %s", _single_line(exc, 120))
         component_getter = getattr(self, "_event_components", None)
         try:
             components = component_getter(event) if callable(component_getter) else []
@@ -3450,7 +3452,7 @@ class PrivateImageMixin:
             raise
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanion] 群聊图片后台理解失败: group=%s message=%s error=%s",
+                "群聊图片后台理解失败: group=%s message=%s error=%s",
                 _single_line(group_id, 80),
                 _single_line(message_id, 120) or "-",
                 _single_line(exc, 160),
@@ -3545,7 +3547,7 @@ class PrivateImageMixin:
         except Exception:
             pass
         logger.info(
-            "[PrivateCompanion] 群聊图片已进入后台理解: group=%s message=%s images=%s",
+            "群聊图片已进入后台理解: group=%s message=%s images=%s",
             group_id,
             message_id or "-",
             len(sources),
@@ -3669,7 +3671,7 @@ class PrivateImageMixin:
                     summary=cached_summary,
                 )
                 logger.info(
-                    "[PrivateCompanion] 群聊图片理解已关闭，复用缓存语义: group=%s message=%s images=%s",
+                    "群聊图片理解已关闭，复用缓存语义: group=%s message=%s images=%s",
                     group_id,
                     message_id or "-",
                     len(sources),
@@ -3707,8 +3709,8 @@ class PrivateImageMixin:
                 summary = await asyncio.wait_for(asyncio.shield(task), timeout=wait_seconds)
             return _single_line(summary, self._private_image_vision_text_limit(1))
         except asyncio.TimeoutError:
-            logger.info(
-                "[PrivateCompanion] 群聊回复等待图片理解超时，主链继续且后台任务保留: group=%s message=%s timeout=%.1fs",
+            logger.warning(
+                "群聊回复等待图片理解超时，主链继续且后台任务保留: group=%s message=%s timeout=%.1fs",
                 group_id,
                 message_id or "-",
             _safe_float(self._private_image_setting("group_image_vision_wait_seconds", 8.0), 8.0, 0.0, 60.0),
@@ -3717,7 +3719,7 @@ class PrivateImageMixin:
         except asyncio.CancelledError:
             raise
         except Exception as exc:
-            logger.warning("[PrivateCompanion] 群聊回复读取图片理解结果失败: %s", _single_line(exc, 160))
+            logger.warning("群聊回复读取图片理解结果失败: %s", _single_line(exc, 160))
             return ""
 
     async def _maybe_group_image_wakeup(self, event: AstrMessageEvent, *, sender_id: str = "") -> dict[str, Any]:
@@ -3820,7 +3822,7 @@ class PrivateImageMixin:
         try:
             sources = [str(item).strip() for item in (await finder(event) or []) if str(item or "").strip()][:5]
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 群聊引用图片来源读取失败: %s", _single_line(exc, 120))
+            logger.debug("群聊引用图片来源读取失败: %s", _single_line(exc, 120))
             return "", False
         if not sources:
             return "", False
@@ -3869,11 +3871,11 @@ class PrivateImageMixin:
                 namespace="group_reply_vision",
             )
         except Exception as exc:
-            logger.warning("[PrivateCompanion] 群聊引用图片识别失败: %s", _single_line(exc, 160))
+            logger.warning("群聊引用图片识别失败: %s", _single_line(exc, 160))
             return "", False
         if summary:
             logger.info(
-                "[PrivateCompanion] 群聊引用图片已注入视觉摘要: group=%s images=%s",
+                "群聊引用图片已注入视觉摘要: group=%s images=%s",
                 group_id or "unknown",
                 len(sources),
             )
@@ -4183,11 +4185,11 @@ class PrivateImageMixin:
             return caption
         except asyncio.TimeoutError:
             failure_cache[cache_key] = _now_ts() + CONTEXT_IMAGE_FAILURE_COOLDOWN_SECONDS
-            logger.warning("[PrivateCompanion] 上下文图片补全等待超时: images=%s timeout=%.1fs", len(clean_sources), wait_seconds)
+            logger.warning("上下文图片补全等待超时: images=%s timeout=%.1fs", len(clean_sources), wait_seconds)
             return ""
         except Exception as exc:
             failure_cache[cache_key] = _now_ts() + CONTEXT_IMAGE_FAILURE_COOLDOWN_SECONDS
-            logger.warning("[PrivateCompanion] 上下文图片补全失败: images=%s error=%s", len(clean_sources), _single_line(exc, 120))
+            logger.warning("上下文图片补全失败: images=%s error=%s", len(clean_sources), _single_line(exc, 120))
             return ""
 
     async def _enrich_request_context_image_placeholders(self, event: AstrMessageEvent, req: ProviderRequest) -> dict[str, int]:
@@ -4267,7 +4269,7 @@ class PrivateImageMixin:
             except Exception:
                 return {"contexts": len(contexts), "replaced": 0, "missed": missed}
             logger.info(
-                "[PrivateCompanion] 已将历史上下文图片占位替换为视觉摘要: contexts=%s replaced=%s missed=%s",
+                "已将历史上下文图片占位替换为视觉摘要: contexts=%s replaced=%s missed=%s",
                 len(contexts),
                 replaced,
                 missed,
@@ -4360,7 +4362,7 @@ class PrivateImageMixin:
             initial_target_ts = min(initial_target_ts, max_deadline_ts)
         already_due = initial_target_ts > 0 and _now_ts() >= initial_target_ts
         logger.info(
-            "[PrivateCompanion] 消息收口等待开始: kind=%s scope=%s sender=%s wait=%.1fs count=%s deadline=%s",
+            "消息收口等待开始: kind=%s scope=%s sender=%s wait=%.1fs count=%s deadline=%s",
             buffer_kind,
             log_scope,
             log_sender,
@@ -4421,7 +4423,7 @@ class PrivateImageMixin:
                         message_count=len(learned_messages),
                     )
                 logger.info(
-                    "[PrivateCompanion] 智能防抖等待结束未等到补话: scope=%s sender=%s messages=%s",
+                    "智能防抖等待结束未等到补话: scope=%s sender=%s messages=%s",
                     scope,
                     sender_id,
                     len(learned_messages),
@@ -4441,7 +4443,7 @@ class PrivateImageMixin:
                         message_count=len(learned_messages),
                     )
                 logger.info(
-                    "[PrivateCompanion] 智能防抖等待命中补话: scope=%s sender=%s messages=%s",
+                    "智能防抖等待命中补话: scope=%s sender=%s messages=%s",
                     scope,
                     sender_id,
                     len(learned_messages),
@@ -4462,7 +4464,7 @@ class PrivateImageMixin:
                     lines.append(text)
         if len(lines) <= 1:
             logger.info(
-                "[PrivateCompanion] 消息收口等待结束: kind=%s scope=%s sender=%s count=%s result=single",
+                "消息收口等待结束: kind=%s scope=%s sender=%s count=%s result=single",
                 buffer_kind,
                 log_scope,
                 log_sender,
@@ -4471,7 +4473,7 @@ class PrivateImageMixin:
             return ""
         merged = "\n".join(f"{idx + 1}. {line}" for idx, line in enumerate(lines))
         logger.info(
-            "[PrivateCompanion] 消息收口等待结束: kind=%s scope=%s sender=%s count=%s result=merged preview=%s",
+            "消息收口等待结束: kind=%s scope=%s sender=%s count=%s result=merged preview=%s",
             buffer_kind,
             log_scope,
             log_sender,
@@ -4490,7 +4492,7 @@ class PrivateImageMixin:
         try:
             return _single_line(vision_task.result(), 1400)
         except Exception as exc:
-            logger.warning("[PrivateCompanion] 私聊单图后台视觉任务结果读取失败: %s", _single_line(exc, 120))
+            logger.warning("私聊单图后台视觉任务结果读取失败: %s", _single_line(exc, 120))
             return ""
 
     def _private_image_vision_handoff_ttl_seconds(self) -> float:
@@ -4581,7 +4583,7 @@ class PrivateImageMixin:
             return str(restorer(source, framework_event) or source).strip()
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanion] 私聊单图主链 TTS 占位符恢复失败: %s",
+                "私聊单图主链 TTS 占位符恢复失败: %s",
                 _single_line(exc, 120),
             )
             return source
@@ -4656,7 +4658,7 @@ class PrivateImageMixin:
         reply = _single_line(_strip_internal_message_blocks(raw_reply or ""), max_chars)
         if reply and self._private_image_reply_is_internal_error(reply):
             logger.warning(
-                "[PrivateCompanion] 私聊单图兜底 LLM 返回内部错误文本,已丢弃: user=%s source=%s preview=%s",
+                "私聊单图兜底 LLM 返回内部错误文本,已丢弃: user=%s source=%s preview=%s",
                 user_id,
                 source,
                 _single_line(reply, 180),
@@ -4703,7 +4705,7 @@ class PrivateImageMixin:
             raise
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanion] 私聊单图强约束重试失败: user=%s error=%s",
+                "私聊单图强约束重试失败: user=%s error=%s",
                 user_id,
                 _single_line(exc, 160),
             )
@@ -4711,7 +4713,7 @@ class PrivateImageMixin:
         reply = _single_line(_strip_internal_message_blocks(raw_reply or ""), 300)
         if reply and self._private_image_reply_is_internal_error(reply):
             logger.warning(
-                "[PrivateCompanion] 私聊单图强约束重试返回内部错误文本,已丢弃: user=%s preview=%s",
+                "私聊单图强约束重试返回内部错误文本,已丢弃: user=%s preview=%s",
                 user_id,
                 _single_line(reply, 180),
             )
@@ -4756,7 +4758,7 @@ class PrivateImageMixin:
             self._record_llm_usage(**kwargs)
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanion] 私聊单图用量统计失败,不影响回复发送: %s",
+                "私聊单图用量统计失败,不影响回复发送: %s",
                 _single_line(exc, 160),
             )
 
@@ -4920,7 +4922,7 @@ class PrivateImageMixin:
         if len(outbound_chains) <= 1:
             await self._send_private_image_reply_chain(event, outbound_chains[0])
             return self._private_image_chain_text(outbound_chains[0]) or self._private_image_context_assistant_message(text)
-        logger.info("[PrivateCompanion] 私聊单图回复按手动链路分段发送: segments=%s", len(outbound_chains))
+        logger.info("私聊单图回复按手动链路分段发送: segments=%s", len(outbound_chains))
         remainder_started_at = _now_ts()
         await self._send_private_image_reply_chain(event, outbound_chains[0])
         first_text = self._private_image_chain_text(outbound_chains[0])
@@ -4952,7 +4954,7 @@ class PrivateImageMixin:
                     pass
                 except Exception as exc:
                     logger.warning(
-                        "[PrivateCompanion] private image remainder task failed: %s",
+                        "private image remainder task failed: %s",
                         _single_line(exc, 160),
                     )
                 finally:
@@ -4974,7 +4976,7 @@ class PrivateImageMixin:
             cleaned = placeholder_cleaner(normalized)
             if cleaned != normalized:
                 logger.warning(
-                    "[PrivateCompanion] 私聊单图发送前清理孤儿 TTS 占位符: before=%s after=%s",
+                    "私聊单图发送前清理孤儿 TTS 占位符: before=%s after=%s",
                     _single_line(normalized, 120),
                     _single_line(cleaned, 120),
                 )
@@ -4993,7 +4995,7 @@ class PrivateImageMixin:
                 try:
                     chain = await processor(normalized, event, fallback_plain=fallback_plain)
                 except Exception as exc:
-                    logger.warning("[PrivateCompanion] 私聊单图 TTS 组件生成失败,回退文本发送: %s", _single_line(exc, 120))
+                    logger.warning("私聊单图 TTS 组件生成失败,回退文本发送: %s", _single_line(exc, 120))
                     chain = []
                 cleaned_chain = self._private_image_clean_reply_chain(chain)
                 if cleaned_chain:
@@ -5057,7 +5059,7 @@ class PrivateImageMixin:
             await event.send(result)
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanion] 图片回复发送返回异常，为避免平台已接收后重复发送，本轮不再重试: session=%s error=%s",
+                "图片回复发送返回异常，为避免平台已接收后重复发送，本轮不再重试: session=%s error=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                 _single_line(exc, 180),
             )
@@ -5101,7 +5103,7 @@ class PrivateImageMixin:
                     if sent_text:
                         sent_texts.append(sent_text)
                     logger.info(
-                        "[PrivateCompanion] 私聊单图剩余片段已发送: index=%s/%s preview=%s",
+                        "私聊单图剩余片段已发送: index=%s/%s preview=%s",
                         sent_index,
                         total,
                         self._private_image_chain_text(chain) or chain[0].__class__.__name__,
@@ -5111,7 +5113,7 @@ class PrivateImageMixin:
                     raise
                 except Exception as exc:
                     logger.warning(
-                        "[PrivateCompanion] 私聊单图剩余片段发送失败: error=%s",
+                        "私聊单图剩余片段发送失败: error=%s",
                         _single_line(exc, 160),
                         exc_info=True,
                     )
@@ -5201,13 +5203,13 @@ class PrivateImageMixin:
                                     image_limit,
                                 )
                     except asyncio.TimeoutError:
-                        logger.debug(
-                            "[PrivateCompanion] 关键词模型路由等待图片转述超时: user=%s",
+                        logger.warning(
+                            "关键词模型路由等待图片转述超时: user=%s",
                             user_id,
                         )
                     except Exception as exc:
                         logger.debug(
-                            "[PrivateCompanion] 关键词模型路由读取图片转述失败: user=%s error=%s",
+                            "关键词模型路由读取图片转述失败: user=%s error=%s",
                             user_id,
                             _single_line(exc, 120),
                         )
@@ -5244,7 +5246,7 @@ class PrivateImageMixin:
                         source_field = "private_companion_reply_image_vision_text"
                 except Exception as exc:
                     logger.debug(
-                        "[PrivateCompanion] 关键词模型路由预取引用图片转述失败: user=%s error=%s",
+                        "关键词模型路由预取引用图片转述失败: user=%s error=%s",
                         user_id,
                         _single_line(exc, 120),
                     )
@@ -5254,7 +5256,7 @@ class PrivateImageMixin:
         setattr(event, source_field, vision_text)
         setattr(event, "private_companion_image_caption_route_text", vision_text)
         logger.info(
-            "[PrivateCompanion] 图片转述已提供给关键词模型路由: user=%s source=%s preview=%s",
+            "图片转述已提供给关键词模型路由: user=%s source=%s preview=%s",
             user_id,
             source_field,
             _single_line(vision_text, 160),
@@ -5282,7 +5284,7 @@ class PrivateImageMixin:
             return bool(route(event, caption))
         except Exception as exc:
             logger.debug(
-                "[PrivateCompanion] 调用关键词模型路由失败，保留原 Provider: %s",
+                "调用关键词模型路由失败，保留原 Provider: %s",
                 _single_line(exc, 120),
             )
             return False
@@ -5332,7 +5334,7 @@ class PrivateImageMixin:
         current_session = self._private_image_vision_handoff_session(event)
         if stored_session != current_session:
             logger.info(
-                "[PrivateCompanion] 私聊图片视觉交接会话不匹配,保留给原会话: sender=%s stored=%s current=%s",
+                "私聊图片视觉交接会话不匹配,保留给原会话: sender=%s stored=%s current=%s",
                 sender_id,
                 stored_session,
                 current_session or "-",
@@ -5349,7 +5351,7 @@ class PrivateImageMixin:
                 image_limit,
             )
         logger.info(
-            "[PrivateCompanion] 私聊补充文字已领取延迟图片视觉交接: sender=%s images=%s has_vision=%s pending=%s",
+            "私聊补充文字已领取延迟图片视觉交接: sender=%s images=%s has_vision=%s pending=%s",
             sender_id,
             len(images),
             bool(vision_text),
@@ -5432,16 +5434,16 @@ class PrivateImageMixin:
 
                 written = await db_operation("archive_private_image_turn", _write) if callable(db_operation) else await _write()
                 if written:
-                    logger.info("[PrivateCompanion] 已将私聊图片回复写入 AstrBot 会话历史: %s", umo)
+                    logger.info("已将私聊图片回复写入 AstrBot 会话历史: %s", umo)
                 else:
-                    logger.warning("[PrivateCompanion] 私聊图片回复写入会话历史失败: 无法获取或创建 AstrBot 会话 history umo=%s", umo)
+                    logger.warning("私聊图片回复写入会话历史失败: 无法获取或创建 AstrBot 会话 history umo=%s", umo)
                 return
             except Exception as exc:
                 text = str(exc or "").lower()
                 if ("database is locked" in text or "sqlite3.operationalerror" in text) and attempt < 3:
                     await asyncio.sleep(0.25 * (attempt + 1))
                     continue
-                logger.warning("[PrivateCompanion] 私聊图片回复写入会话历史失败: %s", _single_line(exc, 160))
+                logger.warning("私聊图片回复写入会话历史失败: %s", _single_line(exc, 160))
                 return
 
     async def _memory_companion_record_private_image_visible_turn(
@@ -5461,7 +5463,7 @@ class PrivateImageMixin:
             optional_failed = getattr(self, "_memory_companion_optional_dependency_failed", None)
             if callable(optional_failed) and optional_failed(exc, where="private_image_visible_turn_bridge"):
                 return
-            logger.debug("[PrivateCompanion] MemoryCompanion 桥接读取失败，跳过私聊图片可见上下文写入: %s", _single_line(exc, 120))
+            logger.debug("MemoryCompanion 桥接读取失败，跳过私聊图片可见上下文写入: %s", _single_line(exc, 120))
             return
         recorder = getattr(bridge, "record_visible_turn", None) if bridge is not None else None
         if not callable(recorder) or not user_message or not assistant_message:
@@ -5508,12 +5510,12 @@ class PrivateImageMixin:
                 source="private_companion_private_image_turn",
                 metadata={**base_metadata, "turn_role": "assistant"},
             )
-            logger.info("[PrivateCompanion] 已将私聊图片回复同步为 MemoryCompanion 可见上下文: session=%s", session_id)
+            logger.info("已将私聊图片回复同步为 MemoryCompanion 可见上下文: session=%s", session_id)
         except Exception as exc:
             optional_failed = getattr(self, "_memory_companion_optional_dependency_failed", None)
             if callable(optional_failed) and optional_failed(exc, where="record_private_image_visible_turn"):
                 return
-            logger.debug("[PrivateCompanion] MemoryCompanion 私聊图片可见上下文写入失败: %s", _single_line(exc, 120))
+            logger.debug("MemoryCompanion 私聊图片可见上下文写入失败: %s", _single_line(exc, 120))
 
     async def _archive_private_image_turn_context(
         self,
@@ -5592,7 +5594,7 @@ class PrivateImageMixin:
                 }
                 self._save_data_sync(sections={"users"})
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 私聊图片视觉反馈目标记录失败: %s", exc)
+            logger.debug("私聊图片视觉反馈目标记录失败: %s", exc)
 
     async def _send_delayed_private_image_only_event(
         self,
@@ -5608,7 +5610,7 @@ class PrivateImageMixin:
         )
         if not feature_enabled:
             logger.info(
-                "[PrivateCompanion] 私聊单图处理期间图片转述增强已关闭,但原事件已接管,继续完成本轮回复: user=%s",
+                "私聊单图处理期间图片转述增强已关闭,但原事件已接管,继续完成本轮回复: user=%s",
                 user_id,
             )
         images = buffer.get("images") if isinstance(buffer.get("images"), list) else []
@@ -5620,13 +5622,13 @@ class PrivateImageMixin:
             timeout = self._private_image_vision_wait_budget_seconds()
             try:
                 if timeout > 0:
-                    logger.info("[PrivateCompanion] 私聊单图等待视觉转述完成: user=%s timeout=%.1fs", user_id, timeout)
+                    logger.info("私聊单图等待视觉转述完成: user=%s timeout=%.1fs", user_id, timeout)
                     vision_text = _single_line(await asyncio.wait_for(asyncio.shield(vision_task), timeout=timeout), image_limit)
             except asyncio.TimeoutError:
                 vision_wait_timed_out = True
-                logger.info("[PrivateCompanion] 私聊单图延迟处理时视觉转述仍未完成: user=%s timeout=%.1fs", user_id, timeout)
+                logger.warning("私聊单图延迟处理时视觉转述仍未完成: user=%s timeout=%.1fs", user_id, timeout)
             except Exception as exc:
-                logger.warning("[PrivateCompanion] 私聊单图延迟视觉转述失败: user=%s error=%s", user_id, _single_line(exc, 120))
+                logger.warning("私聊单图延迟视觉转述失败: user=%s error=%s", user_id, _single_line(exc, 120))
         ownership_line = self._private_image_ownership_line(vision_text)
         intent_line = self._private_image_intent_line(vision_text)
         reply_objective = self._private_image_reply_objective(ownership_line, vision_text=vision_text)
@@ -5646,7 +5648,7 @@ class PrivateImageMixin:
                 )
             )
         logger.info(
-            "[PrivateCompanion] 私聊单图准备进入主链: user=%s images=%s has_vision=%s intent=%s ownership=%s objective=%s vision_preview=%s",
+            "私聊单图准备进入主链: user=%s images=%s has_vision=%s intent=%s ownership=%s objective=%s vision_preview=%s",
             user_id,
             len(images),
             bool(vision_text),
@@ -5686,13 +5688,13 @@ class PrivateImageMixin:
                             framework_event.set_extra("selected_provider", selected_provider)
                     except Exception:
                         pass
-                    logger.info("[PrivateCompanion] 私聊单图主链使用合成私聊事件执行: user=%s session=%s", user_id, umo)
+                    logger.info("私聊单图主链使用合成私聊事件执行: user=%s session=%s", user_id, umo)
                 except Exception as exc:
                     framework_event = event
-                    logger.info("[PrivateCompanion] 私聊单图合成私聊事件创建失败,回退原事件: user=%s error=%s", user_id, _single_line(exc, 160))
+                    logger.info("私聊单图合成私聊事件创建失败,回退原事件: user=%s error=%s", user_id, _single_line(exc, 160))
             elif umo:
                 logger.warning(
-                    "[PrivateCompanion] 私聊单图主链未取得 AstrBot 原生 Context,已直接转入视觉摘要兜底: user=%s",
+                    "私聊单图主链未取得 AstrBot 原生 Context,已直接转入视觉摘要兜底: user=%s",
                     user_id,
                 )
             setattr(framework_event, "private_companion_deferred_private_image_only_ready", True)
@@ -5738,14 +5740,14 @@ class PrivateImageMixin:
                 if completed_vision:
                     vision_text = _single_line(completed_vision, self._private_image_vision_text_limit(len(images)))
                     logger.info(
-                        "[PrivateCompanion] 私聊单图主链前取到后台视觉摘要: user=%s preview=%s",
+                        "私聊单图主链前取到后台视觉摘要: user=%s preview=%s",
                         user_id,
                         _single_line(vision_text, 220),
                     )
                 elif not vision_wait_timed_out:
                     vision_text = _single_line(await self._transcribe_private_inbound_images(images, umo=umo), self._private_image_vision_text_limit(len(images)))
                 else:
-                    logger.info("[PrivateCompanion] 私聊单图识图等待已超时,主链不再重复发起视觉转述: user=%s", user_id)
+                    logger.warning("私聊单图识图等待已超时,主链不再重复发起视觉转述: user=%s", user_id)
                     setattr(framework_event, "private_companion_delayed_image_mode", "no_vision")
                 if vision_text:
                     setattr(framework_event, "private_companion_delayed_image_vision_text", vision_text)
@@ -5757,7 +5759,7 @@ class PrivateImageMixin:
                     reply_objective = self._private_image_reply_objective(ownership_line, vision_text=vision_text)
             if has_dynamic_gif_sources and request_image_refs:
                 logger.info(
-                    "[PrivateCompanion] 私聊单图检测到动态 GIF,已改用抽帧视觉摘要链路: user=%s has_vision=%s",
+                    "私聊单图检测到动态 GIF,已改用抽帧视觉摘要链路: user=%s has_vision=%s",
                     user_id,
                     bool(vision_text),
             )
@@ -5834,7 +5836,7 @@ class PrivateImageMixin:
                     await segmenting_injector(framework_event, req)
                 except Exception as exc:
                     logger.debug(
-                        "[PrivateCompanion] 私聊单图分段说明注入失败，继续生成正文: %s",
+                        "私聊单图分段说明注入失败，继续生成正文: %s",
                         _single_line(exc, 120),
                     )
             request_plan = get_conversation_injection_plan(req, create=False)
@@ -5849,7 +5851,7 @@ class PrivateImageMixin:
                         existing.append(image_ref)
                 req.image_urls = existing
                 logger.info(
-                    "[PrivateCompanion] 私聊单图主链已挂载图片: user=%s provider=%s source=%s images=%s has_vision=%s",
+                    "私聊单图主链已挂载图片: user=%s provider=%s source=%s images=%s has_vision=%s",
                     user_id,
                     direct_provider_id,
                     direct_provider_source,
@@ -5884,7 +5886,7 @@ class PrivateImageMixin:
                         )
                         if captured_tool_sends:
                             logger.info(
-                                "[PrivateCompanion] 私聊单图主链拦截到框架工具直发: user=%s count=%s",
+                                "私聊单图主链拦截到框架工具直发: user=%s count=%s",
                                 user_id,
                                 len(captured_tool_sends),
                             )
@@ -5897,7 +5899,7 @@ class PrivateImageMixin:
             except Exception as exc:
                 if direct_image_mode and self._exception_indicates_image_input_unsupported(exc):
                     logger.warning(
-                        "[PrivateCompanion] 私聊单图主链模型不支持图片输入,已降级为视觉摘要兜底: user=%s provider=%s error=%s",
+                        "私聊单图主链模型不支持图片输入,已降级为视觉摘要兜底: user=%s provider=%s error=%s",
                         user_id,
                         direct_provider_id,
                         _single_line(exc, 180),
@@ -5908,7 +5910,7 @@ class PrivateImageMixin:
                     result = None
                 elif self._exception_indicates_tool_schema_invalid(exc):
                     logger.warning(
-                        "[PrivateCompanion] 私聊单图主链工具 schema 不兼容,已转入兜底回复: user=%s error=%s",
+                        "私聊单图主链工具 schema 不兼容,已转入兜底回复: user=%s error=%s",
                         user_id,
                         _single_line(exc, 180),
                     )
@@ -5918,7 +5920,7 @@ class PrivateImageMixin:
                     result = None
                 else:
                     logger.warning(
-                        "[PrivateCompanion] 私聊单图主链异常,已转入人格兜底: user=%s error=%s",
+                        "私聊单图主链异常,已转入人格兜底: user=%s error=%s",
                         user_id,
                         _single_line(exc, 180),
                         exc_info=True,
@@ -5940,7 +5942,7 @@ class PrivateImageMixin:
                 reply = self._private_image_framework_response_text(llm_resp)
                 if reply and not str(getattr(llm_resp, "completion_text", "") or "").strip():
                     logger.info(
-                        "[PrivateCompanion] 私聊单图主链 completion_text 为空,已从 result_chain 恢复可见文本: user=%s preview=%s",
+                        "私聊单图主链 completion_text 为空,已从 result_chain 恢复可见文本: user=%s preview=%s",
                         user_id,
                         _single_line(reply, 180),
                     )
@@ -5952,7 +5954,7 @@ class PrivateImageMixin:
             )
             if reply and self._private_image_reply_is_internal_error(reply):
                 logger.warning(
-                    "[PrivateCompanion] 私聊单图主链返回内部错误文本,已拦截转入兜底: user=%s preview=%s",
+                    "私聊单图主链返回内部错误文本,已拦截转入兜底: user=%s preview=%s",
                     user_id,
                     _single_line(reply, 180),
                 )
@@ -5960,7 +5962,7 @@ class PrivateImageMixin:
                 reply_source = "internal_error_fallback"
             if reply and direct_image_mode and self._private_image_reply_denies_image_capability(reply):
                 logger.warning(
-                    "[PrivateCompanion] 私聊单图主链返回无法看图声明,已转视觉摘要兜底: user=%s provider=%s preview=%s",
+                    "私聊单图主链返回无法看图声明,已转视觉摘要兜底: user=%s provider=%s preview=%s",
                     user_id,
                     direct_provider_id,
                     _single_line(reply, 180),
@@ -5990,14 +5992,14 @@ class PrivateImageMixin:
                 if reply:
                     reply_source = "main_chain_tool_capture"
                     logger.info(
-                        "[PrivateCompanion] 私聊单图主链工具直发文本已转为普通回复: user=%s chars=%s reply_preview=%s",
+                        "私聊单图主链工具直发文本已转为普通回复: user=%s chars=%s reply_preview=%s",
                         user_id,
                         len(reply),
                         _single_line(reply, 180),
                     )
             if reply and vision_text and self._private_image_reply_ignores_vision_summary(reply):
                 logger.info(
-                    "[PrivateCompanion] 私聊单图主链疑似忽略视觉摘要,转入兜底回复: user=%s reply_preview=%s",
+                    "私聊单图主链疑似忽略视觉摘要,转入兜底回复: user=%s reply_preview=%s",
                     user_id,
                     _single_line(reply, 180),
                 )
@@ -6006,7 +6008,7 @@ class PrivateImageMixin:
                 trimmed_reply = self._trim_private_image_stale_context_tail(reply)
                 if trimmed_reply and trimmed_reply != reply and not self._private_image_reply_drifts_to_stale_context(trimmed_reply):
                     logger.info(
-                        "[PrivateCompanion] 私聊单图主链回复夹带旧上下文,已裁剪: user=%s before=%s after=%s",
+                        "私聊单图主链回复夹带旧上下文,已裁剪: user=%s before=%s after=%s",
                         user_id,
                         _single_line(reply, 180),
                         _single_line(trimmed_reply, 180),
@@ -6014,7 +6016,7 @@ class PrivateImageMixin:
                     reply = trimmed_reply
                 else:
                     logger.info(
-                        "[PrivateCompanion] 私聊单图主链回复夹带旧上下文,转入兜底回复: user=%s reply_preview=%s",
+                        "私聊单图主链回复夹带旧上下文,转入兜底回复: user=%s reply_preview=%s",
                         user_id,
                         _single_line(reply, 180),
                     )
@@ -6028,7 +6030,7 @@ class PrivateImageMixin:
                     except Exception:
                         reply_preview = reply
                 logger.info(
-                    "[PrivateCompanion] 私聊单图主链回复生成: user=%s chars=%s intent=%s ownership=%s reply_preview=%s",
+                    "私聊单图主链回复生成: user=%s chars=%s intent=%s ownership=%s reply_preview=%s",
                     user_id,
                     len(reply),
                     intent_line or "无",
@@ -6040,14 +6042,14 @@ class PrivateImageMixin:
                     vision_text = self._completed_private_image_vision_task_text(vision_task)
                     if vision_text:
                         logger.info(
-                            "[PrivateCompanion] 私聊单图兜底前取到后台视觉摘要: user=%s preview=%s",
+                            "私聊单图兜底前取到后台视觉摘要: user=%s preview=%s",
                             user_id,
                             _single_line(vision_text, 220),
                         )
                     elif not vision_wait_timed_out:
                         vision_text = _single_line(await self._transcribe_private_inbound_images(images, umo=umo), self._private_image_vision_text_limit(len(images)))
                     else:
-                        logger.info("[PrivateCompanion] 私聊单图兜底阶段跳过重复视觉转述: user=%s", user_id)
+                        logger.info("私聊单图兜底阶段跳过重复视觉转述: user=%s", user_id)
                     setattr(event, "private_companion_delayed_image_vision_text", vision_text)
                     ownership_line = self._private_image_ownership_line(vision_text)
                     intent_line = self._private_image_intent_line(vision_text)
@@ -6061,14 +6063,14 @@ class PrivateImageMixin:
                 )
                 if not vision_text:
                     logger.info(
-                        "[PrivateCompanion] 私聊单图无可靠视觉摘要,已尝试人格兜底回复: user=%s chars=%s reply_preview=%s",
+                        "私聊单图无可靠视觉摘要,已尝试人格兜底回复: user=%s chars=%s reply_preview=%s",
                         user_id,
                         len(reply),
                         _single_line(reply, 180),
                     )
                 else:
                     logger.info(
-                        "[PrivateCompanion] 私聊单图兜底回复生成: user=%s chars=%s intent=%s ownership=%s objective=%s reply_preview=%s",
+                        "私聊单图兜底回复生成: user=%s chars=%s intent=%s ownership=%s objective=%s reply_preview=%s",
                         user_id,
                         len(reply),
                         intent_line or "无",
@@ -6078,7 +6080,7 @@ class PrivateImageMixin:
                     )
                 if not reply:
                     logger.warning(
-                        "[PrivateCompanion] 私聊单图原生链路与兜底 LLM 均未生成有效回复,不启用本地静态兜底: user=%s images=%s has_vision=%s",
+                        "私聊单图原生链路与兜底 LLM 均未生成有效回复,不启用本地静态兜底: user=%s images=%s has_vision=%s",
                         user_id,
                         len(images),
                         bool(vision_text),
@@ -6094,7 +6096,7 @@ class PrivateImageMixin:
                         budget_exempt=True,
                     )
                     return
-                logger.info("[PrivateCompanion] 私聊单图原生链路回复为空,已使用兜底 LLM 回复: user=%s images=%s", user_id, len(images))
+                logger.info("私聊单图原生链路回复为空,已使用兜底 LLM 回复: user=%s images=%s", user_id, len(images))
             self._record_llm_usage(
                 provider_id="framework",
                 task="private_image_only_framework",
@@ -6125,16 +6127,16 @@ class PrivateImageMixin:
                     image_count=len(images),
                 )
             if reply_source == "main_chain":
-                logger.info("[PrivateCompanion] 私聊单图无补充说明,已由原生 LLM 链路回复: user=%s images=%s", user_id, len(images))
+                logger.info("私聊单图无补充说明,已由原生 LLM 链路回复: user=%s images=%s", user_id, len(images))
             else:
                 logger.info(
-                    "[PrivateCompanion] 私聊单图无补充说明,原生链路为空,已由兜底回复发送: user=%s images=%s source=%s",
+                    "私聊单图无补充说明,原生链路为空,已由兜底回复发送: user=%s images=%s source=%s",
                     user_id,
                     len(images),
                     reply_source,
                 )
         except Exception as exc:
-            logger.warning("[PrivateCompanion] 私聊单图延迟回复失败: user=%s error=%s", user_id, _single_line(exc, 180), exc_info=True)
+            logger.warning("私聊单图延迟回复失败: user=%s error=%s", user_id, _single_line(exc, 180), exc_info=True)
 
     async def _finalize_private_image_buffer_after_wait(self, key: str, user_id: str, first_ts: float) -> None:
         wait = self._message_debounce_seconds("image")
@@ -6154,12 +6156,12 @@ class PrivateImageMixin:
             for item in messages
         )
         if has_followup:
-            logger.info("[PrivateCompanion] 私聊单图已由补充消息接管: user=%s", user_id)
+            logger.info("私聊单图已由补充消息接管: user=%s", user_id)
             return
         claimed_ts = _safe_float(buffer.get("vision_context_claimed_ts"), 0.0)
         if claimed_ts > 0:
             logger.info(
-                "[PrivateCompanion] 私聊单图上下文已由补充文字请求认领,跳过延迟派发: user=%s claimed_ago=%.1fs",
+                "私聊单图上下文已由补充文字请求认领,跳过延迟派发: user=%s claimed_ago=%.1fs",
                 user_id,
                 max(0.0, _now_ts() - claimed_ts),
             )
@@ -6196,5 +6198,5 @@ class PrivateImageMixin:
         vision_task = delayed_buffer.get("vision_task")
         if isinstance(vision_task, asyncio.Task) and not vision_task.done():
             vision_task.cancel()
-        logger.info("[PrivateCompanion] 私聊单图等待补充后无文字指示,但原事件不可用: user=%s", user_id)
+        logger.info("私聊单图等待补充后无文字指示,但原事件不可用: user=%s", user_id)
 

--- a/proactive.py
+++ b/proactive.py
@@ -31,7 +31,7 @@ from typing import Any
 from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlunparse
 from xml.etree import ElementTree as ET
 
-from astrbot.api import AstrBotConfig, logger
+from astrbot.api import AstrBotConfig
 from astrbot.api.event import AstrMessageEvent, MessageChain, filter
 try:
     from astrbot.api.message_components import At, Image, Plain, Record, Reply
@@ -129,6 +129,9 @@ from .planning import (
     normalize_story_plan,
     pick_detail_segment,
 )
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 DEFAULT_AI_DAILY_NEWS_SOURCE = "B站 AI早报|bilibili:285286947"
 
@@ -1937,7 +1940,7 @@ class ProactiveMixin(UserRestGateMixin):
                     impulse["last_note"] = safe_note
                     impulse["updated_ts"] = check_now
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 清理次要用户未回应主动念头失败: %s", _single_line(exc, 120))
+                logger.debug("清理次要用户未回应主动念头失败: %s", _single_line(exc, 120))
         pool_cleaner = getattr(self, "_cleanup_proactive_candidate_pool", None)
         pending_checker = getattr(self, "_pending_candidate_status", None)
         candidate_user_getter = getattr(self, "_candidate_user_id", None)
@@ -1958,7 +1961,7 @@ class ProactiveMixin(UserRestGateMixin):
                     candidate["note"] = safe_note
                     candidate["updated_ts"] = check_now
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 清理次要用户未回应主动候选失败: %s", _single_line(exc, 120))
+                logger.debug("清理次要用户未回应主动候选失败: %s", _single_line(exc, 120))
 
     @staticmethod
     def _friend_unanswered_should_remove_action(action: str) -> bool:
@@ -3329,7 +3332,7 @@ class ProactiveMixin(UserRestGateMixin):
                 self._block_friend_unanswered_pending_proactive(user, note=silence_reason, now=now)
                 self._clear_pending_proactive_plan(user)
                 logger.info(
-                    "[PrivateCompanion] 次要用户连续未回应,停止安排普通主动: user=%s ignored=%s reason=%s",
+                    "次要用户连续未回应,停止安排普通主动: user=%s ignored=%s reason=%s",
                     _single_line(user_id, 40) or "unknown",
                     _safe_int(user.get("ignored_streak"), 0, 0),
                     _single_line(silence_reason, 120),
@@ -3695,7 +3698,7 @@ class ProactiveMixin(UserRestGateMixin):
                 try:
                     await snapshot_recorder(snapshot)
                 except Exception as exc:
-                    logger.debug("[PrivateCompanion] C3 agenda snapshot archival failed: %s", _single_line(exc, 160))
+                    logger.debug("C3 agenda snapshot archival failed: %s", _single_line(exc, 160))
             if callable(reconciliation_recorder) and isinstance(history, list):
                 snapshot_id = _single_line(snapshot.get("snapshot_id"), 160)
                 for reconciliation in reversed(history):
@@ -3707,14 +3710,14 @@ class ProactiveMixin(UserRestGateMixin):
                     try:
                         await reconciliation_recorder(reconciliation)
                     except Exception as exc:
-                        logger.debug("[PrivateCompanion] C3 agenda reconciliation archival failed: %s", _single_line(exc, 160))
+                        logger.debug("C3 agenda reconciliation archival failed: %s", _single_line(exc, 160))
                     break
         flusher = getattr(self, "_memory_companion_flush_bot_personal_outbox", None)
         if callable(flusher):
             try:
                 await flusher(limit=24)
             except Exception as exc:
-                logger.debug("[PrivateCompanion] C3 Bot Personal outbox delivery failed: %s", _single_line(exc, 160))
+                logger.debug("C3 Bot Personal outbox delivery failed: %s", _single_line(exc, 160))
         if snapshots and callable(getattr(self, "_schedule_data_save", None)):
             self._schedule_data_save(
                 sections={"window_snapshots", "agenda_reconciliation_history"},
@@ -3762,7 +3765,7 @@ class ProactiveMixin(UserRestGateMixin):
                     except Exception as exc:
                         self._record_maintenance_task_failure(label, exc)
                         logger.warning(
-                            "[PrivateCompanion] %s维护步骤失败,已跳过: persona=%s task=%s error=%s",
+                            "%s维护步骤失败,已跳过: persona=%s task=%s error=%s",
                             "主动链即时" if immediate else "主动循环",
                             persona_id or "single",
                             label,
@@ -3786,7 +3789,7 @@ class ProactiveMixin(UserRestGateMixin):
             except asyncio.CancelledError:
                 raise
             except Exception as e:
-                logger.error(f"[PrivateCompanion] 主动消息循环异常: {e}", exc_info=True)
+                logger.error(f"主动消息循环异常: {e}", exc_info=True)
 
     def _mobile_location_watch_user_ids(self) -> list[str]:
         users = self.data.get("users") if isinstance(getattr(self, "data", None), dict) else {}
@@ -4083,7 +4086,7 @@ class ProactiveMixin(UserRestGateMixin):
                 user_ids={normalized},
             )
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 手机位置事件处理暂时失败: %s", _single_line(exc, 160))
+            logger.debug("手机位置事件处理暂时失败: %s", _single_line(exc, 160))
             return {"handled": False, "reason": "watch_failed"}
         return {"handled": True, "triggered": bool(triggered)}
 
@@ -4094,7 +4097,7 @@ class ProactiveMixin(UserRestGateMixin):
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 移动位置主动监视暂时失败: %s", _single_line(exc, 160))
+                logger.debug("移动位置主动监视暂时失败: %s", _single_line(exc, 160))
             try:
                 await asyncio.wait_for(self._stop_event.wait(), timeout=15.0)
             except asyncio.TimeoutError:
@@ -4104,7 +4107,7 @@ class ProactiveMixin(UserRestGateMixin):
         try:
             await self._run_scheduler_cycle(immediate=True)
         except Exception as e:
-            logger.warning(f"[PrivateCompanion] 主动链即时唤醒失败: {e}", exc_info=True)
+            logger.warning(f"主动链即时唤醒失败: {e}", exc_info=True)
 
     def _next_scheduler_timeout(self) -> float:
         active_getter = getattr(self, "_active_persona_scope", None)

--- a/proactive_chat_runtime_bridge.py
+++ b/proactive_chat_runtime_bridge.py
@@ -8,13 +8,15 @@ import uuid
 from types import MethodType
 from typing import Any, Awaitable, Callable
 
-from astrbot.api import logger
 try:
     from astrbot.core.message.message_event_result import MessageChain
 except ImportError:
     from astrbot.api.event import MessageChain
 from astrbot.core.platform.message_type import MessageType
 from astrbot.core.platform.platform import PlatformStatus
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 try:
     from astrbot.core.platform.astr_message_event import MessageSession
 except ImportError:
@@ -185,7 +187,7 @@ class ProactiveChatRuntimeBridge:
         self._last_event = "生成前、终审、平台发送与结算链路已接管"
         self._last_event_at = self._attached_at
         logger.info(
-            "[PrivateCompanion] Proactive Chat 深度联动已接入: version=%s methods=%s",
+            "Proactive Chat 深度联动已接入: version=%s methods=%s",
             self.version,
             ",".join(self.REQUIRED_METHODS),
         )
@@ -203,7 +205,7 @@ class ProactiveChatRuntimeBridge:
                         setattr(instance, name, original)
                     except Exception as exc:
                         logger.debug(
-                            "[PrivateCompanion] 恢复 Proactive Chat 方法失败: method=%s error=%s",
+                            "恢复 Proactive Chat 方法失败: method=%s error=%s",
                             name,
                             _short(exc),
                         )
@@ -222,7 +224,7 @@ class ProactiveChatRuntimeBridge:
             self._last_event = reason
             self._last_event_at = time.time()
         if was_attached:
-            logger.info("[PrivateCompanion] Proactive Chat 深度联动已卸载: %s", reason or "正常释放")
+            logger.info("Proactive Chat 深度联动已卸载: %s", reason or "正常释放")
 
     def _is_intact(self) -> bool:
         instance = self.instance
@@ -336,7 +338,7 @@ class ProactiveChatRuntimeBridge:
             self._last_event = "生成前已阻断: " + _short(prepared.get("reason"), 120)
             self._last_event_at = time.time()
             logger.info(
-                "[PrivateCompanion] Proactive Chat 生成前已阻断: session=%s reason=%s",
+                "Proactive Chat 生成前已阻断: session=%s reason=%s",
                 _short(session_id, 120),
                 _short(prepared.get("reason"), 160),
             )
@@ -468,7 +470,7 @@ class ProactiveChatRuntimeBridge:
         self._last_event = f"平台发送已确认，逻辑消息 1 条，物理发送 {physical_count}/{total_count} 条成功"
         self._last_event_at = time.time()
         logger.info(
-            "[PrivateCompanion] Proactive Chat 深度联动发送结算: session=%s success=%s/%s recorded=%s",
+            "Proactive Chat 深度联动发送结算: session=%s success=%s/%s recorded=%s",
             _short(session_id, 120),
             physical_count,
             total_count,
@@ -545,7 +547,7 @@ class ProactiveChatRuntimeBridge:
             }
         except Exception as exc:
             logger.error(
-                "[PrivateCompanion] Proactive Chat 平台发送失败: session=%s error=%s",
+                "Proactive Chat 平台发送失败: session=%s error=%s",
                 _short(session_id, 120),
                 _short(exc, 200),
             )
@@ -565,7 +567,7 @@ class ProactiveChatRuntimeBridge:
         if callable(scheduler):
             await scheduler(session_id)
         logger.info(
-            "[PrivateCompanion] Proactive Chat 本轮无已确认发送，已跳过成功历史与未回复计数: session=%s",
+            "Proactive Chat 本轮无已确认发送，已跳过成功历史与未回复计数: session=%s",
             _short(session_id, 120),
         )
         return None
@@ -665,4 +667,4 @@ class ProactiveChatRuntimeBridge:
         self._last_error = f"{label}: {_short(exc, 180)}"
         self._last_event = label
         self._last_event_at = time.time()
-        logger.warning("[PrivateCompanion] %s: %s", label, _short(exc, 180))
+        logger.warning("%s: %s", label, _short(exc, 180))

--- a/proactive_engine.py
+++ b/proactive_engine.py
@@ -31,7 +31,7 @@ from typing import Any
 from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlunparse
 from xml.etree import ElementTree as ET
 
-from astrbot.api import AstrBotConfig, logger
+from astrbot.api import AstrBotConfig
 from astrbot.api.event import AstrMessageEvent, MessageChain, filter
 try:
     from astrbot.api.message_components import At, Image, Plain, Record, Reply
@@ -119,6 +119,9 @@ from .planning import (
 )
 from .proactive_routes import PROACTIVE_ROUTE_REGISTRY
 from .persona_config import runtime_persona_setting
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 def _persona_provider_id(owner: Any, canonical_key: str, legacy_attr: str, quick_role: str) -> str:
@@ -475,7 +478,7 @@ class ProactiveEngineMixin:
         if removed > 0:
             self.data["proactive_candidate_pool"] = kept
             logger.info(
-                "[PrivateCompanion] 主动候选自动收缩: user=%s removed=%s cap=%s note=%s",
+                "主动候选自动收缩: user=%s removed=%s cap=%s note=%s",
                 target_user_id,
                 removed,
                 pending_cap or "default",
@@ -710,7 +713,7 @@ class ProactiveEngineMixin:
                 changed = True
         if changed:
             logger.info(
-                "[PrivateCompanion] 用户已询问当前状态,已清理状态分享主动念头: user=%s text=%s",
+                "用户已询问当前状态,已清理状态分享主动念头: user=%s text=%s",
                 target_user_id or "unknown",
                 _single_line(text, 80),
             )
@@ -2656,13 +2659,13 @@ class ProactiveEngineMixin:
         parsed = self._parse_json_object(raw)
         result = self._normalize_proactive_model_judgement(parsed)
         if not isinstance(result, dict):
-            logger.info("[PrivateCompanion] 模型人格判定无有效 JSON,降级本地判定")
+            logger.info("模型人格判定无有效 JSON,降级本地判定")
             return {"decision": "send", "score": 0, "reason": "模型判定失败,降级本地"}
         result["signature"] = signature
         result = self._apply_proactive_model_judgement_policy(user, result)
         result["elapsed_ms"] = int((time.perf_counter() - started) * 1000)
         logger.info(
-            "[PrivateCompanion] 主动模型人格判定: decision=%s score=%s reason=%s elapsed=%sms",
+            "主动模型人格判定: decision=%s score=%s reason=%s elapsed=%sms",
             result.get("decision"),
             result.get("score"),
             _single_line(result.get("reason"), 100),
@@ -3307,7 +3310,7 @@ class ProactiveEngineMixin:
             selected["last_note"] = "同一来源短时间重复物化已熔断"
             selected["updated_ts"] = check_now
             logger.warning(
-                "[PrivateCompanion] 主动念头重复物化熔断: user=%s origin=%s count=%s",
+                "主动念头重复物化熔断: user=%s origin=%s count=%s",
                 _single_line(user_id, 40),
                 _single_line(selected.get("origin_event_id"), 80) or _single_line(selected.get("id"), 20),
                 materialized_count,
@@ -3749,7 +3752,7 @@ class ProactiveEngineMixin:
                     reason=invalid_window_reason,
                 )
             logger.info(
-                "[PrivateCompanion] 主动来源在入队前终止: user=%s source=%s reason=%s note=%s",
+                "主动来源在入队前终止: user=%s source=%s reason=%s note=%s",
                 _single_line(user_id, 40),
                 source,
                 _single_line(candidate.get("reason"), 40),
@@ -4251,7 +4254,7 @@ class ProactiveEngineMixin:
             return False, "缺少私聊会话"
         if umo_filled:
             logger.info(
-                "[PrivateCompanion] 已为主动私聊对象补全 UMO: user=%s umo=%s",
+                "已为主动私聊对象补全 UMO: user=%s umo=%s",
                 _single_line(user_id, 40),
                 _single_line(user.get("umo"), 120),
             )
@@ -4412,7 +4415,7 @@ class ProactiveEngineMixin:
                 if callable(schedule_save):
                     schedule_save(sections={"users"})
                 logger.info(
-                    "[PrivateCompanion] %s已顺延主动消息: user=%s until=%s reason=%s source=%s detail=%s",
+                    "%s已顺延主动消息: user=%s until=%s reason=%s source=%s detail=%s",
                     "实时共处期间" if external_realtime else "繁忙回复闸门",
                     _single_line(user.get("user_id") or user.get("umo") or user.get("nickname"), 80),
                     int(busy_until),
@@ -4482,7 +4485,7 @@ class ProactiveEngineMixin:
                 user["planned_proactive_best_until_at"] = after_next_at + 45 * 60
                 user["planned_proactive_expire_at"] = after_next_at + 90 * 60
             logger.info(
-                "[PrivateCompanion] 统一互动/联系边界闸门拦截主动: mode=%s gate_until=%s reason=%s",
+                "统一互动/联系边界闸门拦截主动: mode=%s gate_until=%s reason=%s",
                 relationship_mode or emotion_mode,
                 int(gate_until),
                 _single_line(interaction.get("reason"), 80),
@@ -4568,7 +4571,7 @@ class ProactiveEngineMixin:
             and timeliness == "routine"
         ):
             logger.debug(
-                "[PrivateCompanion] Bot 表达温度偏低，交由正文提示收敛为短句而不延后: user=%s detail=%s",
+                "Bot 表达温度偏低，交由正文提示收敛为短句而不延后: user=%s detail=%s",
                 _single_line(user.get("user_id") or user.get("umo"), 80),
                 _single_line(inner_readiness.get("detail"), 120),
             )
@@ -4762,7 +4765,7 @@ class ProactiveEngineMixin:
             return False, "候选语义不够自然,已重新挑选"
         if semantic_score < 0.32 and semantic_pressure >= 0.58:
             logger.debug(
-                "[PrivateCompanion] 候选由头偏弱且压力偏高，交由正文提示改成低压短句: user=%s note=%s",
+                "候选由头偏弱且压力偏高，交由正文提示改成低压短句: user=%s note=%s",
                 _single_line(user.get("user_id") or user.get("umo"), 80),
                 _single_line(planned_semantics.get("note"), 120),
             )
@@ -4788,7 +4791,7 @@ class ProactiveEngineMixin:
             return False, "人格/世界观贴合度不足,已重新挑选"
         if persona_fit < persona_threshold:
             logger.debug(
-                "[PrivateCompanion] 人格贴合度偏低，交由人格判定/正文生成修正而不延后: user=%s fit=%.2f note=%s",
+                "人格贴合度偏低，交由人格判定/正文生成修正而不延后: user=%s fit=%.2f note=%s",
                 _single_line(user.get("user_id") or user.get("umo"), 80),
                 persona_fit,
                 _single_line(persona_alignment.get("note"), 120),
@@ -4803,7 +4806,7 @@ class ProactiveEngineMixin:
             and timeliness == "routine"
         ):
             logger.debug(
-                "[PrivateCompanion] 连续未回应时保留低压候选，由提示词缩短且禁止追问: user=%s ignored=%s value=%.2f",
+                "连续未回应时保留低压候选，由提示词缩短且禁止追问: user=%s ignored=%s value=%.2f",
                 _single_line(user.get("user_id") or user.get("umo"), 80),
                 ignored_streak,
                 impulse_value,
@@ -4981,7 +4984,7 @@ class ProactiveEngineMixin:
                 try:
                     outcome_recorder(user, status=status, note=note)
                 except Exception as exc:
-                    logger.debug("[PrivateCompanion] 主动结果余韵记录失败: %s", _single_line(exc, 120))
+                    logger.debug("主动结果余韵记录失败: %s", _single_line(exc, 120))
             candidate_id = str(user.get("planned_candidate_id") or "")
             user_id = str(user.get("user_id") or user.get("id") or "")
             if candidate_id:
@@ -5803,7 +5806,7 @@ class ProactiveEngineMixin:
         user["proactive_sending"] = False
         user["proactive_sending_started_at"] = 0
         logger.warning(
-            "[PrivateCompanion] 检测到残留的主动发送标记,已自动清理: user=%s started_at=%s",
+            "检测到残留的主动发送标记,已自动清理: user=%s started_at=%s",
             user.get("user_id") or user.get("id") or "unknown",
             self._environment_fromtimestamp(started_at).strftime("%m-%d %H:%M:%S") if started_at > 0 else "unknown",
         )
@@ -6046,7 +6049,7 @@ class ProactiveEngineMixin:
         executor = spec.get("executor")
         availability = spec.get("availability")
         if not name or not callable(executor):
-            logger.warning("[PrivateCompanion] 外部主动能力注册失败: name/executor 无效")
+            logger.warning("外部主动能力注册失败: name/executor 无效")
             return False
         default_config = spec.get("default_config") if isinstance(spec.get("default_config"), dict) else {}
         config_schema = spec.get("config_schema") if isinstance(spec.get("config_schema"), dict) else {}
@@ -6093,8 +6096,8 @@ class ProactiveEngineMixin:
             store[name] = item
             self._save_data_sync(sections={"external_proactive_abilities"})
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 外部主动能力状态保存失败: %s", exc)
-        logger.info("[PrivateCompanion] 已注册外部主动能力: %s", name)
+            logger.debug("外部主动能力状态保存失败: %s", exc)
+        logger.info("已注册外部主动能力: %s", name)
         return True
 
     def unregister_external_proactive_ability(self, name: str) -> bool:
@@ -6198,7 +6201,7 @@ class ProactiveEngineMixin:
                         continue
                 except Exception as exc:
                     logger.debug(
-                        "[PrivateCompanion] 外部主动能力可用性检查失败: %s: %s",
+                        "外部主动能力可用性检查失败: %s: %s",
                         name,
                         _single_line(exc, 120),
                     )
@@ -7805,7 +7808,7 @@ class ProactiveEngineMixin:
             lunar = Converter.Solar2Lunar(Solar(current.year, current.month, current.day))
             return int(lunar.month) == month and int(lunar.day) == day and not bool(getattr(lunar, "isleap", False))
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 农历生日匹配失败: %s", _single_line(exc, 120))
+            logger.debug("农历生日匹配失败: %s", _single_line(exc, 120))
             return False
 
     def _birthday_stage_for_date(self, user: dict[str, Any], current: datetime) -> str:
@@ -9408,7 +9411,7 @@ class ProactiveEngineMixin:
         try:
             return bool(self._photo_text_available(user))
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 主动生图规划可用性检查失败: %s", _single_line(exc, 120))
+            logger.debug("主动生图规划可用性检查失败: %s", _single_line(exc, 120))
             return False
 
     def _poke_available(self) -> bool:
@@ -10180,7 +10183,7 @@ class ProactiveEngineMixin:
                 sleep_block = self._proactive_sleep_phase_block_reason(reason)
                 if sleep_block:
                     logger.debug(
-                        "[PrivateCompanion] 主动消息被 Bot 睡眠相位拦下: reason=%s phase=%s",
+                        "主动消息被 Bot 睡眠相位拦下: reason=%s phase=%s",
                         reason,
                         sleep_block,
                     )
@@ -10407,7 +10410,7 @@ class ProactiveEngineMixin:
         if not bool(action_payload.get("success", True)):
             if "photo_text" in {planned_action, effective_action}:
                 logger.info(
-                    "[PrivateCompanion] 主动图片动作未产出,降级为纯文字分享: user=%s reason=%s topic=%s",
+                    "主动图片动作未产出,降级为纯文字分享: user=%s reason=%s topic=%s",
                     _single_line(user.get("user_id"), 40),
                     reason,
                     _single_line(user.get("planned_proactive_topic"), 80),
@@ -10456,7 +10459,7 @@ class ProactiveEngineMixin:
                 else "unknown"
             )
             logger.info(
-                "[PrivateCompanion] 主动消息采用 pc_generate_photo 成图并进入统一发送链: user=%s kind=%s",
+                "主动消息采用 pc_generate_photo 成图并进入统一发送链: user=%s kind=%s",
                 _single_line(user.get("user_id"), 40),
                 deferred_intent_kind or "unknown",
             )
@@ -10501,7 +10504,7 @@ class ProactiveEngineMixin:
             motive=planned_motive,
         )
         if pre_poke_context and not pre_poke_context.startswith("poke：已"):
-            logger.info("[PrivateCompanion] 消息前置戳一戳失败,跳过本次前置戳: %s", _single_line(pre_poke_context, 120))
+            logger.info("消息前置戳一戳失败,跳过本次前置戳: %s", _single_line(pre_poke_context, 120))
         if pre_poke_count > 0:
             action_summary = f"先戳了 {pre_poke_count} 下 + {action_summary}"
             effective_action = f"poke+{effective_action}" if effective_action != "poke" else "poke"

--- a/proactive_message.py
+++ b/proactive_message.py
@@ -38,7 +38,7 @@ from xml.etree import ElementTree as ET
 
 _PHOTO_GENERATION_TRACE_FILE_LOCK = threading.Lock()
 
-from astrbot.api import AstrBotConfig, logger
+from astrbot.api import AstrBotConfig
 from astrbot.api.event import AstrMessageEvent, MessageChain, filter
 try:
     from astrbot.api.message_components import At, Image, Plain, Record, Reply
@@ -232,6 +232,9 @@ _EXTERNAL_IMAGE_DOWNLOAD_TIMEOUT_OVERRIDE: ContextVar[float | None] = ContextVar
 )
 from .proactive_routes import PROACTIVE_ROUTE_REGISTRY
 from .persona_config import runtime_persona_setting
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 def _persona_provider_id(owner: Any, canonical_key: str, legacy_attr: str, quick_role: str) -> str:
@@ -943,7 +946,7 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
                 )
             except Exception as exc:
                 logger.warning(
-                    "[PrivateCompanion] Proactive Chat 联动终审失败，已回退本地检查: %s",
+                    "Proactive Chat 联动终审失败，已回退本地检查: %s",
                     _single_line(exc, 160),
                 )
 
@@ -1053,7 +1056,7 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
                     topic_recorder(current, text=visible or text, topic="Proactive Chat", motive="即时主动触发")
                 self._save_data_sync(sections={"users"})
         logger.info(
-            "[PrivateCompanion] 已同步 Proactive Chat 主动发送: user=%s session=%s text=%s",
+            "已同步 Proactive Chat 主动发送: user=%s session=%s text=%s",
             user_id,
             _single_line(session_id, 120),
             _single_line(visible, 120),
@@ -2506,7 +2509,7 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
                 if text:
                     return text
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 主动链解析会话人格失败: session=%s error=%s", _single_line(session, 100), _single_line(exc, 120))
+                logger.debug("主动链解析会话人格失败: session=%s error=%s", _single_line(session, 100), _single_line(exc, 120))
         getter = getattr(self, "_get_default_persona_prompt", None)
         if callable(getter):
             try:
@@ -3424,7 +3427,7 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
             try:
                 semantics = semantic_getter(user)
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 主动生成语义提示读取失败: %s", _single_line(exc, 120))
+                logger.debug("主动生成语义提示读取失败: %s", _single_line(exc, 120))
                 semantics = {}
         readiness: dict[str, Any] = {}
         readiness_getter = getattr(self, "_proactive_inner_readiness", None)
@@ -3432,7 +3435,7 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
             try:
                 readiness = readiness_getter(user)
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 主动生成内在状态提示读取失败: %s", _single_line(exc, 120))
+                logger.debug("主动生成内在状态提示读取失败: %s", _single_line(exc, 120))
                 readiness = {}
 
         kind = _single_line(semantics.get("kind"), 40)
@@ -3744,7 +3747,7 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
             if session_text == target_session and isinstance(messages, list):
                 captured.append(_CapturedSendMessageCall(session_text, messages))
                 logger.info(
-                    "[PrivateCompanion] 已拦截框架内 send_message_to_user 工具调用: session=%s components=%s",
+                    "已拦截框架内 send_message_to_user 工具调用: session=%s components=%s",
                     session_text,
                     len(messages),
                 )
@@ -3761,7 +3764,7 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
                         pass
                 except (_CapturedFrameworkSendMessage, _ToolExecutionInterrupted):
                     logger.info(
-                        "[PrivateCompanion] 主动主链工具发送已捕获,提前结束工具循环: session=%s captured=%s",
+                        "主动主链工具发送已捕获,提前结束工具循环: session=%s captured=%s",
                         target_session,
                         len(captured),
                     )
@@ -3806,7 +3809,7 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
             remove_tool(name)
         if removed:
             logger.info(
-                "[PrivateCompanion] 主动主链已隔离不兼容全局工具: %s",
+                "主动主链已隔离不兼容全局工具: %s",
                 ",".join(removed),
             )
         return removed
@@ -3872,7 +3875,7 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
                         completion_text.encode("utf-8", errors="replace")
                     ).hexdigest()[:12]
                     logger.warning(
-                        "[PrivateCompanion] 主动主链识别到 Provider 错误响应,已交给 AstrBot 原生回退链: label=%s provider=%s kind=%s response_ref=%s",
+                        "主动主链识别到 Provider 错误响应,已交给 AstrBot 原生回退链: label=%s provider=%s kind=%s response_ref=%s",
                         _single_line(label, 80),
                         provider_id or type(provider).__name__,
                         "native_error" if is_native_provider_error else "semantic_error",
@@ -3909,7 +3912,7 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
             setattr(runner, installed_marker, True)
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanion] 主动主链无法安装 Provider 语义错误回退适配器: label=%s error_type=%s",
+                "主动主链无法安装 Provider 语义错误回退适配器: label=%s error_type=%s",
                 _single_line(label, 80),
                 type(exc).__name__,
             )
@@ -4002,7 +4005,7 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
                 if locked and attempt < 4:
                     await asyncio.sleep(0.2 * (attempt + 1))
                     continue
-                logger.debug("[PrivateCompanion] 会话数据库操作失败: %s error=%s", label, exc)
+                logger.debug("会话数据库操作失败: %s error=%s", label, exc)
                 raise
 
     def _is_sqlite_locked_error(self, exc: Exception) -> bool:
@@ -4039,7 +4042,7 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
                 conv_id = await conv_mgr.new_conversation(umo)
         if conv_id:
             logger.info(
-                "[PrivateCompanion] 已为主动消息存档创建 AstrBot 会话: umo=%s cid=%s",
+                "已为主动消息存档创建 AstrBot 会话: umo=%s cid=%s",
                 _single_line(umo, 140),
                 _single_line(conv_id, 80),
             )
@@ -4111,7 +4114,7 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
             return scoped
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanion] 无法为主动主链应用插件指定人格,继续使用会话人格: persona=%s error=%s",
+                "无法为主动主链应用插件指定人格,继续使用会话人格: persona=%s error=%s",
                 _single_line(specific_id, 80),
                 _single_line(exc, 120),
             )
@@ -4143,7 +4146,7 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
             if getattr(self, "_proactive_framework_context_warning_key", "") != warning_key:
                 self._proactive_framework_context_warning_key = warning_key
                 logger.warning(
-                    "[PrivateCompanion] 主动主链未取得 AstrBot 原生 Context,已直接转入人格化兜底: input_type=%s；请重载插件或重启 AstrBot",
+                    "主动主链未取得 AstrBot 原生 Context,已直接转入人格化兜底: input_type=%s；请重载插件或重启 AstrBot",
                     context_type,
                 )
             return ""
@@ -4224,7 +4227,7 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
                     if self._is_sqlite_locked_error(exc) and attempt < 2:
                         wait_seconds = 0.35 * (attempt + 1)
                         logger.info(
-                            "[PrivateCompanion] 主动主链遇到会话库锁,稍后重试: label=%s session=%s retry=%s",
+                            "主动主链遇到会话库锁,稍后重试: label=%s session=%s retry=%s",
                             label,
                             _single_line(umo, 120),
                             attempt + 1,
@@ -4265,7 +4268,7 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
                 self._framework_captured_send_cache.pop(cache_key, None)
                 getattr(self, "_framework_captured_send_cache_at", {}).pop(cache_key, None)
                 logger.info(
-                    "[PrivateCompanion] 主动主链已接收 pc_generate_photo 成图，等待统一发送: label=%s session=%s",
+                    "主动主链已接收 pc_generate_photo 成图，等待统一发送: label=%s session=%s",
                     label,
                     _single_line(cache_key, 120),
                 )
@@ -4278,7 +4281,7 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
         if captured_text:
             if text and self._framework_agent_meta_summary_leak(text):
                 logger.warning(
-                    "[PrivateCompanion] 主动主链 final 疑似工具循环摘要或 Provider 失败,改用已捕获发送文本: label=%s final=%s captured=%s",
+                    "主动主链 final 疑似工具循环摘要或 Provider 失败,改用已捕获发送文本: label=%s final=%s captured=%s",
                     label,
                     _single_line(text, 160),
                     _single_line(captured_text, 160),
@@ -4288,7 +4291,7 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
             text and self._framework_agent_meta_summary_leak(text)
         ):
             logger.warning(
-                "[PrivateCompanion] 主动主链 final 疑似工具循环摘要或 Provider 失败且无可用捕获文本,已丢弃: label=%s text=%s",
+                "主动主链 final 疑似工具循环摘要或 Provider 失败且无可用捕获文本,已丢弃: label=%s text=%s",
                 label,
                 _single_line(text, 180),
             )
@@ -4365,15 +4368,15 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
             cleaned_text, payloads = self._extract_timer_directives(raw_text)
             if payloads:
                 logger.info(
-                    "[PrivateCompanion] 主动消息中清理到对话临时预约标签,不再由主动链路登记: user=%s",
+                    "主动消息中清理到对话临时预约标签,不再由主动链路登记: user=%s",
                     _single_line(user.get("user_id"), 40),
                 )
             return cleaned_text
         except Exception as exc:
             if self._is_sqlite_locked_error(exc):
-                logger.warning("[PrivateCompanion] 主动消息主链被会话数据库锁住,本轮跳过并等待下次调度: %s", _single_line(umo, 120))
+                logger.warning("主动消息主链被会话数据库锁住,本轮跳过并等待下次调度: %s", _single_line(umo, 120))
             else:
-                logger.warning("[PrivateCompanion] 主动消息主链生成失败: %s", exc)
+                logger.warning("主动消息主链生成失败: %s", exc)
             return ""
 
     def _proactive_history_limit(self, stage: str) -> int:
@@ -4477,7 +4480,7 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
                     if line:
                         lines.append(line)
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 主动润色读取私聊历史失败: %s", _single_line(exc, 120))
+                logger.debug("主动润色读取私聊历史失败: %s", _single_line(exc, 120))
         if not lines:
             last_user = _single_line(user.get("last_user_message"), 180)
             last_bot = _single_line(user.get("last_companion_message"), 180)
@@ -4621,11 +4624,11 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
                 task=task,
             )
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 人格参考意图改写失败: %s", _single_line(exc, 120))
+            logger.debug("人格参考意图改写失败: %s", _single_line(exc, 120))
             raw = ""
         if self._looks_like_internal_provider_error_text(raw):
             logger.warning(
-                "[PrivateCompanion] 人格参考意图改写收到 Provider 错误正文，已丢弃: task=%s",
+                "人格参考意图改写收到 Provider 错误正文，已丢弃: task=%s",
                 _single_line(task, 80) or "persona_reference_rewrite",
             )
             raw = ""
@@ -5774,7 +5777,7 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
                     )
                     if accepted_reference:
                         logger.info(
-                            "[PrivateCompanion] 主动外界分享人格润色未通过统一验收，已使用确定性来源文本: reason=%s",
+                            "主动外界分享人格润色未通过统一验收，已使用确定性来源文本: reason=%s",
                             reason,
                         )
                 rewritten_reference = accepted_reference or ""
@@ -5960,7 +5963,7 @@ Output:
             if now - last_log_at >= 600:
                 self._proactive_review_fallback_log_at = now
                 logger.info(
-                    "[PrivateCompanion] 主动最终内容复核模型暂不可用，已安全回退本地复核（同类日志 10 分钟内不重复）: %s",
+                    "主动最终内容复核模型暂不可用，已安全回退本地复核（同类日志 10 分钟内不重复）: %s",
                     self._format_send_exception(exc),
                 )
             return local_model_fallback(self._format_send_exception(exc))
@@ -6102,7 +6105,7 @@ Output:
             reviewed_text = ""
             note = "主动候选疑似工具循环/内部发送摘要泄漏"
         logger.info(
-            "[PrivateCompanion] Proactive final content gate: decision=%s raw=%s strength=%s elapsed=%dms reason=%s",
+            "Proactive final content gate: decision=%s raw=%s strength=%s elapsed=%dms reason=%s",
             decision,
             original_decision,
             strength,
@@ -6303,9 +6306,9 @@ Output:
             return str(raw_text or "").strip()
         except Exception as exc:
             if self._is_sqlite_locked_error(exc):
-                logger.warning("[PrivateCompanion] 主动语音主链被会话数据库锁住,本轮跳过并等待下次调度: %s", _single_line(umo, 120))
+                logger.warning("主动语音主链被会话数据库锁住,本轮跳过并等待下次调度: %s", _single_line(umo, 120))
             else:
-                logger.warning("[PrivateCompanion] 主动语音主链内容生成失败: %s", exc)
+                logger.warning("主动语音主链内容生成失败: %s", exc)
             return ""
 
     async def _generate_proactive_message_with_llm(
@@ -6334,7 +6337,7 @@ Output:
         deferred_photo_cache = getattr(self, "_framework_deferred_photo_cache", None)
         if isinstance(deferred_photo_cache, dict) and umo in deferred_photo_cache:
             logger.info(
-                "[PrivateCompanion] 主动正文已由 pc_generate_photo caption/纯图承载，跳过文本兜底: user=%s",
+                "主动正文已由 pc_generate_photo caption/纯图承载，跳过文本兜底: user=%s",
                 _single_line(user.get("user_id"), 40),
             )
             return str(raw_text or "")
@@ -6359,7 +6362,7 @@ Output:
                         )
                     except Exception as exc:
                         logger.debug(
-                            "[PrivateCompanion] 高频主动表情兜底构建失败: error_type=%s",
+                            "高频主动表情兜底构建失败: error_type=%s",
                             type(exc).__name__,
                         )
             finalized, failure_stage = await self._finalize_proactive_generated_text(
@@ -6400,7 +6403,7 @@ Output:
             finalized, failure_stage = await finalize_candidate(fallback_text)
             if finalized:
                 logger.info(
-                    "[PrivateCompanion] 主动框架主链为空后已由直接人格化兜底恢复: user=%s reason=%s",
+                    "主动框架主链为空后已由直接人格化兜底恢复: user=%s reason=%s",
                     _single_line(user.get("user_id"), 40),
                     reason,
                 )
@@ -6412,7 +6415,7 @@ Output:
         failure_detail = "；".join(failure_stages)[:240]
         user["_proactive_render_failure_stage"] = failure_detail
         logger.warning(
-            "[PrivateCompanion] 主动正文两级生成均未产出: user=%s reason=%s stage=%s",
+            "主动正文两级生成均未产出: user=%s reason=%s stage=%s",
             _single_line(user.get("user_id"), 40),
             reason,
             failure_detail,
@@ -6601,7 +6604,7 @@ Output:
             ) if bounded_segments else ("", "自主分段正文处理后为空")
         if self._looks_like_internal_provider_error_text(raw_text):
             logger.warning(
-                "[PrivateCompanion] 主动正文生成收到 Provider 错误正文，跳过清洗并进入回退: user=%s reason=%s",
+                "主动正文生成收到 Provider 错误正文，跳过清洗并进入回退: user=%s reason=%s",
                 _single_line(user.get("user_id"), 40),
                 _single_line(reason, 60) or "check_in",
             )
@@ -6618,7 +6621,7 @@ Output:
         cleaned, repaired_address = self._repair_proactive_recipient_address(cleaned, user, name)
         if repaired_address:
             logger.warning(
-                "[PrivateCompanion] 主动消息已纠正串用户句首称呼: user=%s wrong=%s replacement=%s",
+                "主动消息已纠正串用户句首称呼: user=%s wrong=%s replacement=%s",
                 _single_line(user.get("user_id"), 40),
                 repaired_address,
                 _single_line(name or user.get("nickname"), 40) or "你",
@@ -6644,7 +6647,7 @@ Output:
         relay_claim_note = self._unexecuted_relay_claim_reason(cleaned, action_context=action_context)
         if relay_claim_note:
             logger.info(
-                "[PrivateCompanion] 主动消息含未执行转述承诺,已丢弃: reason=%s text=%s",
+                "主动消息含未执行转述承诺,已丢弃: reason=%s text=%s",
                 relay_claim_note,
                 _single_line(cleaned, 120),
             )
@@ -6659,7 +6662,7 @@ Output:
             # 连续未回应时的泛泛措辞是表达质量问题，不是安全问题。
             # 交给主动生成提示词收短、降压，避免在终审关闭时被本地规则直接吞掉。
             logger.debug(
-                "[PrivateCompanion] 泛化主动由提示词收敛，不再直接拦截: user=%s text=%s",
+                "泛化主动由提示词收敛，不再直接拦截: user=%s text=%s",
                 _single_line(user.get("user_id") or user.get("umo"), 80),
                 _single_line(cleaned, 140),
             )
@@ -6678,7 +6681,7 @@ Output:
         reviewed, repaired_review_address = self._repair_proactive_recipient_address(reviewed, user, name)
         if repaired_review_address:
             logger.warning(
-                "[PrivateCompanion] 主动复核结果已纠正串用户称呼: user=%s wrong=%s",
+                "主动复核结果已纠正串用户称呼: user=%s wrong=%s",
                 _single_line(user.get("user_id"), 40),
                 repaired_review_address,
             )
@@ -6837,7 +6840,7 @@ Output:
                 cleaned = "\n".join(safe_units).strip()
                 if not cleaned:
                     logger.info(
-                        "[PrivateCompanion] 主动消息仅剩不可用动作/内部回执,本地安全检查已丢弃: flags=%s",
+                        "主动消息仅剩不可用动作/内部回执,本地安全检查已丢弃: flags=%s",
                         ",".join(flags),
                     )
                     return ""
@@ -6856,14 +6859,14 @@ Output:
             ) if repaired else flags
             if repaired and not remaining_flags:
                 logger.info(
-                    "[PrivateCompanion] 主动消息疑似回复空气,已用本地轻量规则修正: flags=%s before=%s after=%s",
+                    "主动消息疑似回复空气,已用本地轻量规则修正: flags=%s before=%s after=%s",
                     ",".join(flags),
                     _single_line(cleaned, 100),
                     _single_line(repaired, 100),
                 )
                 return repaired
             logger.warning(
-                "[PrivateCompanion] 主动消息疑似回复空气但终审未启用,本地无法可靠改写，保留原文并交由生成提示词约束: flags=%s text=%s",
+                "主动消息疑似回复空气但终审未启用,本地无法可靠改写，保留原文并交由生成提示词约束: flags=%s text=%s",
                 ",".join(flags),
                 _single_line(cleaned, 120),
             )
@@ -6984,18 +6987,18 @@ Output:
         )
         if self._looks_like_internal_provider_error_text(candidate):
             logger.warning(
-                "[PrivateCompanion] 回复/主动复核返回 Provider 错误正文，已丢弃: task=response_review"
+                "回复/主动复核返回 Provider 错误正文，已丢弃: task=response_review"
             )
             return ""
         meta_leak_checker = getattr(self, "_response_review_meta_leak_reason", None)
         if callable(meta_leak_checker) and meta_leak_checker(candidate):
             logger.error(
-                "[PrivateCompanion] 回复/主动复核返回内部判断，已丢弃: output=%s",
+                "回复/主动复核返回内部判断，已丢弃: output=%s",
                 _single_line(candidate, 180),
             )
             return ""
         logger.info(
-            "[PrivateCompanion] 回复/主动复核完成: mode=%s flags=%s elapsed=%dms before=%s after=%s",
+            "回复/主动复核完成: mode=%s flags=%s elapsed=%dms before=%s after=%s",
             mode,
             ",".join(flags),
             int((time.perf_counter() - started) * 1000),
@@ -7016,7 +7019,7 @@ Output:
         )
         if remaining_flags:
             logger.info(
-                "[PrivateCompanion] 回复/主动复核后仍疑似回复空气,已丢弃: flags=%s text=%s",
+                "回复/主动复核后仍疑似回复空气,已丢弃: flags=%s text=%s",
                 ",".join(remaining_flags),
                 _single_line(candidate, 120),
             )
@@ -7063,14 +7066,14 @@ Output:
         repaired = re.sub(r"\s+", " ", repaired).strip(" ，,。！？!?、")
         if repaired:
             logger.info(
-                "[PrivateCompanion] 主动消息修正主客体错位问句: reason=%s before=%s after=%s",
+                "主动消息修正主客体错位问句: reason=%s before=%s after=%s",
                 reason,
                 _single_line(cleaned, 120),
                 _single_line(repaired, 120),
             )
             return repaired
         logger.info(
-            "[PrivateCompanion] 主动消息主客体错位且无剩余自然内容,已丢弃本轮生成: reason=%s text=%s",
+            "主动消息主客体错位且无剩余自然内容,已丢弃本轮生成: reason=%s text=%s",
             reason,
             _single_line(cleaned, 120),
         )
@@ -7090,7 +7093,7 @@ Output:
         )
         if reason in {"morning_greeting", "noon_greeting", "evening_greeting"} and cleaned.startswith(reply_openers) and any(token in cleaned for token in old_invite_markers):
             logger.info(
-                "[PrivateCompanion] 主动消息疑似把旧邀约当成当前回复,已丢弃: reason=%s text=%s",
+                "主动消息疑似把旧邀约当成当前回复,已丢弃: reason=%s text=%s",
                 reason,
                 cleaned,
             )
@@ -7106,7 +7109,7 @@ Output:
             )
             if any(re.search(pattern, cleaned) for pattern in stale_reply_patterns):
                 logger.info(
-                    "[PrivateCompanion] 主动消息疑似接续旧对话而非主动开口,已丢弃: reason=%s text=%s",
+                    "主动消息疑似接续旧对话而非主动开口,已丢弃: reason=%s text=%s",
                     reason,
                     cleaned,
                 )
@@ -7151,7 +7154,7 @@ Output:
             if len(collapsed_lines) < len(lines):
                 result = "\n".join(collapsed_lines).strip()
                 logger.info(
-                    "[PrivateCompanion] 主动消息已合并同轮近似候选: before=%s after=%s",
+                    "主动消息已合并同轮近似候选: before=%s after=%s",
                     _single_line(cleaned, 180),
                     _single_line(result, 160),
                 )
@@ -7565,7 +7568,7 @@ Output:
         fallback_action = self._fallback_action_for_unavailable(action, user)
         if fallback_action != action:
             logger.info(
-                "[PrivateCompanion] 主动行为依赖不可用,已回退: requested=%s fallback=%s user=%s",
+                "主动行为依赖不可用,已回退: requested=%s fallback=%s user=%s",
                 action,
                 fallback_action,
                 str(user.get("user_id") or ""),
@@ -7715,7 +7718,7 @@ Output:
             if hasattr(result, "__await__"):
                 result = await result
         except Exception as exc:
-            logger.warning("[PrivateCompanion] 外部主动能力执行失败: %s: %s", name, exc, exc_info=True)
+            logger.warning("外部主动能力执行失败: %s: %s", name, exc, exc_info=True)
             self._note_external_ability_execution(
                 name,
                 user=user,
@@ -7999,7 +8002,7 @@ Output:
             try:
                 event = plugin._create_virtual_event(target)
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 创建晚安识屏虚拟事件失败: %s", _single_line(exc, 160))
+                logger.debug("创建晚安识屏虚拟事件失败: %s", _single_line(exc, 160))
         prompt = (
             "这是一次用户已授权的晚安后单次状态确认，只用于决定是否需要轻声提醒休息。"
             "请只判断当前画面是否能明确证明用户仍在主动使用电脑，不要转述或摘录任何屏幕内容。"
@@ -8017,7 +8020,7 @@ Output:
             )
         except Exception as exc:
             context = f"goodnight_screen_check：失败,{_single_line(exc, 240)}"
-            logger.warning("[PrivateCompanion] 晚安识屏判断失败: %s", _single_line(exc, 180))
+            logger.warning("晚安识屏判断失败: %s", _single_line(exc, 180))
             if self._is_screen_peek_provider_failure(context):
                 self._note_screen_peek_failure(user, context)
             return "uncertain"
@@ -8232,7 +8235,7 @@ Output:
             try:
                 event = plugin._create_virtual_event(target)
             except Exception as e:
-                logger.debug(f"[PrivateCompanion] 创建屏幕虚拟事件失败: {e}")
+                logger.debug(f"创建屏幕虚拟事件失败: {e}")
         prompt = (
             f"这是一次用户已授权的主动陪伴行为。请只做视觉观察,"
             f"用很短的话描述用户电脑当前大概在看什么、做什么、是不是像在忙。"
@@ -8252,7 +8255,7 @@ Output:
             return context
         except Exception as e:
             error_text = _single_line(e, 240)
-            logger.warning(f"[PrivateCompanion] screen_peek 主动行为失败: {error_text}")
+            logger.warning(f"screen_peek 主动行为失败: {error_text}")
             context = f"screen_peek：失败,{error_text}"
             if self._is_screen_peek_provider_failure(context):
                 self._note_screen_peek_failure(user, context)
@@ -8367,7 +8370,7 @@ Output:
                         self._save_data_sync(sections={"users"})
                 except Exception:
                     pass
-            logger.warning(f"[PrivateCompanion] poke 主动行为失败: {e}")
+            logger.warning(f"poke 主动行为失败: {e}")
             return f"poke：失败,{e}"
 
     def _choose_poke_repeat_count(self, user: dict[str, Any], reason: str) -> int:
@@ -8575,7 +8578,7 @@ Output:
 
     def _log_uncertain_onebot_submission(self, action: str, error: Any) -> None:
         logger.warning(
-            "[PrivateCompanion] OneBot 动作回执不确定，为避免同一内容被别名立即重复提交，本次按已提交处理: action=%s error=%s",
+            "OneBot 动作回执不确定，为避免同一内容被别名立即重复提交，本次按已提交处理: action=%s error=%s",
             action,
             self._format_send_exception(error),
         )
@@ -8740,7 +8743,7 @@ Output:
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 私聊输入状态刷新失败: %s", _single_line(exc, 120))
+                logger.debug("私聊输入状态刷新失败: %s", _single_line(exc, 120))
                 return
             await asyncio.sleep(random.uniform(3.2, 4.8))
 
@@ -8854,7 +8857,7 @@ Output:
         try:
             await self._ensure_current_detail_presence_status()
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 启动同步当前 QQ 状态失败: %s", exc)
+            logger.debug("启动同步当前 QQ 状态失败: %s", exc)
         async with self._data_lock:
             state = self.data.get("qq_presence_state", {})
             if not isinstance(state, dict) or str(state.get("date") or "") == _today_key():
@@ -8910,7 +8913,7 @@ Output:
             spoken = str(framework_text).strip()
             if requirement["strict"] and not self._voice_text_matches_requirement(spoken, requirement):
                 logger.info(
-                    "[PrivateCompanion] 主动语音未命中格式要求,进行框架严格重试: target=%s summary=%s",
+                    "主动语音未命中格式要求,进行框架严格重试: target=%s summary=%s",
                     target,
                     requirement["summary"],
                 )
@@ -8948,14 +8951,14 @@ Output:
                         spoken = re.sub(r"[“”\"'`]", "", spoken).strip()
             if requirement["strict"] and not self._voice_text_matches_requirement(spoken, requirement):
                 logger.warning(
-                    "[PrivateCompanion] 主动语音仍未完全命中格式要求,保留当前结果: target=%s summary=%s text=%s",
+                    "主动语音仍未完全命中格式要求,保留当前结果: target=%s summary=%s text=%s",
                     target,
                     requirement["summary"],
                     self._strip_tts_markup(spoken),
                 )
             else:
                 logger.info(
-                    "[PrivateCompanion] 主动语音最终文本已命中格式要求: target=%s text=%s",
+                    "主动语音最终文本已命中格式要求: target=%s text=%s",
                     target,
                     self._strip_tts_markup(spoken),
                 )
@@ -9050,7 +9053,7 @@ Output:
         try:
             astrbot_provider = self.context.get_using_tts_provider(target)
         except Exception as e:
-            logger.debug("[PrivateCompanion] 主动语音读取 AstrBot TTS provider 失败: %s", _single_line(e, 120))
+            logger.debug("主动语音读取 AstrBot TTS provider 失败: %s", _single_line(e, 120))
         resolver = getattr(self, "_resolve_tts_synthesis_provider", None)
         if callable(resolver):
             try:
@@ -9106,7 +9109,7 @@ Output:
         try:
             audio_path = await tts_provider.get_audio(spoken_text)
         except Exception as e:
-            logger.warning(f"[PrivateCompanion] voice 主动行为生成失败: {e}")
+            logger.warning(f"voice 主动行为生成失败: {e}")
             return [], str(e)
         if not audio_path:
             return [], "TTS 没有返回音频文件"
@@ -9125,7 +9128,7 @@ Output:
                     token = await file_token_service.register_file(str(audio_path))
                     final_ref = f"{callback_api_base}/api/file/{token}"
                 except Exception as e:
-                    logger.warning(f"[PrivateCompanion] 注册语音文件失败,将回退到本地路径: {e}")
+                    logger.warning(f"注册语音文件失败,将回退到本地路径: {e}")
         try:
             component = Record(file=final_ref, url=final_ref)
         except TypeError:
@@ -9231,7 +9234,7 @@ Output:
                 config,
             )
         except Exception as e:
-            logger.warning(f"[PrivateCompanion] TTS强化处理主动语音失败: {e}")
+            logger.warning(f"TTS强化处理主动语音失败: {e}")
             return [], str(e)
         audio_note = self._extract_record_note(components)
         return components or [], audio_note or "已通过 TTS强化生成语音"
@@ -9412,7 +9415,7 @@ Output:
                         reference_selection_source = "selected_reference"
                 except Exception as exc:
                     logger.debug(
-                        "[PrivateCompanion] proactive photo reference selection failed: %s",
+                        "proactive photo reference selection failed: %s",
                         _single_line(exc, 160),
                     )
             if not reference_image_path:
@@ -9428,7 +9431,7 @@ Output:
                         )
                     except Exception as exc:
                         logger.debug(
-                            "[PrivateCompanion] proactive photo identity fallback failed: %s",
+                            "proactive photo identity fallback failed: %s",
                             _single_line(exc, 160),
                         )
                 if not reference_image_path:
@@ -9444,7 +9447,7 @@ Output:
                             )
                         except Exception as exc:
                             logger.debug(
-                                "[PrivateCompanion] proactive photo identity path fallback failed: %s",
+                                "proactive photo identity path fallback failed: %s",
                                 _single_line(exc, 160),
                             )
                 if reference_image_path:
@@ -9629,7 +9632,7 @@ Output:
                     max_chars=900,
                 )
             except Exception as exc:
-                logger.debug("[PrivateCompanion] 每日穿搭 我会牢牢记住你 上下文读取失败: %s", _single_line(exc, 120))
+                logger.debug("每日穿搭 我会牢牢记住你 上下文读取失败: %s", _single_line(exc, 120))
         schedule_hint = self._daily_outfit_schedule_text()
         weather = self._format_weather_for_prompt() if callable(getattr(self, "_format_weather_for_prompt", None)) else ""
         outfit_profile = self._select_daily_outfit_profile(
@@ -9710,12 +9713,12 @@ Output:
         if image_path:
             await self._memory_companion_record_daily_outfit(item)
             logger.info(
-                "[PrivateCompanion] 每日穿搭照片已生成: backend=%s path=%s",
+                "每日穿搭照片已生成: backend=%s path=%s",
                 _single_line(backend, 80) or "-",
                 _single_line(image_path, 160),
             )
         else:
-            logger.info("[PrivateCompanion] 每日穿搭照片未生成: %s", _single_line(error or note, 180))
+            logger.info("每日穿搭照片未生成: %s", _single_line(error or note, 180))
         return item
 
     def _daily_outfit_schedule_text(self) -> str:
@@ -10704,7 +10707,7 @@ Output:
                 states.pop(normalized_trace, None)
         except Exception as exc:
             logger.debug(
-                "[PrivateCompanion] 记录生图可观测 trace 失败: %s",
+                "记录生图可观测 trace 失败: %s",
                 _single_line(exc, 120),
             )
 
@@ -10934,7 +10937,7 @@ Output:
             del raw[48:]
             self._save_data_sync(sections={"recent_photo_generations"})
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 记录最近生图提示词失败: %s", _single_line(exc, 120))
+            logger.debug("记录最近生图提示词失败: %s", _single_line(exc, 120))
 
     def _record_photo_reference_feedback(
         self,
@@ -11184,7 +11187,7 @@ Output:
             return str(path), prompt_hash
         except Exception as exc:
             logger.debug(
-                "[PrivateCompanion] 写入完整生图提示词调试文件失败: trace=%s error=%s",
+                "写入完整生图提示词调试文件失败: trace=%s error=%s",
                 _single_line(trace_id, 40),
                 _single_line(exc, 160),
             )
@@ -11415,7 +11418,7 @@ Output:
                 self._save_data_sync(sections=save_sections)
                 return
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 标注最近生图记录失败: %s", _single_line(exc, 120))
+            logger.debug("标注最近生图记录失败: %s", _single_line(exc, 120))
 
     def _apply_photo_generation_fixed_prompt(self, prompt_text: str) -> str:
         prompt = str(prompt_text or "").strip()
@@ -11849,7 +11852,7 @@ Output:
                     return snapshot_text
             except Exception as exc:
                 logger.debug(
-                    "[PrivateCompanion] 自拍场景读取统一情境快照失败，已回退旧路径: %s",
+                    "自拍场景读取统一情境快照失败，已回退旧路径: %s",
                     _single_line(exc, 160),
                 )
         plan = self.data.get("daily_plan", {}) if isinstance(getattr(self, "data", {}), dict) else {}
@@ -12784,7 +12787,7 @@ Output:
                 scene_snapshot = {}
                 scene_context = ""
                 logger.debug(
-                    "[PrivateCompanion] 主动照片读取统一情境快照失败，已回退旧路径: %s",
+                    "主动照片读取统一情境快照失败，已回退旧路径: %s",
                     _single_line(exc, 160),
                 )
         if not scene_context:
@@ -12884,7 +12887,7 @@ Output:
             )
         except Exception as exc:
             logger.debug(
-                "[PrivateCompanion] proactive photo prompt model failed; using deterministic fallback: %s",
+                "proactive photo prompt model failed; using deterministic fallback: %s",
                 _single_line(exc, 160),
             )
         payload = self._extract_json_payload(text or "")
@@ -13060,7 +13063,7 @@ Output:
         )
         if not plan:
             logger.info(
-                "[PrivateCompanion] Q5 受管参考素材未进入图片输入汇: trace=%s status=%s",
+                "Q5 受管参考素材未进入图片输入汇: trace=%s status=%s",
                 _single_line(generation_id, 80),
                 status,
             )
@@ -13460,10 +13463,10 @@ Output:
         try:
             stable_path = await resolver(raw, stem="config_url_reference")
         except Exception as exc:
-            logger.info("[PrivateCompanion] 配置页人设参考图 URL 下载失败: %s url=%s", _single_line(exc, 120), _single_line(raw, 120))
+            logger.info("配置页人设参考图 URL 下载失败: %s url=%s", _single_line(exc, 120), _single_line(raw, 120))
             return ""
         if not stable_path:
-            logger.info("[PrivateCompanion] 配置页人设参考图 URL 未能转为本地参考图: url=%s", _single_line(raw, 120))
+            logger.info("配置页人设参考图 URL 未能转为本地参考图: url=%s", _single_line(raw, 120))
             return ""
         setter = getattr(self, "_set_photo_reference_config_path", None)
         if callable(setter):
@@ -13473,12 +13476,12 @@ Output:
                     result = await result
                 if result is False:
                     logger.info(
-                        "[PrivateCompanion] 配置页人设参考图 URL 已下载但配置保存返回失败: path=%s",
+                        "配置页人设参考图 URL 已下载但配置保存返回失败: path=%s",
                         _single_line(stable_path, 160),
                     )
             except Exception as exc:
-                logger.info("[PrivateCompanion] 配置页人设参考图 URL 已下载但回写失败: %s path=%s", _single_line(exc, 120), _single_line(stable_path, 160))
-        logger.info("[PrivateCompanion] 配置页人设参考图 URL 已缓存为本地文件: path=%s", _single_line(stable_path, 160))
+                logger.info("配置页人设参考图 URL 已下载但回写失败: %s path=%s", _single_line(exc, 120), _single_line(stable_path, 160))
+        logger.info("配置页人设参考图 URL 已缓存为本地文件: path=%s", _single_line(stable_path, 160))
         return stable_path
 
     def _photo_reference_config_value(self, item: dict[str, Any], source: str = "") -> Any:
@@ -13741,7 +13744,7 @@ Output:
                     path = await resolver(source, stem=item.id)
                 except Exception as exc:
                     logger.info(
-                        "[PrivateCompanion] 参考图库远程图片下载失败: item=%s error=%s",
+                        "参考图库远程图片下载失败: item=%s error=%s",
                         item.id,
                         _single_line(exc, 120),
                     )
@@ -13777,10 +13780,10 @@ Output:
                     if hasattr(result, "__await__"):
                         result = await result
                     if result is False:
-                        logger.info("[PrivateCompanion] 参考图库远程图片已下载但配置保存返回失败")
+                        logger.info("参考图库远程图片已下载但配置保存返回失败")
                 except Exception as exc:
                     logger.info(
-                        "[PrivateCompanion] 参考图库远程图片已下载但回写失败: %s",
+                        "参考图库远程图片已下载但回写失败: %s",
                         _single_line(exc, 120),
                     )
 
@@ -14292,7 +14295,7 @@ Output:
             except Exception as exc:
                 selection_reason = f"model_error:{type(exc).__name__}"
                 logger.info(
-                    "[PrivateCompanion] 参考图库模型选图失败，使用规则兜底: error=%s",
+                    "参考图库模型选图失败，使用规则兜底: error=%s",
                     _single_line(exc, 120),
                 )
         elif len(candidates) == 1 and not specialized_candidate:
@@ -14308,14 +14311,14 @@ Output:
             for item, score in scored_candidates
         )
         logger.info(
-            "[PrivateCompanion] 参考图库候选评分: fallback=%s scores=%s request=%s ambient=%s",
+            "参考图库候选评分: fallback=%s scores=%s request=%s ambient=%s",
             fallback.get("id") if isinstance(fallback, dict) else "none",
             score_summary,
             _single_line(request_text, 180),
             _single_line(ambient_context, 120),
         )
         logger.info(
-            "[PrivateCompanion] 参考图库已选图: source=%s reason=%s id=%s kind=%s fallback=%s "
+            "参考图库已选图: source=%s reason=%s id=%s kind=%s fallback=%s "
             "model_reply=%s path=%s note=%s candidates=%s",
             selection_source,
             selection_reason,
@@ -14479,7 +14482,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
             confidence = _safe_float(payload.get("confidence"), 0.0, 0.0, 1.0)
         except Exception as exc:
             logger.debug(
-                "[PrivateCompanion] 参考职责模型解析失败，使用保守规则: %s",
+                "参考职责模型解析失败，使用保守规则: %s",
                 _single_line(exc, 120),
             )
             return rule_intent
@@ -15075,7 +15078,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
             setattr(event, "_private_companion_proactive_delivery_umo", umo)
             if self._apply_proactive_tts_message_scope(event, chain):
                 logger.info(
-                    "[PrivateCompanion] 主动消息按 TTS 生效范围进入强化链: session=%s",
+                    "主动消息按 TTS 生效范围进入强化链: session=%s",
                     _single_line(umo, 120) or "unknown",
                 )
             for component in chain:
@@ -15100,21 +15103,21 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
             ):
                 setattr(event, "_private_companion_skip_tts_enhancement", "proactive_prebuilt_voice")
         except Exception as e:
-            logger.debug("[PrivateCompanion] 构造主动消息装饰事件失败,跳过 hooks: %s", e)
+            logger.debug("构造主动消息装饰事件失败,跳过 hooks: %s", e)
             return chain
         try:
             handlers = star_handlers_registry.get_handlers_by_event_type(
                 EventType.OnDecoratingResultEvent
             )
         except Exception as e:
-            logger.debug("[PrivateCompanion] 获取装饰 hooks 失败: %s", e)
+            logger.debug("获取装饰 hooks 失败: %s", e)
             return chain
         for handler in handlers:
             try:
                 await handler.handler(event)
             except Exception as e:
                 logger.warning(
-                    "[PrivateCompanion] 主动消息装饰 hook 失败: %s: %s",
+                    "主动消息装饰 hook 失败: %s: %s",
                     getattr(handler, "handler_full_name", "unknown"),
                     e,
                 )
@@ -15601,7 +15604,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
         if runtime_persona_setting(self, "enable_tts_enhancement", False) and any(
             re.search(r"</?t{2,}s\b", item, flags=re.IGNORECASE) for item in raw_segments
         ):
-            logger.info("[PrivateCompanion] 分段合并消息跳过 TTS 内容: source=%s target=%s:%s", source or "unknown", target_type, target_id)
+            logger.info("分段合并消息跳过 TTS 内容: source=%s target=%s:%s", source or "unknown", target_type, target_id)
             return False
         cleaned_segments = self._clean_forward_segment_texts(raw_segments)
         if len(cleaned_segments) <= 1:
@@ -15609,7 +15612,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
         hit = self._forbidden_recall_hit("\n".join(cleaned_segments))
         if hit:
             logger.warning(
-                "[PrivateCompanion] 分段合并消息命中违禁词，已拦截发送: source=%s target=%s:%s word=%s",
+                "分段合并消息命中违禁词，已拦截发送: source=%s target=%s:%s word=%s",
                 source or "unknown",
                 target_type,
                 target_id,
@@ -15648,7 +15651,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
                     [Plain(segment) for segment in cleaned_segments],
                 )
                 logger.info(
-                    "[PrivateCompanion] 分段消息已合并转发发送: source=%s target=%s:%s segments=%s",
+                    "分段消息已合并转发发送: source=%s target=%s:%s segments=%s",
                     source or "unknown",
                     target_type,
                     target_id,
@@ -15656,7 +15659,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
                 )
                 return True
         logger.info(
-            "[PrivateCompanion] 分段合并转发发送不可用，回退普通分段: source=%s target=%s:%s segments=%s",
+            "分段合并转发发送不可用，回退普通分段: source=%s target=%s:%s segments=%s",
             source or "unknown",
             target_type,
             target_id,
@@ -15836,7 +15839,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
         )
         if ok:
             logger.info(
-                "[PrivateCompanion] 主动消息已通过 OneBot 原生兜底发送: action=%s target=%s segments=%s umo=%s",
+                "主动消息已通过 OneBot 原生兜底发送: action=%s target=%s segments=%s umo=%s",
                 action,
                 target_id,
                 len(messages),
@@ -15855,7 +15858,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
         bot_scope_checker = getattr(self, "_bot_scope_allows_umo", None)
         if callable(bot_scope_checker) and not bot_scope_checker(umo):
             logger.info(
-                "[PrivateCompanion] Bot 作用域已跳过后台投递: umo=%s",
+                "Bot 作用域已跳过后台投递: umo=%s",
                 _single_line(umo, 140),
             )
             return False
@@ -15875,11 +15878,11 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
         if callable(chain_redactor):
             chain, redacted = chain_redactor(chain)
             if redacted:
-                logger.error("[PrivateCompanion] 主动发送前检测到敏感凭据并已脱敏: umo=%s stage=before_hooks", _single_line(umo, 120))
+                logger.error("主动发送前检测到敏感凭据并已脱敏: umo=%s stage=before_hooks", _single_line(umo, 120))
         hit = self._forbidden_recall_hit(self._chain_text_for_forbidden_recall(chain))
         if hit:
             logger.warning(
-                "[PrivateCompanion] 主动待发送消息命中违禁词，已拦截发送: umo=%s word=%s",
+                "主动待发送消息命中违禁词，已拦截发送: umo=%s word=%s",
                 umo,
                 _single_line(hit, 40),
             )
@@ -15912,7 +15915,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
         if callable(chain_redactor):
             processed_chain, redacted = chain_redactor(processed_chain)
             if redacted:
-                logger.error("[PrivateCompanion] 主动装饰后检测到敏感凭据并已脱敏: umo=%s stage=after_hooks", _single_line(umo, 120))
+                logger.error("主动装饰后检测到敏感凭据并已脱敏: umo=%s stage=after_hooks", _single_line(umo, 120))
         tts_chain_guard = getattr(self, "_sanitize_outbound_tts_chain_without_event", None)
         if callable(tts_chain_guard):
             processed_chain = await tts_chain_guard(processed_chain, umo=umo)
@@ -15924,7 +15927,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
         hit = self._forbidden_recall_hit(self._chain_text_for_forbidden_recall(processed_chain))
         if hit:
             logger.warning(
-                "[PrivateCompanion] 主动装饰后消息命中违禁词，已拦截发送: umo=%s word=%s",
+                "主动装饰后消息命中违禁词，已拦截发送: umo=%s word=%s",
                 umo,
                 _single_line(hit, 40),
             )
@@ -15944,7 +15947,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
         if runtime_persona_setting(self, "enable_precise_platform_send", True) and session and platform:
             status = getattr(platform, "status", None)
             if status is not None and status != PlatformStatus.RUNNING:
-                logger.warning("[PrivateCompanion] 目标平台未运行,跳过主动发送: %s", umo)
+                logger.warning("目标平台未运行,跳过主动发送: %s", umo)
                 notifier = getattr(self, "_schedule_reply_interception_forward", None)
                 if callable(notifier):
                     notifier(
@@ -15963,7 +15966,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
                     return True
                 precise_error = RuntimeError("精确平台发送返回 False（平台未接受消息）")
                 logger.warning(
-                    "[PrivateCompanion] 精确平台发送未被目标平台接受,回退核心发送: target=%s",
+                    "精确平台发送未被目标平台接受,回退核心发送: target=%s",
                     self._describe_send_target(umo, session, platform),
                 )
             except Exception as e:
@@ -15971,20 +15974,20 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
                 if self._is_onebot_event_checker_send_rejection(e):
                     summary = self._onebot_event_checker_rejection_summary()
                     logger.info(
-                        "[PrivateCompanion] 主动发送被 QQ/NTQQ 底层拒绝，停止对同一 sendMsg 链路的立即重复尝试: target=%s",
+                        "主动发送被 QQ/NTQQ 底层拒绝，停止对同一 sendMsg 链路的立即重复尝试: target=%s",
                         self._describe_send_target(umo, session, platform),
                     )
                     raise RuntimeError(summary) from e
                 if self._delivery_outcome_is_uncertain(e):
                     logger.warning(
-                        "[PrivateCompanion] 精确平台发送回执不确定，为避免同一主动消息立即重复发送，本次按已提交处理: target=%s error=%s",
+                        "精确平台发送回执不确定，为避免同一主动消息立即重复发送，本次按已提交处理: target=%s error=%s",
                         self._describe_send_target(umo, session, platform),
                         self._format_send_exception(e),
                     )
                     self._confirm_outbound_delivery(umo, processed_chain)
                     return True
                 logger.warning(
-                    "[PrivateCompanion] 精确平台发送失败,回退核心发送: target=%s error=%s",
+                    "精确平台发送失败,回退核心发送: target=%s error=%s",
                     self._describe_send_target(umo, session, platform),
                     self._format_send_exception(e),
                 )
@@ -16001,25 +16004,25 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
             platform_supports = getattr(self, "_platform_supports", None)
             if not callable(platform_supports) or platform_supports("onebot_actions", umo=umo):
                 logger.warning(
-                    "[PrivateCompanion] 主动核心发送未找到匹配平台,尝试 OneBot 原生兜底: target=%s",
+                    "主动核心发送未找到匹配平台,尝试 OneBot 原生兜底: target=%s",
                     self._describe_send_target(umo, session, platform),
                 )
             else:
                 logger.warning(
-                    "[PrivateCompanion] 主动核心发送未被官方平台接受,不使用 OneBot 原生兜底: target=%s",
+                    "主动核心发送未被官方平台接受,不使用 OneBot 原生兜底: target=%s",
                     self._describe_send_target(umo, session, platform),
                 )
         except Exception as e:
             core_error = e
             if self._is_onebot_event_checker_send_rejection(e):
                 logger.info(
-                    "[PrivateCompanion] 主动核心发送被 QQ/NTQQ 底层拒绝，停止同链立即重试: target=%s",
+                    "主动核心发送被 QQ/NTQQ 底层拒绝，停止同链立即重试: target=%s",
                     self._describe_send_target(umo, session, platform),
                 )
                 raise RuntimeError(self._onebot_event_checker_rejection_summary()) from e
             if self._delivery_outcome_is_uncertain(e):
                 logger.warning(
-                    "[PrivateCompanion] 主动核心发送回执不确定，为避免 OneBot 兜底重复发送，本次按已提交处理: target=%s error=%s",
+                    "主动核心发送回执不确定，为避免 OneBot 兜底重复发送，本次按已提交处理: target=%s error=%s",
                     self._describe_send_target(umo, session, platform),
                     self._format_send_exception(e),
                 )
@@ -16029,7 +16032,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
             precise_text = self._format_send_exception(precise_error) or "未尝试或未失败"
             fallback_text = self._format_send_exception(e)
             logger.warning(
-                "[PrivateCompanion] 主动核心发送失败: target=%s precise_error=%s fallback_error=%s",
+                "主动核心发送失败: target=%s precise_error=%s fallback_error=%s",
                 target,
                 precise_text,
                 fallback_text,
@@ -16059,7 +16062,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
         else:
             fallback_text = "未尝试或未失败"
         logger.warning(
-            "[PrivateCompanion] 主动发送兜底也失败: target=%s precise_error=%s fallback_error=%s direct_error=%s",
+            "主动发送兜底也失败: target=%s precise_error=%s fallback_error=%s direct_error=%s",
             target,
             precise_text,
             fallback_text,
@@ -16122,7 +16125,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
             )
             if quote_message_id and not platform_quote:
                 logger.info(
-                    "[PrivateCompanion] 当前平台不支持主动引用，正文与表情同链发送已降级为普通发送: umo=%s",
+                    "当前平台不支持主动引用，正文与表情同链发送已降级为普通发送: umo=%s",
                     _single_line(umo, 140),
                 )
                 quote_message_id = ""
@@ -16131,7 +16134,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
             )
             if recalled_message_id:
                 logger.info(
-                    "[PrivateCompanion] 触发消息已撤回，取消主动正文与表情同链发送: umo=%s message_id=%s",
+                    "触发消息已撤回，取消主动正文与表情同链发送: umo=%s message_id=%s",
                     umo,
                     recalled_message_id,
                 )
@@ -16162,7 +16165,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
         platform_quote = not callable(platform_supports) or platform_supports("reply_quote", umo=umo)
         if quote_message_id and not platform_quote:
             logger.info(
-                "[PrivateCompanion] 当前平台不支持主动引用，已降级为普通发送: umo=%s",
+                "当前平台不支持主动引用，已降级为普通发送: umo=%s",
                 _single_line(umo, 140),
             )
             quote_message_id = ""
@@ -16185,7 +16188,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
             )
         if len(segments) > 1:
             logger.info(
-                "[PrivateCompanion] 主动媒体文本已分段: umo=%s segments=%s lengths=%s",
+                "主动媒体文本已分段: umo=%s segments=%s lengths=%s",
                 _single_line(umo, 140),
                 len(segments),
                 [len(segment) for segment in segments],
@@ -16260,7 +16263,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
         has_media = bool(outbound_components or image_exists)
         if has_media:
             logger.info(
-                "[PrivateCompanion] 主动媒体已按组件策略规划: text_segments=%s chunks=%s image=%s extra_components=%s strategies=%s",
+                "主动媒体已按组件策略规划: text_segments=%s chunks=%s image=%s extra_components=%s strategies=%s",
                 len(segments),
                 len(chunks),
                 image_exists,
@@ -16310,7 +16313,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
             )
             if recalled_message_id:
                 logger.info(
-                    "[PrivateCompanion] 触发消息已撤回，停止主动组件发送: umo=%s message_id=%s chunk=%s/%s",
+                    "触发消息已撤回，停止主动组件发送: umo=%s message_id=%s chunk=%s/%s",
                     umo,
                     recalled_message_id,
                     chunk_index + 1,
@@ -16335,7 +16338,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
                         f"第 {chunk_index + 1} 条组件发送失败：{_single_line(exc, 160)}"
                     )
                     logger.warning(
-                        "[PrivateCompanion] 主动前置组件发送失败，继续发送正文: umo=%s chunk=%s error=%s",
+                        "主动前置组件发送失败，继续发送正文: umo=%s chunk=%s error=%s",
                         _single_line(umo, 140),
                         chunk_index + 1,
                         _single_line(exc, 180),
@@ -16345,7 +16348,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
                     raise
                 complete = False
                 logger.warning(
-                    "[PrivateCompanion] 主动组件部分送达后后续发送失败，不再整条重试: umo=%s chunk=%s error=%s",
+                    "主动组件部分送达后后续发送失败，不再整条重试: umo=%s chunk=%s error=%s",
                     _single_line(umo, 140),
                     chunk_index + 1,
                     _single_line(exc, 180),
@@ -16487,7 +16490,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
             if isinstance(pending, dict):
                 await settle(pending, sent=False, reason="attachment_prepare_failed")
             logger.warning(
-                "[PrivateCompanion] 主动表情附件准备失败,继续发送纯文字: error_type=%s",
+                "主动表情附件准备失败,继续发送纯文字: error_type=%s",
                 type(exc).__name__,
             )
             return None, None
@@ -16516,7 +16519,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
         except Exception as exc:
             await settle(pending, sent=False, reason="attachment_component_failed")
             logger.warning(
-                "[PrivateCompanion] 主动表情图片组件构建失败,继续发送纯文字: error_type=%s",
+                "主动表情图片组件构建失败,继续发送纯文字: error_type=%s",
                 type(exc).__name__,
             )
             return None, None
@@ -16559,7 +16562,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
             # Delivery state is authoritative. A bookkeeping failure must not
             # make the caller retry content that the platform already received.
             logger.warning(
-                "[PrivateCompanion] 主动表情发送结算失败,不改变消息投递结果: "
+                "主动表情发送结算失败,不改变消息投递结果: "
                 "sent=%s reason=%s error_type=%s",
                 bool(sent),
                 _single_line(reason, 80),
@@ -16605,7 +16608,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
             allowed = bool(result.get("ok")) if isinstance(result, dict) else bool(result)
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanion] 主动消息最终人格一致性校验失败: multi=%s persona=%s umo=%s error=%s",
+                "主动消息最终人格一致性校验失败: multi=%s persona=%s umo=%s error=%s",
                 multi_persona,
                 _single_line(scheduled_persona_id, 96) or "-",
                 _single_line(target_umo, 140) or "-",
@@ -16618,7 +16621,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
         reason_code = _single_line(result.get("reason_code"), 80) if isinstance(result, dict) else ""
         action = _single_line(result.get("action"), 40) if isinstance(result, dict) else ""
         logger.warning(
-            "[PrivateCompanion] 主动投递因人格不一致被取消: multi=%s persona=%s umo=%s action=%s reason=%s",
+            "主动投递因人格不一致被取消: multi=%s persona=%s umo=%s action=%s reason=%s",
             multi_persona,
             _single_line(scheduled_persona_id, 96) or "-",
             _single_line(target_umo, 140) or "-",
@@ -16652,7 +16655,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
                 busy_context = {}
             if isinstance(busy_context, dict) and busy_context.get("kind") == "external_realtime":
                 logger.info(
-                    "[PrivateCompanion] 实时共同活动期间在最终发送边界取消主动消息: umo=%s",
+                    "实时共同活动期间在最终发送边界取消主动消息: umo=%s",
                     _single_line(umo, 140),
                 )
                 return _ProactiveSendOutcome(False, False, note="实时共同活动期间已取消主动消息")
@@ -16662,7 +16665,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
             cleaned_text = placeholder_cleaner(text)
             if cleaned_text != text:
                 logger.warning(
-                    "[PrivateCompanion] 主动发送前清理孤儿 TTS 占位符: umo=%s before=%s after=%s",
+                    "主动发送前清理孤儿 TTS 占位符: umo=%s before=%s after=%s",
                     _single_line(umo, 120),
                     _single_line(text, 120),
                     _single_line(cleaned_text, 120),
@@ -16706,7 +16709,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
                     except Exception as exc:
                         reaction_sent = False
                         logger.warning(
-                            "[PrivateCompanion] 主动表情先行发送失败，继续发送正文: "
+                            "主动表情先行发送失败，继续发送正文: "
                             "umo=%s error_type=%s",
                             _single_line(umo, 140),
                             type(exc).__name__,
@@ -16791,7 +16794,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
             )
         if len(segments) > 1:
             logger.info(
-                "[PrivateCompanion] 主动文本已分段: umo=%s segments=%s lengths=%s",
+                "主动文本已分段: umo=%s segments=%s lengths=%s",
                 _single_line(umo, 140),
                 len(segments),
                 [len(segment) for segment in segments],
@@ -16804,7 +16807,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
                 quote_message_id = ""
             recalled_message_id = self._should_cancel_reply_for_recalled_message_ids(trigger_message_id)
             if recalled_message_id:
-                logger.info("[PrivateCompanion] 触发消息已撤回，取消主动消息发送: umo=%s message_id=%s", umo, recalled_message_id)
+                logger.info("触发消息已撤回，取消主动消息发送: umo=%s message_id=%s", umo, recalled_message_id)
                 return _ProactiveSendOutcome(False, False, note="触发消息已撤回")
             sent = await self._send_chain_components(
                 umo,
@@ -16823,7 +16826,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
             )
         recalled_message_id = self._should_cancel_reply_for_recalled_message_ids(trigger_message_id)
         if recalled_message_id:
-            logger.info("[PrivateCompanion] 触发消息已撤回，取消主动合并分段发送: umo=%s message_id=%s", umo, recalled_message_id)
+            logger.info("触发消息已撤回，取消主动合并分段发送: umo=%s message_id=%s", umo, recalled_message_id)
             return _ProactiveSendOutcome(False, False, note="触发消息已撤回")
         if await self._send_segmented_proactive_forward_message(umo, segments, source="proactive_text"):
             return _ProactiveSendOutcome(True, True, delivered_text="\n".join(segments).strip())
@@ -16834,7 +16837,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
                 quote_message_id = ""
             recalled_message_id = self._should_cancel_reply_for_recalled_message_ids(trigger_message_id)
             if recalled_message_id:
-                logger.info("[PrivateCompanion] 触发消息已撤回，停止主动消息分段发送: umo=%s message_id=%s index=%s", umo, recalled_message_id, index + 1)
+                logger.info("触发消息已撤回，停止主动消息分段发送: umo=%s message_id=%s index=%s", umo, recalled_message_id, index + 1)
                 return _ProactiveSendOutcome(
                     bool(delivered_segments),
                     False,
@@ -16849,7 +16852,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
                 if not delivered_segments:
                     raise
                 logger.warning(
-                    "[PrivateCompanion] 主动文本部分送达后后续分段失败，不再整条重试: umo=%s index=%s error=%s",
+                    "主动文本部分送达后后续分段失败，不再整条重试: umo=%s index=%s error=%s",
                     _single_line(umo, 140),
                     index + 1,
                     _single_line(exc, 180),
@@ -17099,19 +17102,19 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
 
                 written = await self._conversation_db_operation("archive_proactive_message", _write)
                 if not written:
-                    logger.warning("[PrivateCompanion] 主动消息存档失败: 无法获取或创建 AstrBot 会话 history umo=%s", _single_line(umo, 140))
+                    logger.warning("主动消息存档失败: 无法获取或创建 AstrBot 会话 history umo=%s", _single_line(umo, 140))
                     return False
                 if attempt > 0:
-                    logger.info("[PrivateCompanion] 主动消息写入 AstrBot 会话历史成功: %s retry=%s", umo, attempt)
+                    logger.info("主动消息写入 AstrBot 会话历史成功: %s retry=%s", umo, attempt)
                 else:
-                    logger.info("[PrivateCompanion] 已将主动消息写入 AstrBot 会话历史: %s", umo)
+                    logger.info("已将主动消息写入 AstrBot 会话历史: %s", umo)
                 return True
             except Exception as e:
                 text = str(e or "").lower()
                 if ("database is locked" in text or "sqlite3.operationalerror" in text) and attempt < 3:
                     await asyncio.sleep(0.25 * (attempt + 1))
                     continue
-                logger.warning("[PrivateCompanion] 主动消息写入会话历史失败: %s", e)
+                logger.warning("主动消息写入会话历史失败: %s", e)
                 return False
         return False
 
@@ -17399,7 +17402,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
             if kept:
                 result = self._finish_trimmed_proactive_text(kept)
                 logger.info(
-                    "[PrivateCompanion] 主动消息已去除刻意状态尾巴: before=%s after=%s",
+                    "主动消息已去除刻意状态尾巴: before=%s after=%s",
                     _single_line(cleaned, 160),
                     _single_line(result, 160),
                 )
@@ -17438,7 +17441,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
         result = result.strip()
         if result:
             logger.info(
-                "[PrivateCompanion] 主动消息已去除刻意状态尾巴: before=%s after=%s",
+                "主动消息已去除刻意状态尾巴: before=%s after=%s",
                 _single_line(cleaned, 160),
                 _single_line(result, 160),
             )
@@ -17529,7 +17532,7 @@ continuity_mode 只能是 continuation、edit、new_topic、ambiguous。
         chosen = self._ensure_chat_sentence_punctuation(chosen)
         if chosen and chosen != cleaned:
             logger.info(
-                "[PrivateCompanion] 主动消息已收束状态清单: before=%s after=%s",
+                "主动消息已收束状态清单: before=%s after=%s",
                 _single_line(cleaned, 180),
                 _single_line(chosen, 160),
             )

--- a/qzone_auth.py
+++ b/qzone_auth.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import time
 from typing import Any
 
-from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent
 
 from .helpers import _now_ts, _safe_float, _safe_int, _single_line
 from .qzone_recent_parser import parse_qzone_h5_index_html
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 __all__ = ("QzoneAuthMixin",)
 
@@ -120,7 +122,7 @@ class QzoneAuthMixin:
         state["last_auth_status"] = status
         if status == "stopped":
             logger.warning(
-                "[PrivateCompanion] QQ 空间认证连续失败,自动说说进入保守等待: count=%s until=%s reason=%s",
+                "QQ 空间认证连续失败,自动说说进入保守等待: count=%s until=%s reason=%s",
                 failure_count,
                 self._qzone_format_block_until(state["auth_block_until"]),
                 clean_reason,
@@ -178,7 +180,7 @@ class QzoneAuthMixin:
             token = ctx.get("qzonetoken") or await self._qzone_ensure_qzonetoken(event, cookie_header=cookie_header, ctx=ctx)
             if not str(token or "").strip():
                 state["last_qzonetoken_status"] = "missing:h5_index"
-                logger.info("[PrivateCompanion] QQ 空间自动发布预检继续: qzonetoken 未找到,纯文字发布仍可使用 g_tk")
+                logger.info("QQ 空间自动发布预检继续: qzonetoken 未找到,纯文字发布仍可使用 g_tk")
             else:
                 state["last_qzonetoken_status"] = "ok"
         except Exception as exc:
@@ -230,10 +232,10 @@ class QzoneAuthMixin:
                 async with session.get(url) as response:
                     text = await response.text()
                     if response.status >= 400:
-                        logger.info("[PrivateCompanion] QQ 空间 qzonetoken 获取失败: HTTP %s", response.status)
+                        logger.info("QQ 空间 qzonetoken 获取失败: HTTP %s", response.status)
                         return {"token": "", "payload": {}, "cached": False, "http_status": response.status}
         except Exception as exc:
-            logger.info("[PrivateCompanion] QQ 空间 qzonetoken 获取失败: %s", _single_line(exc, 120))
+            logger.info("QQ 空间 qzonetoken 获取失败: %s", _single_line(exc, 120))
             return {"token": "", "payload": {}, "cached": False, "http_status": 0}
         parsed = parse_qzone_h5_index_html(text)
         parsed_token = str(parsed.get("token") or "").strip()
@@ -251,9 +253,9 @@ class QzoneAuthMixin:
             "http_status": response.status,
         }
         if not parsed_token:
-            logger.info("[PrivateCompanion] QQ 空间 qzonetoken 未在 H5 首页中找到")
+            logger.info("QQ 空间 qzonetoken 未在 H5 首页中找到")
         else:
-            logger.info("[PrivateCompanion] QQ 空间 qzonetoken 已自动获取: uin=%s", ctx.get("uin"))
+            logger.info("QQ 空间 qzonetoken 已自动获取: uin=%s", ctx.get("uin"))
         return {
             "token": token,
             "payload": payload,

--- a/qzone_comments.py
+++ b/qzone_comments.py
@@ -8,11 +8,13 @@ import re
 import time
 from typing import Any
 
-from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent
 
 from .helpers import _now_ts, _safe_float, _safe_int, _single_line
 from .persona_config import runtime_persona_setting
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 __all__ = ("QzoneCommentMixin",)
 
@@ -674,7 +676,7 @@ class QzoneCommentMixin:
                 state["last_comment_inbox_checked_at"] = now
                 state["last_comment_inbox_status"] = f"seeded:{len(observed_ids)}"
                 self._save_data_sync(sections={"qzone_integration"})
-                logger.info("[PrivateCompanion] QQ 空间评论收件箱首次启用,已记录现有评论: count=%s", len(observed_ids))
+                logger.info("QQ 空间评论收件箱首次启用,已记录现有评论: count=%s", len(observed_ids))
                 return
             history_lost_after_init = bool(
                 state.get("comment_inbox_initialized_at")
@@ -691,7 +693,7 @@ class QzoneCommentMixin:
                 state["last_comment_inbox_status"] = f"reseeded:history_lost:{len(observed_ids)}"
                 self._save_data_sync(sections={"qzone_integration"})
                 logger.warning(
-                    "[PrivateCompanion] QQ 空间评论收件箱历史 key 为空,已重新播种当前可见评论并跳过本轮回复: count=%s",
+                    "QQ 空间评论收件箱历史 key 为空,已重新播种当前可见评论并跳过本轮回复: count=%s",
                     len(observed_ids),
                 )
                 return
@@ -766,7 +768,7 @@ class QzoneCommentMixin:
                     state["last_comment_inbox_reason"] = _single_line(exc, 120)
                     self._save_data_sync(sections={"qzone_integration"})
                     logger.warning(
-                        "[PrivateCompanion] QQ 空间评论回复失败: retryable=%s error=%s",
+                        "QQ 空间评论回复失败: retryable=%s error=%s",
                         retryable,
                         _single_line(exc, 120),
                     )
@@ -809,7 +811,7 @@ class QzoneCommentMixin:
                 state["last_comment_inbox_reply_text"] = _single_line(sent_text, 120)
                 self._save_data_sync(sections={"qzone_integration"})
                 logger.info(
-                    "[PrivateCompanion] QQ 空间评论收件箱已追加评论回复: post=%s type=%s comment=%s key=%s author=%s text=%s",
+                    "QQ 空间评论收件箱已追加评论回复: post=%s type=%s comment=%s key=%s author=%s text=%s",
                     state["last_comment_inbox_reply_post_tid"] or "-",
                     post_type,
                     comment_id,
@@ -860,6 +862,6 @@ class QzoneCommentMixin:
             state["last_comment_inbox_status"] = f"failed:{_single_line(reason, 80)}"
             self._save_data_sync(sections={"qzone_integration"})
             if any(token in reason for token in ("没有可用的 OneBot 连接", "获取 QQ 空间 Cookie 失败", "Cookie")):
-                logger.warning("[PrivateCompanion] QQ 空间评论收件箱处理失败: %s", reason)
+                logger.warning("QQ 空间评论收件箱处理失败: %s", reason)
             else:
-                logger.warning("[PrivateCompanion] QQ 空间评论收件箱处理失败: %s", reason, exc_info=True)
+                logger.warning("QQ 空间评论收件箱处理失败: %s", reason, exc_info=True)

--- a/qzone_feed.py
+++ b/qzone_feed.py
@@ -10,12 +10,14 @@ import time
 from types import SimpleNamespace
 from typing import Any
 
-from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent
 
 from .helpers import _safe_float, _safe_int, _single_line
 from .persona_config import runtime_persona_setting
 from .qzone_recent_parser import is_official_qzone_promotion
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 __all__ = ("QzoneFeedMixin",)
 
@@ -408,7 +410,7 @@ class QzoneFeedMixin:
         code = self._qzone_response_code(payload)
         if code not in {0, "0"}:
             logger.warning(
-                "[PrivateCompanion] QQ 空间点赞失败: code=%s message=%s uin=%s tid=%s appid=%s typeid=%s fid=%s http=%s",
+                "QQ 空间点赞失败: code=%s message=%s uin=%s tid=%s appid=%s typeid=%s fid=%s http=%s",
                 code,
                 _single_line(payload.get("message") or payload.get("msg") or payload.get("_raw_message"), 100),
                 uin,
@@ -426,7 +428,7 @@ class QzoneFeedMixin:
             )
         verification = await self._qzone_verify_like_post(event, post, cookie_header=cookie_header, target_liked=True)
         logger.info(
-            "[PrivateCompanion] QQ 空间点赞成功: uin=%s tid=%s appid=%s typeid=%s fid=%s verified=%s",
+            "QQ 空间点赞成功: uin=%s tid=%s appid=%s typeid=%s fid=%s verified=%s",
             uin,
             tid,
             appid,
@@ -500,7 +502,7 @@ class QzoneFeedMixin:
         code = self._qzone_response_code(payload)
         if code not in {0, "0"}:
             logger.warning(
-                "[PrivateCompanion] QQ 空间删除说说失败: code=%s message=%s uin=%s tid=%s http=%s",
+                "QQ 空间删除说说失败: code=%s message=%s uin=%s tid=%s http=%s",
                 code,
                 _single_line(payload.get("message") or payload.get("msg") or payload.get("_raw_message"), 100),
                 uin,
@@ -508,7 +510,7 @@ class QzoneFeedMixin:
                 payload.get("_http_status"),
             )
             raise RuntimeError(_single_line(payload.get("message") or payload.get("msg") or f"删除失败 code={code}", 160))
-        logger.info("[PrivateCompanion] QQ 空间删除说说成功: uin=%s tid=%s", uin, tid)
+        logger.info("QQ 空间删除说说成功: uin=%s tid=%s", uin, tid)
 
     async def _qzone_generate_comment(self, post: Any) -> str:
         prompt = f"""

--- a/qzone_media.py
+++ b/qzone_media.py
@@ -15,12 +15,14 @@ from types import SimpleNamespace
 from typing import Any
 from urllib.parse import parse_qs, unquote, urljoin, urlparse
 
-from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent
 
 from .helpers import _safe_int, _single_line
 from .qzone_auth import QzoneAuthMixin
 from .qzone_errors import QzoneIntegrationError
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 __all__ = (
     "QZONE_IMAGE_UPLOAD_URL",
@@ -416,7 +418,7 @@ class QzoneMediaMixin(QzoneAuthMixin):
                 for source in await reply_image_getter(event):
                     add(source)
             except Exception as exc:
-                logger.info("[PrivateCompanion] QQ 空间引用图片读取失败: %s", _single_line(exc, 120))
+                logger.info("QQ 空间引用图片读取失败: %s", _single_line(exc, 120))
         normalized: list[str] = []
         for source in sources:
             resolved = await self._qzone_resolve_onebot_image_source(event, source)
@@ -436,7 +438,7 @@ class QzoneMediaMixin(QzoneAuthMixin):
                 return (0, len(text))
 
             best = sorted(normalized, key=rank, reverse=True)[0]
-            logger.info("[PrivateCompanion] QQ 空间单图消息解析到多个来源,已选择一个: candidates=%s chosen=%s", len(normalized), _single_line(best, 120))
+            logger.info("QQ 空间单图消息解析到多个来源,已选择一个: candidates=%s chosen=%s", len(normalized), _single_line(best, 120))
             return [best]
         return normalized[:9]
 
@@ -575,7 +577,7 @@ class QzoneMediaMixin(QzoneAuthMixin):
             if str(code) not in message:
                 message = _single_line(f"code={code} {message}", 160)
             logger.info(
-                "[PrivateCompanion] QQ 空间发布失败: endpoint=%s code=%s msg=%s",
+                "QQ 空间发布失败: endpoint=%s code=%s msg=%s",
                 urlparse(endpoint).netloc,
                 code,
                 message,
@@ -583,7 +585,7 @@ class QzoneMediaMixin(QzoneAuthMixin):
             stage = "Cookie/g_tk" if self._qzone_auth_failure_message(message) else "发布失败"
             raise QzoneIntegrationError(stage, message)
         logger.info(
-            "[PrivateCompanion] QQ 空间说说发布成功: endpoint=%s images=%s",
+            "QQ 空间说说发布成功: endpoint=%s images=%s",
             urlparse(endpoint).netloc,
             len(richvals),
         )
@@ -669,7 +671,7 @@ class QzoneMediaMixin(QzoneAuthMixin):
                     image_list = [str(item).strip() for item in list(generated or []) if str(item or "").strip()]
                 except Exception as exc:
                     logger.info(
-                        "[PrivateCompanion] QQ 空间手动发说说自动配图失败,继续纯文字发布: %s",
+                        "QQ 空间手动发说说自动配图失败,继续纯文字发布: %s",
                         _single_line(exc, 160),
                     )
         if not content and not image_list:
@@ -713,7 +715,7 @@ class QzoneMediaMixin(QzoneAuthMixin):
                         event=event,
                     )
                 except Exception as record_exc:
-                    logger.debug("[PrivateCompanion] QQ 空间发布后自我记录失败: %s", _single_line(record_exc, 120))
+                    logger.debug("QQ 空间发布后自我记录失败: %s", _single_line(record_exc, 120))
             return result
 
         try:
@@ -725,7 +727,7 @@ class QzoneMediaMixin(QzoneAuthMixin):
                     self._qzone_mark_auth_failure(message, source="publish", save=True)
                 if content and image_list and exc.stage in {"图片读取失败", "图片校验失败", "图片上传失败"}:
                     logger.warning(
-                        "[PrivateCompanion] QQ 空间图片发布失败,尝试降级纯文字: stage=%s msg=%s",
+                        "QQ 空间图片发布失败,尝试降级纯文字: stage=%s msg=%s",
                         exc.stage,
                         message,
                     )

--- a/qzone_publish.py
+++ b/qzone_publish.py
@@ -9,11 +9,13 @@ import time
 from pathlib import Path
 from typing import Any
 
-from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent
 
 from .helpers import _now_ts, _path_text, _safe_float, _safe_int, _single_line
 from .persona_config import runtime_persona_setting
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 __all__ = ("QzonePublishMixin",)
 
@@ -255,7 +257,7 @@ class QzonePublishMixin:
         try:
             self._save_data_sync(sections={"qzone_integration"})
         except Exception as exc:
-            logger.debug("[PrivateCompanion] QQ 空间发布记录保存失败: %s", _single_line(exc, 120))
+            logger.debug("QQ 空间发布记录保存失败: %s", _single_line(exc, 120))
 
     def _qzone_append_publish_to_current_detail(
         self,
@@ -405,7 +407,7 @@ class QzonePublishMixin:
         )
         if relationship_cleaned != cleaned:
             logger.warning(
-                "[PrivateCompanion] QQ 空间说说草稿含未声明关系,已移除污染片段: %s",
+                "QQ 空间说说草稿含未声明关系,已移除污染片段: %s",
                 _single_line(cleaned, 160),
             )
             cleaned = relationship_cleaned
@@ -415,7 +417,7 @@ class QzonePublishMixin:
             return cleaned
         stripped = self._strip_qzone_internal_state_fragments(cleaned)
         if stripped and not self._qzone_text_leaks_internal_state(stripped) and len(stripped) >= 12:
-            logger.warning("[PrivateCompanion] QQ 空间说说草稿含内部状态,已净化: %s", _single_line(cleaned, 160))
+            logger.warning("QQ 空间说说草稿含内部状态,已净化: %s", _single_line(cleaned, 160))
             return stripped
         rewrite_prompt = f"""
 下面是一条 QQ 空间说说草稿,里面泄露了内部状态/数值。请重写成自然生活动态。
@@ -446,11 +448,11 @@ class QzonePublishMixin:
                 180,
             )
             if rewritten and not self._qzone_text_leaks_internal_state(rewritten):
-                logger.warning("[PrivateCompanion] QQ 空间说说草稿含内部状态,已重写: %s", _single_line(cleaned, 160))
+                logger.warning("QQ 空间说说草稿含内部状态,已重写: %s", _single_line(cleaned, 160))
                 return rewritten
         except Exception as exc:
-            logger.warning("[PrivateCompanion] QQ 空间说说内部状态重写失败: %s", _single_line(exc, 120))
-        logger.warning("[PrivateCompanion] QQ 空间说说草稿含内部状态且重写失败,已取消本次发布")
+            logger.warning("QQ 空间说说内部状态重写失败: %s", _single_line(exc, 120))
+        logger.warning("QQ 空间说说草稿含内部状态且重写失败,已取消本次发布")
         return ""
 
     async def _test_qzone_publish_tool_chain(self, event: AstrMessageEvent | None = None) -> str:
@@ -851,7 +853,7 @@ class QzonePublishMixin:
             return []
         if not re.match(r"^(?:https?://|file://|data:)", image_path, flags=re.I) and not Path(image_path).exists():
             return []
-        logger.info("[PrivateCompanion] QQ 空间复用待发布配图: reason=%s path=%s", reason, _single_line(image_path, 160))
+        logger.info("QQ 空间复用待发布配图: reason=%s path=%s", reason, _single_line(image_path, 160))
         return [image_path]
 
     def _qzone_note_publish_image_status(
@@ -933,12 +935,12 @@ class QzonePublishMixin:
             self._qzone_note_publish_image_status(state, reason, "skipped:probability", f"未命中配图概率 {probability:.0%}")
             return []
         if callable(getattr(self, "_daily_token_soft_limit_should_defer", None)) and self._daily_token_soft_limit_should_defer("photo_prompt"):
-            logger.info("[PrivateCompanion] QQ 空间主动配图跳过: token_soft_limit")
+            logger.info("QQ 空间主动配图跳过: token_soft_limit")
             self._qzone_note_publish_image_status(state, reason, "skipped:token_budget", "token 软上限保护")
             return []
         generator = getattr(self, "_generate_photo_image", None)
         if not callable(generator):
-            logger.info("[PrivateCompanion] QQ 空间主动配图跳过: image_generator_unavailable")
+            logger.info("QQ 空间主动配图跳过: image_generator_unavailable")
             self._qzone_note_publish_image_status(state, reason, "skipped:no_generator", "缺少 _generate_photo_image 生图入口")
             return []
 
@@ -979,7 +981,7 @@ class QzonePublishMixin:
                 )
             except Exception as ref_exc:
                 logger.info(
-                    "[PrivateCompanion] QQ 空间自拍参考图预检失败: reason=%s error=%s",
+                    "QQ 空间自拍参考图预检失败: reason=%s error=%s",
                     _single_line(reason, 40),
                     _single_line(ref_exc, 120),
                 )
@@ -1104,7 +1106,7 @@ class QzonePublishMixin:
             reference_image_path = qzone_selfie_reference_path if workflow_kind == "selfie" else ""
             reference_exists = qzone_selfie_reference_exists if workflow_kind == "selfie" else False
             logger.info(
-                "[PrivateCompanion] QQ 空间配图生图开始: reason=%s kind=%s anchor=%s composition=%s reference=%s reference_exists=%s post=%s prompt=%s",
+                "QQ 空间配图生图开始: reason=%s kind=%s anchor=%s composition=%s reference=%s reference_exists=%s post=%s prompt=%s",
                 _single_line(reason, 40),
                 _single_line(workflow_kind, 30),
                 _single_line(visual_anchor, 80) or "-",
@@ -1121,7 +1123,7 @@ class QzonePublishMixin:
                 reference_image_path=reference_image_path,
             )
         except Exception as exc:
-            logger.info("[PrivateCompanion] QQ 空间主动配图失败: %s", _single_line(exc, 120))
+            logger.info("QQ 空间主动配图失败: %s", _single_line(exc, 120))
             self._qzone_note_publish_image_status(
                 state,
                 reason,
@@ -1132,7 +1134,7 @@ class QzonePublishMixin:
             )
             return []
         if not image_path:
-            logger.info("[PrivateCompanion] QQ 空间主动配图跳过: %s", _single_line(workflow_note, 160))
+            logger.info("QQ 空间主动配图跳过: %s", _single_line(workflow_note, 160))
             self._qzone_note_publish_image_status(
                 state,
                 reason,
@@ -1146,7 +1148,7 @@ class QzonePublishMixin:
             )
             return []
         if not re.match(r"^(?:https?://|file://|data:)", str(image_path), flags=re.I) and not Path(str(image_path)).exists():
-            logger.info("[PrivateCompanion] QQ 空间主动配图跳过: image_path_missing path=%s", _single_line(image_path, 160))
+            logger.info("QQ 空间主动配图跳过: image_path_missing path=%s", _single_line(image_path, 160))
             self._qzone_note_publish_image_status(
                 state,
                 reason,
@@ -1197,7 +1199,7 @@ class QzonePublishMixin:
                 composition=composition,
             )
         logger.info(
-            "[PrivateCompanion] QQ 空间主动配图完成: reason=%s backend=%s reference=%s reference_exists=%s path=%s",
+            "QQ 空间主动配图完成: reason=%s backend=%s reference=%s reference_exists=%s path=%s",
             reason,
             _single_line(backend_name, 40),
             bool(reference_image_path),

--- a/qzone_runtime.py
+++ b/qzone_runtime.py
@@ -10,12 +10,14 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
-from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent
 
 from .helpers import _now_ts, _single_line
 from .qzone_json import load_qzone_json
 from .qzone_errors import QzoneIntegrationError
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 __all__ = ("QzoneRuntimeMixin",)
 
@@ -597,7 +599,7 @@ class QzoneRuntimeMixin:
             if callable(getattr(self, "_save_data_sync", None)):
                 self._save_data_sync(sections={"qzone_integration"})
         except Exception:
-            logger.debug("[PrivateCompanion] QQ 空间 Cookie 状态记录失败", exc_info=True)
+            logger.debug("QQ 空间 Cookie 状态记录失败", exc_info=True)
 
     async def _qzone_fetch_login_uin(self, bot: Any) -> int:
         for action in self._QZONE_LOGIN_INFO_ACTIONS:
@@ -671,7 +673,7 @@ class QzoneRuntimeMixin:
                     f"{_single_line(exc, 120)}；"
                     "需包含 uin/p_uin 与 p_skey 或 skey，可从已登录 QQ 空间的浏览器请求头 Cookie 复制"
                 ) from exc
-            logger.debug("[PrivateCompanion] QQ 空间使用手动 QZONE_COOKIE: uin=%s", ctx.get("uin"))
+            logger.debug("QQ 空间使用手动 QZONE_COOKIE: uin=%s", ctx.get("uin"))
             self._qzone_note_cookie_fetch_status("manual_ok", ctx=ctx)
             return ctx["cookie_header"]
         bot = getattr(event, "bot", None) if event is not None else None
@@ -696,7 +698,7 @@ class QzoneRuntimeMixin:
         if self._qzone_cookie_has_identity_and_secret(merged):
             cookie_text = self._qzone_cookie_header(self._qzone_normalize_cookie_fields(merged))
             ctx = self._qzone_context_from_cookies(cookie_text)
-            logger.debug("[PrivateCompanion] QQ 空间自动获取 Cookie 成功: uin=%s", ctx.get("uin"))
+            logger.debug("QQ 空间自动获取 Cookie 成功: uin=%s", ctx.get("uin"))
             self._qzone_note_cookie_fetch_status("ok", ctx=ctx)
             return ctx["cookie_header"]
         self._qzone_note_cookie_fetch_status("failed", cookies=merged)

--- a/qzone_schedule.py
+++ b/qzone_schedule.py
@@ -11,10 +11,12 @@ import time
 from datetime import datetime
 from typing import Any
 
-from astrbot.api import logger
 
 from .helpers import _day_start_ts, _now_ts, _safe_float, _safe_int, _single_line, _today_key
 from .persona_config import runtime_persona_setting
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 def _persona_provider_id(owner: Any, canonical_key: str, legacy_attr: str, quick_role: str) -> str:
@@ -743,7 +745,7 @@ class QzoneScheduleMixin:
                 task="qzone_publish_length",
             )
         except Exception as exc:
-            logger.warning("[PrivateCompanion] QQ 空间说说字数重写失败: %s", _single_line(exc, 120))
+            logger.warning("QQ 空间说说字数重写失败: %s", _single_line(exc, 120))
             return ""
         # A rewrite bypasses the original sanitizer, so re-run it here.
         return await self._sanitize_qzone_life_post_text(rewritten, prompt=rewrite_prompt)
@@ -823,7 +825,7 @@ class QzoneScheduleMixin:
                 task="qzone_publish_deduplicate",
             )
         except Exception as exc:
-            logger.warning("[PrivateCompanion] QQ 空间说说去重重写失败: %s", _single_line(exc, 120))
+            logger.warning("QQ 空间说说去重重写失败: %s", _single_line(exc, 120))
             return ""
         # A rewrite bypasses the original sanitizer, so re-run it here.
         return await self._sanitize_qzone_life_post_text(rewritten, prompt=rewrite_prompt)
@@ -861,7 +863,7 @@ class QzoneScheduleMixin:
                 try:
                     await ensure_daily_plan()
                 except Exception as exc:
-                    logger.warning("[PrivateCompanion] QQ 空间建计划前确保今日日程失败，继续使用当下状态: %s", _single_line(exc, 120))
+                    logger.warning("QQ 空间建计划前确保今日日程失败，继续使用当下状态: %s", _single_line(exc, 120))
         plan = self._qzone_life_publish_daily_plan(state, now=now)
         plan_changed = self._qzone_backfill_plan_schedule_labels(plan)
         # The cross-day gap is applied while building the first slot. Once that
@@ -974,7 +976,7 @@ class QzoneScheduleMixin:
         if reusable_text:
             text = reusable_text
             logger.info(
-                "[PrivateCompanion] QQ 空间复用待发布生活说说草稿: age=%ds",
+                "QQ 空间复用待发布生活说说草稿: age=%ds",
                 int(now - _safe_float(state.get("last_life_publish_draft_at"), now)),
             )
         else:
@@ -1048,7 +1050,7 @@ class QzoneScheduleMixin:
                 state["last_life_publish_checked_at"] = now
                 self._qzone_plan_item_finish(plan, plan_item, "cancelled", now=now)
                 self._save_data_sync(sections={"qzone_integration"})
-                logger.warning("[PrivateCompanion] QQ 空间生活动态草稿为空或不安全,已跳过发布")
+                logger.warning("QQ 空间生活动态草稿为空或不安全,已跳过发布")
                 return
             if not self._qzone_text_length_ok(text, length_profile):
                 relengthed = await self._qzone_life_publish_rewrite_to_length(
@@ -1065,7 +1067,7 @@ class QzoneScheduleMixin:
                     self._qzone_plan_item_finish(plan, plan_item, "cancelled", now=now)
                     self._save_data_sync(sections={"qzone_integration"})
                     logger.info(
-                        "[PrivateCompanion] QQ 空间说说字数不合要求且重写失败,已取消: profile=%s len=%s",
+                        "QQ 空间说说字数不合要求且重写失败,已取消: profile=%s len=%s",
                         length_profile,
                         len(re.sub(r"\s+", "", text or "")),
                     )
@@ -1081,7 +1083,7 @@ class QzoneScheduleMixin:
                 self._qzone_clear_pending_publish_assets(state, "life_publish")
                 self._qzone_plan_item_finish(plan, plan_item, "cancelled", now=now)
                 self._save_data_sync(sections={"qzone_integration"})
-                logger.info("[PrivateCompanion] QQ 空间复用草稿与近期说说重复,已取消发布")
+                logger.info("QQ 空间复用草稿与近期说说重复,已取消发布")
                 return
             rewritten = await self._qzone_life_publish_rewrite_deduplicated(
                 text,
@@ -1096,14 +1098,14 @@ class QzoneScheduleMixin:
                 text = rewritten
                 state["last_life_publish_draft"] = _single_line(text, 300)
                 state["last_life_publish_draft_at"] = now
-                logger.info("[PrivateCompanion] QQ 空间草稿与近期说说重复,已重写避开: %s", _single_line(text, 120))
+                logger.info("QQ 空间草稿与近期说说重复,已重写避开: %s", _single_line(text, 120))
             else:
                 state["last_life_publish_failed_at"] = now
                 state["last_life_publish_status"] = "cancelled:duplicate_after_retry"
                 state["last_life_publish_checked_at"] = now
                 self._qzone_plan_item_finish(plan, plan_item, "cancelled", now=now)
                 self._save_data_sync(sections={"qzone_integration"})
-                logger.info("[PrivateCompanion] QQ 空间草稿重写后仍与近期说说重复,已取消发布")
+                logger.info("QQ 空间草稿重写后仍与近期说说重复,已取消发布")
                 return
         if reusable_text:
             image_sources = self._qzone_reusable_generated_image(state, "life_publish", text, now=now)
@@ -1197,7 +1199,7 @@ class QzoneScheduleMixin:
                 role = ""
             if role != "owner":
                 logger.info(
-                    "[PrivateCompanion] 公开心情动态跳过: user_role=%s intensity=%s",
+                    "公开心情动态跳过: user_role=%s intensity=%s",
                     role or "friend",
                     event_intensity,
                 )
@@ -1217,7 +1219,7 @@ class QzoneScheduleMixin:
             ),
         ) * 3600
         if now - _safe_float(state.get("last_emotional_vent_at"), 0) < cooldown:
-            logger.info("[PrivateCompanion] 公开心情动态跳过: cooldown intensity=%s", event_intensity)
+            logger.info("公开心情动态跳过: cooldown intensity=%s", event_intensity)
             return
         block_reason = self._qzone_auto_publish_block_reason(state, now=now)
         if block_reason:
@@ -1300,7 +1302,7 @@ class QzoneScheduleMixin:
             if reusable_text:
                 text = reusable_text
                 logger.info(
-                    "[PrivateCompanion] QQ 空间复用待发布心情动态草稿: age=%ds",
+                    "QQ 空间复用待发布心情动态草稿: age=%ds",
                     int(now - _safe_float(state.get("last_emotional_vent_draft_at"), now)),
                 )
             else:
@@ -1321,7 +1323,7 @@ class QzoneScheduleMixin:
                     state["last_emotional_vent_status"] = "cancelled:empty_or_unsafe_draft"
                     state["last_emotional_vent_checked_at"] = now
                     self._save_data_sync(sections={"qzone_integration"})
-                    logger.warning("[PrivateCompanion] 公开心情动态草稿为空或不安全,已跳过发布")
+                    logger.warning("公开心情动态草稿为空或不安全,已跳过发布")
                     return
                 state["last_emotional_vent_draft"] = _single_line(text, 240)
                 state["last_emotional_vent_draft_at"] = now
@@ -1356,11 +1358,11 @@ class QzoneScheduleMixin:
                 else:
                     state.pop("last_emotional_vent_image_fallback", None)
                 self._qzone_clear_pending_publish_assets(state, "emotional_vent")
-                logger.info("[PrivateCompanion] 公开心情动态已发布: intensity=%s text=%s", event_intensity, _single_line(result.get("text") or text, 120))
+                logger.info("公开心情动态已发布: intensity=%s text=%s", event_intensity, _single_line(result.get("text") or text, 120))
             else:
                 state["last_emotional_vent_failed_at"] = now
                 state["last_emotional_vent_status"] = f"failed:{_single_line(result.get('message'), 80)}"
-                logger.warning("[PrivateCompanion] 公开心情动态发布失败: %s", _single_line(result.get("message"), 120))
+                logger.warning("公开心情动态发布失败: %s", _single_line(result.get("message"), 120))
             state["last_emotional_vent_checked_at"] = now
             state["last_emotional_vent_text"] = _single_line(result.get("text") or text, 180)
             state["last_emotional_vent_images"] = _safe_int(result.get("image_count"), len(result.get("images") or []), 0, 99) if result.get("success") else 0
@@ -1370,4 +1372,4 @@ class QzoneScheduleMixin:
             state["last_emotional_vent_status"] = f"failed:{_single_line(exc, 80)}"
             state["last_emotional_vent_checked_at"] = now
             self._save_data_sync(sections={"qzone_integration"})
-            logger.warning("[PrivateCompanion] 公开心情动态异常: %s", _single_line(exc, 160), exc_info=True)
+            logger.warning("公开心情动态异常: %s", _single_line(exc, 160), exc_info=True)

--- a/reality_companion_bridge.py
+++ b/reality_companion_bridge.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 import time
 from typing import Any
 
-from astrbot.api import logger
 
 from .helpers import _safe_float, _single_line
 from .external_bridge_resolver import resolve_external_bridge
 from .conversation_prompt_section import prompt_section
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 class RealityCompanionBridgeMixin:
@@ -64,7 +66,7 @@ class RealityCompanionBridgeMixin:
                     delivered_at=delivered_at,
                 )
             except Exception as exc:
-                logger.warning("[PrivateCompanion] 外部现实触及输出写入失败: %s", _single_line(exc, 160))
+                logger.warning("外部现实触及输出写入失败: %s", _single_line(exc, 160))
                 return {"recorded": False, "reason": "reality_companion_write_failed"}
         return {"recorded": False, "reason": "reality_companion_unavailable"}
 
@@ -197,7 +199,7 @@ class RealityCompanionBridgeMixin:
         api = self._reality_companion_api()
         scheduler = getattr(api, "schedule_reminder", None) if api is not None else None
         if not callable(scheduler):
-            logger.info("[PrivateCompanion] 未安装或未启用“我会来到你身边”，现实提醒未创建")
+            logger.info("未安装或未启用“我会来到你身边”，现实提醒未创建")
             return False
         return bool(
             await scheduler(

--- a/scripts/build_plugin_package.py
+++ b/scripts/build_plugin_package.py
@@ -28,6 +28,7 @@ RUNTIME_DIRECTORIES = (
 )
 REQUIRED_ARCHIVE_FILES = (
     "main.py",
+    "logging_util.py",
     "metadata.yaml",
     "_conf_schema.json",
     "requirements.txt",

--- a/standalone_webui.py
+++ b/standalone_webui.py
@@ -312,25 +312,25 @@ class StandaloneWebUIServer:
         if self.is_running:
             return True
         if not self.enabled:
-            logger.debug("[PrivateCompanion] 独立 WebUI 未启用")
+            logger.debug("[独立WebUI] 独立 WebUI 未启用")
             return False
         if not self._has_access_token or self._access_token_length < 16:
             logger.warning(
-                "[PrivateCompanion] 独立 WebUI 未启动: 访问令牌至少需要 16 个字符"
+                "[独立WebUI] 独立 WebUI 未启动: 访问令牌至少需要 16 个字符"
             )
             return False
         if self.page_api is None:
-            logger.warning("[PrivateCompanion] 独立 WebUI 未启动: Page API 不可用")
+            logger.warning("[独立WebUI] 独立 WebUI 未启动: Page API 不可用")
             return False
         if not self.dependencies_available():
             logger.warning(
-                "[PrivateCompanion] 独立 WebUI 未启动: 缺少 Quart/Hypercorn 运行依赖 (quart=%s hypercorn=%s)",
+                "[独立WebUI] 独立 WebUI 未启动: 缺少 Quart/Hypercorn 运行依赖 (quart=%s hypercorn=%s)",
                 _QUART_IMPORT_ERROR or "ok",
                 _HYPERCORN_IMPORT_ERROR or "ok",
             )
             return False
         if not self._resolve_static_path("index.html"):
-            logger.warning("[PrivateCompanion] 独立 WebUI 未启动: 面板静态文件不存在")
+            logger.warning("[独立WebUI] 独立 WebUI 未启动: 面板静态文件不存在")
             return False
 
         try:
@@ -356,12 +356,12 @@ class StandaloneWebUIServer:
             self._serve_task = None
             self._shutdown_event = None
             logger.warning(
-                "[PrivateCompanion] 独立 WebUI 启动失败: error_type=%s",
+                "[独立WebUI] 独立 WebUI 启动失败: error_type=%s",
                 type(exc).__name__,
             )
             return False
 
-        logger.info("[PrivateCompanion] 独立 WebUI 已启动: %s", self.url)
+        logger.info("[独立WebUI] 独立 WebUI 已启动: %s", self.url)
         return True
 
     async def stop(self) -> None:
@@ -374,7 +374,7 @@ class StandaloneWebUIServer:
                 await asyncio.wait_for(asyncio.shield(task), timeout=10.0)
             except asyncio.TimeoutError:
                 logger.warning(
-                    "[PrivateCompanion] 独立 WebUI 优雅停止超时,正在取消服务任务"
+                    "[独立WebUI] 独立 WebUI 优雅停止超时,正在取消服务任务"
                 )
                 task.cancel()
                 await asyncio.gather(task, return_exceptions=True)
@@ -464,7 +464,7 @@ class StandaloneWebUIServer:
         @app.errorhandler(500)
         async def standalone_internal_error(_error: Any) -> Any:
             logger.warning(
-                "[PrivateCompanion] 独立 WebUI 请求失败: path=%s reason=internal_error",
+                "[独立WebUI] 独立 WebUI 请求失败: path=%s reason=internal_error",
                 str(_request.path or "")[:160],
             )
             if str(_request.path or "").startswith(API_PREFIX):
@@ -565,7 +565,7 @@ class StandaloneWebUIServer:
             rule = f"{API_PREFIX}{suffix}"
             if rule.startswith(f"{API_PREFIX}/auth/"):
                 logger.warning(
-                    "[PrivateCompanion] 独立 WebUI 跳过冲突的 Page API 路由: %s", rule
+                    "[独立WebUI] 独立 WebUI 跳过冲突的 Page API 路由: %s", rule
                 )
                 continue
             app.add_url_rule(
@@ -898,7 +898,7 @@ class StandaloneWebUIServer:
 
     def _log_auth_rejection(self, reason: str, client_key: str | None = None) -> None:
         logger.warning(
-            "[PrivateCompanion] 独立 WebUI 鉴权拒绝: ip=%s reason=%s",
+            "[独立WebUI] 独立 WebUI 鉴权拒绝: ip=%s reason=%s",
             client_key or self._client_key(),
             re.sub(r"[^a-z0-9_-]", "_", str(reason or "unknown").casefold())[:48],
         )
@@ -918,7 +918,7 @@ class StandaloneWebUIServer:
             return
         if error is not None:
             logger.warning(
-                "[PrivateCompanion] 独立 WebUI 服务任务已结束: error_type=%s",
+                "[独立WebUI] 独立 WebUI 服务任务已结束: error_type=%s",
                 type(error).__name__,
             )
 

--- a/storage/json_backend.py
+++ b/storage/json_backend.py
@@ -10,9 +10,11 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Callable
 
-from astrbot.api import logger
 
 from .backend_base import StoreBackendBase
+from ..logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 class JsonStoreBackend(StoreBackendBase):
@@ -43,7 +45,7 @@ class JsonStoreBackend(StoreBackendBase):
             return self.ensure_defaults(data)
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanion] 读取 JSON 数据失败,已保留原文件并中止加载: %s",
+                "读取 JSON 数据失败,已保留原文件并中止加载: %s",
                 exc,
             )
             raise

--- a/storage/migration.py
+++ b/storage/migration.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Any
 
-from astrbot.api import logger
 
 from .sqlite_backend import SqliteStoreNotInitializedError
+from ..logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 def _initialize_backend_from_payload(
@@ -18,14 +20,14 @@ def _initialize_backend_from_payload(
     try:
         backend.initialize_empty_store(deepcopy(payload))
         logger.info(
-            "[PrivateCompanion] 已%s到 %s 后端",
+            "已%s到 %s 后端",
             action,
             backend.backend_name(),
         )
         return backend.load_store()
     except Exception as exc:
         logger.warning(
-            "[PrivateCompanion] %s到 %s 后端失败,本次继续使用来源数据: %s",
+            "%s到 %s 后端失败,本次继续使用来源数据: %s",
             action,
             backend.backend_name(),
             exc,

--- a/storage/sqlite_backend.py
+++ b/storage/sqlite_backend.py
@@ -12,9 +12,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from astrbot.api import logger
 
 from .backend_base import StoreBackendBase
+from ..logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 _SCHEMA_VERSION = 2
 _SQLITE_INTEGER_MAX = (1 << 63) - 1
@@ -438,7 +440,7 @@ class SqliteStoreBackend(StoreBackendBase):
                 raise SqliteSchemaError("SQLite v1 to v2 integrity check failed")
             connection.commit()
             logger.info(
-                "[PrivateCompanion] Migrated SQLite store schema to v2 after creating backup: %s",
+                "Migrated SQLite store schema to v2 after creating backup: %s",
                 backup_path,
             )
         except Exception:
@@ -544,7 +546,7 @@ class SqliteStoreBackend(StoreBackendBase):
             raise
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanion] 读取 SQLite 数据失败,已保留原数据库并中止加载: %s",
+                "读取 SQLite 数据失败,已保留原数据库并中止加载: %s",
                 exc,
             )
             raise

--- a/storage/store_manager.py
+++ b/storage/store_manager.py
@@ -8,13 +8,15 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
-from astrbot.api import logger
 
 from . import cleanup_storage_bytecode_cache
 from .factory import build_store_backend
 from .json_backend import JsonStoreBackend
 from .migration import migrate_json_to_backend_if_needed
 from .sqlite_backend import SqliteStoreNotInitializedError
+from ..logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 _BOOKSHELF_SECTIONS = (
     "bookshelf_items",
@@ -316,7 +318,7 @@ class StoreManager:
             if strict:
                 raise
             logger.warning(
-                "[PrivateCompanion] 备用 %s 存储读取失败，跳过夹层恢复: %s",
+                "备用 %s 存储读取失败，跳过夹层恢复: %s",
                 backend.backend_name(),
                 exc,
             )
@@ -350,7 +352,7 @@ class StoreManager:
         if not changed:
             return selected
         logger.warning(
-            "[PrivateCompanion] 检测到夹层存储来源不完整，已从 %s 保守恢复: items=%s revision=%s",
+            "检测到夹层存储来源不完整，已从 %s 保守恢复: items=%s revision=%s",
             fallback_name,
             recovered,
             _bookshelf_revision(reconciled),
@@ -370,7 +372,7 @@ class StoreManager:
                     self.backend.save_store(reconciled)
             except Exception as exc:
                 logger.warning(
-                    "[PrivateCompanion] 夹层恢复结果暂未写回 %s，本进程继续使用已恢复数据: %s",
+                    "夹层恢复结果暂未写回 %s，本进程继续使用已恢复数据: %s",
                     self.backend.backend_name(),
                     exc,
                 )
@@ -413,7 +415,7 @@ class StoreManager:
             if key in reconciled:
                 data[key] = deepcopy(reconciled[key])
         logger.warning(
-            "[PrivateCompanion] 拦截到可能清空夹层的旧快照，已保留现有存储内容: items=%s revision=%s",
+            "拦截到可能清空夹层的旧快照，已保留现有存储内容: items=%s revision=%s",
             recovered,
             _bookshelf_revision(reconciled),
         )

--- a/tests/test_smart_imagechat_integration.py
+++ b/tests/test_smart_imagechat_integration.py
@@ -265,7 +265,7 @@ class _ReactionHarness(SceneContextMixin, LlmToolActionsMixin):
 
 
 def _reaction_log_payloads(log_info) -> list[dict[str, object]]:
-    prefix = "[PrivateCompanion][ReactionExpression] %s"
+    prefix = "[ReactionExpression] %s"
     payloads: list[dict[str, object]] = []
     for call in log_info.call_args_list:
         if len(call.args) < 2 or call.args[0] != prefix:

--- a/token_budget.py
+++ b/token_budget.py
@@ -8,7 +8,6 @@ import time
 from datetime import datetime
 from typing import Any
 
-from astrbot.api import logger
 
 from .constants import (
     MODEL_PROVIDER_KEYS,
@@ -19,6 +18,9 @@ from .constants import (
 from .helpers import _flat_get, _now_ts, _safe_float, _safe_int, _single_line, _today_key
 from .model_routing import contains_sensitive_refusal, scope_allows
 from .persona_config import runtime_persona_setting
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 def _looks_like_upstream_llm_error_response(text: Any) -> bool:
@@ -877,14 +879,14 @@ class TokenBudgetMixin:
             self._token_budget_skip_logged_key = log_key
             if error in {"daily_token_soft_limit_deferred", "maintenance_token_saver_deferred"}:
                 logger.info(
-                    "[PrivateCompanion] 每日 Token 软限额已暂缓低优先级 LLM 任务: used=%s soft_limit=%s task=%s",
+                    "每日 Token 软限额已暂缓低优先级 LLM 任务: used=%s soft_limit=%s task=%s",
                     self._today_llm_token_total(),
                     self.daily_token_soft_limit,
                     task or "other",
                 )
             else:
                 logger.warning(
-                    "[PrivateCompanion] 今日插件 Token 限额已达到: %s/%s",
+                    "今日插件 Token 限额已达到: %s/%s",
                     self._today_llm_token_total(),
                     self.daily_token_limit,
                 )
@@ -938,10 +940,10 @@ class TokenBudgetMixin:
         # provider 的任务（日程、日记）会静默退化成模板兜底，且无从归因。
         fallback_id = self._chat_provider_id_from_registry(context)
         if fallback_id:
-            logger.info("[PrivateCompanion] 默认对话 Provider 经注册表兜底解析: %s", fallback_id)
+            logger.info("默认对话 Provider 经注册表兜底解析: %s", fallback_id)
             return fallback_id
         logger.warning(
-            "[PrivateCompanion] 无法解析默认对话 Provider：get_using_provider 与注册表兜底都没有结果；"
+            "无法解析默认对话 Provider：get_using_provider 与注册表兜底都没有结果；"
             "未显式配置 provider 的模型任务将退化为模板兜底"
         )
         return ""
@@ -1288,7 +1290,7 @@ class TokenBudgetMixin:
         if limit is None or estimate <= limit:
             return False, limit, estimate
         logger.warning(
-            "[PrivateCompanion] 请求预估 Token 超过模型卡上限，跳过主模型并切换备用模型: task=%s card=%s estimate=%s limit=%s primary=%s fallback=%s",
+            "请求预估 Token 超过模型卡上限，跳过主模型并切换备用模型: task=%s card=%s estimate=%s limit=%s primary=%s fallback=%s",
             _single_line(task, 80) or "unknown",
             provider_key or "unknown",
             estimate,
@@ -1480,14 +1482,14 @@ class TokenBudgetMixin:
                         sensitive_replacement_used = True
                         candidates.append(sensitive_replacement)
                         logger.info(
-                            "[PrivateCompanion] 插件工具模型命中敏感拒答，切换指定模型重试: provider=%s target=%s keyword=%s",
+                            "插件工具模型命中敏感拒答，切换指定模型重试: provider=%s target=%s keyword=%s",
                             _single_line(attempt_provider, 120),
                             _single_line(sensitive_replacement, 120),
                             _single_line(sensitive_keyword, 80),
                         )
                         continue
                     logger.warning(
-                        "[PrivateCompanion] 插件工具指定模型仍返回敏感拒答，丢弃本次文本: provider=%s keyword=%s",
+                        "插件工具指定模型仍返回敏感拒答，丢弃本次文本: provider=%s keyword=%s",
                         _single_line(attempt_provider, 120),
                         _single_line(sensitive_keyword, 80),
                     )
@@ -1513,7 +1515,7 @@ class TokenBudgetMixin:
                     )
                     if attempt_index + 1 < len(candidates):
                         logger.warning(
-                            "[PrivateCompanion] 工具调用主模型失败，尝试卡片备用模型: task=%s card=%s primary=%s fallback=%s kind=%s",
+                            "工具调用主模型失败，尝试卡片备用模型: task=%s card=%s primary=%s fallback=%s kind=%s",
                             _single_line(task_key, 80) or "unknown",
                             provider_key or "unknown",
                             _single_line(selected_provider, 120),
@@ -1548,7 +1550,7 @@ class TokenBudgetMixin:
                 )
                 if attempt_index > 0 or token_routed:
                     logger.info(
-                        "[PrivateCompanion] 工具调用使用备用模型: task=%s card=%s provider=%s estimated_tokens=%s",
+                        "工具调用使用备用模型: task=%s card=%s provider=%s estimated_tokens=%s",
                         _single_line(task_key, 80) or "unknown",
                         provider_key or "unknown",
                         _single_line(attempt_provider, 120),
@@ -1569,7 +1571,7 @@ class TokenBudgetMixin:
                 )
                 if attempt_index + 1 < len(candidates):
                     logger.warning(
-                        "[PrivateCompanion] 工具调用失败，尝试卡片备用模型: task=%s card=%s error=%s",
+                        "工具调用失败，尝试卡片备用模型: task=%s card=%s error=%s",
                         _single_line(task_key, 80) or "unknown",
                         provider_key or "unknown",
                         _single_line(exc, 160),
@@ -1675,14 +1677,14 @@ class TokenBudgetMixin:
                                 sensitive_replacement_used = True
                                 candidates.append(sensitive_replacement)
                                 logger.info(
-                                    "[PrivateCompanion] 插件模型命中敏感拒答，切换指定模型重试: provider=%s target=%s keyword=%s",
+                                    "插件模型命中敏感拒答，切换指定模型重试: provider=%s target=%s keyword=%s",
                                     _single_line(attempt_provider, 120),
                                     _single_line(sensitive_replacement, 120),
                                     _single_line(sensitive_keyword, 80),
                                 )
                                 continue
                             logger.warning(
-                                "[PrivateCompanion] 插件指定模型仍返回敏感拒答，丢弃本次文本: provider=%s keyword=%s",
+                                "插件指定模型仍返回敏感拒答，丢弃本次文本: provider=%s keyword=%s",
                                 _single_line(attempt_provider, 120),
                                 _single_line(sensitive_keyword, 80),
                             )
@@ -1710,7 +1712,7 @@ class TokenBudgetMixin:
                             )
                             if attempt_index + 1 < len(candidates):
                                 logger.warning(
-                                    "[PrivateCompanion] 主模型返回 Provider 错误响应,尝试卡片备用模型: task=%s card=%s primary=%s fallback=%s kind=%s",
+                                    "主模型返回 Provider 错误响应,尝试卡片备用模型: task=%s card=%s primary=%s fallback=%s kind=%s",
                                     _single_line(task_key, 80) or "unknown",
                                     provider_key or "unknown",
                                     _single_line(attempt_provider, 120),
@@ -1719,7 +1721,7 @@ class TokenBudgetMixin:
                                 )
                             else:
                                 logger.warning(
-                                    "[PrivateCompanion] LLM 返回 Provider 错误响应: task=%s provider=%s kind=%s",
+                                    "LLM 返回 Provider 错误响应: task=%s provider=%s kind=%s",
                                     _single_line(task_key, 80) or "unknown",
                                     _single_line(attempt_provider, 120) or "default",
                                     failure_code,
@@ -1737,7 +1739,7 @@ class TokenBudgetMixin:
                         )
                         if attempt_index > 0 or token_routed:
                             logger.info(
-                                "[PrivateCompanion] 备用模型调用成功: task=%s card=%s provider=%s estimated_tokens=%s",
+                                "备用模型调用成功: task=%s card=%s provider=%s estimated_tokens=%s",
                                 _single_line(task_key, 80) or "unknown",
                                 provider_key or "unknown",
                                 _single_line(attempt_provider, 120),
@@ -1757,7 +1759,7 @@ class TokenBudgetMixin:
                 )
                 if attempt_index + 1 < len(candidates):
                     logger.warning(
-                        "[PrivateCompanion] 主模型返回空结果,尝试卡片备用模型: task=%s card=%s primary=%s fallback=%s",
+                        "主模型返回空结果,尝试卡片备用模型: task=%s card=%s primary=%s fallback=%s",
                         _single_line(task_key, 80) or "unknown",
                         provider_key or "unknown",
                         _single_line(attempt_provider, 120),
@@ -1776,7 +1778,7 @@ class TokenBudgetMixin:
                 )
                 if attempt_index + 1 < len(candidates):
                     logger.warning(
-                        "[PrivateCompanion] 主模型调用失败,尝试卡片备用模型: task=%s card=%s primary=%s fallback=%s error=%s",
+                        "主模型调用失败,尝试卡片备用模型: task=%s card=%s primary=%s fallback=%s error=%s",
                         _single_line(task_key, 80) or "unknown",
                         provider_key or "unknown",
                         _single_line(attempt_provider, 120) or "default",
@@ -1785,7 +1787,7 @@ class TokenBudgetMixin:
                     )
                     continue
                 logger.warning(
-                    "[PrivateCompanion] LLM 调用失败: task=%s provider=%s error=%s",
+                    "LLM 调用失败: task=%s provider=%s error=%s",
                     _single_line(task_key, 80) or "unknown",
                     _single_line(attempt_provider, 120) or "default",
                     _single_line(e, 160),

--- a/tts_enhancement.py
+++ b/tts_enhancement.py
@@ -18,7 +18,6 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import unquote, urlparse
 
-from astrbot.api import logger
 try:
     from astrbot.api.message_components import Plain, Record
 except ImportError:
@@ -48,6 +47,9 @@ from .segmented_message import (
     component_strategies_from_owner,
     plan_component_chunks,
 )
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 TTS_BLOCK_PATTERN = re.compile(r"<t{2,}s\b[^>]*>.*?</t{2,}s>", re.IGNORECASE | re.DOTALL)
@@ -383,7 +385,7 @@ class TtsEnhancementMixin:
                 pass
             except Exception as exc:
                 logger.warning(
-                    "[PrivateCompanion] TTS background task failed: label=%s error=%s",
+                    "TTS background task failed: label=%s error=%s",
                     label,
                     _single_line(exc, 160),
                 )
@@ -591,7 +593,7 @@ class TtsEnhancementMixin:
         try:
             manager = self.context.get_llm_tool_manager()
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 读取 MiMo TTS 工具管理器失败: %s", _single_line(exc, 120))
+            logger.debug("读取 MiMo TTS 工具管理器失败: %s", _single_line(exc, 120))
             return None
         if manager is None:
             return None
@@ -620,7 +622,7 @@ class TtsEnhancementMixin:
             if getattr(self, "_tts_mimo_bridge_handler_warning_key", "") != warning_key:
                 self._tts_mimo_bridge_handler_warning_key = warning_key
                 logger.warning(
-                    "[PrivateCompanion] 已找到 MiMo TTS 工具但无法取得插件公开合成服务: tool=%s",
+                    "已找到 MiMo TTS 工具但无法取得插件公开合成服务: tool=%s",
                     tool_name,
                 )
             return None
@@ -628,7 +630,7 @@ class TtsEnhancementMixin:
         if getattr(self, "_tts_mimo_bridge_key", "") != bridge_key:
             self._tts_mimo_bridge_key = bridge_key
             logger.info(
-                "[PrivateCompanion] 已发现 MiMo TTS Voice Clone: tool=%s service=%s",
+                "已发现 MiMo TTS Voice Clone: tool=%s service=%s",
                 tool_name,
                 plugin.__class__.__name__,
             )
@@ -686,7 +688,7 @@ class TtsEnhancementMixin:
         if getattr(self, "_tts_language_provider_warning_key", "") != warning_key:
             self._tts_language_provider_warning_key = warning_key
             logger.warning(
-                "[PrivateCompanion] 当前语种配置的 TTS Provider 不可用,已回退现有合成链路: language=%s provider=%s",
+                "当前语种配置的 TTS Provider 不可用,已回退现有合成链路: language=%s provider=%s",
                 language,
                 provider_id,
             )
@@ -718,7 +720,7 @@ class TtsEnhancementMixin:
                             "voice_not_found": "指定音色不存在或已停用",
                         }.get(reason, reason)
                         logger.info(
-                            "[PrivateCompanion] 自动识别到 MiMo TTS Voice Clone,但暂不接管合成: reason=%s fallback=%s",
+                            "自动识别到 MiMo TTS Voice Clone,但暂不接管合成: reason=%s fallback=%s",
                             reason_label,
                             "AstrBot TTS provider" if astrbot_provider is not None else "文字/浏览器朗读",
                         )
@@ -727,7 +729,7 @@ class TtsEnhancementMixin:
                 if getattr(self, "_tts_mimo_auto_ready_log_key", "") != ready_key:
                     self._tts_mimo_auto_ready_log_key = ready_key
                     logger.info(
-                        "[PrivateCompanion] MiMo TTS Voice Clone 已自动识别并接管语音合成: tool=%s",
+                        "MiMo TTS Voice Clone 已自动识别并接管语音合成: tool=%s",
                         mimo_adapter.tool_name,
                     )
             return mimo_adapter
@@ -736,7 +738,7 @@ class TtsEnhancementMixin:
             if getattr(self, "_tts_mimo_bridge_fallback_warning_key", "") != fallback_key:
                 self._tts_mimo_bridge_fallback_warning_key = fallback_key
                 logger.warning(
-                    "[PrivateCompanion] MiMo TTS Voice Clone 联动不可用,本次回退 AstrBot TTS provider: tool=%s",
+                    "MiMo TTS Voice Clone 联动不可用,本次回退 AstrBot TTS provider: tool=%s",
                     fallback_key,
                 )
         return astrbot_provider
@@ -1046,7 +1048,7 @@ class TtsEnhancementMixin:
         except Exception:
             return ""
         logger.info(
-            "[PrivateCompanion] 已识别本轮 TTS 语种要求: session=%s language=%s match=%s",
+            "已识别本轮 TTS 语种要求: session=%s language=%s match=%s",
             _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             language,
             matched,
@@ -1514,7 +1516,7 @@ class TtsEnhancementMixin:
             normalized.append(normalized_segment)
         if removed_cues:
             logger.info(
-                "[PrivateCompanion] FishAudio 自动控制已移除高风险或堆叠标签: mode=%s cues=%s",
+                "FishAudio 自动控制已移除高风险或堆叠标签: mode=%s cues=%s",
                 mode,
                 ",".join(removed_cues[:8]),
             )
@@ -2058,7 +2060,7 @@ class TtsEnhancementMixin:
             return True
         if probability <= 0.0:
             logger.info(
-                "[PrivateCompanion] TTS全局触发概率为0,本轮不注入TTS提示词: reason=%s session=%s",
+                "TTS全局触发概率为0,本轮不注入TTS提示词: reason=%s session=%s",
                 reason,
                 _single_line(self._tts_session_key(event), 80) or "unknown",
             )
@@ -2074,7 +2076,7 @@ class TtsEnhancementMixin:
             pass
         if not allowed:
             logger.info(
-                "[PrivateCompanion] TTS全局触发概率未命中,本轮不注入TTS提示词: reason=%s probability=%.2f session=%s",
+                "TTS全局触发概率未命中,本轮不注入TTS提示词: reason=%s probability=%.2f session=%s",
                 reason,
                 probability,
                 _single_line(self._tts_session_key(event), 80) or "unknown",
@@ -2252,12 +2254,12 @@ TTS 朗读文本：
                     return translated
                 if translated:
                     logger.warning(
-                        "[PrivateCompanion] TTS中文释义结果不像中文,已丢弃: source=%s result=%s",
+                        "TTS中文释义结果不像中文,已丢弃: source=%s result=%s",
                         _single_line(spoken, 80),
                         _single_line(translated, 80),
                     )
         except Exception as exc:
-            logger.warning("[PrivateCompanion] TTS中文释义生成失败: %s", _single_line(exc, 120))
+            logger.warning("TTS中文释义生成失败: %s", _single_line(exc, 120))
         return ""
 
     async def _ensure_tts_blocks_have_visible_chinese(self, text: str, event: Any, *, provider_kind: str) -> str:
@@ -2297,13 +2299,13 @@ TTS 朗读文本：
                     pieces.append(f"{separator}{visible_translation}")
                     changed = True
                     logger.info(
-                        "[PrivateCompanion] TTS记录文本已补中文释义: 语音=%s 中文=%s",
+                        "TTS记录文本已补中文释义: 语音=%s 中文=%s",
                         _single_line(spoken, 80),
                         _single_line(visible_translation, 80),
                     )
                 else:
                     logger.warning(
-                        "[PrivateCompanion] TTS记录文本缺少中文释义且自动补充失败: 语音=%s",
+                        "TTS记录文本缺少中文释义且自动补充失败: 语音=%s",
                         _single_line(spoken, 100),
                     )
             pieces.append(visible_after_this_block)
@@ -2532,7 +2534,7 @@ TTS 朗读文本：
             try:
                 persona = str(await refresher(umo) or "").strip()
             except Exception as exc:
-                logger.debug("[PrivateCompanion] TTS读取人格上下文失败,使用缓存: %s", _single_line(exc, 120))
+                logger.debug("TTS读取人格上下文失败,使用缓存: %s", _single_line(exc, 120))
         if not persona:
             getter = getattr(self, "_get_default_persona_prompt", None)
             if callable(getter):
@@ -2562,7 +2564,7 @@ TTS 朗读文本：
         setter = getattr(event, "set_extra", None)
         if not callable(setter):
             logger.debug(
-                "[PrivateCompanion] TTS 回合无法关闭流式：事件不支持 set_extra session=%s",
+                "TTS 回合无法关闭流式：事件不支持 set_extra session=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             )
             return False
@@ -2579,13 +2581,13 @@ TTS 朗读文本：
             setattr(event, "_private_companion_tts_streaming_previous", previous)
         except Exception as exc:
             logger.debug(
-                "[PrivateCompanion] TTS 回合关闭流式失败 session=%s error=%s",
+                "TTS 回合关闭流式失败 session=%s error=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                 _single_line(exc, 160),
             )
             return False
         logger.info(
-            "[PrivateCompanion] TTS 已预留本回合完整消息链并关闭流式输出: session=%s previous=%s",
+            "TTS 已预留本回合完整消息链并关闭流式输出: session=%s previous=%s",
             _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             previous,
         )
@@ -2640,7 +2642,7 @@ TTS 朗读文本：
             return
         if not hasattr(req, "system_prompt"):
             logger.info(
-                "[PrivateCompanion] TTS请求注入跳过: req无system_prompt session=%s",
+                "TTS请求注入跳过: req无system_prompt session=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             )
             return
@@ -2702,7 +2704,7 @@ TTS 朗读文本：
                     if helper(req, fragment_marker, text):
                         return "prompt"
                 except Exception as exc:
-                    logger.debug("[PrivateCompanion] TTS 指定位置动态注入失败,回退 system_prompt: %s", _single_line(exc, 120))
+                    logger.debug("TTS 指定位置动态注入失败,回退 system_prompt: %s", _single_line(exc, 120))
             req.system_prompt = (
                 f"{getattr(req, 'system_prompt', '') or ''}\n\n{fragment_marker}\n{text}"
             ).strip()
@@ -2953,7 +2955,7 @@ TTS 朗读文本：
             if re.search(r"</?(?:pc[_-]?tts|t{2,}s)\b", text, flags=re.IGNORECASE):
                 resp.completion_text = _normalize_outbound_punctuation_flow(self._strip_any_tts_markup(text))
                 logger.info(
-                    "[PrivateCompanion] TTS强化未开启,已从模型回复中移除 TTS 标签: session=%s preview=%s",
+                    "TTS强化未开启,已从模型回复中移除 TTS 标签: session=%s preview=%s",
                     _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                     _single_line(resp.completion_text, 160),
                 )
@@ -2966,7 +2968,7 @@ TTS 朗读文本：
                 text = self._tts_plain_markup_fallback_text(text_before_safety_drop)
             resp.completion_text = _normalize_outbound_punctuation_flow(text)
             logger.warning(
-                "[PrivateCompanion] 已从模型回复中移除提供商安全回执语音块: session=%s remaining=%s",
+                "已从模型回复中移除提供商安全回执语音块: session=%s remaining=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                 _single_line(text, 160) or "empty",
             )
@@ -2983,7 +2985,7 @@ TTS 朗读文本：
                     )
                     resp.completion_text = _normalize_outbound_punctuation_flow(cleaned)
                     logger.info(
-                        "[PrivateCompanion] TTS后处理模式已移除主模型自写语音标签,改由发送前后处理判断: session=%s preview=%s",
+                        "TTS后处理模式已移除主模型自写语音标签,改由发送前后处理判断: session=%s preview=%s",
                         _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                         _single_line(cleaned, 160),
                     )
@@ -3000,7 +3002,7 @@ TTS 朗读文本：
                 visible_fallback = self._tts_unwrapped_foreign_translation_fallback(text, event)
                 if visible_fallback:
                     logger.warning(
-                        "[PrivateCompanion] 快速标签回复漏写语音标记，已仅保留中文可见正文: session=%s original=%s visible=%s",
+                        "快速标签回复漏写语音标记，已仅保留中文可见正文: session=%s original=%s visible=%s",
                         _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                         _single_line(text, 160),
                         _single_line(visible_fallback, 160),
@@ -3016,7 +3018,7 @@ TTS 朗读文本：
             return
         if not bool(getattr(event, "_private_companion_tts_request_applied", False)):
             logger.debug(
-                "[PrivateCompanion] TTS 强化跳过未经过主回复链的发送结果: session=%s",
+                "TTS 强化跳过未经过主回复链的发送结果: session=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             )
             return
@@ -3032,7 +3034,7 @@ TTS 朗读文本：
             skip_reason = "proactive_prebuilt_voice"
         if skip_reason:
             logger.info(
-                "[PrivateCompanion] 主动正文已有预生成语音,跳过二次 TTS 转换: session=%s reason=%s",
+                "主动正文已有预生成语音,跳过二次 TTS 转换: session=%s reason=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                 skip_reason,
             )
@@ -3055,7 +3057,7 @@ TTS 朗读文本：
                     if str(item or "").strip()
                 ]
             except Exception as exc:
-                logger.debug("[PrivateCompanion] TTS 前自主分段解析失败: %s", _single_line(exc, 120))
+                logger.debug("TTS 前自主分段解析失败: %s", _single_line(exc, 120))
                 planned_segments = []
             if len(planned_segments) > 1:
                 source_segments = planned_segments
@@ -3084,7 +3086,7 @@ TTS 朗读文本：
             cleaned_text, leaked_calls = tool_cleaner(text)
             if leaked_calls:
                 logger.warning(
-                    "[PrivateCompanion] TTS 发送前已移除明文工具调用: session=%s tools=%s",
+                    "TTS 发送前已移除明文工具调用: session=%s tools=%s",
                     _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                     ",".join(str(item.get("name") or "") for item in leaked_calls),
                 )
@@ -3097,7 +3099,7 @@ TTS 朗读文本：
         normalized, dropped_safety_voice = self._drop_tts_provider_safety_blocks(normalized)
         if dropped_safety_voice:
             logger.warning(
-                "[PrivateCompanion] TTS发送前已移除提供商安全回执语音块: session=%s remaining=%s",
+                "TTS发送前已移除提供商安全回执语音块: session=%s remaining=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                 _single_line(normalized, 160) or "empty",
             )
@@ -3162,7 +3164,7 @@ TTS 朗读文本：
                 )
                 event.set_result(self._build_result_from_chain(primary_chain))
                 logger.info(
-                    "[PrivateCompanion] 表情表达先发送完整正文,自动 TTS 延后生成: session=%s chars=%s",
+                    "表情表达先发送完整正文,自动 TTS 延后生成: session=%s chars=%s",
                     _single_line(getattr(event, "unified_msg_origin", ""), 120)
                     or "unknown",
                     len(visible_text),
@@ -3180,7 +3182,7 @@ TTS 朗读文本：
             )
             if full_scope_fallback:
                 logger.info(
-                    "[PrivateCompanion] TTS全量转换已在发送前覆盖整条回复: session=%s chars=%s preview=%s",
+                    "TTS全量转换已在发送前覆盖整条回复: session=%s chars=%s preview=%s",
                     _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                     len(full_scope_fallback),
                     _single_line(full_scope_fallback, 140),
@@ -3198,7 +3200,7 @@ TTS 朗读文本：
                 if translated:
                     normalized = translated
                     logger.info(
-                        "[PrivateCompanion] TTS后处理纯文本检测到未包装外语,已转为可见中文: session=%s",
+                        "TTS后处理纯文本检测到未包装外语,已转为可见中文: session=%s",
                         _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                     )
                 event.set_result(self._build_result_from_chain([Plain(normalized)]))
@@ -3223,7 +3225,7 @@ TTS 朗读文本：
                     [Plain(translated)],
                 )
                 logger.info(
-                    "[PrivateCompanion] TTS后处理可见组件检测到未包装外语,已转为可见中文: session=%s",
+                    "TTS后处理可见组件检测到未包装外语,已转为可见中文: session=%s",
                     _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                 )
         new_chain = self._tts_record_first_visible_last_chain(new_chain)
@@ -3360,7 +3362,7 @@ TTS 朗读文本：
             pass
         except Exception as exc:
             logger.debug(
-                "[PrivateCompanion] 查询 AstrBot 官方 TTS 会话状态失败，保留插件分段: session=%s error=%s",
+                "查询 AstrBot 官方 TTS 会话状态失败，保留插件分段: session=%s error=%s",
                 _single_line(umo, 120) or "unknown",
                 _single_line(exc, 120),
             )
@@ -3378,7 +3380,7 @@ TTS 朗读文本：
             if result is not None and bool(result.is_llm_result()):
                 result.set_result_content_type(ResultContentType.GENERAL_RESULT)
                 logger.debug(
-                    "[PrivateCompanion] 插件已接管本轮 TTS，阻止 AstrBot 官方 TTS 二次处理: session=%s",
+                    "插件已接管本轮 TTS，阻止 AstrBot 官方 TTS 二次处理: session=%s",
                     _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                 )
         except Exception:
@@ -3418,7 +3420,7 @@ TTS 朗读文本：
                 )
             )
             logger.warning(
-                "[PrivateCompanion] 发送前终检已丢弃仅包含提供商安全回执的语音块: session=%s",
+                "发送前终检已丢弃仅包含提供商安全回执的语音块: session=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             )
             return
@@ -3451,7 +3453,7 @@ TTS 朗读文本：
                 new_chain = list(new_chain) + non_plain_tail
         new_chain = self._tts_record_first_visible_last_chain(new_chain)
         logger.warning(
-            "[PrivateCompanion] 发送前终检拦截残留 TTS 标签: session=%s preview=%s",
+            "发送前终检拦截残留 TTS 标签: session=%s preview=%s",
             _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             _single_line(self._tts_chain_log_text(new_chain), 160),
         )
@@ -3494,7 +3496,7 @@ TTS 朗读文本：
                 cleaned_chain.append(Plain(fallback_text))
         if changed:
             logger.warning(
-                "[PrivateCompanion] 外发兜底清理残留内部控制标记: umo=%s preview=%s",
+                "外发兜底清理残留内部控制标记: umo=%s preview=%s",
                 _single_line(umo, 120) or "unknown",
                 _single_line(self._tts_chain_log_text(cleaned_chain), 160),
             )
@@ -3655,7 +3657,7 @@ TTS 朗读文本：
                 and visible_signature("".join(cleaned_segments)) == visible_signature(cleaned_visible)
             ):
                 logger.info(
-                    "[PrivateCompanion] TTS 完整合成后恢复上游正文分段: session=%s segments=%s first=%s",
+                    "TTS 完整合成后恢复上游正文分段: session=%s segments=%s first=%s",
                     _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                     len(cleaned_segments),
                     _single_line(cleaned_segments[0], 100),
@@ -3699,7 +3701,7 @@ TTS 朗读文本：
             cleaned_text, leaked_calls = tool_cleaner(text)
             if leaked_calls:
                 logger.warning(
-                    "[PrivateCompanion] TTS 分块前已移除明文工具调用: session=%s tools=%s",
+                    "TTS 分块前已移除明文工具调用: session=%s tools=%s",
                     _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                     ",".join(str(item.get("name") or "") for item in leaked_calls),
                 )
@@ -3720,14 +3722,14 @@ TTS 朗读文本：
             chinese_text = self._tts_chinese_visible_fallback_from_mixed(text)
             if chinese_text:
                 logger.warning(
-                    "[PrivateCompanion] TTS 后置文本混有朗读语种,已仅保留中文释义: session=%s text=%s",
+                    "TTS 后置文本混有朗读语种,已仅保留中文释义: session=%s text=%s",
                     _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                     _single_line(chinese_text, 120),
                 )
                 text = chinese_text
             else:
                 logger.warning(
-                    "[PrivateCompanion] TTS 后置文本不是中文释义,已跳过发送: session=%s text=%s",
+                    "TTS 后置文本不是中文释义,已跳过发送: session=%s text=%s",
                     _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                     _single_line(text, 120),
                 )
@@ -3756,7 +3758,7 @@ TTS 朗读文本：
                 split_result = splitter(text)
             segments = [item for item in split_result if str(item or "").strip()]
         except Exception as exc:
-            logger.debug("[PrivateCompanion] TTS 后置文本分段失败,保持原样: %s", _single_line(exc, 120))
+            logger.debug("TTS 后置文本分段失败,保持原样: %s", _single_line(exc, 120))
             return [chunk]
         if len(segments) <= 1:
             cleaned = segments[0] if segments else text
@@ -3767,7 +3769,7 @@ TTS 朗读文本：
                 return [[visible_part]] if visible_part is not None else []
             return [[Plain(cleaned)]] if cleaned != text or text != original_text else [chunk]
         logger.info(
-            "[PrivateCompanion] TTS 后置文本按分段规则拆分: session=%s segments=%s first=%s",
+            "TTS 后置文本按分段规则拆分: session=%s segments=%s first=%s",
             _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             len(segments),
             _single_line(segments[0], 100),
@@ -3819,7 +3821,7 @@ TTS 朗读文本：
             source_had_plain = any(isinstance(component, Plain) for component in chunk)
             if source_had_plain and not has_visible_plain and not has_delivery_component:
                 logger.warning(
-                    "[PrivateCompanion] TTS 尾段清理后仅剩孤立上下文组件,已跳过: session=%s",
+                    "TTS 尾段清理后仅剩孤立上下文组件,已跳过: session=%s",
                     outbound_umo,
                 )
                 continue
@@ -3829,7 +3831,7 @@ TTS 朗读文本：
         case_updater = getattr(self, "_update_daily_review_case", None)
         if not expanded_chunks:
             logger.info(
-                "[PrivateCompanion] TTS 尾段清理后无可发送内容: session=%s",
+                "TTS 尾段清理后无可发送内容: session=%s",
                 outbound_umo,
             )
             if case_id and callable(case_updater):
@@ -3873,7 +3875,7 @@ TTS 朗读文本：
                     and not generation_checker(scope, turn_generation)
                 ):
                     logger.info(
-                        "[PrivateCompanion] 新回合已到达，停止旧 TTS 尾段: session=%s sent=%s/%s",
+                        "新回合已到达，停止旧 TTS 尾段: session=%s sent=%s/%s",
                         _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                         sent_chunks,
                         total_chunks,
@@ -3898,7 +3900,7 @@ TTS 朗读文本：
                     and not generation_checker(scope, turn_generation)
                 ):
                     logger.info(
-                        "[PrivateCompanion] 等待期间收到新回合，停止旧 TTS 尾段: session=%s",
+                        "等待期间收到新回合，停止旧 TTS 尾段: session=%s",
                         _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                     )
                     return
@@ -3917,7 +3919,7 @@ TTS 朗读文本：
                     else:
                         await event.send(event.chain_result(chunk))
                     logger.info(
-                        "[PrivateCompanion] TTS 分块后台补发完成: session=%s %s",
+                        "TTS 分块后台补发完成: session=%s %s",
                         _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                         self._tts_chain_log_text(chunk),
                     )
@@ -3942,7 +3944,7 @@ TTS 朗读文本：
                                 signals={"segments_expected": total_chunks, "segments_sent": sent_chunks},
                             )
                         logger.warning(
-                            "[PrivateCompanion] TTS 主动消息中文正文补发失败: session=%s error=%s %s",
+                            "TTS 主动消息中文正文补发失败: session=%s error=%s %s",
                             proactive_umo,
                             _single_line(exc, 160),
                             self._tts_chain_log_text(chunk),
@@ -3951,7 +3953,7 @@ TTS 朗读文本：
                     try:
                         await event.send(self._build_result_from_chain(chunk))
                         logger.info(
-                            "[PrivateCompanion] TTS 分块后台补发完成: session=%s %s",
+                            "TTS 分块后台补发完成: session=%s %s",
                             _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                             self._tts_chain_log_text(chunk),
                         )
@@ -3978,7 +3980,7 @@ TTS 朗读文本：
                                     "visible_text_complete": False,
                                 },
                             )
-                        logger.warning("[PrivateCompanion] TTS 分块后台补发失败: %s", _single_line(exc, 120))
+                        logger.warning("TTS 分块后台补发失败: %s", _single_line(exc, 120))
                         return
                 previous_text = " ".join(
                     str(getattr(comp, "text", "") or "").strip()
@@ -4005,7 +4007,7 @@ TTS 朗读文本：
             pending.get("turn_generation", 0),
         ):
             logger.info(
-                "[PrivateCompanion] 新回合已到达，跳过旧表情 TTS: session=%s",
+                "新回合已到达，跳过旧表情 TTS: session=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             )
             return
@@ -4054,7 +4056,7 @@ TTS 朗读文本：
         records = [component for component in generated if isinstance(component, Record)]
         if not records:
             logger.info(
-                "[PrivateCompanion] 表情表达后台 TTS 未生成语音,正文与表情已保持送达: session=%s",
+                "表情表达后台 TTS 未生成语音,正文与表情已保持送达: session=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120)
                 or "unknown",
             )
@@ -4081,7 +4083,7 @@ TTS 朗读文本：
                 return
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanion] 表情表达后台语音投递失败: error_type=%s",
+                "表情表达后台语音投递失败: error_type=%s",
                 type(exc).__name__,
             )
             return
@@ -4095,7 +4097,7 @@ TTS 朗读文本：
                 self._tts_auto_voice_last_at = state
             state[session] = time.time()
         logger.info(
-            "[PrivateCompanion] 表情表达后台语音已在正文和图片后单独送达: session=%s records=%s",
+            "表情表达后台语音已在正文和图片后单独送达: session=%s records=%s",
             _single_line(session, 120) or "unknown",
             len(records),
         )
@@ -4104,7 +4106,7 @@ TTS 朗读文本：
         mode = self._tts_setting("tts_generation_mode", "fast_tag")
         if self._tts_text_is_provider_safety_refusal(text):
             logger.info(
-                "[PrivateCompanion] 提供商安全回执保持纯文字,不进入 TTS: session=%s preview=%s",
+                "提供商安全回执保持纯文字,不进入 TTS: session=%s preview=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                 _single_line(text, 140),
             )
@@ -4112,7 +4114,7 @@ TTS 朗读文本：
         visible_override, suppress_visible, conversion_source, skip_conversion = self._tts_proactive_segment_visible_policy(event)
         if skip_conversion:
             logger.info(
-                "[PrivateCompanion] 主动分段 TTS 只在首段判定,后续分段保持文字: session=%s text=%s",
+                "主动分段 TTS 只在首段判定,后续分段保持文字: session=%s text=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                 _single_line(text, 100),
             )
@@ -4200,7 +4202,7 @@ TTS 朗读文本：
             ):
                 self._tts_auto_voice_last_at[session] = time.time()
             logger.info(
-                "[PrivateCompanion] TTS强化已转换纯文本回复: reason=%s session=%s %s",
+                "TTS强化已转换纯文本回复: reason=%s session=%s %s",
                 reason,
                 _single_line(session, 80),
                 self._tts_chain_log_text(chain),
@@ -4438,7 +4440,7 @@ Provider 规则：{emotion_rule}
             else:
                 converted = f"<tts>{source}</tts>"
         except Exception as exc:
-            logger.warning("[PrivateCompanion] TTS强化转换模型失败: %s", _single_line(exc, 120))
+            logger.warning("TTS强化转换模型失败: %s", _single_line(exc, 120))
             converted = f"<tts>{source}</tts>"
         converted = self._normalize_tts_tags(converted)
         if "<tts>" not in converted.lower():
@@ -4582,7 +4584,7 @@ Provider 规则：{emotion_rule}
             reason = _single_line(payload.get("reason"), 120)
             if not use_tts or not voice:
                 logger.info(
-                    "[PrivateCompanion] TTS 后处理判定不使用语音: session=%s reason=%s",
+                    "TTS 后处理判定不使用语音: session=%s reason=%s",
                     _single_line(getattr(event, "unified_msg_origin", ""), 100) or "unknown",
                     reason or "no_voice",
                 )
@@ -4590,7 +4592,7 @@ Provider 规则：{emotion_rule}
             if self._tts_voice_language_for_event(event) != "zh" and not self._tts_visible_text_is_allowed_after_voice(visible):
                 visible = source
             logger.info(
-                "[PrivateCompanion] TTS 后处理判定使用语音: session=%s reason=%s voice=%s",
+                "TTS 后处理判定使用语音: session=%s reason=%s voice=%s",
                 _single_line(getattr(event, "unified_msg_origin", ""), 100) or "unknown",
                 reason or "use_voice",
                 _single_line(voice, 80),
@@ -4600,9 +4602,9 @@ Provider 规则：{emotion_rule}
             return f"<tts>{voice}</tts>\n{visible}"
         except Exception as exc:
             if bool(getattr(exc, "_private_companion_tts_provider_logged", False)):
-                logger.info("[PrivateCompanion] TTS 后处理已回退纯文本: %s", _single_line(exc, 120))
+                logger.info("TTS 后处理已回退纯文本: %s", _single_line(exc, 120))
             else:
-                logger.warning("[PrivateCompanion] TTS 后处理判断失败,已保持纯文本: %s", _single_line(exc, 120))
+                logger.warning("TTS 后处理判断失败,已保持纯文本: %s", _single_line(exc, 120))
             return ""
 
     async def _get_tts_conversion_provider(self, event: Any) -> Any:
@@ -4702,7 +4704,7 @@ Provider 规则：{emotion_rule}
                     error="model_token_limit_exceeded",
                 )
             logger.info(
-                "[PrivateCompanion] TTS主模型预估超出 Token 上限，跳过并切换备用模型: primary=%s fallback=%s",
+                "TTS主模型预估超出 Token 上限，跳过并切换备用模型: primary=%s fallback=%s",
                 _single_line(provider_id, 80) or "default",
                 _single_line(fallback_id, 80),
             )
@@ -4754,7 +4756,7 @@ Provider 规则：{emotion_rule}
             elapsed_ms = int((time.time() - start) * 1000)
             completion = str(getattr(resp, "completion_text", resp) or "")
             logger.info(
-                "[PrivateCompanion] TTS文本模型完成: task=%s provider=%s elapsed=%sms prompt_chars=%s completion_chars=%s",
+                "TTS文本模型完成: task=%s provider=%s elapsed=%sms prompt_chars=%s completion_chars=%s",
                 task,
                 _single_line(provider_id, 80) or "default",
                 elapsed_ms,
@@ -4779,14 +4781,14 @@ Provider 规则：{emotion_rule}
                 )
             if safety_refusal:
                 logger.warning(
-                    "[PrivateCompanion] TTS语种转换模型返回安全拒绝话术,不作为朗读文本: provider=%s preview=%s",
+                    "TTS语种转换模型返回安全拒绝话术,不作为朗读文本: provider=%s preview=%s",
                     _single_line(provider_id, 80) or "default",
                     _single_line(completion, 160),
                 )
             if (not completion.strip() or safety_refusal) and allow_fallback:
                 if fallback_provider is not None:
                     logger.warning(
-                        "[PrivateCompanion] TTS文本主模型%s,尝试卡片备用模型: primary=%s fallback=%s",
+                        "TTS文本主模型%s,尝试卡片备用模型: primary=%s fallback=%s",
                         "返回安全拒绝话术" if safety_refusal else "返回空结果",
                         _single_line(provider_id, 80) or "default",
                         _single_line(fallback_id, 80),
@@ -4803,7 +4805,7 @@ Provider 规则：{emotion_rule}
         except Exception as exc:
             elapsed_ms = int((time.time() - start) * 1000)
             logger.warning(
-                "[PrivateCompanion] TTS文本模型失败: task=%s provider=%s elapsed=%sms prompt_chars=%s error=%s",
+                "TTS文本模型失败: task=%s provider=%s elapsed=%sms prompt_chars=%s error=%s",
                 task,
                 _single_line(provider_id, 80) or "default",
                 elapsed_ms,
@@ -4827,7 +4829,7 @@ Provider 规则：{emotion_rule}
             if allow_fallback:
                 if fallback_provider is not None:
                     logger.warning(
-                        "[PrivateCompanion] TTS文本主模型失败,尝试卡片备用模型: primary=%s fallback=%s",
+                        "TTS文本主模型失败,尝试卡片备用模型: primary=%s fallback=%s",
                         _single_line(provider_id, 80) or "default",
                         _single_line(fallback_id, 80),
                     )
@@ -4895,7 +4897,7 @@ Provider 规则：{emotion_rule}
                     playback.unlink(missing_ok=True)
                 except Exception as exc:
                     logger.debug(
-                        "[PrivateCompanion] 清理 TTS 播放修复文件失败: %s",
+                        "清理 TTS 播放修复文件失败: %s",
                         _single_line(exc, 120),
                     )
 
@@ -4946,7 +4948,7 @@ Provider 规则：{emotion_rule}
                 f.write(payload)
             return str(fixed)
         except Exception as exc:
-            logger.debug("[PrivateCompanion] 修正 WAV 播放头失败，使用原文件: %s", _single_line(exc, 120))
+            logger.debug("修正 WAV 播放头失败，使用原文件: %s", _single_line(exc, 120))
             return path
 
     def _run_windows_media_player_script(
@@ -5009,7 +5011,7 @@ Provider 规则：{emotion_rule}
         if result.returncode == 0:
             return True
         logger.debug(
-            "[PrivateCompanion] Windows 静默播放方式失败: mode=%s code=%s err=%s",
+            "Windows 静默播放方式失败: mode=%s code=%s err=%s",
             "wpf" if use_wpf else "wmp",
             result.returncode,
             _single_line(result.stderr or result.stdout, 160),
@@ -5037,9 +5039,9 @@ Provider 规则：{emotion_rule}
 
         try:
             await asyncio.to_thread(_post)
-            logger.info("[PrivateCompanion] 已同步 TTS 文本到直播打字机字幕: %s", _single_line(cleaned, 80))
+            logger.info("已同步 TTS 文本到直播打字机字幕: %s", _single_line(cleaned, 80))
         except Exception as exc:
-            logger.debug("[PrivateCompanion] TTS 直播字幕同步失败: %s", _single_line(exc, 120))
+            logger.debug("TTS 直播字幕同步失败: %s", _single_line(exc, 120))
 
     async def _after_tts_audio_generated(
         self,
@@ -5073,7 +5075,7 @@ Provider 规则：{emotion_rule}
             retry_after = float(getattr(self, "_tts_local_playback_retry_after", 0.0) or 0.0)
             if retry_after > now:
                 logger.debug(
-                    "[PrivateCompanion] TTS 本机播放处于失败退避: remain=%.1fs failures=%s",
+                    "TTS 本机播放处于失败退避: remain=%.1fs failures=%s",
                     retry_after - now,
                     int(getattr(self, "_tts_local_playback_failures", 0) or 0),
                 )
@@ -5087,7 +5089,7 @@ Provider 规则：{emotion_rule}
                     self._tts_local_playback_failures = 0
                     self._tts_local_playback_retry_after = 0.0
                     logger.info(
-                        "[PrivateCompanion] 已触发 TTS 本机播放: source=%s live_only=%s path=%s",
+                        "已触发 TTS 本机播放: source=%s live_only=%s path=%s",
                         source or "unknown",
                         live_only,
                         _single_line(audio_path, 160),
@@ -5098,7 +5100,7 @@ Provider 规则：{emotion_rule}
                     self._tts_local_playback_failures = failures
                     self._tts_local_playback_retry_after = now + retry_seconds
                     logger.warning(
-                        "[PrivateCompanion] TTS 本机播放失败,已进入退避: failures=%s retry=%.0fs error=%s",
+                        "TTS 本机播放失败,已进入退避: failures=%s retry=%.0fs error=%s",
                         failures,
                         retry_seconds,
                         _single_line(exc, 120),
@@ -5214,7 +5216,7 @@ Provider 规则：{emotion_rule}
                     and self._tts_visible_text_is_allowed_after_voice(visible_after)
                 ):
                     logger.info(
-                        "[PrivateCompanion] TTS全量快速标签已保留主模型外语块,中文仅作可见译文: voice=%s visible=%s",
+                        "TTS全量快速标签已保留主模型外语块,中文仅作可见译文: voice=%s visible=%s",
                         _single_line(spoken, 80),
                         _single_line(visible_after, 80),
                     )
@@ -5335,7 +5337,7 @@ Provider 规则：{emotion_rule}
                 event=event,
             ) or self._tts_plain_markup_fallback_text(normalized)
             logger.info(
-                "[PrivateCompanion] TTS强约束已阻止语音生成: session=%s reason=%s text=%s",
+                "TTS强约束已阻止语音生成: session=%s reason=%s text=%s",
                 _single_line(self._tts_session_key(event), 80) or "unknown",
                 hard_block,
                 _single_line(fallback_text or normalized, 120),
@@ -5353,7 +5355,7 @@ Provider 规则：{emotion_rule}
                 fallback_text = "我这边暂时没有可用的语音通道，先用文字陪你说。"
             if fallback_text:
                 logger.warning(
-                    "[PrivateCompanion] TTS强化检测到标签但当前没有可用合成后端,已隐藏朗读文本并按普通文本发送: backend=%s text=%s",
+                    "TTS强化检测到标签但当前没有可用合成后端,已隐藏朗读文本并按普通文本发送: backend=%s text=%s",
                     _single_line(self._tts_setting("tts_synthesis_backend", "astrbot_provider"), 40),
                     _single_line(fallback_text, 160),
                 )
@@ -5397,7 +5399,7 @@ Provider 规则：{emotion_rule}
                 if self._tts_text_is_provider_safety_refusal(source_spoken):
                     record_failed = True
                     logger.warning(
-                        "[PrivateCompanion] TTS转换结果命中提供商安全回执,已跳过合成并保留原回复: session=%s preview=%s",
+                        "TTS转换结果命中提供商安全回执,已跳过合成并保留原回复: session=%s preview=%s",
                         _single_line(self._tts_session_key(event), 80) or "unknown",
                         _single_line(source_spoken, 140),
                     )
@@ -5406,7 +5408,7 @@ Provider 规则：{emotion_rule}
             remaining = self._tts_session_interval_remaining(event)
             if remaining > 0:
                 logger.info(
-                    "[PrivateCompanion] TTS会话级节流生效,已隐藏朗读文本并保留可见文本: session=%s remain=%.1fs text=%s",
+                    "TTS会话级节流生效,已隐藏朗读文本并保留可见文本: session=%s remain=%.1fs text=%s",
                     _single_line(self._tts_session_key(event), 80) or "unknown",
                     remaining,
                     _single_line(spoken, 80),
@@ -5422,7 +5424,7 @@ Provider 规则：{emotion_rule}
                 spoken = await self._convert_text_to_spoken_language(spoken, event, provider_kind=provider_kind)
                 if spoken != before_convert:
                     logger.info(
-                        "[PrivateCompanion] TTS语音块已按目标语种修正: '%s' -> '%s'",
+                        "TTS语音块已按目标语种修正: '%s' -> '%s'",
                         _single_line(before_convert, 80),
                         _single_line(spoken, 80),
                     )
@@ -5463,20 +5465,20 @@ Provider 规则：{emotion_rule}
                             if visible_plain is not None:
                                 output.append(visible_plain)
                             logger.info(
-                                "[PrivateCompanion] TTS语音块已补中文释义: 语音=%s 中文=%s",
+                                "TTS语音块已补中文释义: 语音=%s 中文=%s",
                                 _single_line(spoken, 80),
                                 _single_line(visible_translation, 80),
                             )
                         else:
                             logger.warning(
-                                "[PrivateCompanion] TTS语音块缺少中文释义且自动补充失败: 语音=%s",
+                                "TTS语音块缺少中文释义且自动补充失败: 语音=%s",
                                 _single_line(spoken, 100),
                             )
             else:
                 record_failed = True
                 if fallback_plain:
                     logger.warning(
-                        "[PrivateCompanion] TTS语音组件生成失败,已隐藏朗读文本并保留可见中文: %s",
+                        "TTS语音组件生成失败,已隐藏朗读文本并保留可见中文: %s",
                         _single_line(spoken, 120),
                     )
                 elif voice_language != "zh":
@@ -5484,7 +5486,7 @@ Provider 规则：{emotion_rule}
                     visible_after_this_block = normalized[match.end():next_start]
                     if self._tts_visible_text_is_allowed_after_voice(visible_after_this_block):
                         logger.warning(
-                            "[PrivateCompanion] TTS语音组件生成失败,已隐藏朗读文本并保留后置中文: %s",
+                            "TTS语音组件生成失败,已隐藏朗读文本并保留后置中文: %s",
                             _single_line(spoken, 120),
                         )
                     elif not complete_chinese_before_voice:
@@ -5498,12 +5500,12 @@ Provider 规则：{emotion_rule}
                             if visible_plain is not None:
                                 output.append(visible_plain)
                             logger.warning(
-                                "[PrivateCompanion] TTS语音组件生成失败,已改用中文释义文本: %s",
+                                "TTS语音组件生成失败,已改用中文释义文本: %s",
                                 _single_line(visible_translation, 120),
                             )
                         else:
                             logger.warning(
-                                "[PrivateCompanion] TTS语音组件生成失败且无法得到中文释义,已隐藏朗读文本: %s",
+                                "TTS语音组件生成失败且无法得到中文释义,已隐藏朗读文本: %s",
                                 _single_line(spoken, 120),
                             )
                 else:
@@ -5523,13 +5525,13 @@ Provider 规则：{emotion_rule}
             chinese_after = self._tts_chinese_visible_fallback_from_mixed(after)
             if chinese_after:
                 logger.warning(
-                    "[PrivateCompanion] TTS语音块后置可见文本混有朗读语种,已仅保留中文释义: text=%s",
+                    "TTS语音块后置可见文本混有朗读语种,已仅保留中文释义: text=%s",
                     _single_line(chinese_after, 120),
                 )
                 after = chinese_after
             else:
                 logger.warning(
-                    "[PrivateCompanion] TTS语音块后置可见文本不是中文释义,已丢弃: text=%s",
+                    "TTS语音块后置可见文本不是中文释义,已丢弃: text=%s",
                     _single_line(after, 120),
                 )
                 after = ""
@@ -5615,7 +5617,7 @@ Provider 规则：{emotion_rule}
                 normalized = self._normalize_tts_spoken_text(converted, provider_kind=provider_kind)
                 if normalized and self._tts_text_is_provider_safety_refusal(normalized):
                     logger.warning(
-                        "[PrivateCompanion] TTS语种转换最终结果仍为安全拒绝话术,已回退原回复: session=%s preview=%s",
+                        "TTS语种转换最终结果仍为安全拒绝话术,已回退原回复: session=%s preview=%s",
                         _single_line(self._tts_session_key(event), 80) or "unknown",
                         _single_line(normalized, 160),
                     )
@@ -5683,7 +5685,7 @@ Provider 规则：{emotion_rule}
                     break
                 if attempt == 0:
                     logger.info(
-                        "[PrivateCompanion] 外部实时 TTS 语种转换结果不合格,正在重试: target=%s",
+                        "外部实时 TTS 语种转换结果不合格,正在重试: target=%s",
                         self._tts_language_label(),
                     )
             if not converted or self._tts_text_needs_language_conversion(
@@ -5693,7 +5695,7 @@ Provider 规则：{emotion_rule}
                 result["fallback_text"] = ""
                 result["reason"] = "language_conversion_failed"
                 logger.warning(
-                    "[PrivateCompanion] 外部实时 TTS 语种转换失败,已阻止原文送入%s声线或浏览器朗读: text=%s",
+                    "外部实时 TTS 语种转换失败,已阻止原文送入%s声线或浏览器朗读: text=%s",
                     self._tts_language_label(),
                     _single_line(source_text, 120),
                 )
@@ -5728,7 +5730,7 @@ Provider 规则：{emotion_rule}
             audio_path = await self._tts_generate_audio_path(tts_provider, sanitized)
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanion] 外部实时 TTS 合成失败: provider=%s error=%s",
+                "外部实时 TTS 合成失败: provider=%s error=%s",
                 provider_kind,
                 _single_line(exc, 120),
             )
@@ -5808,7 +5810,7 @@ Provider 规则：{emotion_rule}
             if getattr(self, "_tts_fishaudio_provider_copy_warning_key", "") != warning_key:
                 self._tts_fishaudio_provider_copy_warning_key = warning_key
                 logger.warning(
-                    "[PrivateCompanion] FishAudio Provider 无法隔离本次模型参数，已保留 AstrBot 原配置: "
+                    "FishAudio Provider 无法隔离本次模型参数，已保留 AstrBot 原配置: "
                     "provider=%s model=%s error_type=%s",
                     tts_provider.__class__.__name__,
                     model,
@@ -5826,7 +5828,7 @@ Provider 规则：{emotion_rule}
         if getattr(self, "_tts_fishaudio_request_model_log_key", "") != log_key:
             self._tts_fishaudio_request_model_log_key = log_key
             logger.info(
-                "[PrivateCompanion] FishAudio TTS 已在隔离请求副本应用模型参数: model=%s",
+                "FishAudio TTS 已在隔离请求副本应用模型参数: model=%s",
                 model,
             )
         return request_provider, model
@@ -5896,7 +5898,7 @@ Provider 规则：{emotion_rule}
             return None
         if sanitized != spoken:
             logger.info(
-                "[PrivateCompanion] TTS强化朗读文本已清洗: '%s' -> '%s'",
+                "TTS强化朗读文本已清洗: '%s' -> '%s'",
                 _single_line(spoken, 80),
                 _single_line(sanitized, 80),
             )
@@ -5913,7 +5915,7 @@ Provider 规则：{emotion_rule}
                     for cue in applied_cues
                 )
                 logger.info(
-                    "[PrivateCompanion] FishAudio 专用情绪控制已应用: model=%s mode=%s cues=%s",
+                    "FishAudio 专用情绪控制已应用: model=%s mode=%s cues=%s",
                     fish_model or ("s1" if s1 else "s2-compatible"),
                     self._fishaudio_emotion_mode(),
                     rendered_cues,
@@ -5935,14 +5937,14 @@ Provider 规则：{emotion_rule}
                 )
                 if can_retry:
                     logger.info(
-                        "[PrivateCompanion] 后台 TTS 瞬时连接失败,准备重试一次: provider=%s error_type=%s",
+                        "后台 TTS 瞬时连接失败,准备重试一次: provider=%s error_type=%s",
                         provider_kind or "unknown",
                         exc.__class__.__name__,
                     )
                     await asyncio.sleep(0.2)
                     continue
                 logger.warning(
-                    "[PrivateCompanion] TTS强化生成语音失败: provider=%s error_type=%s error=%s text=%s",
+                    "TTS强化生成语音失败: provider=%s error_type=%s error=%s text=%s",
                     provider_kind or "unknown",
                     exc.__class__.__name__,
                     _single_line(repr(exc), 160),
@@ -5956,10 +5958,10 @@ Provider 规则：{emotion_rule}
             audio_file = Path(audio_path).resolve()
             expected_dir = Path(get_astrbot_data_path()).resolve()
             if not audio_file.is_relative_to(expected_dir):
-                logger.warning("[PrivateCompanion] TTS强化拒绝不安全语音路径: %s", _single_line(audio_path, 160))
+                logger.warning("TTS强化拒绝不安全语音路径: %s", _single_line(audio_path, 160))
                 return None
         except Exception as exc:
-            logger.warning("[PrivateCompanion] TTS强化检查语音路径失败: %s", _single_line(exc, 120))
+            logger.warning("TTS强化检查语音路径失败: %s", _single_line(exc, 120))
             return None
         final_ref = str(audio_path)
         if not defer_delivery_effects:
@@ -5978,7 +5980,7 @@ Provider 规则：{emotion_rule}
                     token = await file_token_service.register_file(str(audio_path))
                     final_ref = f"{callback_api_base}/api/file/{token}"
                 except Exception as exc:
-                    logger.warning("[PrivateCompanion] TTS强化注册语音文件失败: %s", _single_line(exc, 120))
+                    logger.warning("TTS强化注册语音文件失败: %s", _single_line(exc, 120))
         record_text = source_text or sanitized
         try:
             component = Record(file=final_ref, url=final_ref, text=record_text)
@@ -5988,5 +5990,5 @@ Provider 规则：{emotion_rule}
             except TypeError:
                 component = Record.fromFileSystem(str(audio_path), text=record_text)
         self._annotate_tts_record_component(component, sanitized, source_text=source_text or spoken)
-        logger.info("[PrivateCompanion] TTS语音组件已生成: %s", self._tts_component_log_note(component))
+        logger.info("TTS语音组件已生成: %s", self._tts_component_log_note(component))
         return component

--- a/tts_tool_sanitizer.py
+++ b/tts_tool_sanitizer.py
@@ -6,7 +6,6 @@ import os
 import re
 from typing import Any
 
-from astrbot.api import logger
 
 from .helpers import (
     _redact_outbound_secrets,
@@ -16,6 +15,9 @@ from .helpers import (
 )
 from .persona_config import runtime_persona_setting
 from .segmented_message import sanitize_llm_segment_control_tokens
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 class TtsToolSanitizerMixin:
@@ -159,7 +161,7 @@ class TtsToolSanitizerMixin:
         except Exception:
             pass
         logger.info(
-            "[PrivateCompanion] 同会话 send_message_to_user 文本延后到最终回复: session=%s text=%s",
+            "同会话 send_message_to_user 文本延后到最终回复: session=%s text=%s",
             _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
             _single_line(text, 160),
         )
@@ -177,7 +179,7 @@ class TtsToolSanitizerMixin:
         )
         if cleaned_outbound != text:
             logger.info(
-                "[PrivateCompanion] 已清理工具直发文本中的内部控制标记: before=%s after=%s",
+                "已清理工具直发文本中的内部控制标记: before=%s after=%s",
                 _single_line(text, 120),
                 _single_line(cleaned_outbound, 120),
             )
@@ -187,7 +189,7 @@ class TtsToolSanitizerMixin:
         cleaned_control = _strip_nonstandard_chat_control_tags(text)
         if cleaned_control != text:
             logger.info(
-                "[PrivateCompanion] 已清理工具直发文本中的非标准控制标签: before=%s after=%s",
+                "已清理工具直发文本中的非标准控制标签: before=%s after=%s",
                 _single_line(text, 120),
                 _single_line(cleaned_control, 120),
             )
@@ -207,7 +209,7 @@ class TtsToolSanitizerMixin:
         visible = re.sub(r"\n{3,}", "\n\n", str(visible or "").strip())
         if visible and visible != text:
             logger.info(
-                "[PrivateCompanion] 已清理工具直发文本中的 TTS 标签: before=%s after=%s",
+                "已清理工具直发文本中的 TTS 标签: before=%s after=%s",
                 _single_line(text, 120),
                 _single_line(visible, 120),
             )
@@ -283,7 +285,7 @@ class TtsToolSanitizerMixin:
                 and self._same_session_tool_has_only_empty_plain(event, kwargs)
             ):
                 logger.info(
-                    "[PrivateCompanion] 已忽略同会话 send_message_to_user 空文本，等待 Agent 输出最终回复: session=%s",
+                    "已忽略同会话 send_message_to_user 空文本，等待 Agent 输出最终回复: session=%s",
                     _single_line(getattr(event, "unified_msg_origin", ""), 120) or "unknown",
                 )
                 return (
@@ -320,7 +322,7 @@ class TtsToolSanitizerMixin:
             from astrbot.core.message.message_event_result import MessageChain as CoreMessageChain
             from astrbot.core.platform.message_session import MessageSession
         except Exception as exc:
-            logger.debug("[PrivateCompanion] send_message_to_user TTS 接管不可用: %s", _single_line(exc, 120))
+            logger.debug("send_message_to_user TTS 接管不可用: %s", _single_line(exc, 120))
             return None
 
         components: list[Any] = []
@@ -380,14 +382,14 @@ class TtsToolSanitizerMixin:
                         if tts_components:
                             components.extend(tts_components)
                             logger.info(
-                                "[PrivateCompanion] 已接管 send_message_to_user 的 record 文本并转为插件 TTS: session=%s text=%s",
+                                "已接管 send_message_to_user 的 record 文本并转为插件 TTS: session=%s text=%s",
                                 _single_line(session, 120),
                                 _single_line(text, 120),
                             )
                         else:
                             components.append(Comp.Plain(text=text))
                             logger.warning(
-                                "[PrivateCompanion] send_message_to_user 的 record 文本无法生成语音,已改为普通文字: session=%s text=%s",
+                                "send_message_to_user 的 record 文本无法生成语音,已改为普通文字: session=%s text=%s",
                                 _single_line(session, 120),
                                 _single_line(text, 120),
                             )
@@ -438,7 +440,7 @@ class TtsToolSanitizerMixin:
             return f"error: invalid session: {session}"
         await context.context.context.send_message(target_session, CoreMessageChain(chain=components))
         logger.info(
-            "[PrivateCompanion] send_message_to_user 工具文本已接管 TTS 处理: session=%s components=%s",
+            "send_message_to_user 工具文本已接管 TTS 处理: session=%s components=%s",
             _single_line(session, 120),
             len(components),
         )
@@ -448,7 +450,7 @@ class TtsToolSanitizerMixin:
         try:
             from astrbot.core.tools.message_tools import SendMessageToUserTool
         except Exception as exc:
-            logger.debug("[PrivateCompanion] send_message_to_user 工具清理包装未安装: %s", _single_line(exc, 120))
+            logger.debug("send_message_to_user 工具清理包装未安装: %s", _single_line(exc, 120))
             return
         original_call = getattr(SendMessageToUserTool, "_private_companion_tts_sanitizer_original_call", None)
         if original_call is None:
@@ -464,7 +466,7 @@ class TtsToolSanitizerMixin:
                         return processed
                     kwargs["messages"] = plugin._clean_send_message_to_user_tool_messages(kwargs.get("messages"))
                 except Exception as exc:
-                    logger.debug("[PrivateCompanion] send_message_to_user 文本清理失败: %s", _single_line(exc, 120))
+                    logger.debug("send_message_to_user 文本清理失败: %s", _single_line(exc, 120))
                     try:
                         kwargs = dict(kwargs)
                         kwargs["messages"] = plugin._clean_send_message_to_user_tool_messages(kwargs.get("messages"))
@@ -476,4 +478,4 @@ class TtsToolSanitizerMixin:
         setattr(SendMessageToUserTool, "_private_companion_tts_sanitizer_plugin", self)
         SendMessageToUserTool.call = _private_companion_sanitized_call
         setattr(SendMessageToUserTool, "_private_companion_tts_sanitizer_installed", True)
-        logger.info("[PrivateCompanion] send_message_to_user 工具 TTS 标签处理已安装/刷新")
+        logger.info("send_message_to_user 工具 TTS 标签处理已安装/刷新")

--- a/user_memory.py
+++ b/user_memory.py
@@ -31,7 +31,7 @@ from typing import Any
 from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlunparse
 from xml.etree import ElementTree as ET
 
-from astrbot.api import AstrBotConfig, logger
+from astrbot.api import AstrBotConfig
 from astrbot.api.event import AstrMessageEvent, MessageChain, filter
 try:
     from astrbot.api.message_components import At, Image, Plain, Record, Reply
@@ -137,6 +137,9 @@ from .planning import (
     normalize_story_plan,
     pick_detail_segment,
 )
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 DEFAULT_AI_DAILY_NEWS_SOURCE = "B站 AI早报|bilibili:285286947"
 OWNER_EXCLUSIVE_RELATIONSHIP_PROMPT_MAX_CHARS = 2400
@@ -3494,7 +3497,7 @@ class UserMemoryMixin:
             return int(record.get("revision") or 0) or None
         except (AuthoritativePrivateMemoryError, TypeError, ValueError) as exc:
             logger.warning(
-                "[PrivateCompanion] REQ-041 权威私聊记忆准备失败: %s",
+                "REQ-041 权威私聊记忆准备失败: %s",
                 _single_line(exc, 120),
             )
             return None
@@ -3524,13 +3527,13 @@ class UserMemoryMixin:
             if isinstance(record, dict) and isinstance(record.get("content"), dict):
                 apply_private_memory_content(user, record["content"])
             logger.warning(
-                "[PrivateCompanion] REQ-041 权威私聊记忆写入拒绝: code=%s",
+                "REQ-041 权威私聊记忆写入拒绝: code=%s",
                 _single_line(result.get("code"), 80),
             )
             return False
         except (AuthoritativePrivateMemoryError, TypeError, ValueError) as exc:
             logger.warning(
-                "[PrivateCompanion] REQ-041 权威私聊记忆写入失败: %s",
+                "REQ-041 权威私聊记忆写入失败: %s",
                 _single_line(exc, 120),
             )
             return False
@@ -5229,7 +5232,7 @@ class UserMemoryMixin:
                         pass
                     except Exception as exc:
                         logger.warning(
-                            "[PrivateCompanion] 用户习惯记忆同步后台任务失败: %s",
+                            "用户习惯记忆同步后台任务失败: %s",
                             _single_line(exc, 160),
                         )
 
@@ -6204,7 +6207,7 @@ Character-specific bottom-line baseline (reference only; empty means use the con
             refined = None
             request_failed = True
             logger.debug(
-                "[PrivateCompanion] Emotion judgement request failed: error_type=%s",
+                "Emotion judgement request failed: error_type=%s",
                 type(exc).__name__,
             )
         async with self._data_lock:
@@ -6262,7 +6265,7 @@ Character-specific bottom-line baseline (reference only; empty means use the con
             if refined:
                 user.pop("last_emotion_judgement_error", None)
                 logger.info(
-                    "[PrivateCompanion] Emotion judgement completed: user=%s event=%s target=%s intensity=%s confidence=%s reason=%s",
+                    "Emotion judgement completed: user=%s event=%s target=%s intensity=%s confidence=%s reason=%s",
                     user_id,
                     refined.get("emotion_event"),
                     refined.get("emotion_target"),
@@ -6273,7 +6276,7 @@ Character-specific bottom-line baseline (reference only; empty means use the con
             elif normalized:
                 user.pop("last_emotion_judgement_error", None)
                 logger.info(
-                    "[PrivateCompanion] Emotion judgement retained local result: user=%s outcome=%s event=%s confidence=%s",
+                    "Emotion judgement retained local result: user=%s outcome=%s event=%s confidence=%s",
                     user_id,
                     review_outcome,
                     normalized.get("event"),
@@ -6508,7 +6511,7 @@ Character-specific bottom-line baseline (reference only; empty means use the con
             if value not in (None, "")
         )
         logger.info(
-            "[PrivateCompanion][BoundaryFeedback] user=%s decision=%s%s",
+            "[BoundaryFeedback] user=%s decision=%s%s",
             _single_line(user.get("user_id"), 80),
             _single_line(decision, 32),
             f" {details}" if details else "",
@@ -7113,7 +7116,7 @@ Character-specific bottom-line baseline (reference only; empty means use the con
             events.append(event)
             story["today_events"] = events[-16:]
         logger.info(
-            "[PrivateCompanion] 关系边界事件已融入生活叙事: user=%s target=%s level=%s",
+            "关系边界事件已融入生活叙事: user=%s target=%s level=%s",
             _single_line(user.get("user_id"), 80),
             target,
             level,
@@ -7209,7 +7212,7 @@ Character-specific bottom-line baseline (reference only; empty means use the con
                 sent = True
             except Exception as exc:
                 logger.warning(
-                    "[PrivateCompanion] 关系边界转达发送失败: target=%s error=%s",
+                    "关系边界转达发送失败: target=%s error=%s",
                     _single_line(route, 100),
                     _single_line(exc, 160),
                 )
@@ -7544,7 +7547,7 @@ Character-specific bottom-line baseline (reference only; empty means use the con
             now=now,
         )
         logger.info(
-            "[PrivateCompanion] 互动状态已统一结算: band=%s reason=%s expires=%s",
+            "互动状态已统一结算: band=%s reason=%s expires=%s",
             band,
             reason_code,
             int(expires_at) if expires_at else 0,
@@ -7823,8 +7826,8 @@ Character-specific bottom-line baseline (reference only; empty means use the con
         except asyncio.TimeoutError:
             result = {"decision": "send", "reason": f"timeout>{timeout_seconds:.1f}s", "confidence": 0.0, "source": "timeout"}
             cache[cache_key] = {"ts": now, "result": result}
-            logger.info(
-                "[PrivateCompanion] 智能沉默判定超时,默认放行: trigger=%s timeout=%.1fs text=%s",
+            logger.warning(
+                "智能沉默判定超时,默认放行: trigger=%s timeout=%.1fs text=%s",
                 trigger,
                 timeout_seconds,
                 _single_line(inbound, 100),
@@ -7833,7 +7836,7 @@ Character-specific bottom-line baseline (reference only; empty means use the con
         except Exception as exc:
             result = {"decision": "send", "reason": _single_line(exc, 80), "confidence": 0.0, "source": "error"}
             cache[cache_key] = {"ts": now, "result": result}
-            logger.info("[PrivateCompanion] 智能沉默判定失败,默认放行: %s", _single_line(exc, 120))
+            logger.warning("智能沉默判定失败,默认放行: %s", _single_line(exc, 120))
             return result
 
         payload = self._extract_json_payload(raw or "")
@@ -7866,7 +7869,7 @@ Character-specific bottom-line baseline (reference only; empty means use the con
         }
         cache[cache_key] = {"ts": now, "result": result}
         logger.info(
-            "[PrivateCompanion] 智能沉默判定: decision=%s confidence=%.2f trigger=%s elapsed=%dms reason=%s user=%s reply=%s",
+            "智能沉默判定: decision=%s confidence=%.2f trigger=%s elapsed=%dms reason=%s user=%s reply=%s",
             decision,
             confidence,
             trigger,
@@ -8514,7 +8517,7 @@ Character-specific bottom-line baseline (reference only; empty means use the con
                 fallback_builder = getattr(self, "_fallback_unexecuted_relay_reply", None)
                 fallback = fallback_builder(inbound_text) if callable(fallback_builder) else ""
                 logger.info(
-                    "[PrivateCompanion] 被动回复含未执行转述承诺,已改为诚实边界: reason=%s before=%s after=%s",
+                    "被动回复含未执行转述承诺,已改为诚实边界: reason=%s before=%s after=%s",
                     relay_claim_note,
                     _single_line(response_text, 120),
                     _single_line(fallback, 120),
@@ -8524,7 +8527,7 @@ Character-specific bottom-line baseline (reference only; empty means use the con
             fallback = self._music_album_reply_from_context(music_album_context, user_text=inbound_text)
             if fallback:
                 logger.info(
-                    "[PrivateCompanion] 音乐专辑回复已按卡片上下文纠偏: before=%s after=%s",
+                    "音乐专辑回复已按卡片上下文纠偏: before=%s after=%s",
                     _single_line(response_text, 120),
                     _single_line(fallback, 160),
                 )
@@ -8663,7 +8666,7 @@ Character-specific bottom-line baseline (reference only; empty means use the con
             if content_tier == "adult":
                 review_provider_id = _single_line(getattr(self, "adult_content_provider_id", ""), 160)
                 if not review_provider_id:
-                    logger.warning("[PrivateCompanion] 成人内容复核缺少指定 Provider，跳过二次模型调用")
+                    logger.warning("成人内容复核缺少指定 Provider，跳过二次模型调用")
                     return response_text
             rewritten = await self._llm_call(
                 prompt,
@@ -8674,7 +8677,7 @@ Character-specific bottom-line baseline (reference only; empty means use the con
             )
         except Exception as exc:
             logger.warning(
-                "[PrivateCompanion] 被动回复模型自检失败,保留原回复: flags=%s error=%s",
+                "被动回复模型自检失败,保留原回复: flags=%s error=%s",
                 ",".join(effective_flags),
                 _single_line(exc, 160),
             )
@@ -8685,7 +8688,7 @@ Character-specific bottom-line baseline (reference only; empty means use the con
                 user=user,
             ) or response_text
         logger.info(
-            "[PrivateCompanion] 被动回复模型自检完成: mode=%s flags=%s elapsed=%dms",
+            "被动回复模型自检完成: mode=%s flags=%s elapsed=%dms",
             review_mode,
             ",".join(effective_flags),
             int((time.perf_counter() - started) * 1000),
@@ -8696,12 +8699,12 @@ Character-specific bottom-line baseline (reference only; empty means use the con
         if self._is_response_review_drop_marker(cleaned):
             if review_strength == "lenient":
                 logger.info(
-                    "[PrivateCompanion] 被动回复宽松复核忽略取消判定,保留原回复: flags=%s",
+                    "被动回复宽松复核忽略取消判定,保留原回复: flags=%s",
                     ",".join(effective_flags),
                 )
                 return response_text
             logger.info(
-                "[PrivateCompanion] 被动回复模型自检判定重复,已标记丢弃: flags=%s before=%s",
+                "被动回复模型自检判定重复,已标记丢弃: flags=%s before=%s",
                 ",".join(effective_flags),
                 _single_line(response_text, 120),
             )
@@ -8709,7 +8712,7 @@ Character-specific bottom-line baseline (reference only; empty means use the con
         meta_leak_reason = self._response_review_meta_leak_reason(cleaned)
         if meta_leak_reason:
             logger.error(
-                "[PrivateCompanion] 被动回复复核模型返回内部判断，已回退复核前正文: reason=%s output=%s",
+                "被动回复复核模型返回内部判断，已回退复核前正文: reason=%s output=%s",
                 meta_leak_reason,
                 _single_line(cleaned, 180),
             )
@@ -8736,7 +8739,7 @@ Character-specific bottom-line baseline (reference only; empty means use the con
             if review_strength == "lenient":
                 return response_text
             logger.info(
-                "[PrivateCompanion] 被动回复模型自检后仍复读,已标记丢弃: before=%s",
+                "被动回复模型自检后仍复读,已标记丢弃: before=%s",
                 _single_line(cleaned, 120),
             )
             return self._response_review_drop_marker()
@@ -10178,7 +10181,7 @@ bot_promises 只记录 Bot 明确承诺要提醒、记住、转述、发送或�
             current[running_key] = 0
             self._save_data_sync(sections={"users"})
         logger.warning(
-            "[PrivateCompanion] 私聊后台整理失败,已进入短冷却避免重复请求: user=%s task=%s retry=%ss error=%s",
+            "私聊后台整理失败,已进入短冷却避免重复请求: user=%s task=%s retry=%ss error=%s",
             user_id,
             task,
             int(delay),

--- a/user_rest_gate.py
+++ b/user_rest_gate.py
@@ -7,9 +7,11 @@ import zoneinfo
 from datetime import datetime, timedelta
 from typing import Any
 
-from astrbot.api import logger
 
 from .helpers import _now_ts, _safe_float, _single_line
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 class UserRestGateMixin:
@@ -115,7 +117,7 @@ class UserRestGateMixin:
             user["user_rest_reason"] = ""
             user["user_rest_set_at"] = 0
             user["user_rest_kind"] = ""
-            logger.info("[PrivateCompanion] 已清理误判的用户休息静默: user=%s", user.get("user_id") or user.get("id") or "")
+            logger.info("已清理误判的用户休息静默: user=%s", user.get("user_id") or user.get("id") or "")
             return 0.0
         if rest_until <= check_now:
             user["user_rest_until"] = 0
@@ -139,7 +141,7 @@ class UserRestGateMixin:
             user["user_rest_set_at"] = 0
             user["user_rest_kind"] = ""
             logger.info(
-                "[PrivateCompanion] 检测到休息后用户再次活动,已解除休息静默: user=%s kind=%s activity_at=%.3f",
+                "检测到休息后用户再次活动,已解除休息静默: user=%s kind=%s activity_at=%.3f",
                 user.get("user_id") or user.get("id") or "",
                 rest_kind,
                 last_activity_at,
@@ -290,7 +292,7 @@ class UserRestGateMixin:
                 user["user_rest_reason"] = ""
                 user["user_rest_set_at"] = 0
                 user["user_rest_kind"] = ""
-                logger.info("[PrivateCompanion] 用户休息静默已解除: user=%s", user.get("user_id") or user.get("id") or "")
+                logger.info("用户休息静默已解除: user=%s", user.get("user_id") or user.get("id") or "")
                 return True
             return False
         if rest_until <= check_now:
@@ -302,7 +304,7 @@ class UserRestGateMixin:
         if str(user.get("planned_proactive_source") or "") != "timer":
             self._clear_user_rest_pending_plan_fallback(user)
         logger.info(
-            "[PrivateCompanion] 已记录用户休息静默: user=%s until=%s reason=%s",
+            "已记录用户休息静默: user=%s until=%s reason=%s",
             user.get("user_id") or user.get("id") or "",
             self._environment_fromtimestamp(rest_until).strftime("%m-%d %H:%M"),
             _single_line(text, 80),

--- a/worldbook.py
+++ b/worldbook.py
@@ -31,7 +31,7 @@ from typing import Any
 from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlunparse
 from xml.etree import ElementTree as ET
 
-from astrbot.api import AstrBotConfig, logger
+from astrbot.api import AstrBotConfig
 from astrbot.api.event import AstrMessageEvent, MessageChain, filter
 try:
     from astrbot.api.message_components import At, Image, Plain, Record, Reply
@@ -117,6 +117,9 @@ from .planning import (
     normalize_story_plan,
     pick_detail_segment,
 )
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 DEFAULT_AI_DAILY_NEWS_SOURCE = "B站 AI早报|bilibili:285286947"
 
@@ -319,7 +322,7 @@ class WorldbookMixin:
             try:
                 payload = json.loads(path.read_text(encoding="utf-8-sig"))
             except Exception as e:
-                logger.warning(f"[PrivateCompanion] 读取关系网配置失败: {path} ({e})")
+                logger.warning(f"读取关系网配置失败: {path} ({e})")
                 continue
             raw_entries = payload.get("entry_storage") if isinstance(payload, dict) else None
             if not isinstance(raw_entries, list):
@@ -993,7 +996,7 @@ class WorldbookMixin:
         profiles[sender_id] = profile
         recent = group.get("recent_messages") if isinstance(group.get("recent_messages"), list) else []
         logger.info(
-            "[PrivateCompanion] 群聊关系网自登记节点: group=%s user=%s name=%s aliases=%s",
+            "群聊关系网自登记节点: group=%s user=%s name=%s aliases=%s",
             group_id or "-",
             sender_id,
             name,
@@ -1135,7 +1138,7 @@ class WorldbookMixin:
                 if block_word:
                     pending.pop(sender_id, None)
                     logger.info(
-                        "[PrivateCompanion] 群聊关系网自登记确认时拒绝: group=%s user=%s name=%s reason=命中自登记屏蔽词 %s",
+                        "群聊关系网自登记确认时拒绝: group=%s user=%s name=%s reason=命中自登记屏蔽词 %s",
                         group_id or "-",
                         sender_id,
                         name,
@@ -1146,7 +1149,7 @@ class WorldbookMixin:
                 if conflict:
                     pending.pop(sender_id, None)
                     logger.info(
-                        "[PrivateCompanion] 群聊关系网自登记确认时拒绝: group=%s user=%s name=%s reason=名称疑似冒领已有节点 %s",
+                        "群聊关系网自登记确认时拒绝: group=%s user=%s name=%s reason=名称疑似冒领已有节点 %s",
                         group_id or "-",
                         sender_id,
                         name,
@@ -1176,7 +1179,7 @@ class WorldbookMixin:
             return None
         if intro.get("blocked"):
             logger.info(
-                "[PrivateCompanion] 群聊关系网自登记已拒绝: group=%s user=%s reason=称呼不合规或超过六字",
+                "群聊关系网自登记已拒绝: group=%s user=%s reason=称呼不合规或超过六字",
                 group_id or "-",
                 sender_id,
             )
@@ -1190,7 +1193,7 @@ class WorldbookMixin:
         block_word = self._worldbook_self_registration_block_word_hit(name, *aliases, text)
         if block_word:
             logger.info(
-                "[PrivateCompanion] 群聊关系网自登记已拒绝: group=%s user=%s name=%s reason=命中自登记屏蔽词 %s",
+                "群聊关系网自登记已拒绝: group=%s user=%s name=%s reason=命中自登记屏蔽词 %s",
                 group_id or "-",
                 sender_id,
                 name,
@@ -1200,7 +1203,7 @@ class WorldbookMixin:
         conflict = self._worldbook_self_registration_conflict(sender_id, [name, *aliases])
         if conflict:
             logger.info(
-                "[PrivateCompanion] 群聊关系网自登记已拒绝: group=%s user=%s name=%s reason=名称疑似冒领已有节点 %s",
+                "群聊关系网自登记已拒绝: group=%s user=%s name=%s reason=名称疑似冒领已有节点 %s",
                 group_id or "-",
                 sender_id,
                 name,
@@ -1227,7 +1230,7 @@ class WorldbookMixin:
             "created_ts": _now_ts(),
         }
         logger.info(
-            "[PrivateCompanion] 群聊关系网自登记待确认: group=%s user=%s name=%s aliases=%s",
+            "群聊关系网自登记待确认: group=%s user=%s name=%s aliases=%s",
             group_id or "-",
             sender_id,
             name,
@@ -1320,7 +1323,7 @@ class WorldbookMixin:
             profile["auto_registration_pending"] = False
             profile["auto_impression_ts"] = _now_ts()
             self._save_data_sync(sections={"worldbook_member_profiles"})
-        logger.info("[PrivateCompanion] 群聊关系网自登记印象已生成: user=%s name=%s", user_id, name)
+        logger.info("群聊关系网自登记印象已生成: user=%s name=%s", user_id, name)
 
     def _group_member_identity_label_for_token(self, group: dict[str, Any], token: str) -> str:
         query = re.sub(r"\s+", "", _single_line(token, 40))
@@ -1514,7 +1517,7 @@ class WorldbookMixin:
                 parts.append(f"边界：{boundary}")
             lines.append("- " + "｜".join(parts))
             injected.append(f"{profile_uid}:{name}")
-        logger.info("[PrivateCompanion] 本轮提及关系网对象注入: users=%s", "；".join(injected))
+        logger.info("本轮提及关系网对象注入: users=%s", "；".join(injected))
         return "\n".join(lines)
 
     def _select_worldbook_member_profiles_for_group(
@@ -1628,7 +1631,7 @@ class WorldbookMixin:
                     f"/{_single_line(profile.get('_match_reason'), 80) or '-'}]"
                 )
             logger.info(
-                "[PrivateCompanion] 群聊关系网注入用户信息: group=%s sender=%s users=%s",
+                "群聊关系网注入用户信息: group=%s sender=%s users=%s",
                 group_id or "-",
                 _single_line(sender_id, 40) or "-",
                 "；".join(injected),


### PR DESCRIPTION
## Summary

- Add `logging_util.get_module_logger(__name__)`: every module logs with a Chinese module tag (e.g. `[空间动态]`); unmapped modules fall back to their raw module name.
- Remove 1500+ redundant manual `[PrivateCompanion]` prefixes — the AstrBot logging pipeline already tags the plugin on every line, and the manual prefix did not identify the source module.
- Promote 22 timeout/fallback logs from DEBUG/INFO to WARNING (QWeather timeouts, vision-caption timeouts, debounce/silence-judgment fallbacks, MemoryCompanion context read timeouts, etc.).
- Inline Chinese tags for the three standalone-mode loggers (`standalone_webui`, `body_monitor_integration`, `bot_personal_outbox`), which intentionally keep the stdlib logger for isolated runs.
- Include `logging_util.py` in the packaging required-files list; sync the reaction log prefix assertion in tests.

## Verification

- Full-tree checks: all modules parse, zero leftover `[PrivateCompanion]` prefixes, 58 modules on the tagged logger.
- Packaging test: archive build + extraction import passes (also guards that the new module ships in the archive).
- Targeted log-assertion tests all green: smart_imagechat (82), provider token logs (12), outbox (6), standalone webui (9) + privacy, build (4).
- Rebased onto current `main` (debcb74): PR #178 changes are preserved, and the new upstream log calls in `main.py` / `passive_state_pipeline.py` were tagged and level-checked as part of the rebase.