### PR TITLE
fix: backend=nai 直连时被动请求的 pc_generate_photo 门控仍只查 image_companion，导致工具被静默移除

### DIFF
--- a/llm_tool_actions.py
+++ b/llm_tool_actions.py
@@ -390,6 +390,15 @@ class LlmToolActionsMixin:
                 return True
         except Exception:
             return False
+        nai_selected = getattr(self, "_nai_image_selected", None)
+        if callable(nai_selected) and nai_selected():
+            nai_available = getattr(self, "_nai_image_available", None)
+            if not callable(nai_available):
+                return False
+            try:
+                return bool(nai_available())
+            except Exception:
+                return False
         available = getattr(self, "_image_companion_available", None)
         if not callable(available):
             return False

--- a/tests/test_user_requested_photo_generation.py
+++ b/tests/test_user_requested_photo_generation.py
@@ -55,6 +55,56 @@ class UserRequestedPhotoGenerationTests(unittest.IsolatedAsyncioTestCase):
         )
         return plugin
 
+    def _nai_direct_plugin(
+        self, *, nai_available: bool = True
+    ) -> PrivateCompanionPlugin:
+        plugin = self._plugin()
+        plugin._user_requested_photo_generation_allowed = (
+            lambda _event=None, **_kwargs: True
+        )
+        plugin.photo_generation_backend = "nai"
+        # 无 Image Companion 插件（停用/未安装）时桥解析返回 None。
+        plugin._image_companion_api = lambda: None
+        plugin._image_companion_available = lambda: False
+        plugin._nai_image_available = lambda: nai_available
+        return plugin
+
+    def test_nai_direct_backend_keeps_photo_tool_without_image_companion(self) -> None:
+        plugin = self._nai_direct_plugin()
+        event = _FakeEvent()
+
+        self.assertTrue(plugin._nai_image_selected())
+        self.assertTrue(plugin._photo_generation_runtime_available())
+        self.assertTrue(plugin._user_photo_generation_prompt_enabled(event))
+
+        req = SimpleNamespace(
+            func_tool=ToolSet([_tool("pc_generate_photo"), _tool("other_tool")])
+        )
+        self.assertFalse(plugin._scope_photo_generation_tool_for_request(req, event))
+        self.assertIsNotNone(req.func_tool.get_tool("pc_generate_photo"))
+        self.assertIsNotNone(req.func_tool.get_tool("other_tool"))
+
+    def test_nai_direct_backend_strips_photo_tool_when_nai_plugin_missing(self) -> None:
+        plugin = self._nai_direct_plugin(nai_available=False)
+        event = _FakeEvent()
+
+        self.assertFalse(plugin._photo_generation_runtime_available())
+        self.assertFalse(plugin._user_photo_generation_prompt_enabled(event))
+
+        original = ToolSet([_tool("pc_generate_photo"), _tool("other_tool")])
+        req = SimpleNamespace(func_tool=original)
+        self.assertTrue(plugin._scope_photo_generation_tool_for_request(req, event))
+        self.assertIsNone(req.func_tool.get_tool("pc_generate_photo"))
+        self.assertIsNotNone(req.func_tool.get_tool("other_tool"))
+        self.assertIsNotNone(original.get_tool("pc_generate_photo"))
+
+    def test_non_nai_backend_still_requires_image_companion(self) -> None:
+        plugin = self._nai_direct_plugin()
+        plugin.photo_generation_backend = "external"
+
+        self.assertFalse(plugin._nai_image_selected())
+        self.assertFalse(plugin._photo_generation_runtime_available())
+
     def test_passive_request_removes_photo_tool_but_keeps_other_tools(self) -> None:
         plugin = self._plugin()
         original = ToolSet([_tool("pc_generate_photo"), _tool("other_tool")])


### PR DESCRIPTION
## 问题

`photo_generation_backend="nai"`（#137 引入的 NAI 直连后端）且 `astrbot_plugin_image_companion` 停用/未安装时，被动聊天里模型完全拿不到生图工具，只能口头承诺"这就画"但永远不发起调用。用户即使明确要求"调用工具"也无法触发。

实际故障现场（AstrBot 6.4.x 运行日志）：

- 请求阶段：`_scope_photo_generation_tool_for_request` 每轮把 `pc_generate_photo` 从 `req.func_tool` 移除；
- 模型回复：纯文本"好嘞，喵这就调工具来发黑丝自拍，英文 prompt 来咯～"，`stop_reason=end_turn`，无任何 tool_use；
- 同期 `nai_image` 插件本身健康（trial key OK），主动生图路径也不受影响。

## 原因

#137 为四处生图可用性判断中的三处加了 nai 分支（主动可用性 `proactive_engine._photo_text_available`、执行入口 `proactive_message._generate_photo_image`、状态标签 `integration_status`），但漏掉了**被动 LLM 工具门控** `llm_tool_actions._photo_generation_runtime_available()`——它仍只查 `_image_companion_available()`。

失效链：门控 False → `_user_photo_generation_prompt_enabled()` False → `_scope_photo_generation_tool_for_request` 移除工具 + `_photo_generation_tool_instruction` 返回空 → 模型侧无工具、无说明。

## 修复

`_photo_generation_runtime_available()` 与主动路径对齐：

- 先判断 `_nai_image_selected()`：选中 NAI 直连时改查 `_nai_image_available()`（走 nai_image 的 `capability_status` 契约，与 #137 的桥接契约一致）；
- 未选中 nai 时维持原有 image_companion 检查，行为不变。

## 测试

`tests/test_user_requested_photo_generation.py` 新增 3 个用例：

1. `backend=nai` + nai 可用 + image_companion 缺失 → 门控放行、工具保留、提示注入；
2. `backend=nai` + nai 缺失 → 工具照常移除且不影响其他工具（顺带验证不影响原 ToolSet）；
3. 非 nai 后端 + image_companion 缺失 → 维持原判 False（回归保护）。

本地全量相关套件通过（`test_user_requested_photo_generation` 12 passed、`test_nai_image_bridge` 全过、`test_photo_tool_delivery_contract` 全过、`test_tool_prompt_sections` 全过）。

## 备注

建议后续在 CI 的核心冒烟组之外考虑把生图门控用例纳入常规跑批，避免同类"某一条路径漏加 nai 分支"的缺口再次存活。