### PR TITLE
fix: 补齐被动用户对话主链提示词结构化

### DIFF
--- a/astrbot_knowledge.py
+++ b/astrbot_knowledge.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from astrbot.core.utils.astrbot_path import get_astrbot_data_path
 
+from .conversation_prompt_section import prompt_section
 from .helpers import _single_line
 from .persona_config import runtime_persona_setting
 from .reference_assets import normalize_reference_asset
@@ -163,7 +164,7 @@ class AstrBotKnowledgeMixin:
             "reference_asset_count": len(asset_view),
         }
 
-    def _format_roleplay_knowledge_context(
+    def _format_roleplay_knowledge_context_body(
         self,
         *,
         query: str = "",
@@ -236,11 +237,44 @@ class AstrBotKnowledgeMixin:
             body = body[:char_budget].rstrip() + "..."
         mode_text = "按当前用途检索匹配片段" if used_search else "未命中检索词，回退为文档代表性取样"
         return (
-            "【AstrBot 知识库世界观参考】\n"
             "以下内容来自拓展页角色设定中勾选的 AstrBot 知识库/文档，只作为日程模拟、生活背景和世界观适配参考；"
             "不要复述“知识库/文档/片段”等后台来源，不要把小说叙事逐字当成当前现实发言。\n"
             f"选取方式：{mode_text}；用途：{_single_line(purpose, 40) or 'roleplay'}。\n"
             f"{body}"
+        )
+
+    def _format_roleplay_knowledge_context(
+        self,
+        *,
+        purpose: str = "roleplay",
+        query: str = "",
+        max_chars: int = 3200,
+        max_chunks: int = 18,
+    ) -> str:
+        body = self._format_roleplay_knowledge_context_body(
+            purpose=purpose,
+            query=query,
+            max_chars=max_chars,
+            max_chunks=max_chunks,
+        )
+        return f"【AstrBot 知识库世界观参考】\n{body}" if body else ""
+
+    def _format_roleplay_knowledge_context_section(
+        self,
+        *,
+        purpose: str = "roleplay",
+        query: str = "",
+        max_chars: int = 3200,
+        max_chunks: int = 18,
+    ) -> dict[str, Any]:
+        return prompt_section(
+            "AstrBot 知识库世界观参考",
+            self._format_roleplay_knowledge_context_body(
+                purpose=purpose,
+                query=query,
+                max_chars=max_chars,
+                max_chunks=max_chunks,
+            ),
         )
 
     def _build_roleplay_knowledge_query(self, *, purpose: str = "roleplay") -> str:

--- a/integration_status.py
+++ b/integration_status.py
@@ -663,6 +663,7 @@ class IntegrationStatusMixin:
         self,
         *,
         include_heading: bool = True,
+        include_knowledge: bool = True,
     ) -> str:
         mode = self._worldview_mode_effective()
         if mode == "off":
@@ -682,7 +683,7 @@ class IntegrationStatusMixin:
         if custom:
             base.append(f"自定义适配：{custom}")
         knowledge_formatter = getattr(self, "_format_roleplay_knowledge_context", None)
-        if callable(knowledge_formatter):
+        if include_knowledge and callable(knowledge_formatter):
             knowledge_context = knowledge_formatter(purpose="worldview", max_chars=1800, max_chunks=10)
             if knowledge_context:
                 base.append(knowledge_context)
@@ -691,8 +692,34 @@ class IntegrationStatusMixin:
     def _format_worldview_adaptation_prompt_section(self) -> dict[str, Any]:
         return prompt_section(
             "世界观适配",
-            self._format_worldview_adaptation_prompt(include_heading=False),
+            self._format_worldview_adaptation_prompt(
+                include_heading=False,
+                include_knowledge=False,
+            ),
         )
+
+    def _format_worldview_adaptation_prompt_sections(self) -> list[dict[str, Any]]:
+        section = self._format_worldview_adaptation_prompt_section()
+        if not str(section.get("content") or "").strip():
+            return []
+        sections = [section]
+        knowledge_formatter = getattr(
+            self,
+            "_format_roleplay_knowledge_context_section",
+            None,
+        )
+        if callable(knowledge_formatter):
+            knowledge_section = knowledge_formatter(
+                purpose="worldview",
+                max_chars=1800,
+                max_chunks=10,
+            )
+            if (
+                isinstance(knowledge_section, dict)
+                and str(knowledge_section.get("content") or "").strip()
+            ):
+                sections.append(knowledge_section)
+        return sections
 
     def _livingmemory_plugin_dir(self) -> Path:
         candidates = [
@@ -788,14 +815,56 @@ class IntegrationStatusMixin:
             boundary = "群聊只查当前群可公开使用的旧事。"
         else:
             boundary = "私聊可查当前用户相关的旧约定、偏好和共同经历。"
+        guidance, joke_boundary = self._livingmemory_guidance_parts(
+            tool_name=tool_name,
+            boundary=boundary,
+        )
         return (
             ("【长期记忆检索】\n" if include_heading else "")
-            +
+            + guidance
+            + "\n【群聊玩笑边界】"
+            + joke_boundary
+        )
+
+    @staticmethod
+    def _livingmemory_guidance_parts(
+        *,
+        tool_name: str,
+        boundary: str,
+    ) -> tuple[str, str]:
+        guidance = (
             f"上下文不够时可用 `{tool_name}` 查记忆。只有当前工具列表确实提供该工具时才调用；工具未出现时不要猜测、重试或输出工具调用。{boundary}结果只作接话背景。\n"
             "召回结果里出现人名、昵称、QQ 或群成员别名时,不要直接当作稳定身份；能查关系网时先用关系网确认,不能确认就按召回文本里的具体说话人原样转述。\n"
-            "如果召回到 Bot 曾说自己在吃饭、整理、犯困、路上、创作等状态/日程，只能理解为当时 Bot 的拟人化表达或历史自称；不要写成用户事实、现实证据或持续状态。\n"
-            "【群聊玩笑边界】群里“记住了/记下某人是XX”这类话（尤其把某人当对象、或带主观评价、攻击、贬损、色情、侮辱标签）通常只是群友之间的玩笑或随口一说。顺应玩笑节奏调侃接梗即可；这类玩笑记录可以另开为旁线补充，但不进入核心人物画像（主要用户画像、关系画像、稳定偏好），落到记忆中只能标为低置信的玩笑性质；只把可验证的客观事实当作主体画像内容。"
+            "如果召回到 Bot 曾说自己在吃饭、整理、犯困、路上、创作等状态/日程，只能理解为当时 Bot 的拟人化表达或历史自称；不要写成用户事实、现实证据或持续状态。"
         )
+        joke_boundary = (
+            "群里“记住了/记下某人是XX”这类话（尤其把某人当对象、或带主观评价、攻击、贬损、色情、侮辱标签）通常只是群友之间的玩笑或随口一说。"
+            "顺应玩笑节奏调侃接梗即可；这类玩笑记录可以另开为旁线补充，但不进入核心人物画像（主要用户画像、关系画像、稳定偏好），"
+            "落到记忆中只能标为低置信的玩笑性质；只把可验证的客观事实当作主体画像内容。"
+        )
+        return guidance, joke_boundary
+
+    def _format_livingmemory_guidance_sections(
+        self,
+        *,
+        scope: str = "private",
+    ) -> list[dict[str, Any]]:
+        if not self.enable_livingmemory_integration or not self._livingmemory_available():
+            return []
+        tool_name = _single_line(self.livingmemory_tool_name, 60) or "recall_long_term_memory"
+        boundary = (
+            "群聊只查当前群可公开使用的旧事。"
+            if scope == "group"
+            else "私聊可查当前用户相关的旧约定、偏好和共同经历。"
+        )
+        guidance, joke_boundary = self._livingmemory_guidance_parts(
+            tool_name=tool_name,
+            boundary=boundary,
+        )
+        return [
+            prompt_section("长期记忆检索", guidance),
+            prompt_section("群聊玩笑边界", joke_boundary),
+        ]
 
     def _format_livingmemory_status(self) -> str:
         # Check for "我会牢牢记住你" (RememberYou) bridge first

--- a/llm_tool_actions.py
+++ b/llm_tool_actions.py
@@ -648,6 +648,7 @@ class LlmToolActionsMixin:
         event: AstrMessageEvent | None = None,
         *,
         include_heading: bool = True,
+        include_recent_context: bool = True,
     ) -> str:
         availability = getattr(self, "_qzone_available", None)
         if not (self.enabled and self.enable_qzone_integration):
@@ -669,8 +670,38 @@ class LlmToolActionsMixin:
 """.strip()
         instruction = f"【QQ 空间动态工具】\n{body}" if include_heading else body
         context_getter = getattr(self, "_qzone_recent_self_publish_chat_context", None)
-        recent_context = context_getter() if callable(context_getter) else ""
+        recent_context = (
+            context_getter()
+            if include_recent_context and callable(context_getter)
+            else ""
+        )
         return f"{instruction}\n\n{recent_context}".strip() if recent_context else instruction
+
+    def _qzone_tool_prompt_sections(
+        self,
+        event: AstrMessageEvent | None = None,
+    ) -> list[dict[str, Any]]:
+        instruction = self._qzone_tool_instruction(
+            event,
+            include_heading=False,
+            include_recent_context=False,
+        )
+        if not instruction:
+            return []
+        sections = [prompt_section("QQ 空间动态工具", instruction)]
+        context_getter = getattr(
+            self,
+            "_qzone_recent_self_publish_chat_prompt_section",
+            None,
+        )
+        if callable(context_getter):
+            recent_context = context_getter()
+            if (
+                isinstance(recent_context, dict)
+                and str(recent_context.get("content") or "").strip()
+            ):
+                sections.append(recent_context)
+        return sections
 
     @staticmethod
     def _qzone_view_target_error_message(error: str) -> str:

--- a/main.py
+++ b/main.py
@@ -14012,10 +14012,28 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             result = func()
             if asyncio.iscoroutine(result):
                 result = await asyncio.wait_for(result, timeout=timeout)
+            sections = []
+            if isinstance(result, (list, tuple)):
+                for raw_section in result:
+                    resolved_section = coerce_prompt_section(raw_section)
+                    if resolved_section is None:
+                        continue
+                    section_content = str(resolved_section.content or "").strip()
+                    if section_content:
+                        sections.append(
+                            {
+                                "title": resolved_section.title,
+                                "content": section_content,
+                            }
+                        )
             section = coerce_prompt_section(result)
             if section is not None:
                 title = section.title
                 content = str(section.content or "").strip()
+            elif sections:
+                content = "\n\n".join(
+                    str(item.get("content") or "") for item in sections
+                )
             else:
                 content = str(result or "").strip()
             elapsed_ms = int((time.time() - started) * 1000)
@@ -14032,6 +14050,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                 "source": source,
                 "priority": priority,
                 "content": content,
+                "sections": sections,
                 "metadata": metadata,
                 "status": "hit" if content else "empty",
             }
@@ -14088,6 +14107,21 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
     def _add_collected_prompt_contexts(self, prompt_surface: PromptSurface, collected: list[dict[str, Any]]) -> None:
         for item in collected:
             if not isinstance(item, dict):
+                continue
+            sections = item.get("sections")
+            if isinstance(sections, list) and sections:
+                for index, raw_section in enumerate(sections):
+                    section = coerce_prompt_section(raw_section)
+                    if section is None or not str(section.content or "").strip():
+                        continue
+                    prompt_surface.add(
+                        f"{_single_line(item.get('key'), 80)}.{index}",
+                        section.content,
+                        title=section.title,
+                        priority=_safe_int(item.get("priority"), 100, 0) + index,
+                        source=_single_line(item.get("source"), 80),
+                        metadata=item.get("metadata") if isinstance(item.get("metadata"), dict) else {},
+                    )
                 continue
             content = str(item.get("content") or "").strip()
             if not content:
@@ -14249,7 +14283,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             "资料柜夹层",
             "bookshelf",
             61,
-            lambda: self._format_bookshelf_secret_for_prompt(inbound_text, current_user),
+            lambda: self._format_bookshelf_secret_prompt_section(inbound_text, current_user),
             timeout=1.2,
         )
         add_spec("bookshelf.reading", "资料柜阅读连续性", "bookshelf", 62, lambda: self._format_bookshelf_reading_context_for_reply(inbound_text, current_user))
@@ -14312,7 +14346,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             )
         add_spec("companion.planner", "私聊互动补充", "companion", 80, lambda: self._format_companion_planner_injection(prompt_user, include_heading=False))
         if not self._memory_companion_should_defer_prompt_section("livingmemory_guidance", event, req):
-            add_spec("livingmemory.guidance", "长期记忆检索", "livingmemory", 90, lambda: self._format_livingmemory_guidance(scope="private" if is_private_chat else "group", include_heading=False))
+            add_spec("livingmemory.guidance", "长期记忆检索", "livingmemory", 90, lambda: self._format_livingmemory_guidance_sections(scope="private" if is_private_chat else "group"))
         add_spec("detail.injection", "Bot 模拟当前片段", "daily_detail", 40, lambda: section_call(self._format_detail_injection))
 
         if is_private_chat:
@@ -14422,11 +14456,18 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             "没有可用工具且没有实际执行结果时,不要承诺“我这就拉你/我帮你操作/我已经处理/我去修/我给你弄好”。"
             "遇到拉人、开房间、修网、重启、登录、下载、现实代办等请求,只能自然说明自己做不到实际操作,可以提醒、陪用户确认、建议对方找能操作的人,或在确有工具时调用工具后再描述结果。"
         )
-        platform_boundary_getter = getattr(self, "_platform_capability_prompt", None)
+        boundary_sections = [prompt_section("能力边界", boundary)]
+        platform_boundary_getter = getattr(
+            self,
+            "_platform_capability_prompt_section",
+            None,
+        )
         if callable(platform_boundary_getter):
             platform_boundary = platform_boundary_getter(event)
-            if platform_boundary:
-                boundary = f"{boundary}\n\n{platform_boundary}"
+            resolved_boundary = coerce_prompt_section(platform_boundary)
+            if resolved_boundary is not None and str(resolved_boundary.content or "").strip():
+                boundary_sections.append(platform_boundary)
+        boundary = render_prompt_sections(boundary_sections)
         self._materialize_conversation_system_block(
             req,
             key="guard.capability_boundary",
@@ -14436,6 +14477,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             priority=30,
             source="guard",
             placement=PLACEMENT_DYNAMIC_SYSTEM,
+            structured=True,
         )
         await self._record_request_prompt_fragment(
             event,
@@ -14546,7 +14588,8 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                 mode="conditional",
                 metadata={"注入位置": placement, "触发原因": "livingmemory" if livingmemory_relation_context and not relation_query else "query"},
             )
-        qzone_instruction = self._qzone_tool_instruction(event, include_heading=False)
+        qzone_sections = self._qzone_tool_prompt_sections(event)
+        qzone_instruction = render_prompt_sections(qzone_sections)
         current_prompt = req.system_prompt or ""
         current_turn_prompt = str(getattr(req, "prompt", "") or "")
         qzone_marker = "<!-- private_companion_qzone_tools_v1 -->"
@@ -14559,6 +14602,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                     title="QQ 空间动态工具",
                     priority=88,
                     source="tools",
+                    structured=True,
                 ) else "system_prompt"
                 if placement == "system_prompt":
                     current_prompt = f"{current_prompt}\n\n{qzone_marker}\n{qzone_instruction}".strip()
@@ -15602,6 +15646,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         event: AstrMessageEvent | None = None,
         *,
         include_heading: bool = True,
+        include_joke_boundary: bool = True,
     ) -> str:
         if not bool(runtime_persona_setting(self, 'enable_group_persona_denoise', True)):
             return ""
@@ -15649,11 +15694,15 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             "群聊里的身份优先按平台稳定 ID 理解；昵称、群名片、角色名、别名和“通常是谁”这类设定，更适合作为称呼线索，不直接当成身份结论。",
             "提到群聊旧消息、群梗、记忆召回或最近群聊时，尽量保留具体成员名或 QQ 标签，例如“A[QQ:...] 说过/起哄过”；只有确实缺少成员线索时，再概括成“群里有人”。除非当前消息或引用明确就是这位发言者，尽量不要顺手改写成“你说过”“主要用户说过”这类直接归到当前对象身上的表达。",
             "群成员画像只用于自然理解当前对话：当前发言者明确询问自己时，最多概括可公开的低敏偏好；不要替任何人整理、推断或披露第三方画像。普通群聊提到某人的爱好、习惯或偏好只是聊天内容，不要把它误当成对你的查询。",
-            "【群聊玩笑边界】群聊里“记住了/记下某人是XX”这类话（尤其把某人当对象、或带主观评价、攻击、贬损、色情、侮辱标签），通常只是群友之间的玩笑或随口一说。把它当作玩笑正面应和，顺着调侃接一下就好；这类玩笑性记录可以作为旁线补充，但不要写进核心人物画像（主要用户画像、关系画像、稳定偏好等），落库时只能标为低置信的玩笑性质，不能混入可验证事实。涉及他人名誉、隐私或主观定性的说法，调侃可以，别替别人正式贴标签、下结论。",
             "状态、日程、情绪和私聊关系更适合只留在语气底色里；如果没有人明确问到，就不必主动展开能量、天气、日程、心情或插件状态。",
             "表达上尽量自然一点，不需要刻意堆动作描写、撒娇、长解释或关系总结；一句能说清，就简单说一句。",
             "如果只是被轻轻提到，或者话题本身并不需要你展开，宁可短一点、轻一点、贴着当前梗回应，也不用顺势写成主动陪伴式长回复。",
         ]
+        if include_joke_boundary:
+            lines.insert(
+                4,
+                "【群聊玩笑边界】" + self._group_persona_denoise_joke_boundary(),
+            )
         if include_heading:
             lines.insert(0, "【群聊人格降噪】")
         if sender_id:
@@ -15678,18 +15727,40 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             lines.append("群里刚才比较密集，这轮回复更适合收一点：抓住一个重点回应就好，不必逐条点名展开。")
         return "\n".join(lines)
 
+    @staticmethod
+    def _group_persona_denoise_joke_boundary() -> str:
+        return (
+            "群聊里“记住了/记下某人是XX”这类话（尤其把某人当对象、或带主观评价、攻击、贬损、色情、侮辱标签），通常只是群友之间的玩笑或随口一说。"
+            "把它当作玩笑正面应和，顺着调侃接一下就好；这类玩笑性记录可以作为旁线补充，但不要写进核心人物画像（主要用户画像、关系画像、稳定偏好等），"
+            "落库时只能标为低置信的玩笑性质，不能混入可验证事实。涉及他人名誉、隐私或主观定性的说法，调侃可以，别替别人正式贴标签、下结论。"
+        )
+
+    def _format_group_persona_denoise_prompt_sections(
+        self,
+        event: AstrMessageEvent | None = None,
+    ) -> list[dict[str, Any]]:
+        body = self._format_group_persona_denoise_prompt(
+            event,
+            include_heading=False,
+            include_joke_boundary=False,
+        )
+        if not body:
+            return []
+        return [
+            prompt_section("群聊人格降噪", body),
+            prompt_section("群聊玩笑边界", self._group_persona_denoise_joke_boundary()),
+        ]
+
     async def _append_group_persona_denoise_to_request(self, event: AstrMessageEvent, req: ProviderRequest) -> None:
         if not bool(runtime_persona_setting(self, 'enable_group_companion', True)):
             return
         group_id = self._extract_group_id_from_event(event)
         if not group_id or not self._group_enabled_for_event(group_id):
             return
-        denoise_text = self._format_group_persona_denoise_prompt(
-            event,
-            include_heading=False,
-        )
-        if not denoise_text:
+        denoise_sections = self._format_group_persona_denoise_prompt_sections(event)
+        if not denoise_sections:
             return
+        denoise_text = render_prompt_sections(denoise_sections)
         marker = "<!-- private_companion_group_persona_denoise_v1 -->"
         current_prompt = req.system_prompt or ""
         current_turn_prompt = str(getattr(req, "prompt", "") or "")
@@ -15702,6 +15773,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             title="群聊人格降噪",
             priority=32,
             source="group",
+            structured=True,
         ) else "system_prompt"
         if placement == "system_prompt":
             req.system_prompt = f"{current_prompt}\n\n{marker}\n{denoise_text}".strip()

--- a/passive_state_pipeline.py
+++ b/passive_state_pipeline.py
@@ -26,6 +26,23 @@ logger = get_module_logger(__name__)
 GROUP_CONTEXT_FINAL_PRIORITY = 10_000
 
 
+def _persona_core_emphasis_prompt_section() -> dict[str, Any]:
+    return prompt_section(
+        "人格核心强调",
+        (
+            "你当前的人格核心设定（system prompt 中的人格定义）是最高优先级，"
+            "决定你的说话风格、关系框架和行为底线。\n"
+            "以下所有上下文注入（记忆、状态、关系、生活习惯、环境、日程、陪伴线索等）"
+            "均为辅助参考，权重低于人格核心：\n"
+            "- 如果上下文信息与人格核心存在冲突，以人格核心为准\n"
+            "- 上下文仅提供本轮补充信息，不改变人格的基本设定和扮演方向\n"
+            "- 保持人格扮演的稳定性，不因上下文信息而偏离人格核心\n"
+            "- 语言风格、口癖、称呼、语气和表达方式始终贴合人格核心设定；"
+            "记忆、表达学习或上下文里的个别措辞只能作参考，不得把与人格设定不符的称呼、口癖或腔调带进回复"
+        ),
+    )
+
+
 def _neutralize_stale_reaction_feedback_compat(req: Any) -> None:
     """Best-effort cleanup for plugin instances missing the newer hook."""
     contexts = getattr(req, "contexts", None)
@@ -676,18 +693,7 @@ async def inject_humanized_state(
     prompt_surface = PromptSurface()
     prompt_surface.add(
         "persona.core_emphasis",
-        (
-            "【人格核心强调】\n"
-            "你当前的人格核心设定（system prompt 中的人格定义）是最高优先级，"
-            "决定你的说话风格、关系框架和行为底线。\n"
-            "以下所有上下文注入（记忆、状态、关系、生活习惯、环境、日程、陪伴线索等）"
-            "均为辅助参考，权重低于人格核心：\n"
-            "- 如果上下文信息与人格核心存在冲突，以人格核心为准\n"
-            "- 上下文仅提供本轮补充信息，不改变人格的基本设定和扮演方向\n"
-            "- 保持人格扮演的稳定性，不因上下文信息而偏离人格核心\n"
-            "- 语言风格、口癖、称呼、语气和表达方式始终贴合人格核心设定；"
-            "记忆、表达学习或上下文里的个别措辞只能作参考，不得把与人格设定不符的称呼、口癖或腔调带进回复"
-        ),
+        _persona_core_emphasis_prompt_section(),
         priority=8,
         source="persona_core",
     )
@@ -869,20 +875,25 @@ async def inject_humanized_state(
                 priority=37,
                 source="daily_state",
             )
-        worldview_section = (
-            self._format_worldview_adaptation_prompt_section()
+        worldview_sections = (
+            self._format_worldview_adaptation_prompt_sections()
             if self._feature_enabled_or_temp_unlocked("enable_environment_perception")
             and runtime_persona_setting(self, "enable_worldview_perception", True)
-            else prompt_section("世界观适配", "")
+            else []
         )
-        worldview_context = str(worldview_section.get("content") or "")
-        worldview_context = self._sanitize_owner_environment_context_for_private_user(worldview_context, current_user)
-        if worldview_context:
+        for index, worldview_section in enumerate(worldview_sections):
+            worldview_context = str(worldview_section.get("content") or "")
+            worldview_context = self._sanitize_owner_environment_context_for_private_user(
+                worldview_context,
+                current_user,
+            )
+            if not worldview_context:
+                continue
             prompt_surface.add(
-                "worldview.adaptation",
+                "worldview.adaptation" if index == 0 else f"worldview.reference.{index}",
                 worldview_context,
                 title=str(worldview_section.get("title") or "世界观适配"),
-                priority=37,
+                priority=37 + index,
                 source="worldview",
             )
     realtime_formatter = getattr(self, "_format_external_realtime_prompt_section", None)

--- a/platform_compat.py
+++ b/platform_compat.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Any
 
+from .conversation_prompt_section import prompt_section
 from .helpers import _single_line
 from .persona_config import runtime_persona_setting
 
@@ -344,17 +345,26 @@ class PlatformCompatibilityMixin:
         target_kind = self._platform_kind_for_umo(getattr(self, "target_platform", ""))
         return target_kind == desired
 
-    def _platform_capability_prompt(self, event: Any | None) -> str:
+    def _platform_capability_prompt_body(self, event: Any | None) -> str:
         profile = self._platform_profile(event=event)
         if profile.get("kind") != "qq_official":
             return ""
         return (
-            "【QQ 官方机器人平台边界】\n"
             "当前用户身份是 openid/平台用户ID，可以正常作为稳定私聊身份使用，不要要求用户提供数字 QQ 号。\n"
             "可以通过当前 AstrBot 会话发送普通文字、图片和已配置的语音；只有实际工具/发送结果成功后才能说已发送。\n"
             "当前平台不支持 OneBot 戳一戳、输入状态、原生撤回、指定消息引用或合并转发；不要承诺执行这些动作，应自然改用普通文字。\n"
             "QQ 官方机器人不支持 QQ 空间读取、发布、点赞或评论；不要调用或承诺使用 QQ 空间能力。\n"
             "主动私聊还受 QQ 官方额度、会话时间窗和审核限制，发送失败时如实说明，不能假装已经触达。"
+        )
+
+    def _platform_capability_prompt(self, event: Any | None) -> str:
+        body = self._platform_capability_prompt_body(event)
+        return f"【QQ 官方机器人平台边界】\n{body}" if body else ""
+
+    def _platform_capability_prompt_section(self, event: Any | None) -> dict[str, Any]:
+        return prompt_section(
+            "QQ 官方机器人平台边界",
+            self._platform_capability_prompt_body(event),
         )
 
     def _platform_adaptation_overview(self) -> dict[str, Any]:

--- a/private_image.py
+++ b/private_image.py
@@ -33,6 +33,7 @@ from .conversation_injection_plan import (
     PLACEMENT_DYNAMIC_SYSTEM,
     get_conversation_injection_plan,
 )
+from .conversation_prompt_section import prompt_section, render_prompt_sections
 from .helpers import _missing_optional_model_dependency, _now_ts, _safe_float, _safe_int, _single_line, _strip_internal_message_blocks, _strip_outbound_control_blocks, _today_key, _url_host_is_public
 from .persona_config import runtime_persona_setting
 from .segmented_message import (
@@ -80,6 +81,7 @@ class PrivateImageMixin:
         content: str,
         title: str,
         priority: int,
+        structured: bool = False,
     ) -> None:
         plan = get_conversation_injection_plan(req)
         if plan is None or (marker and plan.contains_marker(marker)):
@@ -94,6 +96,7 @@ class PrivateImageMixin:
             placement=PLACEMENT_DYNAMIC_SYSTEM,
             temporary=False,
             materialized=True,
+            structured=structured,
         )
 
     def _private_image_framework_context(self) -> Any | None:
@@ -4806,7 +4809,7 @@ class PrivateImageMixin:
         ]
         user["recent_group_messages"] = kept[-8:]
 
-    def _format_recent_group_messages_for_private_image_prompt(self, user_id: str) -> str:
+    def _format_recent_group_messages_for_private_image_prompt_body(self, user_id: str) -> str:
         if not user_id:
             return ""
         try:
@@ -4823,17 +4826,30 @@ class PrivateImageMixin:
         ][-4:]
         if not items:
             return ""
-        lines = ["【用户刚刚在群里的近况】"]
+        lines: list[str] = []
         for item in items:
             elapsed = self._format_elapsed(max(0, now - _safe_float(item.get("ts"), 0)))
             group_id = _single_line(item.get("group_id"), 40)
             text = _single_line(item.get("text"), 160)
             if text:
                 lines.append(f"- {elapsed}前｜群 {group_id}｜{text}")
-        if len(lines) <= 1:
+        if not lines:
             return ""
         lines.append("使用方式：这比私聊压缩历史更新，只作为当前用户近况和语气背景；当前回复仍然优先回应这张图片。")
         return "\n".join(lines)
+
+    def _format_recent_group_messages_for_private_image_prompt(self, user_id: str) -> str:
+        body = self._format_recent_group_messages_for_private_image_prompt_body(user_id)
+        return f"【用户刚刚在群里的近况】\n{body}" if body else ""
+
+    def _format_recent_group_messages_for_private_image_prompt_section(
+        self,
+        user_id: str,
+    ) -> dict[str, Any]:
+        return prompt_section(
+            "用户刚刚在群里的近况",
+            self._format_recent_group_messages_for_private_image_prompt_body(user_id),
+        )
 
     def _trim_private_image_stale_context_tail(self, text: str) -> str:
         cleaned = str(text or "").strip()
@@ -5636,7 +5652,7 @@ class PrivateImageMixin:
         if not prompt or prompt == "[图片]":
             prompt = (
                 "用户刚刚只发了一张图片,没有补充文字。"
-                "图片内容已在系统提示的【本轮延迟图片】视觉摘要中给出；请直接回应那张图,不要说没看到图片。"
+                "图片内容已在系统提示的本轮图片视觉摘要中给出；请直接回应那张图,不要说没看到图片。"
                 "本轮只回应当前图片和用户发图可能表达的态度/梗/疑问；"
                 "但如果最近对话里用户明确规定了这张/下一张图片的回复方式（例如只回复某句话、不要回复其他内容）,必须优先照做。"
                 "除此之外,聊天历史只作语气背景,不要续写、答应或安排旧话题。"
@@ -5813,9 +5829,13 @@ class PrivateImageMixin:
                 "不要把聊天历史、长期记忆、主动消息、旧 TTS 文本或压缩摘要里的邀约当成当前输入；"
                 "不要顺便提下午、五点、放学、出去走走、陪你、到时候叫我等旧约定。"
             )
-            recent_group_context = self._format_recent_group_messages_for_private_image_prompt(user_id)
-            if recent_group_context:
-                boundary_prompt = f"{boundary_prompt}\n\n{recent_group_context}"
+            boundary_sections = [prompt_section("本轮图片回复边界", boundary_prompt)]
+            recent_group_context = self._format_recent_group_messages_for_private_image_prompt_section(
+                user_id
+            )
+            if str(recent_group_context.get("content") or "").strip():
+                boundary_sections.append(recent_group_context)
+            boundary_prompt = render_prompt_sections(boundary_sections)
             current_prompt = str(getattr(req, "system_prompt", "") or "")
             req.system_prompt = f"{current_prompt}\n\n{boundary_prompt}".strip() if current_prompt else boundary_prompt
             self._register_materialized_private_image_context(
@@ -5825,6 +5845,7 @@ class PrivateImageMixin:
                 content=boundary_prompt,
                 title="本轮图片回复边界",
                 priority=31,
+                structured=True,
             )
             segmenting_injector = getattr(
                 self,

--- a/qzone_publish.py
+++ b/qzone_publish.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from astrbot.api.event import AstrMessageEvent
 
+from .conversation_prompt_section import prompt_section
 from .helpers import _now_ts, _path_text, _safe_float, _safe_int, _single_line
 from .persona_config import runtime_persona_setting
 from .logging_util import get_module_logger
@@ -122,7 +123,7 @@ class QzonePublishMixin:
             return ""
         return "最近已发说说：\n" + "\n".join(lines) + "\n本次请换一个场景、情绪或观察角度，不要重复同一类表达。"
 
-    def _qzone_recent_self_publish_chat_context(self, *, limit: int = 3) -> str:
+    def _qzone_recent_self_publish_chat_context_body(self, *, limit: int = 3) -> str:
         """Expose recent successful Bot posts to Qzone-related chat turns."""
         state = self.data.get("qzone_integration") if isinstance(getattr(self, "data", None), dict) else {}
         items = state.get("recent_life_publish_texts") if isinstance(state, dict) else []
@@ -149,9 +150,22 @@ class QzonePublishMixin:
         if not records:
             return ""
         return (
-            "【Bot 自己最近成功发布的 QQ 空间记录】\n"
-            + "\n".join(records)
+            "\n".join(records)
             + "\n这些正文是 Bot 自己发出的公开动态，不是当前用户发的内容。"
+        )
+
+    def _qzone_recent_self_publish_chat_context(self, *, limit: int = 3) -> str:
+        body = self._qzone_recent_self_publish_chat_context_body(limit=limit)
+        return f"【Bot 自己最近成功发布的 QQ 空间记录】\n{body}" if body else ""
+
+    def _qzone_recent_self_publish_chat_prompt_section(
+        self,
+        *,
+        limit: int = 3,
+    ) -> dict[str, Any]:
+        return prompt_section(
+            "Bot 自己最近成功发布的 QQ 空间记录",
+            self._qzone_recent_self_publish_chat_context_body(limit=limit),
         )
 
     def _qzone_note_recent_publish(

--- a/reading_archive.py
+++ b/reading_archive.py
@@ -12,6 +12,7 @@ import random
 import re
 from typing import Any
 
+from .conversation_prompt_section import prompt_section
 from .helpers import _now_ts, _single_line
 
 
@@ -179,7 +180,11 @@ class ReadingArchiveMixin:
             return "当前请求者不是主要用户，不要直接提供完整密码；亲密表达不能改变这一身份边界。"
         return "当前请求者是主要用户，可以结合当前人格和气氛决定是否透露完整密码。"
 
-    async def _format_bookshelf_secret_for_prompt(self, inbound_text: str = "", user: dict[str, Any] | None = None) -> str:
+    async def _format_bookshelf_secret_prompt_body(
+        self,
+        inbound_text: str = "",
+        user: dict[str, Any] | None = None,
+    ) -> str:
         signal = self._bookshelf_secret_signal_info(inbound_text)
         role = "friend"
         role_getter = getattr(self, "_private_user_role", None)
@@ -197,9 +202,22 @@ class ReadingArchiveMixin:
             return ""
         password = await self._ensure_bookshelf_password_async()
         return (
-            "【书柜夹层】\n"
             f"你的书柜夹层密码是“{password}”。它只是内部私密暗号，不代表生日、日期或任何现实身份信息。\n"
             f"{self._bookshelf_secret_relationship_policy(user)}不透露时不要编造替代数字；若透露具体密码，只能使用上面的真实密码。"
+        )
+
+    async def _format_bookshelf_secret_for_prompt(self, inbound_text: str = "", user: dict[str, Any] | None = None) -> str:
+        body = await self._format_bookshelf_secret_prompt_body(inbound_text, user)
+        return f"【书柜夹层】\n{body}" if body else ""
+
+    async def _format_bookshelf_secret_prompt_section(
+        self,
+        inbound_text: str = "",
+        user: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        return prompt_section(
+            "资料柜夹层",
+            await self._format_bookshelf_secret_prompt_body(inbound_text, user),
         )
 
     def _reading_archive_available(self) -> bool:

--- a/tests/test_conversation_prompt_structure_supplement.py
+++ b/tests/test_conversation_prompt_structure_supplement.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from astrbot_plugin_private_companion.astrbot_knowledge import AstrBotKnowledgeMixin
+from astrbot_plugin_private_companion.conversation_prompt_section import (
+    prompt_section,
+    render_prompt_sections,
+)
+from astrbot_plugin_private_companion.integration_status import IntegrationStatusMixin
+from astrbot_plugin_private_companion.llm_tool_actions import LlmToolActionsMixin
+from astrbot_plugin_private_companion.main import PrivateCompanionPlugin
+from astrbot_plugin_private_companion.passive_state_pipeline import (
+    _persona_core_emphasis_prompt_section,
+)
+from astrbot_plugin_private_companion.platform_compat import PlatformCompatibilityMixin
+from astrbot_plugin_private_companion.private_image import PrivateImageMixin
+from astrbot_plugin_private_companion.qzone_publish import QzonePublishMixin
+from astrbot_plugin_private_companion.reading_archive import ReadingArchiveMixin
+
+
+LEGACY_HEADINGS = (
+    "【人格核心强调】",
+    "【QQ 官方机器人平台边界】",
+    "【群聊人格降噪】",
+    "【群聊玩笑边界】",
+    "【长期记忆检索】",
+    "【书柜夹层】",
+    "【AstrBot 知识库世界观参考】",
+    "【QQ 空间动态工具】",
+    "【Bot 自己最近成功发布的 QQ 空间记录】",
+    "【用户刚刚在群里的近况】",
+)
+
+
+class _PlatformHarness(PlatformCompatibilityMixin):
+    @staticmethod
+    def _platform_profile(**_kwargs):
+        return {"kind": "qq_official"}
+
+
+class _LivingMemoryHarness(IntegrationStatusMixin):
+    enable_livingmemory_integration = True
+    livingmemory_tool_name = "recall_long_term_memory"
+
+    @staticmethod
+    def _livingmemory_available() -> bool:
+        return True
+
+
+class _WorldviewHarness(IntegrationStatusMixin):
+    def persona_setting(self, key, default=None):
+        values = {
+            "worldview_adaptation_mode": "modern",
+            "worldview_adaptation_prompt": "",
+            "schedule_persona_prompt": "",
+            "schedule_worldview_prompt": "",
+            "bot_name": "测试人格",
+        }
+        return values.get(key, default)
+
+    @staticmethod
+    def _format_roleplay_knowledge_context(**_kwargs) -> str:
+        return "【AstrBot 知识库世界观参考】\n世界资料"
+
+    @staticmethod
+    def _format_roleplay_knowledge_context_section(**_kwargs):
+        return prompt_section("AstrBot 知识库世界观参考", "世界资料")
+
+
+class _KnowledgeHarness(AstrBotKnowledgeMixin):
+    roleplay_knowledge_source_ids = ["kb:world"]
+
+    @staticmethod
+    def _astrbot_knowledge_sources():
+        return [
+            {
+                "kb_id": "world",
+                "name": "世界",
+                "documents": [{"doc_id": "doc", "id": "doc:world:doc", "name": "设定"}],
+            }
+        ]
+
+    @staticmethod
+    def _read_roleplay_knowledge_chunks(*_args, **_kwargs):
+        return [{"kb_doc_id": "doc", "text": "天空城漂浮在云层上。"}]
+
+
+class _QzoneHarness(LlmToolActionsMixin, QzonePublishMixin):
+    enabled = True
+    enable_qzone_integration = True
+
+    def __init__(self):
+        self.data = {
+            "qzone_integration": {
+                "recent_life_publish_texts": [{"text": "今天看了晚霞", "image_count": 1}]
+            }
+        }
+
+
+class _BookshelfHarness(ReadingArchiveMixin):
+    data = {"bookshelf_secret": {"password": "2468", "basis": "manual"}}
+
+    @staticmethod
+    def _bookshelf_secret_signal_info(_text):
+        return {"likely": True}
+
+    @staticmethod
+    def _private_user_role(_user, *_args):
+        return "owner"
+
+    @staticmethod
+    async def _ensure_bookshelf_password_async() -> str:
+        return "2468"
+
+
+class _PrivateImageHarness(PrivateImageMixin):
+    def _get_user(self, _user_id):
+        return {
+            "recent_group_messages": [
+                {"ts": 1_000.0, "group_id": "group-1", "text": "刚才在群里说的话"}
+            ]
+        }
+
+    @staticmethod
+    def _format_elapsed(_seconds):
+        return "1分钟"
+
+
+class ConversationPromptStructureSupplementTests(unittest.IsolatedAsyncioTestCase):
+    def assert_no_legacy_headings(self, rendered: str) -> None:
+        for heading in LEGACY_HEADINGS:
+            self.assertNotIn(heading, rendered)
+
+    def test_persona_core_is_named_section_without_nested_heading(self) -> None:
+        rendered = render_prompt_sections([_persona_core_emphasis_prompt_section()])
+
+        self.assertIn('<section title="人格核心强调">', rendered)
+        self.assertNotIn('<section title="提示词片段">', rendered)
+        self.assert_no_legacy_headings(rendered)
+
+    def test_platform_boundary_keeps_legacy_text_and_structures_main_chain(self) -> None:
+        harness = _PlatformHarness()
+
+        self.assertTrue(harness._platform_capability_prompt(None).startswith("【QQ 官方机器人平台边界】\n"))
+        rendered = render_prompt_sections(
+            [
+                prompt_section("能力边界", "通用能力约束"),
+                harness._platform_capability_prompt_section(None),
+            ]
+        )
+
+        self.assertIn('<section title="QQ 官方机器人平台边界">', rendered)
+        self.assert_no_legacy_headings(rendered)
+
+    def test_group_denoise_splits_joke_boundary_and_preserves_legacy_output(self) -> None:
+        plugin = object.__new__(PrivateCompanionPlugin)
+        plugin.enable_group_persona_denoise = True
+        plugin.data = {"users": {}}
+        plugin._sender_display_name = lambda _event: "群友"
+        plugin._private_user_id_for_event = lambda _event, sender_id: sender_id
+        plugin._is_target_private_user = lambda *_args, **_kwargs: False
+        event = SimpleNamespace(
+            get_sender_id=lambda: "member-1",
+            private_companion_group_scene={},
+            private_companion_group_high_intensity=None,
+        )
+
+        legacy = plugin._format_group_persona_denoise_prompt(event)
+        rendered = render_prompt_sections(
+            plugin._format_group_persona_denoise_prompt_sections(event)
+        )
+
+        self.assertTrue(legacy.startswith("【群聊人格降噪】\n"))
+        self.assertIn("【群聊玩笑边界】", legacy)
+        self.assertIn('<section title="群聊人格降噪">', rendered)
+        self.assertIn('<section title="群聊玩笑边界">', rendered)
+        self.assert_no_legacy_headings(rendered)
+
+    def test_livingmemory_splits_joke_boundary_and_preserves_legacy_output(self) -> None:
+        harness = _LivingMemoryHarness()
+
+        legacy = harness._format_livingmemory_guidance(scope="group")
+        rendered = render_prompt_sections(
+            harness._format_livingmemory_guidance_sections(scope="group")
+        )
+
+        self.assertTrue(legacy.startswith("【长期记忆检索】\n"))
+        self.assertIn("【群聊玩笑边界】", legacy)
+        self.assertIn('<section title="长期记忆检索">', rendered)
+        self.assertIn('<section title="群聊玩笑边界">', rendered)
+        self.assert_no_legacy_headings(rendered)
+
+    async def test_bookshelf_uses_named_section_and_keeps_legacy_output(self) -> None:
+        harness = _BookshelfHarness()
+
+        legacy = await harness._format_bookshelf_secret_for_prompt("密码是多少", {})
+        rendered = render_prompt_sections(
+            [await harness._format_bookshelf_secret_prompt_section("密码是多少", {})]
+        )
+
+        self.assertTrue(legacy.startswith("【书柜夹层】\n"))
+        self.assertIn('<section title="资料柜夹层">', rendered)
+        self.assert_no_legacy_headings(rendered)
+
+    def test_worldview_splits_knowledge_reference_and_preserves_legacy_output(self) -> None:
+        harness = _WorldviewHarness()
+
+        legacy = harness._format_worldview_adaptation_prompt()
+        rendered = render_prompt_sections(
+            harness._format_worldview_adaptation_prompt_sections()
+        )
+
+        self.assertTrue(legacy.startswith("【世界观适配】\n"))
+        self.assertIn("【AstrBot 知识库世界观参考】", legacy)
+        self.assertIn('<section title="世界观适配">', rendered)
+        self.assertIn('<section title="AstrBot 知识库世界观参考">', rendered)
+        self.assert_no_legacy_headings(rendered)
+
+    def test_knowledge_context_keeps_legacy_heading_outside_structured_body(self) -> None:
+        harness = _KnowledgeHarness()
+
+        legacy = harness._format_roleplay_knowledge_context(purpose="worldview")
+        rendered = render_prompt_sections(
+            [harness._format_roleplay_knowledge_context_section(purpose="worldview")]
+        )
+
+        self.assertTrue(legacy.startswith("【AstrBot 知识库世界观参考】\n"))
+        self.assertIn("天空城漂浮在云层上", rendered)
+        self.assert_no_legacy_headings(rendered)
+
+    def test_qzone_splits_recent_posts_and_preserves_legacy_output(self) -> None:
+        harness = _QzoneHarness()
+
+        legacy = harness._qzone_tool_instruction()
+        rendered = render_prompt_sections(harness._qzone_tool_prompt_sections())
+
+        self.assertTrue(legacy.startswith("【QQ 空间动态工具】\n"))
+        self.assertIn("【Bot 自己最近成功发布的 QQ 空间记录】", legacy)
+        self.assertIn('<section title="QQ 空间动态工具">', rendered)
+        self.assertIn('<section title="Bot 自己最近成功发布的 QQ 空间记录">', rendered)
+        self.assert_no_legacy_headings(rendered)
+
+    def test_private_image_recent_group_context_is_a_sibling_section(self) -> None:
+        harness = _PrivateImageHarness()
+
+        with patch(
+            "astrbot_plugin_private_companion.private_image._now_ts",
+            return_value=1_060.0,
+        ):
+            legacy = harness._format_recent_group_messages_for_private_image_prompt("user-1")
+            rendered = render_prompt_sections(
+                [
+                    prompt_section("本轮图片回复边界", "优先回应当前图片。"),
+                    harness._format_recent_group_messages_for_private_image_prompt_section("user-1"),
+                ]
+            )
+
+        self.assertTrue(legacy.startswith("【用户刚刚在群里的近况】\n"))
+        self.assertIn('<section title="本轮图片回复边界">', rendered)
+        self.assertIn('<section title="用户刚刚在群里的近况">', rendered)
+        self.assert_no_legacy_headings(rendered)
+
+    def test_user_bracket_text_is_preserved(self) -> None:
+        rendered = render_prompt_sections(
+            [prompt_section("引用内容", "用户原话是【这个括号要保留】")]
+        )
+
+        self.assertIn("【这个括号要保留】", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### 背景

插件已经引入结构化的用户对话提示词管线，但部分被动私聊和群聊路径仍会输出 `【标题】内容` 形式的平铺提示词。

这些旧标题进入主 LLM 后，可能影响模型的回复格式和用词习惯；多个独立规则平铺在同一字符串中，也不利于提示词排序、去重和边界控制。

### 主要改动

- 由对应业务模块直接返回 `prompt_section()` 或结构化 section 列表，不再在最终拼接阶段解析旧标题字符串。
- 补齐以下被动用户对话主链内容的结构化：
  - 人格核心强调；
  - QQ Official 平台边界；
  - 群聊人格降噪与群聊玩笑边界；
  - LivingMemory 检索内容与群聊玩笑边界；
  - 资料柜夹层；
  - 世界观适配与 AstrBot 知识库参考；
  - QQ 空间工具说明与最近发布记录；
  - 单图回复边界与最近群聊近况；
  - 过时的“本轮延迟图片”结构引用。
- 对同一段内容中的多个独立语义块使用同级 section，避免把内部规则继续伪装成正文标题。
- 保留稳定的 section key，使现有 `PromptSurface`/`ConversationInjectionPlan` 可以继续完成排序和去重。

### 范围与兼容性

- 本次只修改直接进入被动私聊或群聊回复主 LLM 的插件自有提示词。
- 后台或功能性 LLM、工具 Schema、TTS、生图协议和其他 opaque 协议保持原有格式。
- 保留 `include_heading=True` 的旧文本输出，继续服务尚未纳入本次改造的非用户对话调用方。
- 不执行全局 `【】` 正则清理，避免改写用户原文、人格内容、知识库正文或合法数据标记。
- 不新增配置项，也不升级人格配置版本。

### 验证

- 增加私聊、群聊、QQ Official、QQ 空间、LivingMemory、资料柜、世界观/知识库和单图回复路径的最终请求渲染测试。
- 确认已改造 section 的正文中不再重复保留对应旧标题。
- 确认 `include_heading=True` 的后台及功能性提示词保持兼容。
- 通过 Python 编译、插件打包与校验、真实 AstrBot 导入、两套 WebUI 语法检查和 `git diff --check`。
- 完整测试的失败集合与同环境上游基线一致，没有新增回归。

