### PR TITLE
fix: 修复 LLM 自主分段标记失效并保护 Markdown 结构

### DIFF
--- a/event_dispatch.py
+++ b/event_dispatch.py
@@ -106,6 +106,10 @@ from .dreaming import (
     weighted_unique_fragment_sample,
 )
 from .helpers import _date_key, _now_ts, _safe_float, _safe_int, _single_line, _strip_internal_message_blocks, _today_key
+from .markdown_segment_guard import (
+    MARKDOWN_BLOCK_TOKEN_PATTERN,
+    protect_markdown_blocks,
+)
 from .persona_config import runtime_persona_setting
 from .model_routing import CURRENT_MODEL_REPLACEMENT_SOURCES, build_rules, find_route, scope_allows
 from .relationship_policy import relationship_stage_provider_id
@@ -191,6 +195,7 @@ _SEGMENTED_PROTECTED_LITERAL_PATTERN = re.compile(
     + _SEGMENTED_COMMON_FILE_SUFFIXES
     + r"(?![\w]))"
     r"|(?<![\d.])\d+(?:\.\d+)+(?!\d|\.\d)"
+    r"|" + MARKDOWN_BLOCK_TOKEN_PATTERN
 )
 
 
@@ -5595,6 +5600,22 @@ Bot 近期回复：
                 default=default,
             )
 
+        markdown = protect_markdown_blocks(normalized)
+        source_length = len(normalized)
+        if markdown.active:
+            normalized = markdown.protected_text
+            if event is not None:
+                try:
+                    setattr(event, "_private_companion_segmented_markdown_detected", True)
+                except Exception:
+                    pass
+
+        def restore_markdown(value: Any) -> str:
+            return markdown.restore(value)
+
+        def contains_markdown(value: Any) -> bool:
+            return markdown.contains_token(value)
+
         replaced_text, replacement_count = self._apply_segmented_content_replacements(
             normalized,
             event=event,
@@ -5620,8 +5641,8 @@ Bot 近期回复：
                 8,
             ),
         )
-        if len(normalized) > threshold and not common_transforms_only:
-            return [normalized]
+        if source_length > threshold and not common_transforms_only:
+            return [restore_markdown(normalized)]
 
         cleanup_pattern: re.Pattern[str] | None = None
         cleanup_words: list[str] = []
@@ -5929,7 +5950,7 @@ Bot 近期回复：
             return _normalize_cjk_chat_spaces(cleaned)
 
         def _visible_len(value: str) -> int:
