### PR TITLE
fix: 区分日程计划投影与已核实活动并补齐当前状态问法

### DIFF
--- a/daily_state.py
+++ b/daily_state.py
@@ -10377,6 +10377,27 @@ class DailyStateMixin(DailyStateTickMixin):
                 )
                 phase = _single_line(canonical.get("temporal_phase"), 16).lower()
                 if phase == "past":
+                    # ``normalize_plan_item`` evaluates a HH:MM value on the
+                    # calendar date alone.  A plan that deliberately rolls
+                    # past midnight therefore looks stale even while its
+                    # normalized schedule axis is still current/upcoming.
+                    # Preserve the evidence status as ``planned`` in that
+                    # case; the separate display status may still project the
+                    # wall-clock phase as active.
+                    items = plan.get("items") if isinstance(plan, dict) else None
+                    starts = self._normalized_plan_item_starts(items)
+                    start = starts[index] if isinstance(items, list) and 0 <= index < len(starts) else None
+                    if start is not None:
+                        next_start = next((value for value in starts[index + 1 :] if value is not None), None)
+                        end = self._plan_item_end_minutes(start, item, next_start=next_start)
+                        clock_phase = self._schedule_window_runtime_status(
+                            start,
+                            end,
+                            plan_date=plan_date,
+                            explicit_status=item.get("lifecycle_status"),
+                        )
+                        if clock_phase in {"planned", "active"}:
+                            return "planned"
                     return "unknown"
                 return "planned"
             except Exception:
@@ -11404,6 +11425,48 @@ class DailyStateMixin(DailyStateTickMixin):
             if start - lead <= now_minutes < end:
                 return segment
         return None
+
+    def _current_detail_snapshot_for_update(self) -> dict[str, Any] | None:
+        """Return the finished detail snapshot for the clock-current plan segment."""
+
+        segment = self._current_detail_segment_for_update()
+        if not isinstance(segment, dict):
+            return None
+        plan_date = _single_line(segment.get("plan_date"), 16)
+        now_minutes = self._effective_plan_now_minutes(plan_date)
+        if now_minutes is None:
+            return None
+        start = _safe_int(segment.get("start"), -1, minimum=-1)
+        end = _safe_int(segment.get("end"), -1, minimum=-1)
+        if start < 0 or end < 0:
+            return None
+        if end <= start:
+            end += 24 * 60
+        # Detail generation may select the next segment during its lead
+        # window. Passive state material must remain tied to the actual clock
+        # window so it cannot describe the next scene early.
+        if not (start <= now_minutes < end):
+            return None
+        segment_item = segment.get("item")
+        if isinstance(segment_item, dict):
+            lifecycle = self._normalize_schedule_lifecycle_status(
+                segment_item.get("lifecycle_status") or segment_item.get("status")
+            )
+            # A finished detail snapshot still describes its parent plan. If
+            # that plan was changed, deferred, cancelled, or already closed,
+            # the old atmosphere must not survive as current prompt material.
+            if lifecycle not in {"", "planned", "active"}:
+                return None
+        enhanced = self.data.get("detail_enhanced_segments", {})
+        if not isinstance(enhanced, dict):
+            return None
+        snapshot = enhanced.get(str(segment.get("key") or ""))
+        if not isinstance(snapshot, dict):
+            return None
+        status = _single_line(snapshot.get("status"), 24).lower()
+        if status and status != "done":
+            return None
+        return snapshot
 
     def _current_detail_state_variables(self) -> list[dict[str, str]]:
         segment = self._current_detail_segment_for_update()
@@ -13061,13 +13124,16 @@ class DailyStateMixin(DailyStateTickMixin):
         normalized = _single_line(text, 180)
         if not normalized:
             return False
