### PR TITLE
fix: split address aliases so multi-nickname configs match correctly

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -138,6 +138,49 @@ def _single_line(text: Any, limit: int = 80) -> str:
     return normalized[:limit]
 
 
+_ADDRESS_SEPARATOR_PATTERN = re.compile(r"[/／、,，;；|]+")
+_ADDRESS_TERM_STRIP_CHARS = " -*`_【】[]（）()<>《》\"'“”‘’"
+_ADDRESS_TERM_TAIL_PATTERN = re.compile(r"[：:，,。.!！?？~～…]+$")
+
+
+def _clean_address_term(value: Any) -> str:
+    """Normalize a single display name or address alias."""
+    token = unicodedata.normalize("NFKC", str(value or "")).strip()
+    token = re.sub(r"\s+", " ", token)
+    token = token.strip(_ADDRESS_TERM_STRIP_CHARS)
+    token = token.lstrip("：:")
+    token = _ADDRESS_TERM_TAIL_PATTERN.sub("", token).strip()
+    return token
+
+
+def _split_address_terms(text: Any, limit: int = 8) -> list[str]:
+    """Split slash/separator-delimited aliases into stable, unique terms.
+
+    Users can configure several accepted addresses at once, for example
+    "诗岸/宝宝" or "老板，Sir".  Treating such a value as one token makes
+    every consumer that matches or injects an address fall back to the first
+    entry only, so callers share a single splitting rule here.
+    """
+    normalized = unicodedata.normalize("NFKC", str(text or "")).strip()
+    if not normalized:
+        return []
+    normalized = re.sub(r"\s+", " ", normalized)
+    terms: list[str] = []
+    for part in _ADDRESS_SEPARATOR_PATTERN.split(normalized):
+        token = _clean_address_term(part)
+        if not token or token.isdigit() or len(token) > 40:
+            continue
+        if token not in terms:
+            terms.append(token)
+    return terms[:limit]
+
+
+def _single_address(text: Any, limit: int = 40) -> str:
+    """Collapse delimited aliases into one joined display address."""
+    terms = _split_address_terms(text, limit)
+    return "、".join(terms)[:limit]
+
+
 def _url_host_is_public(url: Any) -> bool:
     """Accept only HTTP(S) URLs whose DNS results are all public addresses."""
     text = str(url or "").strip()

--- a/memory_companion_adapter.py
+++ b/memory_companion_adapter.py
@@ -27,7 +27,7 @@ from .bot_personal_contract import (
     window_for_minutes,
 )
 from .bot_personal_outbox import BotPersonalOutbox
-from .helpers import _missing_optional_model_dependency, _now_ts, _path_text, _safe_float, _safe_int, _single_line
+from .helpers import _missing_optional_model_dependency, _now_ts, _path_text, _safe_float, _safe_int, _single_address, _single_line
 from .companion_interaction_expression import current_interaction_projection
 from .relationship_ledger import normalize_relationship_mode
 from .relationship_policy import relationship_projection_for_bridge
@@ -1616,7 +1616,7 @@ class MemoryCompanionAdapterMixin:
             (user.get("nickname") or user.get("display_name") or user_id) if isinstance(user, dict) else user_id,
             80,
         )
