### PR TITLE
fix: integrate companion issue and PR fixes

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -138,6 +138,49 @@ def _single_line(text: Any, limit: int = 80) -> str:
     return normalized[:limit]
 
 
+_ADDRESS_SEPARATOR_PATTERN = re.compile(r"[/／、,，;；|]+")
+_ADDRESS_TERM_STRIP_CHARS = " -*`_【】[]（）()<>《》\"'“”‘’"
+_ADDRESS_TERM_TAIL_PATTERN = re.compile(r"[：:，,。.!！?？~～…]+$")
+
+
+def _clean_address_term(value: Any) -> str:
+    """Normalize a single display name or address alias."""
+    token = unicodedata.normalize("NFKC", str(value or "")).strip()
+    token = re.sub(r"\s+", " ", token)
+    token = token.strip(_ADDRESS_TERM_STRIP_CHARS)
+    token = token.lstrip("：:")
+    token = _ADDRESS_TERM_TAIL_PATTERN.sub("", token).strip()
+    return token
+
+
+def _split_address_terms(text: Any, limit: int = 8) -> list[str]:
+    """Split slash/separator-delimited aliases into stable, unique terms.
+
+    Users can configure several accepted addresses at once, for example
+    "诗岸/宝宝" or "老板，Sir".  Treating such a value as one token makes
+    every consumer that matches or injects an address fall back to the first
+    entry only, so callers share a single splitting rule here.
+    """
+    normalized = unicodedata.normalize("NFKC", str(text or "")).strip()
+    if not normalized:
+        return []
+    normalized = re.sub(r"\s+", " ", normalized)
+    terms: list[str] = []
+    for part in _ADDRESS_SEPARATOR_PATTERN.split(normalized):
+        token = _clean_address_term(part)
+        if not token or token.isdigit() or len(token) > 40:
+            continue
+        if token not in terms:
+            terms.append(token)
+    return terms[:limit]
+
+
+def _single_address(text: Any, limit: int = 40) -> str:
+    """Collapse delimited aliases into one joined display address."""
+    terms = _split_address_terms(text, limit)
+    return "、".join(terms)[:limit]
+
+
 def _url_host_is_public(url: Any) -> bool:
     """Accept only HTTP(S) URLs whose DNS results are all public addresses."""
     text = str(url or "").strip()

--- a/memory_companion_adapter.py
+++ b/memory_companion_adapter.py
@@ -27,7 +27,7 @@ from .bot_personal_contract import (
     window_for_minutes,
 )
 from .bot_personal_outbox import BotPersonalOutbox
-from .helpers import _missing_optional_model_dependency, _now_ts, _path_text, _safe_float, _safe_int, _single_line
+from .helpers import _missing_optional_model_dependency, _now_ts, _path_text, _safe_float, _safe_int, _single_address, _single_line
 from .companion_interaction_expression import current_interaction_projection
 from .relationship_ledger import normalize_relationship_mode
 from .relationship_policy import relationship_projection_for_bridge
@@ -1616,7 +1616,7 @@ class MemoryCompanionAdapterMixin:
             (user.get("nickname") or user.get("display_name") or user_id) if isinstance(user, dict) else user_id,
             80,
         )
