### PR TITLE
fix: 全量转换模式下保留后处理模型生成的完整语音稿

### DIFF
--- a/tests/test_tts_postprocess_tag_guard.py
+++ b/tests/test_tts_postprocess_tag_guard.py
@@ -1022,6 +1022,67 @@ class TtsPostprocessTagGuardTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(source, markup)
         self.assertEqual("", fallback)
 
+    def test_full_postprocess_keeps_complete_authored_chinese_voice(self):
+        harness = _TtsHarness()
+        harness.tts_generation_mode = "postprocess"
+        harness.tts_conversion_scope = "full"
+        harness.tts_voice_language = "zh"
+        harness.tts_delivery_mode = "voice_and_text"
+        source = (
+            "mua~ mua~ 再来一个~ 嘿嘿 今天怎么这么黏人呀 不过我喜欢~ "
+            "你的亲亲我可都收好啦，甜到心里去咯~"
+        )
+        authored = (
+            "<tts>[kiss sound] 再来一个~ [happy]嘿嘿 今天怎么这么黏人呀 不过我喜欢~ "
+            "你的亲亲我可都收好啦，甜到心里去咯~</tts>"
+        )
+        markup = f"{authored}\n{source}"
+
+        result, fallback = harness._enforce_full_tts_scope_markup(
+            markup,
+            source_text=source,
+            prefer_authored_voice=True,
+        )
+
+        self.assertEqual(markup, result)
+        self.assertEqual("", fallback)
+
+    def test_full_postprocess_keeps_authored_voice_with_emotion_cue(self):
+        harness = _TtsHarness()
+        harness.tts_generation_mode = "postprocess"
+        harness.tts_conversion_scope = "full"
+        harness.tts_voice_language = "zh"
+        harness.tts_delivery_mode = "voice_and_text"
+        source = "嘿嘿 来啦来啦~ 这就拍给你看呀~"
+        authored = "<tts>[开心]嘿嘿 来啦来啦~ 这就拍给你看呀~</tts>"
+
+        result, fallback = harness._enforce_full_tts_scope_markup(
+            authored,
+            source_text=source,
+            prefer_authored_voice=True,
+        )
+
+        self.assertEqual(authored, result)
+        self.assertEqual("", fallback)
+
+    def test_full_postprocess_rebuilds_truncated_authored_chinese_voice(self):
+        harness = _TtsHarness()
+        harness.tts_generation_mode = "postprocess"
+        harness.tts_conversion_scope = "full"
+        harness.tts_voice_language = "zh"
+        harness.tts_delivery_mode = "voice_and_text"
+        source = "今天想和你一起去看晚霞，然后慢慢散步回家。"
+        authored = "<tts>今天想和你一起</tts>"
+
+        result, fallback = harness._enforce_full_tts_scope_markup(
+            authored,
+            source_text=source,
+            prefer_authored_voice=True,
+        )
+
+        self.assertEqual(f"<tts>{source}</tts>", result)
+        self.assertEqual(source, fallback)
+
     def test_full_chinese_scope_keeps_tagged_and_untagged_content(self):
         harness = _TtsHarness()
         harness.tts_generation_mode = "fast_tag"

--- a/tts_enhancement.py
+++ b/tts_enhancement.py
@@ -4171,6 +4171,7 @@ TTS 朗读文本：
             converted,
             source_text=source_text,
             event=event,
+            prefer_authored_voice=(mode == "postprocess"),
         )
         if visible_override or suppress_visible:
             try:
@@ -5152,6 +5153,7 @@ Provider 规则：{emotion_rule}
         *,
         source_text: str = "",
         event: Any = None,
+        prefer_authored_voice: bool = False,
     ) -> tuple[str, str]:
         """Turn any tagged full-scope reply into one structurally complete voice block."""
         normalized = self._normalize_tts_tags(str(text or ""))
@@ -5168,6 +5170,37 @@ Provider 规则：{emotion_rule}
             1600,
         )
         full_source = self._sanitize_tts_visible_text(source_text, max_chars=complete_limit)