-        preferred_address = _single_line(user.get("nickname"), 24) if isinstance(user, dict) else ""
+        preferred_address = _single_address(user.get("nickname"), 24) if isinstance(user, dict) else ""
         return {
             "session_id": umo or f"private_companion:schedule:{user_id or 'bot_self'}",
             "scope": "private" if user_id else "unknown",
@@ -1787,7 +1787,7 @@ class MemoryCompanionAdapterMixin:
                 user_name = _single_line(self._sender_display_name(event), 80)
             except Exception:
                 user_name = ""
-            preferred_address = _single_line(user.get("nickname"), 24) if isinstance(user, dict) else ""
+            preferred_address = _single_address(user.get("nickname"), 24) if isinstance(user, dict) else ""
             session_context = {
                 "session_id": session_id,
                 "scope": scope,
@@ -1803,7 +1803,7 @@ class MemoryCompanionAdapterMixin:
             }
         elif isinstance(user, dict):
             umo = _single_line(user.get("umo"), 200)
-            preferred_address = _single_line(user.get("nickname"), 24)
+            preferred_address = _single_address(user.get("nickname"), 24)
             if not user_id and not umo:
                 # 无用户标识：无法在 memory 插件侧隔离会话作用域，宁可召回为空也不跨用户串线。
                 return ""

--- a/passive_state_pipeline.py
+++ b/passive_state_pipeline.py
@@ -15,7 +15,7 @@ from .group_prompt_context import (
     GROUP_HISTORY_INJECTED_ATTR,
     group_prompt_context_history_count,
 )
-from .helpers import _now_ts, _safe_float, _single_line
+from .helpers import _now_ts, _safe_float, _single_address, _single_line
 from .persona_config import runtime_persona_setting
 from .prompt_surface import PromptSurface
 from .logging_util import get_module_logger
@@ -190,7 +190,7 @@ async def inject_humanized_state(
                         "当前对象画像称呼读取失败，保留既有称呼: %s",
                         _single_line(exc, 120),
                     )
-            preferred_address = portrait_preferred_address or _single_line(
+            preferred_address = portrait_preferred_address or _single_address(
                 private_user.get("nickname")
                 or runtime_persona_setting(self, "default_nickname", "你"),
                 24,

--- a/proactive_message.py
+++ b/proactive_message.py
@@ -135,6 +135,7 @@ from .helpers import (
     _safe_float,
     _safe_int,
     _single_line,
+    _split_address_terms,
     _strip_internal_message_blocks,
     _strip_outbound_control_blocks,
     _today_key,
@@ -2415,9 +2416,9 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
                 raw_names.extend(values[:12])
         names: list[str] = []
         for value in raw_names:
-            token = self._normalize_proactive_address_token(value)
-            if token and not token.isdigit() and token not in names:
-                names.append(token)
+            for token in _split_address_terms(value, 8):
+                if len(token) <= 24 and token not in names:
+                    names.append(token)
         return names[:16]
 
     def _proactive_persona_address_candidates(self) -> list[str]:
@@ -7166,11 +7167,14 @@ Output:
         if len(units) <= 2:
             return cleaned
 
-        opener_tokens = [
-            _single_line(name, 16),
-            _single_line(user.get("nickname") if isinstance(user, dict) else "", 16),
-            _single_line(runtime_persona_setting(self, "default_nickname", ""), 16),
-        ]
+        opener_tokens: list[str] = []
+        for value in (
+            name,
+            user.get("nickname") if isinstance(user, dict) else "",
+            runtime_persona_setting(self, "default_nickname", ""),
+        ):
+            for token in _split_address_terms(value, 8):
+                opener_tokens.append(_single_line(token, 16))
         first_opener = ""
         match = re.match(r"^([\w\u4e00-\u9fffぁ-んァ-ヶー]{1,8})[，,、\s]", units[0])
         if match:

--- a/tests/test_req036_unified_profile.py
+++ b/tests/test_req036_unified_profile.py
@@ -694,7 +694,7 @@ class Req036CompanionTests(unittest.TestCase):
         rendered = ast.unparse(function)
         self.assertIn("await portrait_address_reader(private_user)", rendered)
         self.assertIn(
-            "preferred_address = portrait_preferred_address or _single_line",
+            "preferred_address = portrait_preferred_address or _single_address",
             rendered,
         )
 

--- a/user_memory.py
+++ b/user_memory.py
@@ -105,7 +105,7 @@ from .dreaming import (
     recent_diary_tags,
     weighted_unique_fragment_sample,
 )
-from .helpers import _date_key, _normalize_photo_subject_owner, _now_ts, _photo_subject_owner_prompt_label, _safe_float, _safe_int, _single_line, _strip_internal_message_blocks, _today_key
+from .helpers import _date_key, _normalize_photo_subject_owner, _now_ts, _photo_subject_owner_prompt_label, _safe_float, _safe_int, _single_address, _single_line, _strip_internal_message_blocks, _today_key
 from .relationship_policy import relationship_stage_for_score
 from .expression_scope_ownership import (
     bind_expression_item,
@@ -9942,7 +9942,7 @@ bot_promises 只记录 Bot 明确承诺要提醒、记住、转述、发送或�
     ) -> str:
         # The unified archive is the only person authority.  Retired
         # Worldbook identities and text must never enter a private prompt.
-        stable_name = _single_line(
+        stable_name = _single_address(
             user.get("nickname") or runtime_persona_setting(self, "default_nickname", "你"),
             24,
         )


### PR DESCRIPTION
## 背景
用户可配置多个并存称呼（如 `诗岸/宝宝`、`老板，Sir`）。此前整个字符串被当作单个 token 处理，导致匹配/注入称呼时只回退到第一个条目，多称呼配置失效。

## 改动
- `helpers.py`：新增共享工具 `_clean_address_term`/`_split_address_terms`/`_single_address`，统一按 `/／、,，;；|` 等分隔符拆分并去重称呼别名；保留 `_single_line` 供其他调用方使用。
- `memory_companion_adapter.py` / `passive_state_pipeline.py` / `user_memory.py`：昵称/preferred_address 规范化改用 `_single_address`。
- `proactive_message.py`：收件人允许名单与开场称呼候选支持别名拆分。
- `tests/test_req036_unified_profile.py`：更新 AST 断言以匹配新实现。

## 测试
相关测试子集已通过：`test_req036_unified_profile.py`、`test_memory_companion_schedule_fast_context.py`、`test_cycle_reply_context.py`、`test_proactive_candidate_repeated.py`、`test_req041_identity_assurance.py`、`test_proactive_persona_*` 等，共 167 项通过。