-        preferred_address = _single_line(user.get("nickname"), 24) if isinstance(user, dict) else ""
+        preferred_address = _single_address(user.get("nickname"), 24) if isinstance(user, dict) else ""
         return {
             "session_id": umo or f"private_companion:schedule:{user_id or 'bot_self'}",
             "scope": "private" if user_id else "unknown",
@@ -1787,7 +1787,7 @@ class MemoryCompanionAdapterMixin:
                 user_name = _single_line(self._sender_display_name(event), 80)
             except Exception:
                 user_name = ""
-            preferred_address = _single_line(user.get("nickname"), 24) if isinstance(user, dict) else ""
+            preferred_address = _single_address(user.get("nickname"), 24) if isinstance(user, dict) else ""
             session_context = {
                 "session_id": session_id,
                 "scope": scope,
@@ -1803,7 +1803,7 @@ class MemoryCompanionAdapterMixin:
             }
         elif isinstance(user, dict):
             umo = _single_line(user.get("umo"), 200)
-            preferred_address = _single_line(user.get("nickname"), 24)
+            preferred_address = _single_address(user.get("nickname"), 24)
             if not user_id and not umo:
                 # 无用户标识：无法在 memory 插件侧隔离会话作用域，宁可召回为空也不跨用户串线。
                 return ""

--- a/page_api.py
+++ b/page_api.py
@@ -1172,6 +1172,15 @@ class PrivateCompanionPageApi(
     def route_bindings(self) -> list[tuple[str, Any, list[str], str]]:
         """Return the wrapped page handlers used by every transport."""
         routes = [
+            ("/bookshelf/unlock", self.unlock_bookshelf, ["POST"], "Private Companion Page unlock bookshelf secret drawer"),
+            ("/bookshelf/session", self.get_bookshelf_session, ["POST"], "Private Companion Page restore bookshelf session"),
+            ("/bookshelf/image", self.get_bookshelf_image, ["GET"], "Private Companion Page bookshelf image asset"),
+            ("/bookshelf/image_data", self.get_bookshelf_image_data, ["GET"], "Private Companion Page bookshelf image data url"),
+            ("/bookshelf/delete", self.delete_bookshelf_item, ["POST"], "Private Companion Page delete bookshelf item"),
+            ("/bookshelf/reading_state", self.update_bookshelf_reading_state, ["POST"], "Private Companion Page update bookshelf reading state"),
+            ("/bookshelf/rate", self.rate_bookshelf_item, ["POST"], "Private Companion Page rate bookshelf item"),
+            ("/bookshelf/tags", self.update_bookshelf_item_tags, ["POST"], "Private Companion Page update bookshelf item tags"),
+            ("/bookshelf/comments", self.update_bookshelf_item_comments, ["POST"], "Private Companion Page update bookshelf item comments"),
             ("/overview", self.get_overview, ["GET"], "Private Companion Page overview"),
             ("/calendar", self.get_calendar, ["GET"], "Private Companion Page long-lived calendar"),
             ("/calendar/conflicts", self.get_calendar_conflicts, ["GET"], "Private Companion Page calendar conflicts"),

--- a/pages/companion-panel/app.js
+++ b/pages/companion-panel/app.js
@@ -948,7 +948,7 @@ const pluginIntegrationAvailabilityRules = {
   enable_qzone_generated_image_publish: () => imageCompanionInstalled() && state.overview?.qzone?.platform_supported !== false,
   enable_qzone_comment_inbox: () => state.overview?.qzone?.platform_supported !== false,
   enable_qzone_emotional_vent_publish: () => Boolean(state.overview?.qzone?.available && toBool(state.featureDraft?.enable_emotion_simulation)),
-  enable_creative_writing: () => true,
+  enable_creative_writing: () => false,
   enable_creative_cover_generation: () => true,
   CREATIVE_MODEL_PROVIDER_ID: () => true,
   CREATIVE_PROVIDER_ID: () => true,

--- a/pages/陪伴面板/app.js
+++ b/pages/陪伴面板/app.js
@@ -948,7 +948,7 @@ const pluginIntegrationAvailabilityRules = {
   enable_qzone_generated_image_publish: () => imageCompanionInstalled() && state.overview?.qzone?.platform_supported !== false,
   enable_qzone_comment_inbox: () => state.overview?.qzone?.platform_supported !== false,
   enable_qzone_emotional_vent_publish: () => Boolean(state.overview?.qzone?.available && toBool(state.featureDraft?.enable_emotion_simulation)),
-  enable_creative_writing: () => true,
+  enable_creative_writing: () => false,
   enable_creative_cover_generation: () => true,
   CREATIVE_MODEL_PROVIDER_ID: () => true,
   CREATIVE_PROVIDER_ID: () => true,

--- a/passive_state_pipeline.py
+++ b/passive_state_pipeline.py
@@ -15,7 +15,7 @@ from .group_prompt_context import (
     GROUP_HISTORY_INJECTED_ATTR,
     group_prompt_context_history_count,
 )
-from .helpers import _now_ts, _safe_float, _single_line
+from .helpers import _now_ts, _safe_float, _single_address, _single_line
 from .persona_config import runtime_persona_setting
 from .prompt_surface import PromptSurface
 from .logging_util import get_module_logger
@@ -190,7 +190,7 @@ async def inject_humanized_state(
                         "当前对象画像称呼读取失败，保留既有称呼: %s",
                         _single_line(exc, 120),
                     )
-            preferred_address = portrait_preferred_address or _single_line(
+            preferred_address = portrait_preferred_address or _single_address(
                 private_user.get("nickname")
                 or runtime_persona_setting(self, "default_nickname", "你"),
                 24,

--- a/proactive_message.py
+++ b/proactive_message.py
@@ -135,6 +135,7 @@ from .helpers import (
     _safe_float,
     _safe_int,
     _single_line,
+    _split_address_terms,
     _strip_internal_message_blocks,
     _strip_outbound_control_blocks,
     _today_key,
@@ -2416,9 +2417,9 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
                 raw_names.extend(values[:12])
         names: list[str] = []
         for value in raw_names:
-            token = self._normalize_proactive_address_token(value)
-            if token and not token.isdigit() and token not in names:
-                names.append(token)
+            for token in _split_address_terms(value, 8):
+                if len(token) <= 24 and token not in names:
+                    names.append(token)
         return names[:16]
 
     def _proactive_persona_address_candidates(self) -> list[str]:
@@ -7199,11 +7200,14 @@ Output:
         if len(units) <= 2:
             return cleaned
 
-        opener_tokens = [
-            _single_line(name, 16),
-            _single_line(user.get("nickname") if isinstance(user, dict) else "", 16),
-            _single_line(runtime_persona_setting(self, "default_nickname", ""), 16),
-        ]
+        opener_tokens: list[str] = []
+        for value in (
+            name,
+            user.get("nickname") if isinstance(user, dict) else "",
+            runtime_persona_setting(self, "default_nickname", ""),
+        ):
+            for token in _split_address_terms(value, 8):
+                opener_tokens.append(_single_line(token, 16))
         first_opener = ""
         match = re.match(r"^([\w\u4e00-\u9fffぁ-んァ-ヶー]{1,8})[，,、\s]", units[0])
         if match:

--- a/tests/test_issue_193_194_regressions.py
+++ b/tests/test_issue_193_194_regressions.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from astrbot_plugin_private_companion.persona_config import load_scope_manifest
+
+
+def test_creative_writing_missing_config_defaults_to_disabled() -> None:
+    manifest = load_scope_manifest()
+    assert manifest["enable_creative_writing"]["default"] is False
+
+
+def test_primary_persona_change_keeps_a_recoverable_ownership_audit(tmp_path: Path) -> None:
+    from tests.test_multi_persona_isolation import _plugin_harness
+
+    plugin = _plugin_harness(str(tmp_path))
+    plugin._data_default["users"] = {"u": {"name": "历史"}}
+    warning = plugin._record_primary_persona_change("main", "alt")
+
+    assert warning["code"] == "primary_store_owner_mismatch"
+    backup = Path(warning["backup_path"])
+    assert backup.is_file()
+    assert json.loads(backup.read_text(encoding="utf-8"))["users"] == {"u": {"name": "历史"}}
+    ownership = plugin._data_default["primary_store_ownership"]
+    assert ownership["owner_persona_id"] == "main"
+    assert ownership["active_persona_id"] == "alt"
+    assert ownership["status"] == "pending_review"
+    assert ownership["history"][-1]["from_persona_id"] == "main"
+    assert ownership["history"][-1]["to_persona_id"] == "alt"

--- a/tests/test_req036_unified_profile.py
+++ b/tests/test_req036_unified_profile.py
@@ -716,7 +716,7 @@ class Req036CompanionTests(unittest.TestCase):
         rendered = ast.unparse(function)
         self.assertIn("await portrait_address_reader(private_user)", rendered)
         self.assertIn(
-            "preferred_address = portrait_preferred_address or _single_line",
+            "preferred_address = portrait_preferred_address or _single_address",
             rendered,
         )
 

--- a/user_memory.py
+++ b/user_memory.py
@@ -105,7 +105,7 @@ from .dreaming import (
     recent_diary_tags,
     weighted_unique_fragment_sample,
 )
-from .helpers import _date_key, _normalize_photo_subject_owner, _now_ts, _photo_subject_owner_prompt_label, _safe_float, _safe_int, _single_line, _strip_internal_message_blocks, _today_key
+from .helpers import _date_key, _normalize_photo_subject_owner, _now_ts, _photo_subject_owner_prompt_label, _safe_float, _safe_int, _single_address, _single_line, _strip_internal_message_blocks, _today_key
 from .relationship_policy import relationship_stage_for_score
 from .expression_scope_ownership import (
     bind_expression_item,
@@ -9942,7 +9942,7 @@ bot_promises 只记录 Bot 明确承诺要提醒、记住、转述、发送或�
     ) -> str:
         # The unified archive is the only person authority.  Retired
         # Worldbook identities and text must never enter a private prompt.
-        stable_name = _single_line(
+        stable_name = _single_address(
             user.get("nickname") or runtime_persona_setting(self, "default_nickname", "你"),
             24,
         )


### PR DESCRIPTION
Closes #193. Addresses #194 with ownership-audit regression coverage. Integrates the address-alias normalization from #195 and bookshelf route bindings from #196 with CI whitespace compatibility fixes. #197 is already merged separately.