+        if (
+            prefer_authored_voice
+            and voice_lang == "zh"
+            and full_source
+        ):
+            authored_matches = list(
+                re.finditer(
+                    r"<tts\b[^>]*>.*?</tts>",
+                    normalized,
+                    flags=re.IGNORECASE | re.DOTALL,
+                )
+            )
+            if (
+                len(authored_matches) == 1
+                and not normalized[: authored_matches[0].start()].strip()
+            ):
+                authored_units = self._tts_full_scope_content_units(
+                    authored_matches[0].group(0)
+                )
+                source_units = self._tts_full_scope_content_units(full_source)
+                if (
+                    authored_units
+                    and source_units
+                    and authored_units >= max(6, int(source_units * 0.7))
+                ):
+                    logger.info(
+                        "TTS全量后处理保留模型完整语音稿: spoken_units=%s source_units=%s",
+                        authored_units,
+                        source_units,
+                    )
+                    return normalized, ""
         if (
             not full_source
             and voice_lang != "zh"
@@ -5242,6 +5275,26 @@ Provider 规则：{emotion_rule}
         if not full_source:
             return normalized, ""
         return f"<tts>{full_source}</tts>", full_source
+
+    @staticmethod
+    def _tts_full_scope_content_units(text: Any) -> int:
+        """Count readable content units of a full-scope spoken draft after
+        removing markup and FishAudio control cues, for coverage comparison."""
+        source = str(text or "")
+        source = re.sub(
+            r"</?(?:pc[_-]?tts|t{2,}s)\b[^>]*>",
+            "",
+            source,
+            flags=re.IGNORECASE,
+        )
+        source = FISH_AUDIO_S2_CUE_PATTERN.sub("", source)
+        source = FISH_AUDIO_S1_CUE_PATTERN.sub("", source)
+        return len(
+            re.findall(
+                r"[\u3040-\u30ff\u31f0-\u31ff\u4e00-\u9fffA-Za-z0-9]",
+                source,
+            )
+        )
 
     async def _finalize_tts_delivery_chain(
         self,


### PR DESCRIPTION
## 修复了什么

**故障现象**：开启"主动语音行为 → TTS转换范围 = 全量转换"且 TTS 生成模式为后处理（postprocess）时，语音稿上按"TTS补充规则"或情绪标签要求做的改写不生效：例如把亲吻拟声 mua 换成 FishAudio S2 控制词 `[kiss sound]` 后，最终发送的语音仍然朗读原文的 mua。

**影响范围**：全量转换 + 后处理模式下，后处理模型输出的 voice_text（情绪控制词、语气改写、拟声替换等）不会进入合成音频；该模式的语音正文始终等于"可见原文 + 插件按上下文自动推断的情绪控制"，转换模型为语音稿做的全部工作被丢弃。

**实际根因**：发送前 `tts_enhancement.py::_enforce_full_tts_scope_markup()` 在全量转换时会用可见原文整条重建 `<tts>` 语音块。后处理链路（`_postprocess_text_to_tts_markup()` 返回 `<tts>{voice_text}</tts>` 结构）生成的结构化 voice_text 因此被无条件覆盖。

## 怎么修复

- `_enforce_full_tts_scope_markup()` 新增仅由后处理链路传入的关键字开关 `prefer_authored_voice`：仅当全量转换、目标语种为中文、可见原文非空、且语音稿是"唯一一个位于开头位置的 `<tts>` 块"时，比较语音稿与可见原文去除标签和 FishAudio 控制词后的可读内容覆盖量；
- 覆盖量 ≥ 70%（且不少于 6 个内容单元）时，判定 voice_text 是完整等义语音稿，**保留模型生成的语音稿**，不再用可见原文重建；
- 覆盖量不达标（模型截断、漏内容）时仍走原逻辑，用完整可见正文重建语音块，保证"全量朗读整条回复"的兜底语义不变；
- 非 postprocess 模式（fast_tag 等）与外语全量路径行为保持不变；未传开关的调用完全维持原行为（现有全量重建测试全部原样通过）。

## 已经验证了什么

- 新增 3 个回归用例（`tests/test_tts_postprocess_tag_guard.py`）：完整改写语音稿保留（mua → `[kiss sound]` 场景）、含情绪控制词的等价语音稿保留、截断语音稿回退重建；
- 本机 AstrBot 4.27.3 / Python 3.12 环境实际执行：`test_tts_postprocess_tag_guard.py` 共 87 项通过（含新增 3 例）；相邻 TTS 套件 `test_tts_fishaudio_optimization.py`、`test_tts_mimo_voice_clone_bridge.py`、`test_tts_turn_language_override.py`、`test_tts_tool_full_scope.py`、`test_proactive_voice_tts_dedup.py` 共 83 项通过；
- 提交仅含 `tts_enhancement.py` 与上述测试文件两个文件、纯新增 114 行，行尾与上游各文件既有 blob 保持一致，`git diff --cached --check`（cr-at-eol）无告警；
- 未验证项：真实 FishAudio S2 合成引擎对 `[kiss sound]` 控制词是否产生亲吻音效取决于引擎训练支持，需部署后实测；本修复保证该控制词能进入合成文本。
