### PR TITLE
feat(planning): 日程生成增加防御式外部素材扩展点（供第三方插件注入今日动态）

### DIFF
--- a/planning.py
+++ b/planning.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import re
 import time
 from datetime import datetime
@@ -10,6 +11,9 @@ from typing import Any
 from .constants import DEFAULT_DAILY_PLAN_ITEMS
 from .helpers import _safe_float, _safe_int, _single_line, _today_key
 from .persona_config import runtime_persona_setting
+from .logging_util import get_module_logger
+
+logger = get_module_logger(__name__)
 
 
 def split_detail_prompt_cache_sections(prompt: str) -> tuple[str, str]:
@@ -56,17 +60,16 @@ async def generate_detail_enhancement(
             state=state,
             max_chars=1100,
         )
-    # 外部插件（如 astrbot_plugin_m7a_notify）防御式扩展点：把今日小助手动态并入连续性参考
-    _m7a_getter = getattr(plugin, "_m7a_daily_material_context", None)
-    if callable(_m7a_getter):
-        try:
-            _m7a_block = await _m7a_getter(kind="detail", max_chars=900)
-            if _m7a_block:
-                memory_companion_context = (memory_companion_context or "") + (
-                    "\n\n【今日小助手实况（外部插件提供，仅作生活素材，不得视为既定事实）】\n" + _m7a_block
-                )
-        except Exception:
-            pass
+    external_material = await _external_schedule_material_context(
+        plugin,
+        kind="detail",
+        max_chars=900,
+    )
+    if external_material:
+        memory_companion_context = (memory_companion_context or "") + (
+            "\n\n【外部插件提供的今日实况（仅作生活素材，不得视为既定事实）】\n"
+            + external_material
+        )
     full_prompt = plugin._build_detail_enhancement_prompt(
         segment,
         plan,
@@ -682,17 +685,16 @@ async def generate_daily_plan(plugin) -> dict[str, Any]:
     memory_companion_context_getter = getattr(plugin, "_memory_companion_compose_schedule_context", None)
     if callable(memory_companion_context_getter):
         memory_companion_context = await memory_companion_context_getter(kind="daily_plan", max_chars=1300)
-    # 外部插件（如 astrbot_plugin_m7a_notify）防御式扩展点：把今日小助手动态并入连续性参考
-    _m7a_getter = getattr(plugin, "_m7a_daily_material_context", None)
-    if callable(_m7a_getter):
-        try:
-            _m7a_block = await _m7a_getter(kind="daily_plan", max_chars=1300)
-            if _m7a_block:
-                memory_companion_context = (memory_companion_context or "") + (
-                    "\n\n【今日小助手实况（外部插件提供，仅作生活素材，不得视为既定事实）】\n" + _m7a_block
-                )
-        except Exception:
-            pass
+    external_material = await _external_schedule_material_context(
+        plugin,
+        kind="daily_plan",
+        max_chars=1300,
+    )
+    if external_material:
+        memory_companion_context = (memory_companion_context or "") + (
+            "\n\n【外部插件提供的今日实况（仅作生活素材，不得视为既定事实）】\n"
+            + external_material
+        )
     prompt = plugin._build_daily_plan_prompt(now, memory_companion_context=memory_companion_context)
     plan_provider = plugin._task_provider(
         runtime_persona_setting(plugin, "daily_plan_provider_id", ""),
@@ -930,14 +932,66 @@ def _build_schedule_reference_sections(
     return "\n\n".join(identity_parts), "\n\n".join(behavior_parts)
 
 
-def _sanitize_relationship_generation_source(plugin, value: Any, *, source: str) -> str:
+def _sanitize_relationship_generation_source(
+    plugin,
+    value: Any,
+    *,
+    source: str,
+    max_chars: int = 0,
+) -> str:
     sanitizer = getattr(plugin, "_sanitize_generation_relationship_context", None)
     if callable(sanitizer):
         try:
-            return sanitizer(value, source=source)
+            try:
+                cleaned = sanitizer(value, source=source, max_chars=max_chars)
+            except TypeError:
+                cleaned = sanitizer(value, source=source)
+            cleaned_text = str(cleaned or "").strip()
+            return cleaned_text[:max_chars] if max_chars > 0 else cleaned_text
         except Exception:
             pass
-    return str(value or "").strip()
+    cleaned_text = str(value or "").strip()
+    return cleaned_text[:max_chars] if max_chars > 0 else cleaned_text
+
+
+async def _external_schedule_material_context(
+    plugin,
+    *,
+    kind: str,
+    max_chars: int,
+) -> str:
+    """Read optional external life material without making it a hard fact."""
+    getter = None
+    getter_name = ""
+    for candidate in ("_external_schedule_material_context", "_m7a_daily_material_context"):
+        candidate_getter = getattr(plugin, candidate, None)
+        if callable(candidate_getter):
+            getter = candidate_getter
+            getter_name = candidate
+            break
+    if getter is None:
+        return ""
+    try:
+        try:
+            value = getter(kind=kind, max_chars=max_chars)
+        except TypeError:
+            value = getter(kind=kind)
+        if inspect.isawaitable(value):
+            value = await value
+        return _sanitize_relationship_generation_source(
+            plugin,
+            value,
+            source=f"external_schedule.{kind}",
+            max_chars=max_chars,
+        )
+    except Exception as exc:
+        logger.debug(
+            "外部日程素材提供者不可用: kind=%s getter=%s error=%s",
+            kind,
+            getter_name or "unknown",
+            _single_line(exc, 160),
+        )
+        return ""
 
 
 def _relationship_authority_guard(plugin) -> str:

--- a/planning.py
+++ b/planning.py
@@ -56,6 +56,17 @@ async def generate_detail_enhancement(
             state=state,
             max_chars=1100,
         )
+    # 外部插件（如 astrbot_plugin_m7a_notify）防御式扩展点：把今日小助手动态并入连续性参考
+    _m7a_getter = getattr(plugin, "_m7a_daily_material_context", None)
+    if callable(_m7a_getter):
+        try:
+            _m7a_block = await _m7a_getter(kind="detail", max_chars=900)
+            if _m7a_block:
+                memory_companion_context = (memory_companion_context or "") + (
+                    "\n\n【今日小助手实况（外部插件提供，仅作生活素材，不得视为既定事实）】\n" + _m7a_block
+                )
+        except Exception:
+            pass
     full_prompt = plugin._build_detail_enhancement_prompt(
         segment,
         plan,
@@ -671,6 +682,17 @@ async def generate_daily_plan(plugin) -> dict[str, Any]:
     memory_companion_context_getter = getattr(plugin, "_memory_companion_compose_schedule_context", None)
     if callable(memory_companion_context_getter):
         memory_companion_context = await memory_companion_context_getter(kind="daily_plan", max_chars=1300)
+    # 外部插件（如 astrbot_plugin_m7a_notify）防御式扩展点：把今日小助手动态并入连续性参考
+    _m7a_getter = getattr(plugin, "_m7a_daily_material_context", None)
+    if callable(_m7a_getter):
+        try:
+            _m7a_block = await _m7a_getter(kind="daily_plan", max_chars=1300)
+            if _m7a_block:
+                memory_companion_context = (memory_companion_context or "") + (
+                    "\n\n【今日小助手实况（外部插件提供，仅作生活素材，不得视为既定事实）】\n" + _m7a_block
+                )
+        except Exception:
+            pass
     prompt = plugin._build_daily_plan_prompt(now, memory_companion_context=memory_companion_context)
     plan_provider = plugin._task_provider(
         runtime_persona_setting(plugin, "daily_plan_provider_id", ""),

--- a/proactive_message.py
+++ b/proactive_message.py
@@ -148,6 +148,7 @@ from .final_response_persistence import (
 from .planning import (
     build_daily_plan_prompt,
     build_detail_enhancement_prompt,
+    _external_schedule_material_context,
     format_plan_for_diary,
     generate_daily_plan,
     generate_detail_enhancement,
@@ -2955,6 +2956,17 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
             last_sidecar_at = _safe_float(user.get("last_group_share_life_sidecar_at"), 0)
             if last_sidecar_at > 0 and _now_ts() - last_sidecar_at < 6 * 3600:
                 current_schedule = "（最近群分享已经顺手带过生活片段，本轮只围绕群里那件事）"
+        external_material = ""
+        if not troubleshooting_hint and reason not in source_focused_reasons and reason not in {
+            "goodnight_screen_check",
+            "meal_care",
+            "meal_care_followup",
+        }:
+            external_material = await _external_schedule_material_context(
+                self,
+                kind="proactive",
+                max_chars=900,
+            )
         state_hint = self._format_state_for_framework_prompt(
             state if isinstance(state, dict) else {},
             reason=reason,
@@ -3158,6 +3170,14 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
             prompt = f"{prompt.rstrip()}\n\n{future_schedule_hint}"
         if calendar_constraint_hint and "【今日有效日历约束】" not in prompt:
             prompt = f"{prompt.rstrip()}\n\n{calendar_constraint_hint}"
+        if external_material and "【外部插件提供的今日实况】" not in prompt:
+            prompt = (
+                f"{prompt.rstrip()}\n\n"
+                "【外部插件提供的今日实况（仅作生活素材，不得视为既定事实）】\n"
+                "它只是 Bot 听到或看到的外部动态；贴合当前切口时自然带过即可，不要提及来源插件名，"
+                "不要写成 Bot 亲身经历，也不要把它当成必须提起的事实。\n"
+                f"{external_material}"
+            )
         if reason == "creative_share":
             prompt = f"{prompt.rstrip()}\n\n{self._creative_share_excerpt_prompt_hint()}"
         route_prompt_getter = getattr(self, "_proactive_route_prompt", None)

--- a/tests/test_planning_reference_sources.py
+++ b/tests/test_planning_reference_sources.py
@@ -156,12 +156,14 @@ class DailyPlanGenerationHarness:
         self.parsed = dict(parsed)
         self.calendar_conflict = calendar_conflict
         self.calls = []
+        self.prompt_contexts = []
         self.data = {"daily_plan": dict(previous_plan or {})}
 
     async def _ensure_weather_context(self):
         return None
 
     def _build_daily_plan_prompt(self, _now, *, memory_companion_context=""):
+        self.prompt_contexts.append(memory_companion_context)
         return "DAILY_PLAN_PROMPT"
 
     def _task_provider(self, *provider_ids):
@@ -541,6 +543,42 @@ class PlanningReferenceSourceTests(unittest.TestCase):
 
 
 class DailyPlanGenerationFallbackTests(unittest.IsolatedAsyncioTestCase):
+    async def test_external_material_uses_canonical_hook_and_is_sanitized(self):
+        items = [{"time": "09:00", "end": "10:00", "activity": "整理资料"}]
+        plugin = DailyPlanGenerationHarness(["valid"], {"valid": items})
+
+        async def material(*, kind, max_chars):
+            self.assertEqual(kind, "daily_plan")
+            self.assertEqual(max_chars, 1300)
+            return "外部动态：任务完成。" + ("x" * 3000)
+
+        plugin._external_schedule_material_context = material
+        with patch(
+            "astrbot_plugin_private_companion.planning.evaluate_daily_plan_quality",
+            return_value={"score": 100, "level": "good", "issues": []},
+        ):
+            await generate_daily_plan(plugin)
+
+        self.assertIn("外部插件提供的今日实况", plugin.prompt_contexts[0])
+        self.assertIn("外部动态：任务完成。", plugin.prompt_contexts[0])
+        self.assertLessEqual(len(plugin.prompt_contexts[0]), 1400)
+
+    async def test_external_material_failure_does_not_block_generation(self):
+        items = [{"time": "09:00", "end": "10:00", "activity": "整理资料"}]
+        plugin = DailyPlanGenerationHarness(["valid"], {"valid": items})
+
+        async def material(**_kwargs):
+            raise RuntimeError("provider unavailable")
+
+        plugin._external_schedule_material_context = material
+        with patch(
+            "astrbot_plugin_private_companion.planning.evaluate_daily_plan_quality",
+            return_value={"score": 100, "level": "good", "issues": []},
+        ):
+            plan = await generate_daily_plan(plugin)
+
+        self.assertEqual(plan["source"], "llm")
+
     async def test_unparseable_first_response_retries_before_fallback(self):
         items = [{"time": "09:00", "end": "10:00", "activity": "按世界观整理藏书"}]
         plugin = DailyPlanGenerationHarness(


### PR DESCRIPTION
Allow third-party plugins to inject non-special runtime material (e.g. game-assistant daily activity) Closes #188

为日程生成增加防御式外部素材扩展点：
- build_daily_plan_prompt / build_daily_detail_prompt 构建 prompt 时，
  防御式调用插件实例可选方法 `_external_schedule_material_context`，
  把第三方插件提供的今日素材并入「连续性参考」区。
- 扩展点可选、try/except 包裹，未安装第三方插件时行为与现状完全一致（+18 行）。into daily-plan and detail-plan prompts as continuity-level reference, via an optional plugin method (_external_schedule_material_context). Falls back to current behavior when the hook is absent.

Closes #188