+        third_party_checker = getattr(self, "_user_activity_question_targets_someone_else", None)
+        if callable(third_party_checker) and third_party_checker(normalized):
+            return False
         direct_checker = getattr(self, "_user_asks_bot_current_state_or_activity", None)
         if callable(direct_checker) and direct_checker(normalized):
             return True
         return bool(
             re.search(
-                r"(最近|刚才|现在|今天|这两天|这会儿).{0,12}(在)?(干嘛|干啥|做什么|做啥|忙什么|忙啥|弄什么|写什么|写了什么|创作什么|创作了什么|玩什么|折腾什么)|"
-                r"你.{0,8}(在)?(干嘛|干啥|做什么|做啥|忙什么|忙啥|写什么|写了什么|弄什么|创作什么|创作了什么)",
+                r"(最近|刚才|现在|今天|这两天|这会儿).{0,12}(在)?(干嘛|干啥|干什么|做什么|做啥|忙什么|忙啥|弄什么|写什么|写了什么|创作什么|创作了什么|玩什么|折腾什么)|"
+                r"你.{0,8}(在)?(干嘛|干啥|干什么|做什么|做啥|忙什么|忙啥|写什么|写了什么|弄什么|创作什么|创作了什么)",
                 normalized,
             )
             or re.search(

--- a/main.py
+++ b/main.py
@@ -14181,7 +14181,8 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             prompt_user = dict(current_user)
             prompt_user["_game_current_umo"] = current_umo
 
-        current_state_memory_needed = bool(
+        third_party_activity_question = self._user_activity_question_targets_someone_else(inbound_text)
+        current_state_memory_needed = not third_party_activity_question and bool(
             self._user_asks_bot_current_state_or_activity(inbound_text)
             or re.search(
                 r"(你|星缘|bot|机器人).{0,8}(在干嘛|在做什么|做什么|穿什么|穿的?什么|衣服|衣服颜色|什么颜色|吃了什么|吃的?什么|几点吃|什么时候吃|吃饭|进食|在哪里|在哪儿|当前位置|今天状态|现在状态)",
@@ -14897,6 +14898,13 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         weather_query_detector = getattr(self, "_user_asks_current_weather", None)
         if callable(weather_query_detector) and weather_query_detector(cleaned):
             return False
+        current_activity_detector = getattr(
+            self,
+            "_user_asks_bot_current_state_or_activity",
+            None,
+        )
+        if callable(current_activity_detector) and current_activity_detector(cleaned):
+            return False
         outfit_change_detector = getattr(self, "_detect_dialogue_outfit_change", None)
         if callable(outfit_change_detector):
             try:
@@ -14907,7 +14915,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         heavy_tokens = (
             "图片", "看图", "照片", "语音", "引用", "转发", "聊天记录",
             "帮我", "怎么", "为什么", "是什么", "怎么办", "分析", "解释", "总结",
-            "日程", "状态", "近况", "在干嘛", "做什么", "忙什么",
+            "日程", "状态", "近况", "在干嘛", "干什么", "做什么", "忙什么",
             "资料柜", "夹层", "抽屉", "阅读", "读过", "看过", "素材", "资料", "漫画", "藏本",
             "创作", "作品", "写作", "写书", "写过书", "小说", "随笔", "散文", "剧本", "手稿", "草稿", "出版",
             "新闻", "说说", "空间", "发给", "转告", "@",
@@ -15002,15 +15010,73 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             return limited
         return [limited[0], flatten_component_chunks(limited[1:])]
 
+    def _private_passive_schedule_material(
+        self,
+        current_user: dict[str, Any] | None = None,
+    ) -> tuple[str, str]:
+        """Return evidence-backed and clock-only schedule material separately."""
+
+        plan = self.data.get("daily_plan", {})
+        if not isinstance(plan, dict):
+            return "", ""
+
+        def format_item(item: Any, *, clock_projection: bool = False) -> str:
+            if not isinstance(item, dict):
+                return ""
+            if clock_projection:
+                start = _single_line(item.get("time"), 12)
+                end = _single_line(item.get("end"), 12)
+                window = f"{start}-{end}" if start and end else start
+                activity = _single_line(item.get("activity") or item.get("title"), 120)
+                mood = _single_line(item.get("mood"), 32)
+                text = "｜".join(
+                    part
+                    for part in (
+                        window,
+                        activity,
+                        f"情绪：{mood}" if mood else "",
+                    )
+                    if part
+                )
+            else:
+                text = self._format_plan_item_for_prompt(item)
+            return self._sanitize_schedule_context_for_private_user(
+                text,
+                current_user or {},
+            )
+
+        current_item = self._get_current_plan_item(plan)
+        verified_schedule = format_item(current_item)
+        clock_item = None
+        clock_getter = getattr(self, "_get_clock_plan_item_for_display", None)
+        if callable(clock_getter):
+            try:
+                clock_item = clock_getter(plan)
+            except Exception:
+                clock_item = None
+        if isinstance(clock_item, dict):
+            lifecycle = self._normalize_schedule_lifecycle_status(
+                clock_item.get("lifecycle_status") or clock_item.get("status")
+            )
+            if lifecycle not in {"", "planned", "active"}:
+                clock_item = None
+        return verified_schedule, format_item(clock_item, clock_projection=True)
+
     def _private_passive_state_fingerprint(self, state: dict[str, Any], current_user: dict[str, Any] | None = None) -> dict[str, Any]:
         now = self._environment_now()
         time_label, _ = self._current_time_period_label(now)
         energy = _safe_int(state.get("energy"), 70, 0, 100)
-        current_item = self._get_current_plan_item(self.data.get("daily_plan", {}))
-        activity = _single_line(current_item.get("activity"), 50) if isinstance(current_item, dict) else ""
+        verified_schedule, planned_schedule = self._private_passive_schedule_material(current_user)
         detail = self._current_detail_segment_for_update()
         detail_key = _single_line(detail.get("key"), 80) if isinstance(detail, dict) else ""
-        detail_summary = _single_line(detail.get("summary"), 80) if isinstance(detail, dict) else ""
+        detail_snapshot_getter = getattr(self, "_current_detail_snapshot_for_update", None)
+        detail_snapshot = detail_snapshot_getter() if callable(detail_snapshot_getter) else None
+        detail_summary = _single_line(detail_snapshot.get("summary"), 80) if isinstance(detail_snapshot, dict) else ""
+        if detail_summary:
+            detail_summary = self._sanitize_schedule_context_for_private_user(
+                detail_summary,
+                current_user or {},
+            )
         friend_user = self._private_user_role(current_user or {}) == "friend"
         weather = "" if friend_user else _single_line(state.get("weather"), 60)
         conditions: list[str] = []
@@ -15028,8 +15094,9 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             "time_label": time_label,
             "energy_bracket": (energy // 10) * 10,
             "mood": _single_line(state.get("mood_bias"), 18) or "平稳",
-            "activity": self._sanitize_schedule_context_for_private_user(activity, current_user or {}) if activity else "",
-            "detail": detail_key or detail_summary,
+            "activity": _single_line(verified_schedule, 100),
+            "planned_activity": _single_line(planned_schedule, 100),
+            "detail": f"{detail_key}|{detail_summary}" if detail_summary else detail_key,
             "weather": weather if weather and weather != "暂无天气信息" else "",
             "conditions": conditions[:2],
             "body_cycle": _single_line(state.get("body_cycle"), 120) if cycle_profile else "",
@@ -15051,20 +15118,30 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         pieces = [f"时间节奏：{time_label}", f"精神约 {energy}/100", f"情绪底色偏{mood}"]
         realtime_formatter = getattr(self, "_format_external_realtime_context_for_prompt", None)
         realtime_context = realtime_formatter(current_user, public=False) if callable(realtime_formatter) else ""
-        current_item = self._get_current_plan_item(self.data.get("daily_plan", {}))
-        schedule = self._sanitize_schedule_context_for_private_user(
-            self._format_plan_item_for_prompt(current_item),
-            current_user or {},
-        )
-        if schedule and not realtime_context:
-            pieces.append(f"拟人化日程素材：{schedule}")
-        elif schedule:
-            pieces.append(f"原定日程素材（已被实时共同活动覆盖）：{schedule}")
-        detail = self._current_detail_segment_for_update()
-        if isinstance(detail, dict):
-            summary = _single_line(detail.get("summary"), 90)
+        verified_schedule, planned_schedule = self._private_passive_schedule_material(current_user)
+        if verified_schedule and not realtime_context:
+            pieces.append(f"拟人化日程素材：{verified_schedule}")
+        elif verified_schedule:
+            pieces.append(f"原定日程素材（已被实时共同活动覆盖）：{verified_schedule}")
+        elif planned_schedule and not realtime_context:
+            pieces.append(f"当前计划时段（未确认执行）：{planned_schedule}")
+        elif planned_schedule:
+            pieces.append(f"原定计划时段（未确认执行，已被实时共同活动覆盖）：{planned_schedule}")
+        detail_snapshot_getter = getattr(self, "_current_detail_snapshot_for_update", None)
+        detail_snapshot = detail_snapshot_getter() if callable(detail_snapshot_getter) else None
+        if isinstance(detail_snapshot, dict):
+            summary = _single_line(detail_snapshot.get("summary"), 90)
             if summary:
-                pieces.append(f"模拟氛围：{summary}")
+                summary = self._sanitize_schedule_context_for_private_user(
+                    summary,
+                    current_user or {},
+                )
+            if summary and not realtime_context:
+                pieces.append(f"模拟氛围（计划细化，未确认执行）：{summary}")
+            elif summary:
+                pieces.append(
+                    f"原定模拟氛围（计划细化，未确认执行，已被实时共同活动覆盖）：{summary}"
+                )
         weather = _single_line(state.get("weather"), 60)
         if self._private_user_role(current_user or {}) == "friend":
             weather = ""
@@ -15092,7 +15169,8 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         guidance = (
             "用户正在直接问 Bot 此刻在做什么或当前状态：先回答实时共同活动（若有），它高于固定日程、旧对话、旧记忆和临场发挥。"
             "固定日程只是原计划，若与实时共同活动冲突，必须说原计划被打断/覆盖，禁止继续声称仍在旧地点或旧动作中。"
-            "若没有实时共同活动，先正面回答拟人化日程素材中的当前活动。"
+            "若没有实时共同活动且有拟人化日程素材，先正面回答拟人化日程素材中的当前活动。"
+            "若只有‘当前计划时段（未确认执行）’，必须用‘按计划/原本安排’口径回答，不得声称已经在执行。"
             "不得另编素材未提供的动作、地点、饮食或娱乐活动。"
             "如果素材本身较笼统，就按原有粒度自然转述，例如只说正在专心处理手头的事；不要为了显得具体而补造细节。"
             if direct
@@ -15330,8 +15408,13 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         fingerprint = self._private_passive_state_fingerprint(state, current_user)
         previous = cache.get(session_key) if isinstance(cache.get(session_key), dict) else {}
         changed = previous.get("fingerprint") != fingerprint
-        direct_state_request = self._user_asks_bot_current_state_or_activity(inbound_text) or self._user_asks_recent_bot_activity(inbound_text) or bool(
-            re.search(r"(状态|日程|精力|心情|情绪|在干嘛|做什么|忙什么|近况)", str(inbound_text or ""))
+        third_party_activity_question = self._user_activity_question_targets_someone_else(inbound_text)
+        direct_state_request = not third_party_activity_question and (
+            self._user_asks_bot_current_state_or_activity(inbound_text)
+            or self._user_asks_recent_bot_activity(inbound_text)
+            or bool(
+                re.search(r"(状态|日程|精力|心情|情绪|在干嘛|做什么|忙什么|近况)", str(inbound_text or ""))
+            )
         )
         now_ts = _now_ts()
         cache[session_key] = {

--- a/page_api.py
+++ b/page_api.py
@@ -29403,6 +29403,8 @@ class PrivateCompanionPageApi(
         story = data.get("daily_story_plan") if isinstance(data.get("daily_story_plan"), dict) else {}
         current_item = {}
         current_lifecycle = ""
+        current_evidence_lifecycle = ""
+        current_clock_status = ""
         try:
             current_getter = getattr(self.plugin, "_agenda_current_context_item", None)
             picked = (
@@ -29417,14 +29419,25 @@ class PrivateCompanionPageApi(
             items = plan.get("items") if isinstance(plan.get("items"), list) else []
             current_index = next((index for index, item in enumerate(items) if item is picked), -1)
             if current_item:
+                current_evidence_lifecycle = self.plugin._plan_item_runtime_status(
+                    plan,
+                    current_item,
+                    current_index,
+                )
                 display_status = getattr(self.plugin, "_plan_item_display_status", None)
-                current_lifecycle = (
+                current_clock_status = (
                     display_status(plan, current_item, current_index)
                     if callable(display_status)
-                    else self.plugin._plan_item_runtime_status(plan, current_item, current_index)
+                    else current_evidence_lifecycle
                 )
+                # Preserve the legacy display-oriented field for older page
+                # consumers while exposing the evidence/clock split to new UI.
+                current_lifecycle = current_clock_status
         except Exception:
             current_item = {}
+            current_lifecycle = ""
+            current_evidence_lifecycle = ""
+            current_clock_status = ""
 
         return {
             "dream": {
@@ -29460,6 +29473,8 @@ class PrivateCompanionPageApi(
                 "time": self._single_line(current_item.get("time"), 12),
                 "end": self._single_line(current_item.get("end"), 12),
                 "lifecycle": current_lifecycle,
+                "evidence_lifecycle": current_evidence_lifecycle,
+                "clock_status": current_clock_status,
                 "activity": self._single_line(current_item.get("activity"), 600),
                 "mood": self._single_line(current_item.get("mood"), 40),
                 "message_seed": self._single_line(current_item.get("message_seed"), 500),
@@ -29493,8 +29508,13 @@ class PrivateCompanionPageApi(
             segment = self._segment_from_key(str(key), plan, snapshot)
             seen_segment_keys.add(str(key))
             segment_item = segment.get("item") if isinstance(segment.get("item"), dict) else {}
+            evidence_lifecycle = self.plugin._plan_item_runtime_status(
+                plan,
+                segment_item,
+                self._int(segment.get("index"), -1, -1),
+            ) if segment_item else "planned"
             display_status = getattr(self.plugin, "_plan_item_display_status", None)
-            lifecycle = (
+            clock_status = (
                 display_status(plan, segment_item, self._int(segment.get("index"), -1, -1))
                 if segment_item and callable(display_status)
                 else self.plugin._plan_item_runtime_status(
@@ -29509,7 +29529,12 @@ class PrivateCompanionPageApi(
                     "window": segment.get("window", str(key)),
                     "start": segment.get("start", 99999),
                     "end": segment.get("end", 99999),
-                    "lifecycle": lifecycle,
+                    # Keep lifecycle as the legacy display field for API
+                    # compatibility; new clients should use the explicit
+                    # evidence/clock split below.
+                    "lifecycle": clock_status,
+                    "evidence_lifecycle": evidence_lifecycle,
+                    "clock_status": clock_status,
                     "activity": self._single_line(segment_item.get("activity"), 180),
                     "basis": self.plugin._normalize_schedule_basis(segment_item.get("basis"), default=["coarse_plan"]),
                     "confidence": self._float(segment_item.get("confidence"), 0.72, 0.0, 1.0),
@@ -29525,8 +29550,20 @@ class PrivateCompanionPageApi(
                     "state_variables": self._limited_state_variables(snapshot.get("state_variables")),
                     "presence_status": snapshot.get("presence_status") if isinstance(snapshot.get("presence_status"), dict) else {},
                     "interaction_updates": self._limited_interaction_updates(snapshot.get("interaction_updates")),
-                    "today_events": self._timeline_story_items(snapshot.get("today_events"), 5, str(plan.get("date") or "")),
-                    "proactive_events": self._timeline_story_items(snapshot.get("proactive_events"), 4, str(plan.get("date") or "")),
+                    "today_events": self._timeline_story_items(
+                        snapshot.get("today_events"),
+                        5,
+                        str(plan.get("date") or ""),
+                        parent_start=self._int(segment.get("start"), -1, -1),
+                        parent_end=self._int(segment.get("end"), -1, -1),
+                    ),
+                    "proactive_events": self._timeline_story_items(
+                        snapshot.get("proactive_events"),
+                        4,
+                        str(plan.get("date") or ""),
+                        parent_start=self._int(segment.get("start"), -1, -1),
+                        parent_end=self._int(segment.get("end"), -1, -1),
+                    ),
                 }
             )
         for index, item in enumerate(plan_items):
@@ -29546,17 +29583,21 @@ class PrivateCompanionPageApi(
                     if next_start is not None:
                         break
             end = self.plugin._plan_item_end_minutes(start, item, next_start=next_start)
+            evidence_lifecycle = self.plugin._plan_item_runtime_status(plan, item, index)
+            clock_status = (
+                self.plugin._plan_item_display_status(plan, item, index)
+                if callable(getattr(self.plugin, "_plan_item_display_status", None))
+                else evidence_lifecycle
+            )
             segments.append(
                 {
                     "key": key,
                     "window": f"{self.plugin._minutes_to_hhmm(start)}-{self.plugin._minutes_to_hhmm(end)}",
                     "start": start,
                     "end": end,
-                    "lifecycle": (
-                        self.plugin._plan_item_display_status(plan, item, index)
-                        if callable(getattr(self.plugin, "_plan_item_display_status", None))
-                        else self.plugin._plan_item_runtime_status(plan, item, index)
-                    ),
+                    "lifecycle": clock_status,
+                    "evidence_lifecycle": evidence_lifecycle,
+                    "clock_status": clock_status,
                     "activity": self._single_line(item.get("activity"), 180),
                     "basis": self.plugin._normalize_schedule_basis(item.get("basis"), default=["coarse_plan"]),
                     "confidence": self._float(item.get("confidence"), 0.72, 0.0, 1.0),
@@ -30207,9 +30248,37 @@ class PrivateCompanionPageApi(
             )
         return items
 
-    def _timeline_story_items(self, value: Any, limit: int, plan_date: str) -> list[dict[str, Any]]:
-        items = self._limited_story_items(value, limit)
+    def _timeline_story_items(
+        self,
+        value: Any,
+        limit: int,
+        plan_date: str,
+        *,
+        parent_start: int | None = None,
+        parent_end: int | None = None,
+    ) -> list[dict[str, Any]]:
+        items = self._limited_story_items(
+            value,
+            limit,
+            parent_start=parent_start,
+            parent_end=parent_end,
+        )
         for item in items:
+            start, end = self.plugin._parse_window_minutes(str(item.get("window") or ""))
+            if start is not None and end is not None:
+                duration = end - start
+                if duration <= 0:
+                    duration += 24 * 60
+                axis_start = self._story_item_axis_start(
+                    start,
+                    parent_start=parent_start,
+                    parent_end=parent_end,
+                )
+                item["clock_status"] = self.plugin._schedule_window_runtime_status(
+                    axis_start,
+                    axis_start + duration,
+                    plan_date=plan_date,
+                )
             # Story/detail entries are projections.  Their clock window only
             # describes when a generated scene could occur; it is not an
             # execution observation.  Never turn them into ``active`` or
@@ -30237,12 +30306,48 @@ class PrivateCompanionPageApi(
         return items
 
     @staticmethod
-    def _limited_story_items(value: Any, limit: int) -> list[dict[str, Any]]:
+    def _story_item_axis_start(
+        start: int,
+        *,
+        parent_start: int | None = None,
+        parent_end: int | None = None,
+    ) -> int:
+        if start < 0 or start >= 24 * 60:
+            return start
+        axis_start = start
+        if parent_start is None or parent_start < 0:
+            return axis_start
+        parent_day_start = (parent_start // (24 * 60)) * (24 * 60)
+        axis_start += parent_day_start
+        if (
+            parent_end is not None
+            and parent_end > parent_day_start + 24 * 60
+            and axis_start < parent_start
+        ):
+            axis_start += 24 * 60
+        return axis_start
+
+    @staticmethod
+    def _limited_story_items(
+        value: Any,
+        limit: int,
+        *,
+        parent_start: int | None = None,
+        parent_end: int | None = None,
+    ) -> list[dict[str, Any]]:
         if not isinstance(value, list):
             return []
-        items: list[dict[str, str]] = []
+        items: list[dict[str, Any]] = []
         indexed_items = [
-            (PrivateCompanionPageApi._story_item_start_minutes(item), index, item)
+            (
+                PrivateCompanionPageApi._story_item_axis_start(
+                    PrivateCompanionPageApi._story_item_start_minutes(item),
+                    parent_start=parent_start,
+                    parent_end=parent_end,
+                ),
+                index,
+                item,
+            )
             for index, item in enumerate(value)
             if isinstance(item, dict)
         ]
@@ -30250,6 +30355,15 @@ class PrivateCompanionPageApi(
         for _, _, item in indexed_items[:limit]:
             if not isinstance(item, dict):
                 continue
+            evidence_kind = PrivateCompanionPageApi._single_line(item.get("evidence_kind"), 48).lower()
+            if evidence_kind not in {"interaction", "tool_action", "external_record"}:
+                evidence_kind = ""
+            fact_eligibility = PrivateCompanionPageApi._single_line(item.get("fact_eligibility"), 48).lower()
+            if fact_eligibility not in {"current_observed", "history_observed"}:
+                fact_eligibility = ""
+            status = PrivateCompanionPageApi._single_line(item.get("status"), 32).lower()
+            if status not in {"planned", "unknown", "active", "completed", "partially_completed"}:
+                status = ""
             items.append(
                 {
                     "window": PrivateCompanionPageApi._single_line(item.get("window") or item.get("time"), 24),
@@ -30265,6 +30379,9 @@ class PrivateCompanionPageApi(
                     "action": PrivateCompanionPageApi._single_line(item.get("action"), 24),
                     "reason": PrivateCompanionPageApi._single_line(item.get("reason"), 32),
                     "lifecycle_status": PrivateCompanionPageApi._single_line(item.get("lifecycle_status"), 20),
+                    "evidence_kind": evidence_kind,
+                    "fact_eligibility": fact_eligibility,
+                    "status": status,
                     "basis": [
                         PrivateCompanionPageApi._single_line(value, 24)
                         for value in (item.get("basis") or [])[:3]

--- a/pages/companion-panel/app.js
+++ b/pages/companion-panel/app.js
@@ -11639,9 +11639,10 @@ function renderDashboardLifeDesk(overview = {}) {
   const currentRoot = $("#dashboardCurrentState");
   if (currentRoot) {
     const energy = Math.max(0, Math.min(100, Number(daily.energy || 0)));
+    const currentLifecycleText = scheduleTimelineSegmentLabel(current);
     const activityMeta = [
       current.end ? `${current.time || "--:--"}-${current.end}` : current.time,
-      scheduleLifecycleLabel(current.lifecycle),
+      currentLifecycleText,
       current.mood,
     ].filter(Boolean).join(" · ");
     const states = [
@@ -11654,8 +11655,8 @@ function renderDashboardLifeDesk(overview = {}) {
     ];
     currentRoot.innerHTML = `
       <div class="life-current-activity">
-        <small>${escapeHtml(activityMeta || "当前日程")}</small>
-        <b>${escapeHtml(dashboardLifeText(current.activity, "暂无当前日程"))}</b>
+        <small>${escapeHtml(activityMeta || "当前计划时段")}</small>
+        <b>${escapeHtml(dashboardLifeText(current.activity, "暂无当前计划时段"))}</b>
         <span>${escapeHtml(dashboardLifeText(current.message_seed || daily.note, "暂无状态补充"))}</span>
       </div>
       <div class="life-energy-track" role="meter" aria-label="当前体力" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${Math.round(energy)}"><i style="width:${energy}%"></i></div>
@@ -11678,8 +11679,8 @@ function renderDashboardLifeDesk(overview = {}) {
       return hour >= 0 && hour <= 23 && minute >= 0 && minute <= 59 ? hour * 60 + minute : null;
     };
     const segmentIsCurrent = (segment) => {
-      const lifecycle = String(segment?.lifecycle || "").toLowerCase();
-      return lifecycle === "active"
+      const clockStatus = String(segment?.clock_status || segment?.lifecycle || "").toLowerCase();
+      return clockStatus === "active"
         || Boolean(current.time && String(segment?.window || "").startsWith(String(current.time)));
     };
     const currentSegmentIndex = segments.findIndex(segmentIsCurrent);
@@ -11724,6 +11725,7 @@ function renderDashboardLifeDesk(overview = {}) {
       const segment = entry.segment;
       const lifecycle = String(segment.lifecycle || "planned").toLowerCase();
       const isCurrent = segmentIsCurrent(segment);
+      const segmentLifecycleText = scheduleTimelineSegmentLabel(segment);
       const summary = segment.summary || segment.activity || "这一段尚未细化";
       const windowText = String(segment.window || "未定");
       const windowMatch = windowText.match(/^(\d{1,2}:\d{2})\s*[-~至]\s*(\d{1,2}:\d{2})$/);
@@ -11738,8 +11740,8 @@ function renderDashboardLifeDesk(overview = {}) {
           <div class="life-timeline-content">
             <b>${escapeHtml(summary)}</b>
             <span>${isCurrent
-              ? '<em class="life-current-marker">当前日程</em>'
-              : `<em class="life-schedule-status is-${escapeHtml(lifecycle)}">${escapeHtml(scheduleLifecycleLabel(lifecycle) || "计划中")}</em>`}</span>
+              ? `<em class="life-current-marker">${escapeHtml(segmentLifecycleText || "进行中")}</em>`
+              : `<em class="life-schedule-status is-${escapeHtml(lifecycle)}">${escapeHtml(segmentLifecycleText || "计划中")}</em>`}</span>
           </div>
         </li>
       `;
@@ -20748,8 +20750,8 @@ function renderLifeHero(daily, life) {
   $("#lifeLocation").textContent = normalizeLocationText(daily.location);
   $("#lifeWeather").textContent = daily.weather || "暂无天气";
   const current = life.current_plan || {};
-  $("#lifeCurrentActivity").textContent = current.activity || "暂无当前日程";
-  $("#lifeCurrentSeed").textContent = [current.end ? `${current.time}-${current.end}` : current.time, scheduleLifecycleLabel(current.lifecycle), current.mood, current.message_seed].filter(Boolean).join(" · ") || "暂无细化";
+  $("#lifeCurrentActivity").textContent = current.activity || "暂无当前计划时段";
+  $("#lifeCurrentSeed").textContent = [current.end ? `${current.time}-${current.end}` : current.time, scheduleTimelineSegmentLabel(current), current.mood, current.message_seed].filter(Boolean).join(" · ") || "暂无细化";
 }
 
 function roleplayEnergyLabel(value) {
@@ -23307,7 +23309,7 @@ function renderDailyTimeline() {
     const presence = segment.presence_status || {};
     const statusText = detailSegmentStatusLabel(segment);
     const presenceText = presenceLabel(presence);
-    const lifecycleText = scheduleLifecycleLabel(segment.lifecycle);
+    const lifecycleText = scheduleTimelineSegmentLabel(segment);
     const metaText = [...new Set([lifecycleText, statusText, presenceText].filter(Boolean))].join(" · ");
     const errorText = String(segment.regeneration_error || segment.error || "").trim();
     const quality = segment.quality || {};
@@ -23336,7 +23338,7 @@ function renderDailyTimeline() {
             `).join("") : `<span>暂无状态变量</span>`}
           </div>
           <ul>
-            ${events.length ? events.map((item) => `<li><span>${escapeHtml(scheduleLifecycleLabel(item.lifecycle))}</span>${escapeHtml(item.window ? `${item.window} · ${item.text}` : item.text)}</li>`).join("") : `<li>暂无细化事件</li>`}
+            ${events.length ? events.map((item) => `<li><span>${escapeHtml(scheduleStoryLifecycleLabel(item))}</span>${escapeHtml(item.window ? `${item.window} · ${item.text}` : item.text)}</li>`).join("") : `<li>暂无细化事件</li>`}
           </ul>
         </div>
       </section>
@@ -23355,9 +23357,29 @@ function scheduleLifecycleLabel(value) {
     planned: "计划中",
     active: "进行中",
     completed: "已完成",
+    partially_completed: "部分完成",
     changed: "已变更",
     cancelled: "已取消",
+    deferred: "已顺延",
+    unknown: "未核实",
   }[String(value || "").toLowerCase()] || "";
+}
+
+function scheduleTimelineSegmentLabel(segment) {
+  const evidence = String(segment?.evidence_lifecycle || "").toLowerCase();
+  const clockStatus = String(segment?.clock_status || "").toLowerCase();
+  const legacy = String(segment?.lifecycle || "").toLowerCase();
+  if (!evidence && !clockStatus && !legacy) return "";
+  if (["active", "completed", "partially_completed", "changed", "cancelled", "deferred"].includes(evidence)) {
+    return scheduleLifecycleLabel(evidence);
+  }
+  return scheduleLifecycleLabel(clockStatus || (!evidence ? legacy : "") || evidence || legacy);
+}
+
+function scheduleStoryLifecycleLabel(item) {
+  const lifecycle = String(item?.lifecycle || "").toLowerCase();
+  if (lifecycle !== "planned") return scheduleLifecycleLabel(lifecycle);
+  return scheduleLifecycleLabel(item?.clock_status || lifecycle) || "计划中";
 }
 
 function scheduleBasisLabel(value) {

--- a/pages/陪伴面板/app.js
+++ b/pages/陪伴面板/app.js
@@ -11639,9 +11639,10 @@ function renderDashboardLifeDesk(overview = {}) {
   const currentRoot = $("#dashboardCurrentState");
   if (currentRoot) {
     const energy = Math.max(0, Math.min(100, Number(daily.energy || 0)));
+    const currentLifecycleText = scheduleTimelineSegmentLabel(current);
     const activityMeta = [
       current.end ? `${current.time || "--:--"}-${current.end}` : current.time,
-      scheduleLifecycleLabel(current.lifecycle),
+      currentLifecycleText,
       current.mood,
     ].filter(Boolean).join(" · ");
     const states = [
@@ -11654,8 +11655,8 @@ function renderDashboardLifeDesk(overview = {}) {
     ];
     currentRoot.innerHTML = `
       <div class="life-current-activity">
-        <small>${escapeHtml(activityMeta || "当前日程")}</small>
-        <b>${escapeHtml(dashboardLifeText(current.activity, "暂无当前日程"))}</b>
+        <small>${escapeHtml(activityMeta || "当前计划时段")}</small>
+        <b>${escapeHtml(dashboardLifeText(current.activity, "暂无当前计划时段"))}</b>
         <span>${escapeHtml(dashboardLifeText(current.message_seed || daily.note, "暂无状态补充"))}</span>
       </div>
       <div class="life-energy-track" role="meter" aria-label="当前体力" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${Math.round(energy)}"><i style="width:${energy}%"></i></div>
@@ -11678,8 +11679,8 @@ function renderDashboardLifeDesk(overview = {}) {
       return hour >= 0 && hour <= 23 && minute >= 0 && minute <= 59 ? hour * 60 + minute : null;
     };
     const segmentIsCurrent = (segment) => {
-      const lifecycle = String(segment?.lifecycle || "").toLowerCase();
-      return lifecycle === "active"
+      const clockStatus = String(segment?.clock_status || segment?.lifecycle || "").toLowerCase();
+      return clockStatus === "active"
         || Boolean(current.time && String(segment?.window || "").startsWith(String(current.time)));
     };
     const currentSegmentIndex = segments.findIndex(segmentIsCurrent);
@@ -11724,6 +11725,7 @@ function renderDashboardLifeDesk(overview = {}) {
       const segment = entry.segment;
       const lifecycle = String(segment.lifecycle || "planned").toLowerCase();
       const isCurrent = segmentIsCurrent(segment);
+      const segmentLifecycleText = scheduleTimelineSegmentLabel(segment);
       const summary = segment.summary || segment.activity || "这一段尚未细化";
       const windowText = String(segment.window || "未定");
       const windowMatch = windowText.match(/^(\d{1,2}:\d{2})\s*[-~至]\s*(\d{1,2}:\d{2})$/);
@@ -11738,8 +11740,8 @@ function renderDashboardLifeDesk(overview = {}) {
           <div class="life-timeline-content">
             <b>${escapeHtml(summary)}</b>
             <span>${isCurrent
-              ? '<em class="life-current-marker">当前日程</em>'
-              : `<em class="life-schedule-status is-${escapeHtml(lifecycle)}">${escapeHtml(scheduleLifecycleLabel(lifecycle) || "计划中")}</em>`}</span>
+              ? `<em class="life-current-marker">${escapeHtml(segmentLifecycleText || "进行中")}</em>`
+              : `<em class="life-schedule-status is-${escapeHtml(lifecycle)}">${escapeHtml(segmentLifecycleText || "计划中")}</em>`}</span>
           </div>
         </li>
       `;
@@ -20748,8 +20750,8 @@ function renderLifeHero(daily, life) {
   $("#lifeLocation").textContent = normalizeLocationText(daily.location);
   $("#lifeWeather").textContent = daily.weather || "暂无天气";
   const current = life.current_plan || {};
-  $("#lifeCurrentActivity").textContent = current.activity || "暂无当前日程";
-  $("#lifeCurrentSeed").textContent = [current.end ? `${current.time}-${current.end}` : current.time, scheduleLifecycleLabel(current.lifecycle), current.mood, current.message_seed].filter(Boolean).join(" · ") || "暂无细化";
+  $("#lifeCurrentActivity").textContent = current.activity || "暂无当前计划时段";
+  $("#lifeCurrentSeed").textContent = [current.end ? `${current.time}-${current.end}` : current.time, scheduleTimelineSegmentLabel(current), current.mood, current.message_seed].filter(Boolean).join(" · ") || "暂无细化";
 }
 
 function roleplayEnergyLabel(value) {
@@ -23307,7 +23309,7 @@ function renderDailyTimeline() {
     const presence = segment.presence_status || {};
     const statusText = detailSegmentStatusLabel(segment);
     const presenceText = presenceLabel(presence);
-    const lifecycleText = scheduleLifecycleLabel(segment.lifecycle);
+    const lifecycleText = scheduleTimelineSegmentLabel(segment);
     const metaText = [...new Set([lifecycleText, statusText, presenceText].filter(Boolean))].join(" · ");
     const errorText = String(segment.regeneration_error || segment.error || "").trim();
     const quality = segment.quality || {};
@@ -23336,7 +23338,7 @@ function renderDailyTimeline() {
             `).join("") : `<span>暂无状态变量</span>`}
           </div>
           <ul>
-            ${events.length ? events.map((item) => `<li><span>${escapeHtml(scheduleLifecycleLabel(item.lifecycle))}</span>${escapeHtml(item.window ? `${item.window} · ${item.text}` : item.text)}</li>`).join("") : `<li>暂无细化事件</li>`}
+            ${events.length ? events.map((item) => `<li><span>${escapeHtml(scheduleStoryLifecycleLabel(item))}</span>${escapeHtml(item.window ? `${item.window} · ${item.text}` : item.text)}</li>`).join("") : `<li>暂无细化事件</li>`}
           </ul>
         </div>
       </section>
@@ -23355,9 +23357,29 @@ function scheduleLifecycleLabel(value) {
     planned: "计划中",
     active: "进行中",
     completed: "已完成",
+    partially_completed: "部分完成",
     changed: "已变更",
     cancelled: "已取消",
+    deferred: "已顺延",
+    unknown: "未核实",
   }[String(value || "").toLowerCase()] || "";
+}
+
+function scheduleTimelineSegmentLabel(segment) {
+  const evidence = String(segment?.evidence_lifecycle || "").toLowerCase();
+  const clockStatus = String(segment?.clock_status || "").toLowerCase();
+  const legacy = String(segment?.lifecycle || "").toLowerCase();
+  if (!evidence && !clockStatus && !legacy) return "";
+  if (["active", "completed", "partially_completed", "changed", "cancelled", "deferred"].includes(evidence)) {
+    return scheduleLifecycleLabel(evidence);
+  }
+  return scheduleLifecycleLabel(clockStatus || (!evidence ? legacy : "") || evidence || legacy);
+}
+
+function scheduleStoryLifecycleLabel(item) {
+  const lifecycle = String(item?.lifecycle || "").toLowerCase();
+  if (lifecycle !== "planned") return scheduleLifecycleLabel(lifecycle);
+  return scheduleLifecycleLabel(item?.clock_status || lifecycle) || "计划中";
 }
 
 function scheduleBasisLabel(value) {

--- a/passive_state_pipeline.py
+++ b/passive_state_pipeline.py
@@ -1588,11 +1588,22 @@ async def inject_humanized_state(
         weather = ""
     if weather and weather != "暂无天气信息":
         state_log_parts.append(f"天气={weather}")
-    current_item = self._get_current_plan_item(self.data.get("daily_plan", {}))
-    current_schedule = self._sanitize_schedule_context_for_private_user(
-        self._format_plan_item_for_prompt(current_item),
-        current_user,
-    ) or "无当前日程"
+    schedule_material_getter = getattr(self, "_private_passive_schedule_material", None)
+    if callable(schedule_material_getter):
+        verified_schedule, planned_schedule = schedule_material_getter(current_user)
+    else:
+        current_item = self._get_current_plan_item(self.data.get("daily_plan", {}))
+        verified_schedule = (
+            self._sanitize_schedule_context_for_private_user(
+                self._format_plan_item_for_prompt(current_item),
+                current_user,
+            )
+            if isinstance(current_item, dict)
+            else ""
+        )
+        planned_schedule = ""
+    verified_schedule_log = verified_schedule or "（暂无）"
+    planned_schedule_log = planned_schedule or "（暂无）"
     recorder = getattr(self, "_record_prompt_injection_snapshot", None)
     if callable(recorder):
         await recorder(
@@ -1607,7 +1618,12 @@ async def inject_humanized_state(
             modules=prompt_surface.rendered_fragments(),
             metadata={
                 "状态": "｜".join(state_log_parts),
-                "当前日程": current_schedule,
+                # Keep the legacy key for consumers that already read it, but
+                # make its evidence-backed meaning explicit alongside the
+                # clock-only projection.
+                "当前日程": verified_schedule_log,
+                "已核实当前活动": verified_schedule_log,
+                "当前计划时段": planned_schedule_log,
                 "注入位置": injection_placement,
                 "状态注入模式": "增量"
                 if bool(runtime_persona_setting(self, "enable_passive_state_delta_injection", True))
@@ -1619,7 +1635,7 @@ async def inject_humanized_state(
             },
         )
     logger.info(
-        "已注入被动状态提示词到 %s: mode=%s state_mode=%s reason=%s placement=%s chars=%s 状态=%s；当前日程=%s",
+        "已注入被动状态提示词到 %s: mode=%s state_mode=%s reason=%s placement=%s chars=%s 状态=%s；当前日程=%s；已核实当前活动=%s；当前计划时段=%s",
         _single_line(getattr(event, "unified_msg_origin", ""), 80) or "unknown_session",
         "light" if lightweight_passive else "full",
         "delta" if bool(runtime_persona_setting(self, "enable_passive_state_delta_injection", True)) else "legacy",
@@ -1627,5 +1643,7 @@ async def inject_humanized_state(
         injection_placement,
         len(injection),
         "｜".join(state_log_parts),
-        current_schedule,
+        verified_schedule_log,
+        verified_schedule_log,
+        planned_schedule_log,
     )

--- a/proactive_engine.py
+++ b/proactive_engine.py
@@ -612,6 +612,24 @@ class ProactiveEngineMixin:
         user["proactive_impulses"] = kept[-16:]
         return user["proactive_impulses"]
 
+    def _user_activity_question_targets_someone_else(self, text: str) -> bool:
+        raw = _single_line(text, 180)
+        if not raw:
+            return False
+        compact = re.sub(r"[\s,，。.!！?？~～…·、；;：:（）()【】\[\]\"'“”‘’]+", "", raw)
+        if not compact:
+            return False
+        # “你觉得春希现在在干什么”虽然以“你”开头，询问对象仍是春希。
+        # 这类认知/转述问句不能触发 Bot 自身状态、近期活动或状态记忆注入。
+        return bool(
+            re.search(
+                r"(?:你|bot|机器人)(?:觉得|猜|知道|认为|看看|看|问).{0,24}"
+                r"(?:干嘛|干啥|干什么|做什么|做啥|忙什么|忙啥)(?:呢|呀|啊|吗|嘛|没)?$",
+                compact,
+                flags=re.I,
+            )
+        )
+
     def _user_asks_bot_current_state_or_activity(self, text: str) -> bool:
         raw = _single_line(text, 120)
         if not raw:
@@ -621,24 +639,30 @@ class ProactiveEngineMixin:
         compact = re.sub(r"[\s,，。.!！?？~～…·、；;：:（）()【】\[\]\"'“”‘’]+", "", raw)
         if not compact or len(compact) > 80:
             return False
-        if re.search(r"(?:我|俺|咱|我们)(?:现在|这会儿|刚刚|刚才)?在?(?:干嘛|干啥|做什么|做啥|忙什么|忙啥)", compact):
+        if re.search(r"(?:我|俺|咱|我们)(?:现在|这会儿|刚刚|刚才)?在?(?:干嘛|干啥|干什么|做什么|做啥|忙什么|忙啥)", compact):
             return False
         tech_status_words = ("插件", "系统", "接口", "API", "api", "配置", "页面", "排障", "日志", "服务", "连接", "模型", "任务", "进程")
         if "状态" in compact and any(word in raw for word in tech_status_words):
             return False
         direct_patterns = (
-            r"(?:你|bot|机器人)?(?:现在|这会儿|这时候|刚才|今天)?在?(?:干嘛|干啥|做什么|做啥|忙什么|忙啥)(?:呢|呀|啊|吗|嘛|没)?$",
+            r"(?:你|bot|机器人)?(?:现在|这会儿|这时候|刚才|今天)?在?(?:干嘛|干啥|干什么|做什么|做啥|忙什么|忙啥)(?:呢|呀|啊|吗|嘛|没)?$",
             r"(?:你|bot|机器人)?(?:现在|这会儿|今天)?在(?:上课|上班|睡觉|休息|吃饭|忙|摸鱼|干活|写作业|看书)(?:吗|嘛|没|呢)?$",
             r"(?:你|bot|机器人)(?:现在|这会儿|今天)?(?:状态|情况)?(?:怎么样|咋样|如何|还好吗|还好不|累不累|困不困|忙不忙|饿不饿)$",
             r"(?:你|bot|机器人)(?:现在|这会儿)?(?:什么状态|啥状态)$",
         )
         if any(re.fullmatch(pattern, compact, flags=re.I) for pattern in direct_patterns):
             return True
+        # Do not treat a question addressed to the Bot *about somebody else*
+        # as a request for the Bot's own state.  The permissive colloquial
+        # fallback below intentionally accepts leading observations, so
+        # cognition/reporting verbs need an explicit boundary first.
+        if self._user_activity_question_targets_someone_else(compact):
+            return False
         # 私聊里常见的口语问法会带承接词或观察性前缀，例如
         # “那你现在在干啥呢”“好像你在忙的样子，忙啥呢”。
         return bool(
             re.search(
-                r"(?:你|bot|机器人).{0,16}(?:在)?(?:干嘛|干啥|做什么|做啥|忙什么|忙啥)(?:呢|呀|啊|吗|嘛|没)?$",
+                r"(?:你|bot|机器人).{0,16}(?:在)?(?:干嘛|干啥|干什么|做什么|做啥|忙什么|忙啥)(?:呢|呀|啊|吗|嘛|没)?$",
                 compact,
                 flags=re.I,
             )

--- a/tests/test_cycle_reply_context.py
+++ b/tests/test_cycle_reply_context.py
@@ -35,7 +35,9 @@ def _state_harness() -> PrivateCompanionPlugin:
     plugin._environment_now = lambda: datetime(2026, 7, 31, 20, 0, 0)
     plugin._current_time_period_label = lambda _now: ("晚上", "evening")
     plugin._get_current_plan_item = lambda _plan: {}
+    plugin._get_clock_plan_item_for_display = lambda _plan: None
     plugin._current_detail_segment_for_update = lambda: {}
+    plugin._current_detail_snapshot_for_update = lambda: None
     plugin._private_user_role = lambda *_args, **_kwargs: "owner"
     plugin._sanitize_schedule_context_for_private_user = lambda value, _user: value
     plugin._format_plan_item_for_prompt = lambda _item: ""
@@ -325,6 +327,9 @@ class CycleReplyContextTests(unittest.IsolatedAsyncioTestCase):
         }
         plugin._current_detail_segment_for_update = lambda: {
             "key": "future-detail",
+        }
+        plugin._current_detail_snapshot_for_update = lambda: {
+            "status": "done",
             "summary": "稍后去教室参加完整课程安排",
         }
         state = {"energy": 42, "mood_bias": "疲惫", "weather": "暴雨"}
@@ -535,7 +540,11 @@ class CycleReplyContextTests(unittest.IsolatedAsyncioTestCase):
         )
         state = {"energy": 79, "mood_bias": "专注"}
 
-        for text in ("那你现在在干啥呢", "好像你在忙的样子，忙啥呢"):
+        for text in (
+            "那你现在在干啥呢",
+            "好像你在忙的样子，忙啥呢",
+            "你现在在干什么？",
+        ):
             with self.subTest(text=text):
                 update = plugin._private_passive_state_update_for_prompt(
                     session=f"default:FriendMessage:{text}",
@@ -550,6 +559,186 @@ class CycleReplyContextTests(unittest.IsolatedAsyncioTestCase):
                 self.assertIn("先正面回答拟人化日程素材中的当前活动", update[0])
                 self.assertIn("不得另编素材未提供的动作、地点、饮食或娱乐活动", update[0])
                 self.assertIn("不要为了显得具体而补造细节", update[0])
+
+    def test_current_activity_question_does_not_use_lightweight_changed_path(self) -> None:
+        plugin = _state_harness()
+
+        for text in (
+            "你现在在干什么？",
+            "那你现在在干啥呢",
+            "你这会儿忙啥呢",
+            "你今天在做什么呀",
+        ):
+            with self.subTest(text=text):
+                self.assertTrue(plugin._user_asks_bot_current_state_or_activity(text))
+                self.assertTrue(plugin._user_asks_recent_bot_activity(text))
+                self.assertFalse(plugin._is_lightweight_private_passive_inbound(text))
+
+    def test_third_person_activity_question_is_not_bot_current_state(self) -> None:
+        plugin = _state_harness()
+
+        for text in (
+            "你觉得春希现在在干什么？",
+            "你猜他在干什么？",
+        ):
+            with self.subTest(text=text):
+                self.assertFalse(plugin._user_asks_bot_current_state_or_activity(text))
+                self.assertFalse(plugin._user_asks_recent_bot_activity(text))
+                self.assertFalse(plugin._is_lightweight_private_passive_inbound(text))
+                update = plugin._private_passive_state_update_for_prompt(
+                    session=f"default:FriendMessage:{text}",
+                    state={"energy": 75, "mood_bias": "平稳"},
+                    current_user={},
+                    inbound_text=text,
+                    lightweight=False,
+                )
+                self.assertNotEqual(update[2], "direct")
+
+        self.assertTrue(plugin._user_asks_bot_current_state_or_activity("我猜你现在在干什么？"))
+
+    def test_light_state_uses_clock_plan_and_finished_detail_without_claiming_execution(self) -> None:
+        plugin = _state_harness()
+        plugin._passive_state_session_cache = {}
+        planned_item = {
+            "time": "20:45",
+            "end": "21:30",
+            "activity": "晚餐后回到琴房慢速视奏",
+            "lifecycle_status": "planned",
+            "status": "planned",
+            "evidence_kind": "none",
+            "fact_eligibility": "none",
+        }
+        plugin.data = {
+            "daily_plan": {"date": "2026-07-31", "items": [planned_item]},
+            "detail_enhanced_segments": {
+                "2026-07-31:0:20:45": {
+                    "status": "done",
+                    "summary": "回到琴房只留一盏暖黄落地灯，慢速视奏。",
+                }
+            },
+        }
+        plugin._get_current_plan_item = lambda _plan: None
+        plugin._get_clock_plan_item_for_display = lambda _plan: planned_item
+        plugin._format_plan_item_for_prompt = lambda item: (
+            f"{item['time']}-{item['end']}｜{item['activity']}"
+        )
+        plugin._current_detail_segment_for_update = lambda: {"key": "2026-07-31:0:20:45"}
+        plugin._current_detail_snapshot_for_update = lambda: plugin.data["detail_enhanced_segments"][
+            "2026-07-31:0:20:45"
+        ]
+
+        verified, planned = plugin._private_passive_schedule_material({})
+        update = plugin._private_passive_state_update_for_prompt(
+            session="default:FriendMessage:10001",
+            state={"energy": 75, "mood_bias": "平稳"},
+            current_user={},
+            inbound_text="晚上好",
+            lightweight=True,
+        )
+        direct_update = plugin._private_passive_state_update_for_prompt(
+            session="default:FriendMessage:10002",
+            state={"energy": 75, "mood_bias": "平稳"},
+            current_user={},
+            inbound_text="你现在在干什么？",
+            lightweight=False,
+        )
+
+        self.assertEqual("", verified)
+        self.assertIn("20:45-21:30", planned)
+        self.assertEqual(update[1:], (True, "changed"))
+        self.assertIn("当前计划时段（未确认执行）", update[0])
+        self.assertIn("慢速视奏", update[0])
+        self.assertIn("暖黄落地灯", update[0])
+        self.assertNotIn("拟人化日程素材：（暂无）", update[0])
+        self.assertEqual(direct_update[1:], (True, "direct"))
+        self.assertIn("当前计划时段（未确认执行）", direct_update[0])
+        self.assertIn("必须用‘按计划/原本安排’口径回答", direct_update[0])
+        self.assertIn("慢速视奏", direct_update[0])
+
+    def test_finished_detail_summary_changes_light_state_fingerprint(self) -> None:
+        plugin = _state_harness()
+        plugin._passive_state_session_cache = {}
+        plugin.data = {"daily_plan": {}, "detail_enhanced_segments": {}}
+        plugin._get_current_plan_item = lambda _plan: None
+        plugin._get_clock_plan_item_for_display = lambda _plan: None
+        plugin._current_detail_segment_for_update = lambda: {"key": "2026-07-31:0:20:45"}
+        plugin._current_detail_snapshot_for_update = lambda: plugin.data[
+            "detail_enhanced_segments"
+        ].get("2026-07-31:0:20:45")
+        state = {"energy": 75, "mood_bias": "平稳"}
+
+        first = plugin._private_passive_state_update_for_prompt(
+            session="default:FriendMessage:10001",
+            state=state,
+            current_user={},
+            inbound_text="晚上好",
+            lightweight=True,
+        )
+        plugin.data["detail_enhanced_segments"]["2026-07-31:0:20:45"] = {
+            "status": "done",
+            "summary": "在暖黄灯下慢速视奏。",
+        }
+        second = plugin._private_passive_state_update_for_prompt(
+            session="default:FriendMessage:10001",
+            state=state,
+            current_user={},
+            inbound_text="继续说吧",
+            lightweight=True,
+        )
+
+        self.assertEqual(first[2], "changed")
+        self.assertEqual(second[1:], (True, "changed"))
+        self.assertIn("在暖黄灯下慢速视奏", second[0])
+
+    def test_clock_projection_ignores_deferred_changed_and_completed_rows(self) -> None:
+        plugin = _state_harness()
+        plugin._get_current_plan_item = lambda _plan: None
+        item = {
+            "time": "20:45",
+            "end": "21:30",
+            "activity": "已经失效的原计划",
+        }
+        plugin._get_clock_plan_item_for_display = lambda _plan: item
+
+        for lifecycle in ("deferred", "changed", "completed", "cancelled"):
+            with self.subTest(lifecycle=lifecycle):
+                item["lifecycle_status"] = lifecycle
+                verified, planned = plugin._private_passive_schedule_material({})
+                self.assertEqual("", verified)
+                self.assertEqual("", planned)
+
+    def test_clock_plan_and_detail_are_sanitized_for_friend_profile(self) -> None:
+        plugin = _state_harness()
+        plugin._passive_state_session_cache = {}
+        plugin.config = {}
+        plugin.default_nickname = "有所思"
+        plugin.target_user_ids = []
+        del plugin.__dict__["_sanitize_schedule_context_for_private_user"]
+        plugin._private_user_role = lambda *_args, **_kwargs: "friend"
+        planned_item = {
+            "time": "20:45",
+            "end": "21:30",
+            "activity": "给有所思整理乐谱",
+            "lifecycle_status": "planned",
+        }
+        plugin._get_current_plan_item = lambda _plan: None
+        plugin._get_clock_plan_item_for_display = lambda _plan: planned_item
+        plugin._current_detail_segment_for_update = lambda: {"key": "detail"}
+        plugin._current_detail_snapshot_for_update = lambda: {
+            "status": "done",
+            "summary": "把有所思放在桌边的乐谱收好。",
+        }
+
+        update = plugin._private_passive_state_update_for_prompt(
+            session="default:FriendMessage:20002",
+            state={"energy": 75, "mood_bias": "平稳"},
+            current_user={"relationship_role": "friend"},
+            inbound_text="晚上好",
+            lightweight=True,
+        )
+
+        self.assertNotIn("有所思", update[0])
+        self.assertIn("某个熟人", update[0])
 
     def test_continuity_anchor_omits_missing_optional_state_fields(self) -> None:
         plugin = _state_harness()

--- a/tests/test_daily_schedule_segment_api.py
+++ b/tests/test_daily_schedule_segment_api.py
@@ -440,11 +440,68 @@ class DailyScheduleSegmentApiTests(unittest.IsolatedAsyncioTestCase):
         timeline = self.api._daily_timeline_summary(self.plugin.data)
 
         self.assertEqual(timeline["segment_count"], 2)
+        current = next(item for item in timeline["segments"] if item["key"] == "2026-07-11:0:09:00")
+        self.assertEqual("planned", current["evidence_lifecycle"])
+        self.assertEqual("active", current["clock_status"])
         pending = next(item for item in timeline["segments"] if item["key"] == "2026-07-11:1:10:00")
         self.assertEqual(pending["status"], "")
         self.assertEqual(pending["summary"], "处理手边事项")
         self.assertEqual(pending["basis"], ["state"])
         self.assertEqual(timeline["plan_quality"]["score"], 90)
+
+    def test_story_projection_keeps_evidence_lifecycle_and_adds_clock_status(self):
+        items = self.api._timeline_story_items(
+            [
+                {"window": "08:30-09:00", "event": "先整理书架"},
+                {"window": "09:00-09:20", "event": "再收拾桌面"},
+                {"window": "09:20-09:40", "event": "最后整理抽屉"},
+            ],
+            5,
+            "2026-07-11",
+        )
+
+        self.assertEqual(["planned", "planned", "planned"], [item["lifecycle"] for item in items])
+        self.assertEqual(["completed", "active", "planned"], [item["clock_status"] for item in items])
+
+    def test_story_projection_preserves_only_bounded_execution_evidence(self):
+        items = self.api._timeline_story_items(
+            [
+                {
+                    "window": "09:00-09:20",
+                    "event": "有交互证据",
+                    "evidence_kind": "interaction",
+                    "fact_eligibility": "current_observed",
+                    "status": "active",
+                },
+                {
+                    "window": "09:20-09:40",
+                    "event": "不可信字段",
+                    "evidence_kind": "private_note",
+                    "fact_eligibility": "owner_only",
+                    "status": "executing",
+                },
+            ],
+            5,
+            "2026-07-11",
+        )
+
+        observed = next(item for item in items if item["text"] == "有交互证据")
+        self.assertEqual("interaction", observed["evidence_kind"])
+        self.assertEqual("current_observed", observed["fact_eligibility"])
+        self.assertEqual("active", observed["status"])
+        self.assertEqual("active", observed["lifecycle"])
+        untrusted = next(item for item in items if item["text"] == "不可信字段")
+        self.assertEqual("", untrusted["evidence_kind"])
+        self.assertEqual("", untrusted["fact_eligibility"])
+        self.assertEqual("", untrusted["status"])
+        self.assertEqual("planned", untrusted["lifecycle"])
+
+    def test_current_plan_api_exposes_evidence_and_clock_status_with_legacy_lifecycle(self):
+        current = self.api._life_observation_summary(self.plugin.data)["current_plan"]
+
+        self.assertEqual("planned", current["evidence_lifecycle"])
+        self.assertEqual("active", current["clock_status"])
+        self.assertEqual(current["clock_status"], current["lifecycle"])
 
     def test_timeline_hides_snapshots_when_detail_day_is_stale(self):
         self.plugin.data["detail_enhanced_day"] = "2026-07-10"
@@ -488,9 +545,40 @@ class DailyScheduleSegmentApiTests(unittest.IsolatedAsyncioTestCase):
         # The panel shows clock progress while canonical execution evidence
         # remains separate in the agenda store.
         self.assertEqual(timeline["segments"][2]["lifecycle"], "active")
+        self.assertEqual(timeline["segments"][2]["evidence_lifecycle"], "planned")
+        self.assertEqual(timeline["segments"][2]["clock_status"], "active")
+        story_items = self.api._timeline_story_items(
+            [{"window": "00:30-01:00", "event": "继续收尾"}],
+            5,
+            "2026-07-11",
+            parent_start=24 * 60 + 30,
+            parent_end=25 * 60 + 30,
+        )
+        self.assertEqual("active", story_items[0]["clock_status"])
         current = self.plugin._current_detail_segment_for_update()
         self.assertIsNotNone(current)
         self.assertEqual(current["index"], 2)
+
+    def test_cross_midnight_story_items_sort_and_limit_on_parent_axis(self):
+        items = self.api._timeline_story_items(
+            [
+                {"window": "00:40-00:50", "event": "第五项"},
+                {"window": "23:50-00:00", "event": "第二项"},
+                {"window": "01:00-01:10", "event": "第六项"},
+                {"window": "00:10-00:20", "event": "第三项"},
+                {"window": "23:40-23:50", "event": "第一项"},
+                {"window": "00:20-00:30", "event": "第四项"},
+            ],
+            5,
+            "2026-07-11",
+            parent_start=23 * 60 + 30,
+            parent_end=25 * 60 + 30,
+        )
+
+        self.assertEqual(
+            ["23:40-23:50", "23:50-00:00", "00:10-00:20", "00:20-00:30", "00:40-00:50"],
+            [item["window"] for item in items],
+        )
 
     def test_adjustment_scope_uses_recorded_anchor_instead_of_moving_current_segment(self):
         self.plugin.data["schedule_adjustments"] = [

--- a/tests/test_humanized_schedule_ui_grouping.py
+++ b/tests/test_humanized_schedule_ui_grouping.py
@@ -41,6 +41,28 @@ class HumanizedScheduleUiGroupingTests(unittest.TestCase):
         for key in ("enable_daily_plan", "enable_detail_enhancement", "enable_daily_diary", "enable_daily_greetings", "enable_enhanced_dreams"):
             self.assertIn(f'"{key}",', self.script)
 
+    def test_detail_projection_uses_clock_phase_for_familiar_display_labels(self) -> None:
+        self.assertIn("scheduleTimelineSegmentLabel(segment)", self.script)
+        self.assertIn("scheduleStoryLifecycleLabel(item)", self.script)
+        self.assertIn(
+            'scheduleLifecycleLabel(clockStatus || (!evidence ? legacy : "") || evidence || legacy)',
+            self.script,
+        )
+        self.assertIn('scheduleLifecycleLabel(item?.clock_status || lifecycle)', self.script)
+        self.assertNotIn('active: "当前时段·计划投影"', self.script)
+        self.assertNotIn('completed: "时段已过·未核实"', self.script)
+
+    def test_legacy_dashboard_consumers_use_explicit_plan_projection_labels(self) -> None:
+        self.assertIn("const currentLifecycleText = scheduleTimelineSegmentLabel(current);", self.script)
+        self.assertIn("const segmentLifecycleText = scheduleTimelineSegmentLabel(segment);", self.script)
+        self.assertIn("segment?.clock_status || segment?.lifecycle", self.script)
+        self.assertIn('activityMeta || "当前计划时段"', self.script)
+        self.assertIn('current.activity, "暂无当前计划时段"', self.script)
+        self.assertIn('current.activity || "暂无当前计划时段"', self.script)
+        self.assertIn("scheduleTimelineSegmentLabel(current), current.mood", self.script)
+        self.assertIn('if (!evidence && !clockStatus && !legacy) return "";', self.script)
+        self.assertNotIn('<em class="life-current-marker">当前日程</em>', self.script)
+
     def test_passive_continuity_anchor_is_grouped_after_delta_and_has_dual_visibility(
         self,
     ) -> None:

--- a/tests/test_prompt_cache_and_parallel_context.py
+++ b/tests/test_prompt_cache_and_parallel_context.py
@@ -135,6 +135,34 @@ class PromptCacheAndParallelContextTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(state_calls, 0)
         self.assertNotIn("memory.current_state", {item["key"] for item in collected})
 
+    async def test_third_person_activity_question_skips_current_state_memory_lookup(self) -> None:
+        plugin = _private_collector_harness()
+        state_calls = 0
+
+        async def current_state(**_kwargs) -> str:
+            nonlocal state_calls
+            state_calls += 1
+            return "不应读取"
+
+        async def private_recall(**_kwargs) -> str:
+            return ""
+
+        plugin._memory_companion_compose_feature_context = current_state
+        plugin._memory_companion_compose_private_recall = private_recall
+
+        for text in ("你觉得春希现在在干什么？", "你猜他在做什么？"):
+            with self.subTest(text=text):
+                collected = await plugin._collect_private_passive_prompt_contexts(
+                    _PrivateEvent(),
+                    SimpleNamespace(system_prompt="", prompt=text),
+                    inbound_text=text,
+                    current_user={"user_id": "10001"},
+                    is_private_chat=True,
+                )
+                self.assertNotIn("memory.current_state", {item["key"] for item in collected})
+
+        self.assertEqual(state_calls, 0)
+
     async def test_private_turn_includes_authorized_mobile_location_context(self) -> None:
         plugin = _private_collector_harness()
         plugin._format_mobile_user_location_context = lambda _user: (
@@ -171,7 +199,11 @@ class PromptCacheAndParallelContextTests(unittest.IsolatedAsyncioTestCase):
         plugin._memory_companion_compose_feature_context = current_state
         plugin._memory_companion_compose_private_recall = private_recall
 
-        for text in ("那你现在在干啥呢", "好像你在忙的样子，忙啥呢"):
+        for text in (
+            "那你现在在干啥呢",
+            "好像你在忙的样子，忙啥呢",
+            "你现在在干什么？",
+        ):
             with self.subTest(text=text):
                 collected = await plugin._collect_private_passive_prompt_contexts(
                     _PrivateEvent(),

--- a/tests/test_schedule_runtime_projection_regressions.py
+++ b/tests/test_schedule_runtime_projection_regressions.py
@@ -34,6 +34,7 @@ class _ScheduleHarness(DailyStateMixin):
             "detail_enhanced_segments": {
                 f"{today}:1:10:00": {
                     "status": "done",
+                    "summary": "在学校教室专心上课。",
                     "location": "学校教室",
                     "location_basis": ["coarse_plan"],
                     "location_confidence": 0.8,
@@ -100,6 +101,59 @@ class ScheduleRuntimeProjectionRegressionTests(unittest.IsolatedAsyncioTestCase)
         self.assertIn(harness._plan_item_runtime_status(plan, plan["items"][0], 0), {"planned", "unknown"})
         self.assertEqual("completed", harness._plan_item_display_status(plan, plan["items"][0], 0))
         self.assertEqual("active", harness._plan_item_display_status(plan, plan["items"][1], 1))
+
+    def test_clock_plan_context_does_not_relax_canonical_current_getter(self) -> None:
+        harness = _ScheduleHarness()
+        harness._effective_plan_now_minutes = lambda _date: 10 * 60 + 30
+        plan = harness.data["daily_plan"]
+
+        self.assertIsNone(harness._get_current_plan_item(plan))
+        self.assertEqual(
+            "去学校上课",
+            harness._get_clock_plan_item_for_display(plan)["activity"],
+        )
+        self.assertEqual("active", harness._plan_item_display_status(plan, plan["items"][1], 1))
+
+    def test_current_detail_snapshot_is_loaded_by_segment_key(self) -> None:
+        harness = _ScheduleHarness()
+        harness._effective_plan_now_minutes = lambda _date: 10 * 60 + 15
+
+        snapshot = harness._current_detail_snapshot_for_update()
+
+        self.assertIsNotNone(snapshot)
+        self.assertEqual("done", snapshot["status"])
+        self.assertEqual("在学校教室专心上课。", snapshot["summary"])
+
+    def test_detail_snapshot_is_not_exposed_during_generation_lead_window(self) -> None:
+        harness = _ScheduleHarness()
+        today = _today_key()
+        harness.data["daily_plan"]["items"] = [
+            {"time": "09:00", "end": "10:00", "activity": "整理房间", "lifecycle_status": "planned"},
+            {"time": "10:15", "end": "11:00", "activity": "去学校上课", "lifecycle_status": "planned"},
+        ]
+        harness.data["detail_enhanced_segments"] = {
+            f"{today}:1:10:15": {
+                "status": "done",
+                "summary": "提前生成但尚未进入的上课片段。",
+            }
+        }
+        harness._effective_plan_now_minutes = lambda _date: 10 * 60 + 5
+
+        segment = harness._current_detail_segment_for_update()
+
+        self.assertIsNotNone(segment)
+        self.assertEqual(10 * 60 + 15, segment["start"])
+        self.assertIsNone(harness._current_detail_snapshot_for_update())
+
+    def test_detail_snapshot_is_not_exposed_after_parent_plan_is_invalidated(self) -> None:
+        harness = _ScheduleHarness()
+        harness._effective_plan_now_minutes = lambda _date: 10 * 60 + 15
+        current_item = harness.data["daily_plan"]["items"][1]
+
+        for lifecycle in ("changed", "deferred", "completed", "cancelled"):
+            with self.subTest(lifecycle=lifecycle):
+                current_item["lifecycle_status"] = lifecycle
+                self.assertIsNone(harness._current_detail_snapshot_for_update())
 
     async def test_current_segment_reapplies_prebuilt_detail_location_at_start(self) -> None:
         harness = _ScheduleHarness()


### PR DESCRIPTION
## 问题

- 被动状态管线只读取带执行证据的当前活动；当日程只是按时钟进入当前时段时，日志会显示“当前日程=暂无”，模型也拿不到可用的计划背景。
- “你现在在干什么”没有命中现有口语识别，会误走轻量状态变化路径，可能绕开当前活动的事实约束并自由补写动作。
- 陪伴面板把执行证据状态和时钟进度混在同一个 `lifecycle` 中，导致当前及已过的细化片段长期只显示“计划中”。

## 修改

- 分离“已核实当前活动”和“当前计划时段”：后者明确标记为未确认执行，并要求模型使用“按计划/原本安排”的口径。
- 补齐“干什么”类当前状态问法，使其进入 direct/full 状态上下文并跳过 lightweight 路径；同时避免把询问第三人称活动的问题误判为 Bot 自身状态。
- 只在实际所处时段使用已完成的细化快照；过滤提前生成、已变更、顺延、取消或关闭的片段，并保留好友范围脱敏。
- 日程 API 新增 `evidence_lifecycle` 与 `clock_status`，保留旧 `lifecycle` 兼容。面板继续使用熟悉的“计划中/进行中/已完成”文案，但由 `clock_status` 驱动；执行证据仍独立保存，不会影响模型事实判断。
- 修正跨午夜片段的排序和时钟状态投影。

## 测试

```bash
python -m pytest -q tests/test_cycle_reply_context.py tests/test_prompt_cache_and_parallel_context.py tests/test_schedule_runtime_projection_regressions.py tests/test_daily_schedule_segment_api.py tests/test_humanized_schedule_ui_grouping.py
```

结果：`76 passed`，另有 `42 subtests passed`。

同时通过：

- 上下文、群聊隔离及日程语义相关回归：`55 passed`，另有 `5 subtests passed`
- 仓库 CI 对应测试：`76 passed`
- Python 编译检查与两份面板脚本 `node --check`
- 实际 AstrBot v4.27.0 私聊和面板测试：当前计划能够进入提示上下文，“你现在在干什么”会走 `mode=full / reason=direct`，回复与当前计划一致
