### PR TITLE
fix: register missing bookshelf page api routes

### DIFF
--- a/page_api.py
+++ b/page_api.py
@@ -1172,6 +1172,15 @@ class PrivateCompanionPageApi(
     def route_bindings(self) -> list[tuple[str, Any, list[str], str]]:
         """Return the wrapped page handlers used by every transport."""
         routes = [
+            ("/bookshelf/unlock", self.unlock_bookshelf, ["POST"], "Private Companion Page unlock bookshelf secret drawer"),
+            ("/bookshelf/session", self.get_bookshelf_session, ["POST"], "Private Companion Page restore bookshelf session"),
+            ("/bookshelf/image", self.get_bookshelf_image, ["GET"], "Private Companion Page bookshelf image asset"),
+            ("/bookshelf/image_data", self.get_bookshelf_image_data, ["GET"], "Private Companion Page bookshelf image data url"),
+            ("/bookshelf/delete", self.delete_bookshelf_item, ["POST"], "Private Companion Page delete bookshelf item"),
+            ("/bookshelf/reading_state", self.update_bookshelf_reading_state, ["POST"], "Private Companion Page update bookshelf reading state"),
+            ("/bookshelf/rate", self.rate_bookshelf_item, ["POST"], "Private Companion Page rate bookshelf item"),
+            ("/bookshelf/tags", self.update_bookshelf_item_tags, ["POST"], "Private Companion Page update bookshelf item tags"),
+            ("/bookshelf/comments", self.update_bookshelf_item_comments, ["POST"], "Private Companion Page update bookshelf item comments"),
             ("/overview", self.get_overview, ["GET"], "Private Companion Page overview"),
             ("/calendar", self.get_calendar, ["GET"], "Private Companion Page long-lived calendar"),
             ("/calendar/conflicts", self.get_calendar_conflicts, ["GET"], "Private Companion Page calendar conflicts"),


### PR DESCRIPTION
## 问题
陪伴面板「创作 → 查看抽屉夹层」报错“未找到该路由”。

## 根因
`page_api.route_bindings()` 是页面 API 的唯一注册源，但 179 条注册中缺失整个 bookshelf（资料柜/抽屉夹层）路由组。8 个 handler（`unlock_bookshelf`、`get_bookshelf_session`、`get_bookshelf_image(_data)`、`delete_bookshelf_item`、`update_bookshelf_reading_state`、`rate_bookshelf_item`、`update_bookshelf_item_tags`、`update_bookshelf_item_comments`）均已实现，但从未绑定到路由，前端请求 `/bookshelf/unlock` 等路径时后端返回路由未找到。

## 修复
在 `route_bindings()` 中注册 9 条 `/bookshelf/*` 路由（unlock / session / image / image_data / delete / reading_state / rate / tags / comments）。

## 验证
- 路由绑定相关测试（route_bindings + bookshelf 全套 + standalone）33 项通过
- 全量测试 4308 项通过