### PR TITLE
修复 ReactionExpression 语音回复缺少对应文本

### DIFF
--- a/main.py
+++ b/main.py
@@ -9808,6 +9808,10 @@ class PrivateCompanionPlugin(
             )
             if isinstance(segmented_chunks, list) and segmented_chunks:
                 expected_sources = segmented_chunks
+        elif isinstance(pending, dict):
+            primary_chunk = pending.get("primary_chunk")
+            if isinstance(primary_chunk, list) and primary_chunk:
+                expected_sources = [primary_chunk]
         expected: list[tuple[str, ...]] = []
         for source in expected_sources:
             for item in self._reaction_expression_flatten_delivery_components(source):
@@ -10091,7 +10095,7 @@ class PrivateCompanionPlugin(
         chunks = pending.get("chunks")
         if not isinstance(chunks, list) or not chunks:
             return
-        if not self._reaction_expression_primary_reply_confirmed(event):
+        if not self._reaction_expression_primary_reply_confirmed(event, pending):
             return
         pending["started"] = True
         try:
@@ -11463,6 +11467,7 @@ class PrivateCompanionPlugin(
                     "_private_companion_reaction_expression_segmented_remainder",
                     {
                         "chunks": chunks[1:],
+                        "primary_chunk": chunks[0],
                         "previous_segment": previous_segment,
                         "started_at": activity_baseline,
                         "started": False,

--- a/tests/test_smart_imagechat_integration.py
+++ b/tests/test_smart_imagechat_integration.py
@@ -10,7 +10,7 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
-from astrbot.api.message_components import Image, Plain
+from astrbot.api.message_components import Image, Plain, Record
 from astrbot_plugin_private_companion.llm_tool_actions import (
     LlmToolActionsMixin,
     PHOTO_TOOL_SILENT_SENTINEL,
@@ -988,6 +988,51 @@ class SmartImageChatIntegrationTests(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(pending["sent"])
         self.assertEqual("primary_not_delivered", pending["settled_reason"])
         self.assertEqual([], event.sent_results)
+
+    async def test_reaction_segmented_remainder_accepts_record_primary_after_core_extracts_it(
+        self,
+    ) -> None:
+        api = _FakeSmartImageAPI(self.image_path)
+        harness = _ReactionHarness(api)
+        harness.enable_reaction_experiment()
+        first = Record(file="voice.wav")
+        second = Plain("对应正文")
+        event = _FakeResultEvent([])
+        event._private_companion_reaction_expression_delivery_tracker = {
+            "successful_signatures": [
+                harness._reaction_expression_delivery_signature(first),
+            ],
+            "restored": False,
+        }
+        event._private_companion_reaction_expression_expected_primary_chunks = [
+            [first],
+            [second],
+        ]
+        event._private_companion_reaction_expression_segmented_remainder = {
+            "chunks": [[second]],
+            "primary_chunk": [first],
+            "previous_segment": "[Record]",
+            "started_at": 10.0,
+            "started": False,
+            "completed": False,
+        }
+        sent_remainder: list[list[object]] = []
+
+        async def send_remainder(_event, chunks, **_kwargs):
+            sent_remainder.extend(chunks)
+
+        harness._send_segmented_llm_chain_remainder = send_remainder
+        await PrivateCompanionPlugin.release_reaction_expression_segmented_remainder_after_send(
+            harness,
+            event,
+        )
+
+        self.assertEqual([[second]], sent_remainder)
+        self.assertTrue(
+            event._private_companion_reaction_expression_segmented_remainder[
+                "started"
+            ]
+        )
 
     async def test_separate_after_requires_every_primary_text_segment(self) -> None:
         api = _FakeSmartImageAPI(self.image_path)


### PR DESCRIPTION
## 问题
在群聊中触发语音回复时，TTS 已生成语音和对应中文文本，但当 ReactionExpression 同时参与发送时，首段语音 Record 会被 AstrBot 核心从 event.result.chain 中移除，导致插件无法确认首段已发送，中文文本尾段被静默跳过。

## 修复
- 保存 ReactionExpression 分段首段的组件快照。
- 尾段释放确认使用首段快照，不再依赖已被核心移除的 event.result.chain。
- 保持完整分段完成确认和表情附件发送门槛不变。
- 增加 Record 首段、Plain 文本尾段且核心结果链为空的回归测试。

## 验证
- 相关回归测试：95 passed。
- Python 编译检查通过。
- 插件静态架构与制品检查通过。
- 完整测试集中与本改动相关的测试均通过；其余环境失败项涉及可选 MemoryCompanion 依赖、Windows 临时目录/符号链接权限及既有契约测试。