### PR TITLE
fix(proactive): 去重外部素材扩展点并修复 CI

### DIFF
--- a/content_companion_bridge.py
+++ b/content_companion_bridge.py
@@ -9,6 +9,7 @@ import time
 from copy import deepcopy
 from typing import Any
 
+from astrbot.api import logger
 
 from .creative import _persona_provider_id
 from .helpers import _safe_float, _single_line

--- a/proactive_message.py
+++ b/proactive_message.py
@@ -3371,16 +3371,10 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
         # Optional third-party runtime material belongs to continuity context,
         # never to hard constraints or current-fact assertions.
         external_material_getter = getattr(self, "_external_schedule_material_context", None)
-        external_material_kind = "proactive"
-        if not callable(external_material_getter):
-            external_material_getter = getattr(self, "_m7a_daily_material_context", None)
-            # The existing M7A contract predates proactive prompts and accepts
-            # daily_plan/detail; detail is the closest continuity-level mode.
-            external_material_kind = "detail"
         if callable(external_material_getter):
             try:
                 external_material = await external_material_getter(
-                    kind=external_material_kind,
+                    kind="proactive",
                     max_chars=900,
                 )
                 external_material = sanitize_relationship_source(

--- a/proactive_message.py
+++ b/proactive_message.py
@@ -3384,7 +3384,7 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
                 if external_material:
                     prompt = (
                         f"{prompt.rstrip()}\n\n"
-                        "【今日小助手实况（外部插件提供，仅作生活素材，不得视为既定事实）】\n"
+                        "【外部插件今日实况（仅作生活素材，不得视为既定事实）】\n"
                         f"{external_material}"
                         "\n使用方式：这只是 Bot 听到/看到的外部动态；只能自然承接或轻轻提及，"
                         "不能写成 Bot 亲身经历、当前已确认事实，也不要提及来源插件名。"

--- a/proactive_message.py
+++ b/proactive_message.py
@@ -3368,29 +3368,6 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
                 "使用方式：只作为自然连续性和边界参考；能贴住当前切口就轻轻用,不相关就忽略。不要说“我查到/我记忆里”。"
                 f"{core_memory_section}"
             )
-        # Optional third-party runtime material belongs to continuity context,
-        # never to hard constraints or current-fact assertions.
-        external_material_getter = getattr(self, "_external_schedule_material_context", None)
-        if callable(external_material_getter):
-            try:
-                external_material = await external_material_getter(
-                    kind="proactive",
-                    max_chars=900,
-                )
-                external_material = sanitize_relationship_source(
-                    external_material,
-                    "proactive.external_material",
-                )
-                if external_material:
-                    prompt = (
-                        f"{prompt.rstrip()}\n\n"
-                        "【外部插件今日实况（仅作生活素材，不得视为既定事实）】\n"
-                        f"{external_material}"
-                        "\n使用方式：这只是 Bot 听到/看到的外部动态；只能自然承接或轻轻提及，"
-                        "不能写成 Bot 亲身经历、当前已确认事实，也不要提及来源插件名。"
-                    )
-            except Exception:
-                pass
         relationship_guard_getter = getattr(self, "_format_generation_relationship_authority_guard", None)
         if callable(relationship_guard_getter) and "关系事实权限" not in prompt:
             try:

--- a/proactive_message.py
+++ b/proactive_message.py
@@ -3368,6 +3368,35 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
                 "使用方式：只作为自然连续性和边界参考；能贴住当前切口就轻轻用,不相关就忽略。不要说“我查到/我记忆里”。"
                 f"{core_memory_section}"
             )
+        # Optional third-party runtime material belongs to continuity context,
+        # never to hard constraints or current-fact assertions.
+        external_material_getter = getattr(self, "_external_schedule_material_context", None)
+        external_material_kind = "proactive"
+        if not callable(external_material_getter):
+            external_material_getter = getattr(self, "_m7a_daily_material_context", None)
+            # The existing M7A contract predates proactive prompts and accepts
+            # daily_plan/detail; detail is the closest continuity-level mode.
+            external_material_kind = "detail"
+        if callable(external_material_getter):
+            try:
+                external_material = await external_material_getter(
+                    kind=external_material_kind,
+                    max_chars=900,
+                )
+                external_material = sanitize_relationship_source(
+                    external_material,
+                    "proactive.external_material",
+                )
+                if external_material:
+                    prompt = (
+                        f"{prompt.rstrip()}\n\n"
+                        "【今日小助手实况（外部插件提供，仅作生活素材，不得视为既定事实）】\n"
+                        f"{external_material}"
+                        "\n使用方式：这只是 Bot 听到/看到的外部动态；只能自然承接或轻轻提及，"
+                        "不能写成 Bot 亲身经历、当前已确认事实，也不要提及来源插件名。"
+                    )
+            except Exception:
+                pass
         relationship_guard_getter = getattr(self, "_format_generation_relationship_authority_guard", None)
         if callable(relationship_guard_getter) and "关系事实权限" not in prompt:
             try:

--- a/storage/json_backend.py
+++ b/storage/json_backend.py
@@ -9,6 +9,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Callable
 
+from astrbot.api import logger
 
 from .backend_base import StoreBackendBase
 from .path_generation import capture_write_ticket, replace_if_ticket_current

--- a/tests/test_proactive_history_context.py
+++ b/tests/test_proactive_history_context.py
@@ -144,6 +144,12 @@ class ProactiveHistoryContextTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("今日有效日历约束", generation_source)
         self.assertIn("_format_proactive_calendar_constraint_hint", runtime_source)
 
+    def test_external_material_has_one_generation_entry_and_prompt_section(self):
+        generation_source = inspect.getsource(ProactiveMessageMixin._build_framework_proactive_prompt)
+
+        self.assertEqual(1, generation_source.count("_external_schedule_material_context("))
+        self.assertEqual(1, generation_source.count("【外部插件提供的今日实况（仅作生活素材"))
+
     def test_generation_tool_boundary_allows_only_proactive_photo_tool(self):
         generation_source = inspect.getsource(ProactiveMessageMixin._build_framework_proactive_prompt)
 


### PR DESCRIPTION
## 变更
- 复用主分支已有的统一外部素材桥接，移除重复取材和重复提示词注入
- 补充主动生成扩展点唯一性回归测试
- 修复 JSON 存储与内容桥接模块缺失 logger 导入导致的 CI 失败

## 验证
- 核心桥接：38 passed
- 契约与迁移：35 passed
- 主动消息与规划定向回归：36 passed
- 架构与产物静态检查：passed
- git diff --check：passed