-            visible = str(value or "").replace(
+            visible = restore_markdown(value).replace(
                 _SEGMENTED_GENERATED_PUNCTUATION_MARKER,
                 "",
             )
@@ -5985,6 +6006,7 @@ Bot 近期回复：
 
         if common_transforms_only:
             cleaned = _clean_segment(normalized)
+            cleaned = restore_markdown(cleaned)
             return [cleaned] if cleaned else []
 
         def _is_soft_short_segment(value: str) -> bool:
@@ -6021,6 +6043,8 @@ Bot 近期回复：
                 return right
             if not right:
                 return left
+            if contains_markdown(left) or contains_markdown(right):
+                return f"{left.rstrip()}\n\n{right.lstrip()}"
             if right.startswith(("（", "(")):
                 return _normalize_cjk_chat_spaces(f"{left}{right}")
             visible_left = _strip_generated_punctuation_markers(left)
@@ -6098,7 +6122,7 @@ Bot 近期回复：
             if "\n" not in split_words:
                 split_words.append("\n")
             if not split_words:
-                return [normalized]
+                return [restore_markdown(normalized)]
             raw_segments = _split_words_outside_protected(normalized, split_words)
             segments: list[str] = []
             for segment in raw_segments:
@@ -6110,7 +6134,8 @@ Bot 近期回复：
                     if cleaned:
                         segments.append(cleaned)
             segments = _merge_segments(segments)
-            return segments if segments and (len(segments) > 1 or cleanup_enabled) else [normalized]
+            segments = [restore_markdown(segment) for segment in segments]
+            return segments if segments and (len(segments) > 1 or cleanup_enabled) else [restore_markdown(normalized)]
 
         try:
             raw_segments = re.findall(
@@ -6133,7 +6158,8 @@ Bot 近期回复：
                 if cleaned:
                     segments.append(cleaned)
         segments = _merge_segments(segments)
-        return segments if segments and (len(segments) > 1 or cleanup_enabled) else [normalized]
+        segments = [restore_markdown(segment) for segment in segments]
+        return segments if segments and (len(segments) > 1 or cleanup_enabled) else [restore_markdown(normalized)]
 
     async def _calc_segmented_proactive_interval(
         self,

--- a/helpers.py
+++ b/helpers.py
@@ -610,7 +610,8 @@ def _strip_personality_sync_blocks(text: Any) -> str:
 
 
 def _strip_internal_message_blocks(text: Any) -> str:
-    normalized = str(text or "")
+    original = str(text or "").replace("\r\n", "\n").replace("\r", "\n")
+    normalized = original
     normalized = _strip_personality_sync_blocks(normalized)
     normalized = _strip_group_member_safety_markers(normalized)
     # Strip reasoning/thinking chain content BEFORE _strip_history_media_markers,
@@ -665,14 +666,26 @@ def _strip_internal_message_blocks(text: Any) -> str:
         flags=re.IGNORECASE,
     )
     normalized = re.sub(r"<reasoning\b[^>]*>.*?</reasoning>", "", normalized, flags=re.IGNORECASE | re.DOTALL)
-    normalized = _strip_history_media_markers(normalized)
+    normalized = _strip_history_media_markers(normalized, preserve_whitespace=True)
+    normalized = re.sub(
+        rf"(?m)^[ \t]*{_PHOTO_TOOL_SILENT_SENTINEL_PATTERN.pattern}[ \t]*(?:\n|$)",
+        "",
+        normalized,
+        flags=_PHOTO_TOOL_SILENT_SENTINEL_PATTERN.flags | re.MULTILINE,
+    )
     normalized = _PHOTO_TOOL_SILENT_SENTINEL_PATTERN.sub("", normalized)
     normalized = re.sub(r"\[\[TTSBLOCK:[^\]]*\]\]", "", normalized)
     normalized = re.sub(r"\[\[PCTTS:[^\]]*\]\]", "", normalized)
     normalized = re.sub(r"<timer\b[^>]*>.*?</timer>", "", normalized, flags=re.IGNORECASE | re.DOTALL)
     normalized = re.sub(r"<tts\b[^>]*>.*?</tts>", "", normalized, flags=re.IGNORECASE | re.DOTALL)
-    normalized = _strip_nonstandard_chat_control_tags(normalized)
-    normalized = re.sub(r"\s+", " ", normalized).strip()
+    normalized = _strip_nonstandard_chat_control_tags(
+        normalized,
+        preserve_whitespace=True,
+    )
+    if not original.startswith("\n"):
+        normalized = normalized.lstrip("\n")
+    if not original.endswith("\n"):
+        normalized = normalized.rstrip("\n")
     return normalized
 
 
@@ -713,23 +726,59 @@ def _has_history_media_marker(text: Any) -> bool:
     )
 
 
-def _strip_history_media_markers(text: Any) -> str:
+def _strip_history_media_markers(
+    text: Any,
+    *,
+    preserve_whitespace: bool = False,
+) -> str:
     """Remove internal media metadata and legacy chat-like attachment notes."""
     normalized = str(text or "")
     had_marker = _has_history_media_marker(normalized)
+    legacy_pattern = re.compile(
+        r"[（(]\s*(?:(?:随消息)?发送(?:了)?\s*(?:(?:一张|\d+\s*张)\s*图片|"
+        r"(?:一条|\d+\s*条)\s*语音)\s*(?:[，,]\s*)?)+[）)]"
+    )
+    for pattern in (
+        _HISTORY_MEDIA_MARKER_PATTERN,
+        _ESCAPED_HISTORY_MEDIA_MARKER_PATTERN,
+        legacy_pattern,
+    ):
+        flags = pattern.flags | re.MULTILINE
+        normalized = re.sub(
+            rf"(?<=[^\s])[ \t]+(?:{pattern.pattern})[ \t]+(?=[^\s])",
+            " ",
+            normalized,
+            flags=flags,
+        )
+    standalone_patterns = "|".join(
+        f"(?:{pattern.pattern})"
+        for pattern in (
+            _HISTORY_MEDIA_MARKER_PATTERN,
+            _ESCAPED_HISTORY_MEDIA_MARKER_PATTERN,
+            legacy_pattern,
+        )
+    )
+    standalone_block = re.compile(
+        rf"^(?:[ \t]*(?:{standalone_patterns})[ \t]*(?:\n|$))+",
+        flags=re.IGNORECASE | re.MULTILINE,
+    )
+
+    def remove_standalone_block(match: re.Match[str]) -> str:
+        has_visible_before = bool(normalized[: match.start()].rstrip("\n"))
+        has_visible_after = bool(normalized[match.end() :].lstrip("\n"))
+        return "\n" if has_visible_before and has_visible_after else ""
+
+    normalized = standalone_block.sub(remove_standalone_block, normalized)
     normalized = _HISTORY_MEDIA_MARKER_PATTERN.sub("", normalized)
     normalized = _ESCAPED_HISTORY_MEDIA_MARKER_PATTERN.sub("", normalized)
-    normalized = re.sub(
-        r"[（(]\s*(?:(?:随消息)?发送(?:了)?\s*(?:(?:一张|\d+\s*张)\s*图片|"
-        r"(?:一条|\d+\s*条)\s*语音)\s*(?:[，,]\s*)?)+[）)]",
-        "",
-        normalized,
-    )
+    normalized = legacy_pattern.sub("", normalized)
+    if had_marker:
+        normalized = re.sub(r"(?<!\w)[（(]\s*[）)]", "", normalized)
+    if preserve_whitespace:
+        return normalized
     normalized = re.sub(r"[ \t]+([，,。！？!?；;：:、~～…])", r"\1", normalized)
     normalized = re.sub(r"\n[ \t]+", "\n", normalized)
     normalized = re.sub(r"\n{3,}", "\n\n", normalized)
-    if had_marker:
-        normalized = re.sub(r"(?<!\w)[（(]\s*[）)]", "", normalized)
     return normalized.strip()
 
 
@@ -790,7 +839,11 @@ def _strip_group_member_safety_markers(text: Any) -> str:
     return normalized
 
 
-def _strip_nonstandard_chat_control_tags(text: Any) -> str:
+def _strip_nonstandard_chat_control_tags(
+    text: Any,
+    *,
+    preserve_whitespace: bool = False,
+) -> str:
     """Remove leaked pseudo-control tags such as <bubble/> without touching media blocks."""
     normalized = str(text or "")
     if not normalized:
@@ -803,10 +856,11 @@ def _strip_nonstandard_chat_control_tags(text: Any) -> str:
     normalized = _NONSTANDARD_SELF_CLOSING_TAG_PATTERN.sub("", normalized)
     normalized = _ESCAPED_NONSTANDARD_SELF_CLOSING_TAG_PATTERN.sub("", normalized)
     normalized = _LEAKED_CHAT_EMOTION_CONTROL_PATTERN.sub("", normalized)
-    normalized = re.sub(r"\s+([，,。！？!?；;：:、~～…])", r"\1", normalized)
-    normalized = re.sub(r"([（(【\[])\s+", r"\1", normalized)
-    normalized = re.sub(r"\s+([）)】\]])", r"\1", normalized)
-    normalized = re.sub(r"[ \t]{2,}", " ", normalized)
+    if not preserve_whitespace:
+        normalized = re.sub(r"\s+([，,。！？!?；;：:、~～…])", r"\1", normalized)
+        normalized = re.sub(r"([（(【\[])\s+", r"\1", normalized)
+        normalized = re.sub(r"\s+([）)】\]])", r"\1", normalized)
+        normalized = re.sub(r"[ \t]{2,}", " ", normalized)
     return normalized
 
 
@@ -827,7 +881,8 @@ def _strip_outbound_control_blocks(
     preserve_private_tts_tokens: bool = False,
     allowed_private_tts_tokens: set[str] | None = None,
 ) -> str:
-    normalized = str(text or "")
+    original = str(text or "").replace("\r\n", "\n").replace("\r", "\n")
+    normalized = original
     normalized = _strip_personality_sync_blocks(normalized)
     normalized = _strip_group_member_safety_markers(normalized)
     # Strip reasoning/thinking chain content BEFORE _strip_history_media_markers,
@@ -880,7 +935,13 @@ def _strip_outbound_control_blocks(
         flags=re.IGNORECASE,
     )
     normalized = re.sub(r"<reasoning[^>]*>.*?</reasoning>", "", normalized, flags=re.IGNORECASE | re.DOTALL)
-    normalized = _strip_history_media_markers(normalized)
+    normalized = _strip_history_media_markers(normalized, preserve_whitespace=True)
+    normalized = re.sub(
+        rf"(?m)^[ \t]*{_PHOTO_TOOL_SILENT_SENTINEL_PATTERN.pattern}[ \t]*(?:\n|$)",
+        "",
+        normalized,
+        flags=_PHOTO_TOOL_SILENT_SENTINEL_PATTERN.flags | re.MULTILINE,
+    )
     normalized = _PHOTO_TOOL_SILENT_SENTINEL_PATTERN.sub("", normalized)
     normalized = re.sub(r"\[\[TTSBLOCK:[^\]]*\]\]", "", normalized)
     if preserve_private_tts_tokens and allowed_private_tts_tokens:
@@ -894,8 +955,14 @@ def _strip_outbound_control_blocks(
     elif not preserve_private_tts_tokens:
         normalized = re.sub(r"\[\[PCTTS:[^\]]*\]\]", "", normalized)
     normalized = re.sub(r"<timer\b[^>]*>.*?</timer>", "", normalized, flags=re.IGNORECASE | re.DOTALL)
-    normalized = _strip_nonstandard_chat_control_tags(normalized)
-    normalized = re.sub(r"\n{3,}", "\n\n", normalized).strip()
+    normalized = _strip_nonstandard_chat_control_tags(
+        normalized,
+        preserve_whitespace=True,
+    )
+    if not original.startswith("\n"):
+        normalized = normalized.lstrip("\n")
+    if not original.endswith("\n"):
+        normalized = normalized.rstrip("\n")
     return normalized
 
 

--- a/main.py
+++ b/main.py
@@ -10808,12 +10808,17 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             # TTS/reaction paths) may enter the optional splitter; otherwise a
             # response from an unrelated plugin would be rewritten here.
             return
-        if getattr(result, "use_t2i_", None) or getattr(result, "use_markdown_", None):
+        if getattr(result, "use_t2i_", None):
             return
         if not self._segmented_platform_allows(event=event):
             return
         if not chain:
             return
+        markdown_mode = getattr(result, "use_markdown_", None)
+        try:
+            setattr(event, "_private_companion_segmented_markdown_mode", markdown_mode)
+        except Exception:
+            pass
         chunks, changed, text = self._segment_llm_reply_chain(event, chain)
         if not chunks or not text:
             return
@@ -10823,7 +10828,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         )
         if len(chunks) <= 1:
             if changed:
-                event.set_result(self._build_result_from_chain(chunks[0]))
+                event.set_result(self._segmented_result_from_chain(event, chunks[0]))
             return
         llm_segment_count = max(0, _safe_int(getattr(event, "_private_companion_llm_segment_count", 0), 0, 0))
         logger.debug(
@@ -10842,6 +10847,10 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         plain_segments = self._plain_text_segments_from_chunks(chunks)
         if (
             not has_reaction_intent
+            and not bool(markdown_mode)
+            and not bool(
+                getattr(event, "_private_companion_segmented_markdown_detected", False)
+            )
             and plain_segments
             and len(plain_segments) == len(chunks)
             and await self._send_segmented_event_forward_message(
@@ -10858,7 +10867,7 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             event.set_result(empty_result)
             event.stop_event()
             return
-        event.set_result(self._build_result_from_chain(chunks[0]))
+        event.set_result(self._segmented_result_from_chain(event, chunks[0]))
         if runtime_persona_setting(self, 'enable_daily_case_review_experiment', False):
             self._record_daily_review_outbound_case(event, chunks[0])
         activity_baseline = time.time()
@@ -10914,6 +10923,31 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
         if not body or any(not isinstance(comp, Plain) for comp in body):
             return ""
         return "".join(str(getattr(comp, "text", "") or "") for comp in body).strip()
+
+    def _segmented_result_from_chain(
+        self,
+        event: AstrMessageEvent,
+        chain: list[Any],
+    ) -> Any:
+        result = self._build_result_from_chain(chain)
+        markdown_mode = getattr(
+            event,
+            "_private_companion_segmented_markdown_mode",
+            None,
+        )
+        if markdown_mode is None:
+            return result
+        try:
+            setter = getattr(result, "use_markdown", None)
+            if callable(setter):
+                updated = setter(bool(markdown_mode))
+                if updated is not None:
+                    result = updated
+            elif hasattr(result, "use_markdown_"):
+                result.use_markdown_ = bool(markdown_mode)
+        except Exception:
+            pass
+        return result
 
     def _private_plain_result_allows_segmenting(
         self,
@@ -11598,10 +11632,18 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
             if not accepted:
                 raise RuntimeError("主动分段补发未被平台接受")
             return "platform"
-        try:
-            await event.send(event.chain_result(chain))
-        except Exception:
-            await event.send(self._build_result_from_chain(chain))
+        markdown_mode = getattr(
+            event,
+            "_private_companion_segmented_markdown_mode",
+            None,
+        )
+        if markdown_mode is not None:
+            await event.send(self._segmented_result_from_chain(event, chain))
+        else:
+            try:
+                await event.send(event.chain_result(chain))
+            except Exception:
+                await event.send(self._build_result_from_chain(chain))
         return "event"
 
     async def _send_segmented_llm_chain_remainder(
@@ -11795,7 +11837,9 @@ wakeup_type={_single_line(wakeup.get('type'), 40)} score={_single_line(wakeup.ge
                         )
                         return
                     try:
-                        await event.send(self._build_result_from_chain(outbound_chunk))
+                        await event.send(
+                            self._segmented_result_from_chain(event, outbound_chunk)
+                        )
                         if case_id:
                             self._update_daily_review_case(
                                 case_id,

--- a/markdown_segment_guard.py
+++ b/markdown_segment_guard.py
@@ -87,12 +87,14 @@ def _merge_ranges(ranges: list[tuple[int, int]]) -> list[tuple[int, int]]:
 
 
 def _exclude_trailing_line_ending(text: str, start: int, end: int) -> int:
-    if end <= start:
-        return end
-    if text[max(start, end - 2) : end] == "\r\n":
-        return end - 2
-    if text[end - 1 : end] in {"\n", "\r"}:
-        return end - 1
+    while end > start:
+        if text[max(start, end - 2) : end] == "\r\n":
+            end -= 2
+            continue
+        if text[end - 1 : end] in {"\n", "\r"}:
+            end -= 1
+            continue
+        break
     return end
 
 

--- a/markdown_segment_guard.py
+++ b/markdown_segment_guard.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+try:
+    from markdown_it import MarkdownIt
+except Exception:  # pragma: no cover - exercised by the conservative fallback
+    MarkdownIt = None  # type: ignore[assignment]
+
+
+MARKDOWN_BLOCK_TOKEN_PATTERN = r"\x00PCMARKDOWNBLOCK[0-9]+\x00"
+_MARKDOWN_BLOCK_TOKEN_RE = re.compile(MARKDOWN_BLOCK_TOKEN_PATTERN)
+_MARKDOWN_HINT_RE = re.compile(
+    r"(?m)(?:^[ ]{0,3}(?:#{1,6}[ \t]+|>|(?:[-+*]|\d+[.)])[ \t]+|```|~~~)|"
+    r"^[ ]{0,3}\|.*\|[ \t]*$|"
+    r"(?:`[^`\n]+`|!?\[[^\]\n]+\]\([^\n)]+\)|\*\*[^*\n]+\*\*|__[^_\n]+__))"
+)
+
+_ATOMIC_BLOCK_TYPES = frozenset(
+    {
+        "blockquote_open",
+        "bullet_list_open",
+        "ordered_list_open",
+        "table_open",
+        "fence",
+        "code_block",
+        "html_block",
+        "heading_open",
+        "hr",
+    }
+)
+_STRUCTURED_INLINE_TYPES = frozenset(
+    {
+        "code_inline",
+        "em_open",
+        "strong_open",
+        "s_open",
+        "link_open",
+        "image",
+        "html_inline",
+        "hardbreak",
+    }
+)
+
+
+@dataclass(frozen=True)
+class MarkdownProtection:
+    protected_text: str
+    replacements: tuple[tuple[str, str], ...] = ()
+
+    @property
+    def active(self) -> bool:
+        return bool(self.replacements)
+
+    def restore(self, value: Any) -> str:
+        restored = str(value or "")
+        for token, original in self.replacements:
+            restored = restored.replace(token, original)
+        return restored
+
+    @staticmethod
+    def contains_token(value: Any) -> bool:
+        return bool(_MARKDOWN_BLOCK_TOKEN_RE.search(str(value or "")))
+
+
+def _line_offsets(text: str) -> list[int]:
+    offsets = [0]
+    for match in re.finditer(r"\r\n|\r|\n", text):
+        offsets.append(match.end())
+    if offsets[-1] < len(text):
+        offsets.append(len(text))
+    return offsets
+
+
+def _merge_ranges(ranges: list[tuple[int, int]]) -> list[tuple[int, int]]:
+    merged: list[list[int]] = []
+    for start, end in sorted(ranges):
+        if start >= end:
+            continue
+        if merged and start <= merged[-1][1]:
+            merged[-1][1] = max(merged[-1][1], end)
+        else:
+            merged.append([start, end])
+    return [(start, end) for start, end in merged]
+
+
+def _exclude_trailing_line_ending(text: str, start: int, end: int) -> int:
+    if end <= start:
+        return end
+    if text[max(start, end - 2) : end] == "\r\n":
+        return end - 2
+    if text[end - 1 : end] in {"\n", "\r"}:
+        return end - 1
+    return end
+
+
+def _token_line_ranges(text: str) -> list[tuple[int, int]]:
+    if MarkdownIt is None:
+        return [(0, len(text))] if _MARKDOWN_HINT_RE.search(text) else []
+    try:
+        parser = MarkdownIt("commonmark").enable("table")
+        tokens = parser.parse(text)
+    except Exception:
+        return [(0, len(text))] if _MARKDOWN_HINT_RE.search(text) else []
+
+    line_offsets = _line_offsets(text)
+    line_count = len(line_offsets) - 1
+    line_ranges: list[tuple[int, int]] = []
+    for token in tokens:
+        token_map = getattr(token, "map", None)
+        if (
+            not isinstance(token_map, list)
+            or len(token_map) != 2
+            or not all(isinstance(item, int) for item in token_map)
+        ):
+            continue
+        start_line = max(0, min(line_count, token_map[0]))
+        end_line = max(start_line, min(line_count, token_map[1]))
+        if start_line >= end_line:
+            continue
+        protect = str(getattr(token, "type", "") or "") in _ATOMIC_BLOCK_TYPES
+        if str(getattr(token, "type", "") or "") == "inline":
+            child_types = {
+                str(getattr(child, "type", "") or "")
+                for child in (getattr(token, "children", None) or [])
+            }
+            protect = bool(child_types & _STRUCTURED_INLINE_TYPES)
+        if protect:
+            start = line_offsets[start_line]
+            end = _exclude_trailing_line_ending(
+                text,
+                start,
+                line_offsets[end_line],
+            )
+            line_ranges.append((start, end))
+
+    # Reference definitions are intentionally absent from rendered token streams.
+    for line_index in range(line_count):
+        line = text[line_offsets[line_index] : line_offsets[line_index + 1]]
+        if re.match(r"^[ ]{0,3}\[[^\]\n]+\]:[ \t]*\S+", line):
+            start = line_offsets[line_index]
+            end = _exclude_trailing_line_ending(text, start, start + len(line))
+            line_ranges.append((start, end))
+    return _merge_ranges(line_ranges)
+
+
+def protect_markdown_blocks(text: Any) -> MarkdownProtection:
+    source = str(text or "")
+    if not source:
+        return MarkdownProtection(source)
+    ranges = _token_line_ranges(source)
+    if not ranges:
+        return MarkdownProtection(source)
+
+    parts: list[str] = []
+    replacements: list[tuple[str, str]] = []
+    cursor = 0
+    for index, (start, end) in enumerate(ranges):
+        token = f"\x00PCMARKDOWNBLOCK{index}\x00"
+        parts.append(source[cursor:start])
+        parts.append(token)
+        replacements.append((token, source[start:end]))
+        cursor = end
+    parts.append(source[cursor:])
+    return MarkdownProtection("".join(parts), tuple(replacements))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ aiohttp>=3.9,<4
 Pillow>=10,<13
 chinese-calendar>=1.9.2
 lunarcalendar>=0.0.9
+markdown-it-py>=3,<5

--- a/segmented_message.py
+++ b/segmented_message.py
@@ -120,11 +120,12 @@ def split_llm_controlled_text(text: Any, *, marker: str = LLM_SEGMENT_MARKER) ->
 
 def _replace_reserved_tokens(value: str, *, marker: str) -> tuple[str, dict[str, int]]:
     counts = {"escaped": 0, "placeholder": 0, "marker": 0}
+    replacement_token = "\x00PRIVATE_COMPANION_SEGMENT_TOKEN\x00"
 
     def replace(pattern: re.Pattern[str], key: str, source: str) -> str:
         def repl(_match: re.Match[str]) -> str:
             counts[key] += 1
-            return " "
+            return replacement_token
 
         return pattern.sub(repl, source)
 
@@ -141,7 +142,18 @@ def _replace_reserved_tokens(value: str, *, marker: str) -> tuple[str, dict[str,
         else re.compile(re.escape(marker), flags=re.IGNORECASE)
     )
     cleaned = replace(marker_pattern, "marker", cleaned)
-    cleaned = re.sub(r"[ \t]{2,}", " ", cleaned)
+    if any(counts.values()):
+        token_pattern = re.escape(replacement_token)
+        cleaned = re.sub(
+            rf"(?<=[^\s])[ \t]*(?:{token_pattern}[ \t]*)+(?=[^\s])",
+            " ",
+            cleaned,
+        )
+        cleaned = re.sub(
+            rf"[ \t]*(?:{token_pattern}[ \t]*)+",
+            "",
+            cleaned,
+        )
     return cleaned, counts
 
 
@@ -160,10 +172,28 @@ def parse_llm_segment_control(
     normalized = str(text or "").replace("\r\n", "\n").replace("\r", "\n")
     marker = str(marker or LLM_SEGMENT_MARKER).strip()
     if not normalized or not marker:
-        cleaned = normalized.strip()
         return LlmSegmentParseResult(
-            segments=(cleaned,) if cleaned else (),
-            sanitized_text=cleaned,
+            segments=(normalized,) if normalized else (),
+            sanitized_text=normalized,
+            boundary_kinds=(),
+        )
+    marker_pattern = (
+        _SPACED_LLM_SEGMENT_MARKER_PATTERN
+        if marker == LLM_SEGMENT_MARKER
+        else re.compile(re.escape(marker), flags=re.IGNORECASE)
+    )
+    if not any(
+        pattern.search(normalized)
+        for pattern in (
+            _ESCAPED_LLM_SEGMENT_MARKER_PATTERN,
+            _MARKDOWN_ESCAPED_LLM_SEGMENT_MARKER_PATTERN,
+            _PLACEHOLDER_PATTERN,
+            marker_pattern,
+        )
+    ):
+        return LlmSegmentParseResult(
+            segments=(normalized,),
+            sanitized_text=normalized,
             boundary_kinds=(),
         )
 
@@ -182,9 +212,9 @@ def parse_llm_segment_control(
 
     def append_current() -> bool:
         nonlocal pending_boundary, exact_count, recovered_count
-        body = "\n".join(current).strip()
+        body = "\n".join(current).strip("\n")
         current.clear()
-        if not body:
+        if not body.strip():
             return False
         if segments and pending_boundary:
             boundary_kinds.append(pending_boundary)
@@ -233,7 +263,7 @@ def parse_llm_segment_control(
             quoted_count += token_count
             if token_count and not cleaned.lstrip("> ").strip():
                 cleaned = ""
-        current.append(cleaned.rstrip())
+        current.append(cleaned)
         fence_state = next_fence_state
 
     appended_final = append_current()
@@ -247,8 +277,7 @@ def parse_llm_segment_control(
         recovered_count = 0
         boundary_kinds = []
 
-    sanitized = "\n".join(segments).strip()
-    sanitized = re.sub(r"\n{3,}", "\n\n", sanitized)
+    sanitized = "\n".join(segments).strip("\n")
     return LlmSegmentParseResult(
         segments=tuple(segments) if controlled else ((sanitized,) if sanitized else ()),
         sanitized_text=sanitized,

--- a/tests/test_markdown_safe_segmenting.py
+++ b/tests/test_markdown_safe_segmenting.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, Mock, patch
+
+from astrbot.api.message_components import Plain
+from astrbot.core.message.message_event_result import (
+    MessageEventResult,
+    ResultContentType,
+)
+from markdown_it import MarkdownIt
+
+from astrbot_plugin_private_companion.event_dispatch import EventDispatchMixin
+from astrbot_plugin_private_companion.main import PrivateCompanionPlugin
+from astrbot_plugin_private_companion.markdown_segment_guard import (
+    protect_markdown_blocks,
+)
+from astrbot_plugin_private_companion.proactive_message import ProactiveMessageMixin
+from astrbot_plugin_private_companion.segmented_message import LLM_SEGMENT_MARKER
+
+
+class _Event:
+    unified_msg_origin = "QBot4012710235:GroupMessage:group-id"
+
+
+class _Harness(ProactiveMessageMixin, EventDispatchMixin):
+    def __init__(self) -> None:
+        self.enable_segmented_proactive_reply = True
+        self.enable_llm_controlled_segmenting = True
+        self.enable_segmented_plugin_rules = True
+        self.enable_segmented_proactive_chat_profiles = False
+        self.segmented_proactive_scope = "all_llm"
+        self.segmented_proactive_chat_scope = "all"
+        self.segmented_proactive_threshold = 500
+        self.segmented_proactive_min_segment_chars = 1
+        self.segmented_proactive_max_segments = 5
+        self.segmented_proactive_split_mode = "words"
+        self.segmented_proactive_split_words = ["。", "？", "！", "…"]
+        self.segmented_proactive_match_width_variants = False
+        self.segmented_proactive_regex = r".*?[。？！~…\n]+|.+$"
+        self.enable_segmented_proactive_content_cleanup = False
+        self.segmented_proactive_content_cleanup_scope = "all"
+        self.segmented_proactive_content_cleanup_rule = r"[\n。*]"
+        self.segmented_proactive_content_cleanup_words = ["\n", "。", "*"]
+        self.enable_segmented_proactive_content_replacement = False
+        self.segmented_proactive_content_replacements: list[str] = []
+
+    def _feature_enabled_or_temp_unlocked(
+        self,
+        key: str,
+        default: bool = False,
+    ) -> bool:
+        return bool(getattr(self, key, default))
+
+    @staticmethod
+    def _segmented_scope_allows_event(_event: object) -> bool:
+        return True
+
+    @staticmethod
+    def _segmented_scope_allows_umo(_umo: str) -> bool:
+        return True
+
+    @staticmethod
+    def _segmented_platform_allows(**_kwargs: object) -> bool:
+        return True
+
+
+class MarkdownSafeSegmentingTests(unittest.TestCase):
+    quote = (
+        "> 银月当空，夜色正浓。\n"
+        "> 别以为这种小把戏就能难住本小姐。"
+    )
+    quote_list = (
+        "> * 狐耳状态：微微抖动，带着一丝被打扰的不满\n"
+        "> * 尾巴状态：修长蓬松，随意搭在身侧，偶尔轻轻点地\n"
+        "> * 今日评价：**还算让我满意。**"
+    )
+    source = (
+        "……哈？又来这套。拿我当什么测试工具了？\n\n"
+        "行吧，既然你非要看，那就勉强满足你一次。\n\n"
+        f"{quote}\n\n{quote_list}\n\n"
+        "别得意太早，下不为例。"
+    )
+
+    def test_protection_round_trip_preserves_exact_markdown(self) -> None:
+        protection = protect_markdown_blocks(self.source)
+
+        self.assertTrue(protection.active)
+        self.assertNotIn(self.quote, protection.protected_text)
+        self.assertNotIn(self.quote_list, protection.protected_text)
+        self.assertEqual(self.source, protection.restore(protection.protected_text))
+
+    def test_protection_round_trip_preserves_crlf(self) -> None:
+        source = "> 引用一。\r\n> 引用二。\r\n\r\n普通正文。"
+        protection = protect_markdown_blocks(source)
+
+        self.assertTrue(protection.active)
+        self.assertEqual(source, protection.restore(protection.protected_text))
+
+    def test_words_and_regex_split_only_outside_markdown_blocks(self) -> None:
+        renderer = MarkdownIt("commonmark")
+        for mode in ("words", "regex"):
+            with self.subTest(mode=mode):
+                harness = _Harness()
+                harness.segmented_proactive_split_mode = mode
+                event = _Event()
+
+                segments = harness._split_proactive_text(self.source, event=event)
+
+                self.assertEqual(5, len(segments))
+                self.assertTrue(event._private_companion_segmented_markdown_detected)
+                self.assertEqual(1, sum(self.quote in item for item in segments))
+                self.assertEqual(1, sum(self.quote_list in item for item in segments))
+                self.assertFalse(any(">，" in item or ">," in item for item in segments))
+                self.assertFalse(any("PCMARKDOWNBLOCK" in item for item in segments))
+                quote_segment = next(item for item in segments if self.quote in item)
+                list_segment = next(item for item in segments if self.quote_list in item)
+                self.assertIn(renderer.render(self.quote), renderer.render(quote_segment))
+                self.assertIn(renderer.render(self.quote_list), renderer.render(list_segment))
+
+    def test_fenced_and_unclosed_code_blocks_are_atomic(self) -> None:
+        for closing in ("```\n\n结尾。", ""):
+            with self.subTest(closed=bool(closing)):
+                harness = _Harness()
+                harness.segmented_proactive_max_segments = 4
+                code = "```python\nif value:\n    print('。')\n"
+                source = f"开场一。开场二。\n\n{code}{closing}"
+
+                segments = harness._split_proactive_text(source, event=_Event())
+
+                containing = [item for item in segments if "```python" in item]
+                self.assertEqual(1, len(containing))
+                self.assertIn("if value:\n    print('。')", containing[0])
+                if closing:
+                    self.assertIn("```", containing[0][3:])
+
+    def test_nested_lists_tables_and_inline_markup_are_atomic(self) -> None:
+        harness = _Harness()
+        harness.segmented_proactive_max_segments = 6
+        nested_list = "- 一级。\n  - 二级。\n- 末项。"
+        table = "| A | B |\n|---|---|\n| 1。 | 2。 |"
+        inline = "保留 `code。value`、[链接。](https://example.com/a.b) 和 **加粗。**。"
+        source = f"开场。\n\n{nested_list}\n\n{table}\n\n{inline}\n\n结尾。"
+
+        segments = harness._split_proactive_text(source, event=_Event())
+
+        for markdown in (nested_list, table, inline):
+            self.assertEqual(1, sum(markdown in item for item in segments))
+        self.assertFalse(any("|，|" in item for item in segments))
+
+    def test_missing_parser_fails_closed_for_markdown_shaped_text(self) -> None:
+        source = "普通一。\n\n> 引用一。\n> 引用二。\n\n普通二。"
+        with patch(
+            "astrbot_plugin_private_companion.markdown_segment_guard.MarkdownIt",
+            None,
+        ):
+            protection = protect_markdown_blocks(source)
+
+        self.assertTrue(protection.active)
+        self.assertEqual(1, len(protection.replacements))
+        self.assertEqual(source, protection.restore(protection.protected_text))
+
+    def test_cleanup_and_replacement_do_not_rewrite_markdown_blocks(self) -> None:
+        harness = _Harness()
+        harness.enable_segmented_proactive_content_cleanup = True
+        harness.enable_segmented_proactive_content_replacement = True
+        harness.segmented_proactive_content_replacements = ["引用=>替换"]
+        markdown = "> **引用。**\n> * 引用。"
+        source = f"普通引用。\n\n{markdown}\n\n结尾引用。"
+
+        segments = harness._split_proactive_text(source, event=_Event())
+
+        markdown_segment = next(item for item in segments if markdown in item)
+        self.assertIn(markdown, markdown_segment)
+        self.assertTrue(any("普通替换" in item for item in segments))
+        self.assertTrue(any("结尾替换" in item for item in segments))
+
+    def test_llm_boundaries_keep_priority_and_markdown_uses_remaining_budget(self) -> None:
+        harness = _Harness()
+        harness.segmented_proactive_max_segments = 4
+        source = (
+            f"普通一。普通二。\n{LLM_SEGMENT_MARKER}\n"
+            "> 引用一。\n> 引用二。"
+        )
+        event = _Event()
+
+        segments = PrivateCompanionPlugin._split_llm_controlled_text_for_event(
+            harness,
+            event,
+            source,
+        )
+
+        self.assertEqual(3, len(segments))
+        self.assertEqual(2, event._private_companion_llm_segment_count)
+        self.assertEqual(1, sum("> 引用一。\n> 引用二。" in item for item in segments))
+
+    def test_explicit_markdown_result_is_segmented_and_mode_is_inherited(self) -> None:
+        plugin = PrivateCompanionPlugin.__new__(PrivateCompanionPlugin)
+        plugin.enabled = True
+        plugin.enable_segmented_proactive_reply = True
+        plugin.enable_llm_controlled_segmenting = False
+        plugin.enable_segmented_plugin_rules = True
+        plugin.enable_segmented_proactive_chat_profiles = False
+        plugin.segmented_proactive_scope = "all_llm"
+        plugin.segmented_proactive_chat_scope = "all"
+        plugin.segmented_proactive_threshold = 500
+        plugin.segmented_proactive_min_segment_chars = 1
+        plugin.segmented_proactive_max_segments = 3
+        plugin.segmented_proactive_split_mode = "words"
+        plugin.segmented_proactive_split_words = ["。"]
+        plugin.segmented_proactive_match_width_variants = False
+        plugin.enable_segmented_proactive_content_cleanup = False
+        plugin.enable_segmented_proactive_content_replacement = False
+        plugin.enable_framework_error_leak_guard = False
+        plugin.enable_daily_case_review_experiment = False
+        plugin._proactive_only_blocks_passive_event = lambda *_args: False
+        plugin._feature_enabled_or_temp_unlocked = (
+            lambda key: key == "enable_segmented_proactive_reply"
+        )
+        plugin._segmented_scope_allows_event = lambda _event: True
+        plugin._segmented_platform_allows = lambda **_kwargs: True
+        plugin._restore_response_review_meta_leak_before_send = lambda *_args: False
+        plugin._should_defer_segmenting_to_astrbot_tts = AsyncMock(return_value=False)
+        plugin._limit_private_routine_check_segments = lambda _text, chunks: chunks
+        plugin._plain_text_segments_from_chunks = lambda _chunks: []
+        plugin._create_lifecycle_background_task = Mock(
+            side_effect=lambda operation, **_kwargs: operation.close()
+        )
+        result = MessageEventResult(
+            chain=[Plain("普通一。\n\n> 引用一。\n> 引用二。\n\n普通二。")],
+            result_content_type=ResultContentType.LLM_RESULT,
+        )
+        result.use_markdown(True)
+
+        class Event(_Event):
+            message_str = "测试 Markdown 分段"
+
+            def __init__(self) -> None:
+                self.result = result
+
+            def get_result(self) -> MessageEventResult:
+                return self.result
+
+            def set_result(self, value: MessageEventResult) -> None:
+                self.result = value
+
+        event = Event()
+        asyncio.run(
+            PrivateCompanionPlugin.apply_segmented_llm_reply_scope(plugin, event)
+        )
+
+        self.assertTrue(event.result.use_markdown_)
+        self.assertIn("普通一。", event.result.chain[0].text)
+        plugin._create_lifecycle_background_task.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_markdown_safe_segmenting.py
+++ b/tests/test_markdown_safe_segmenting.py
@@ -119,6 +119,16 @@ class MarkdownSafeSegmentingTests(unittest.TestCase):
                 self.assertIn(renderer.render(self.quote), renderer.render(quote_segment))
                 self.assertIn(renderer.render(self.quote_list), renderer.render(list_segment))
 
+    def test_budget_merge_uses_one_markdown_paragraph_boundary(self) -> None:
+        harness = _Harness()
+        harness.segmented_proactive_max_segments = 3
+
+        segments = harness._split_proactive_text(self.source, event=_Event())
+
+        self.assertEqual(3, len(segments))
+        self.assertIn(f"{self.quote_list}\n\n别得意太早", segments[-1])
+        self.assertNotIn(f"{self.quote_list}\n\n\n", segments[-1])
+
     def test_fenced_and_unclosed_code_blocks_are_atomic(self) -> None:
         for closing in ("```\n\n结尾。", ""):
             with self.subTest(closed=bool(closing)):

--- a/tests/test_structured_whitespace_preservation.py
+++ b/tests/test_structured_whitespace_preservation.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import asyncio
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+from astrbot.api.message_components import Plain
+from astrbot.core.message.message_event_result import (
+    MessageEventResult,
+    ResultContentType,
+)
+from markdown_it import MarkdownIt
+
+from astrbot_plugin_private_companion.helpers import (
+    _strip_internal_message_blocks,
+    _strip_outbound_control_blocks,
+)
+from astrbot_plugin_private_companion.main import (
+    PrivateCompanionPlugin,
+    _strip_chain_plain_thinking,
+)
+from astrbot_plugin_private_companion.segmented_message import (
+    LLM_SEGMENT_MARKER,
+    parse_llm_segment_control,
+    sanitize_llm_segment_control_tokens,
+)
+
+
+class StructuredWhitespacePreservationTests(unittest.TestCase):
+    def test_control_cleaners_only_normalize_line_endings(self) -> None:
+        source = (
+            "\r\n# 标题\r\n\r\n"
+            "- 一级列表  \r\n"
+            "  - 二级列表\r"
+            "\t保留 Tab\n"
+            "普通  连续空格\n"
+            "不换行\u00a0空格｜全角\u3000空格｜行\u2028分隔｜段\u2029分隔\r\n"
+        )
+        expected = source.replace("\r\n", "\n").replace("\r", "\n")
+
+        self.assertEqual(expected, _strip_internal_message_blocks(source))
+        self.assertEqual(expected, _strip_outbound_control_blocks(source))
+
+    def test_markdown_rendering_is_unchanged_after_cleanup(self) -> None:
+        source = (
+            "# 标题\r\n\r\n"
+            "> 引用第一行  \r\n"
+            "> 引用第二行\r\n\r\n"
+            "- 一级列表\r\n"
+            "  - 二级列表\r\n\r\n"
+            "```python\r\n"
+            "if value:\r\n"
+            "\tprint(\"tab\")\r\n"
+            "    print(\"spaces\")\r\n"
+            "```\r\n\r\n"
+            "| A | B |\r\n"
+            "|---|---|\r\n"
+            "| 1 | 2 |"
+        )
+        normalized = source.replace("\r\n", "\n").replace("\r", "\n")
+        cleaned = _strip_outbound_control_blocks(source)
+
+        self.assertEqual(normalized, cleaned)
+        self.assertEqual(
+            MarkdownIt("commonmark").enable("table").render(normalized),
+            MarkdownIt("commonmark").enable("table").render(cleaned),
+        )
+
+    def test_segment_token_sanitizer_preserves_unrelated_whitespace(self) -> None:
+        source = (
+            "\r\n- 一级列表\r\n"
+            "  - 二级列表\r\n"
+            "```python\r\n"
+            "\tprint(\"tab\")\r\n"
+            "    print(\"spaces\")\r\n"
+            "```\r\n"
+            "普通  连续空格\u00a0不换行空格\r\n"
+        )
+        expected = source.replace("\r\n", "\n").replace("\r", "\n")
+
+        self.assertEqual(expected, sanitize_llm_segment_control_tokens(source))
+
+    def test_segment_parser_preserves_markdown_inside_each_segment(self) -> None:
+        first = (
+            "> 引用第一行  \r\n"
+            "> 引用第二行\r\n\r\n"
+            "- 一级列表\r\n"
+            "  - 二级列表"
+        )
+        second = (
+            "```python\r\n"
+            "if value:\r\n"
+            "\tprint(\"tab\")\r\n"
+            "    print(\"spaces\")\r\n"
+            "```"
+        )
+        source = f"{first}\r\n{LLM_SEGMENT_MARKER}\r\n{second}"
+        expected = tuple(
+            part.replace("\r\n", "\n").replace("\r", "\n")
+            for part in (first, second)
+        )
+
+        parsed = parse_llm_segment_control(source)
+
+        self.assertTrue(parsed.controlled)
+        self.assertEqual(expected, parsed.segments)
+        markdown = MarkdownIt("commonmark")
+        self.assertEqual(
+            [markdown.render(value) for value in expected],
+            [markdown.render(value) for value in parsed.segments],
+        )
+
+    def test_cross_plain_thinking_cleanup_preserves_llm_boundaries(self) -> None:
+        chain = [
+            Plain("<thinking>内部推理"),
+            Plain(
+                "内容</thinking>\r\n"
+                f"第一段\r\n{LLM_SEGMENT_MARKER}\r\n第二段"
+            ),
+        ]
+
+        _strip_chain_plain_thinking(object(), chain)
+
+        self.assertEqual(
+            f"第一段\n{LLM_SEGMENT_MARKER}\n第二段",
+            chain[0].text,
+        )
+        self.assertEqual("", chain[1].text)
+        parsed = parse_llm_segment_control(chain[0].text)
+        self.assertTrue(parsed.controlled)
+        self.assertEqual(("第一段", "第二段"), parsed.segments)
+        self.assertEqual(1, parsed.exact_boundary_count)
+
+    def test_decorating_hook_keeps_llm_boundaries_before_plugin_rules(self) -> None:
+        plugin = PrivateCompanionPlugin.__new__(PrivateCompanionPlugin)
+        plugin.enabled = True
+        plugin.enable_segmented_proactive_reply = True
+        plugin.enable_llm_controlled_segmenting = True
+        plugin.enable_segmented_plugin_rules = True
+        plugin.enable_segmented_proactive_chat_profiles = False
+        plugin.segmented_proactive_scope = "all_llm"
+        plugin.segmented_proactive_chat_scope = "all"
+        plugin.segmented_proactive_threshold = 200
+        plugin.segmented_proactive_min_segment_chars = 8
+        plugin.segmented_proactive_max_segments = 5
+        plugin.segmented_proactive_split_mode = "words"
+        plugin.segmented_proactive_split_words = ["。", "？", "?", "！", "!", "…", "~"]
+        plugin.segmented_proactive_match_width_variants = False
+        plugin.enable_segmented_proactive_content_cleanup = True
+        plugin.segmented_proactive_content_cleanup_scope = "trailing"
+        plugin.segmented_proactive_content_cleanup_words = ["，", ",", "；", ";", "。"]
+        plugin.enable_segmented_proactive_content_replacement = False
+        plugin.enable_framework_error_leak_guard = False
+        plugin.enable_daily_case_review_experiment = False
+        plugin._proactive_only_blocks_passive_event = lambda *_args: False
+        plugin._feature_enabled_or_temp_unlocked = lambda key: key == "enable_segmented_proactive_reply"
+        plugin._segmented_scope_allows_event = lambda _event: True
+        plugin._segmented_platform_allows = lambda **_kwargs: True
+        plugin._restore_response_review_meta_leak_before_send = lambda *_args: False
+        plugin._should_defer_segmenting_to_astrbot_tts = AsyncMock(return_value=False)
+        plugin._limit_private_routine_check_segments = lambda _text, chunks: chunks
+        plugin._plain_text_segments_from_chunks = lambda _chunks: []
+        plugin._create_lifecycle_background_task = Mock(
+            side_effect=lambda operation, **_kwargs: operation.close()
+        )
+
+        source = (
+            f"……哈？\r\n{LLM_SEGMENT_MARKER}\r\n"
+            f"『尾巴嫌弃地一甩』\r\n{LLM_SEGMENT_MARKER}\r\n"
+            "满脑子只剩这些了？真没救了你"
+        )
+        result = MessageEventResult(
+            chain=[Plain(source)],
+            result_content_type=ResultContentType.LLM_RESULT,
+        )
+
+        class Event:
+            unified_msg_origin = "QBot4012710235:GroupMessage:group-id"
+            message_str = "测试"
+
+            def __init__(self) -> None:
+                self.result = result
+
+            def get_result(self) -> MessageEventResult:
+                return self.result
+
+            def set_result(self, value: MessageEventResult) -> None:
+                self.result = value
+
+        event = Event()
+        asyncio.run(
+            PrivateCompanionPlugin.apply_segmented_llm_reply_scope(plugin, event)
+        )
+
+        self.assertEqual(3, event._private_companion_llm_segment_count)
+        self.assertEqual(
+            {"exact": 2, "recovered": 0, "cleaned_only": 0},
+            event._private_companion_llm_segment_diagnostics,
+        )
+        self.assertEqual(["……哈？"], [item.text for item in event.result.chain])
+        plugin._create_lifecycle_background_task.assert_called_once()
+
+    def test_final_outbound_guard_preserves_markdown_layout(self) -> None:
+        source = (
+            "# 标题\r\n\r\n"
+            "- 一级列表\r\n"
+            "  - 二级列表\r\n\r\n"
+            "```python\r\n"
+            "if value:\r\n"
+            "\tprint(\"tab\")\r\n"
+            "    print(\"spaces\")\r\n"
+            "```"
+        )
+        expected = source.replace("\r\n", "\n").replace("\r", "\n")
+        plugin = PrivateCompanionPlugin.__new__(PrivateCompanionPlugin)
+        plugin.enabled = True
+        plugin.enable_tts_enhancement = False
+        result = SimpleNamespace(chain=[Plain(source)])
+        event = SimpleNamespace(
+            unified_msg_origin="QBot4012710235:GroupMessage:group-id",
+            get_result=lambda: result,
+        )
+
+        asyncio.run(plugin.final_strip_outbound_control_blocks_before_send(event))
+
+        self.assertEqual(expected, result.chain[0].text)
+        self.assertEqual(
+            MarkdownIt("commonmark").render(expected),
+            MarkdownIt("commonmark").render(result.chain[0].text),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

由于 `30f8c61` 引入的修改将 `_segment_llm_reply_chain()` 的逻辑进行了提前，以及 `_strip_chain_plain_thinking()` 中引入的清理机制对文本的清理过于暴力，破坏性太大，导致自主分段失效，以及输出内容中的 Markdown 格式破坏。

全局空白折叠最早由 `8784241`（`v2.2.0`）加入内部清理器，但当时尚未实现 LLM 自主分段，因此没有直接触发该问题。

本次回归的直接引入点是 `30f8c61`：

> `chore: 基于上游 6.4.2a 重建，仅保留本地三处 LLM 相关增强`

该提交在 `_segment_llm_reply_chain()` 的分段解析之前加入了：

```python
_strip_chain_plain_thinking(self, working_chain)
```

它复用了已有的全空白折叠清理器，从而在解析前破坏了独占行分段标记。后续 `03dede3` 又将相同清理提前到更多早期返回路径，但不是已启用分段路径首次出现问题的提交。

## 修改内容

- 内部控制内容清理只规范化 `CRLF/CR` 为 `LF`。
- 保留原始换行、Tab、连续空格、Unicode 空白和 Markdown 缩进。
- 删除内部控制标记时只清理标记附近产生的空白，不再改写整段文本。
- 保留 LLM 自主分段标记的独占行结构。
- 修复异常或转义分段标记的清理逻辑，避免标记进入最终消息和历史记录。
- 使用 Markdown 块级解析识别引用、列表、表格、标题、代码块和行内结构。
- 插件规则仅在 Markdown 结构外寻找分段点，不拆分结构内部内容。
- 达到分段数量上限需要合并时，使用 Markdown 段落边界连接，不再生成 `>，> *` 等损坏内容。
- 显式 Markdown 回复分段后，首段和后续补发消息继续继承 `use_markdown_`。
- Markdown 解析不可用或结构异常时采取保守策略，不在不确定区域执行插件规则分段。
- LLM 自主分段优先、插件规则使用剩余 `M-N` 预算的原有逻辑保持不变。
- LLM 自主分段超过插件上限时仍完整保留，不截断模型明确给出的边界。

## 兼容性

- 不改变LLM自主分段的协议格式。
- 不改变分段总开关、两个子开关及群聊/私聊范围配置。
- 不改变插件规则的标点、长度、最短段落和最大段数语义。
- 不升级人格配置版本。
- 增加 `markdown-it-py>=3,<5` 依赖，用于可靠获取 Markdown 块级行范围。

## 测试

使用 AstrBot Conda 环境完成：

- OneBot v11 与 QQ Official 真实事件类型模拟：14/14 场景通过。
- 覆盖 LLM 精确标记、纯插件规则、两级分段组合、剩余预算和自主分段超限。
- 覆盖引用、列表、嵌套列表、表格、标题、代码块、行内代码、链接和强调。
- 覆盖闭合及未闭合 Markdown 结构。
- 验证 Markdown 渲染结果、发送模式继承及内部占位符无泄漏。
- 使用 `gpt-5.6-luna` 完成 4 次真实 Provider 请求：
  - 两次明确短消息请求均正确输出自主分段标记；
  - 普通聊天和单条 Markdown 请求均未输出标记；
  - 后续插件规则处理符合预期。
- 专项测试：`85 passed, 23 subtests passed`
- 完整测试：`4432 passed, 32 failed, 1 skipped`
- `origin/main` 同环境基线中的 32 项既有失败未增加。
- `py_compile`、Ruff、架构检查、安装包校验及 `git diff --check` 通过。