### PR TITLE
fix(proactive): honor include_schedule_in_messages in proactive chat bridge

### DIFF
--- a/proactive_message.py
+++ b/proactive_message.py
@@ -873,18 +873,19 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
         except Exception:
             location_context = ""
         schedule_context = ""
-        schedule_formatter = getattr(self, "_format_schedule_context_for_prompt", None)
-        if callable(schedule_formatter):
-            try:
-                schedule_context = str(schedule_formatter() or "").strip()
-            except Exception:
-                schedule_context = ""
-        schedule_sanitizer = getattr(self, "_sanitize_schedule_context_for_private_user", None)
-        if schedule_context and callable(schedule_sanitizer):
-            try:
-                schedule_context = str(schedule_sanitizer(schedule_context, user) or "").strip()
-            except Exception:
-                schedule_context = ""
+        if bool(runtime_persona_setting(self, "include_schedule_in_messages", True)):
+            schedule_formatter = getattr(self, "_format_schedule_context_for_prompt", None)
+            if callable(schedule_formatter):
+                try:
+                    schedule_context = str(schedule_formatter() or "").strip()
+                except Exception:
+                    schedule_context = ""
+            schedule_sanitizer = getattr(self, "_sanitize_schedule_context_for_private_user", None)
+            if schedule_context and callable(schedule_sanitizer):
+                try:
+                    schedule_context = str(schedule_sanitizer(schedule_context, user) or "").strip()
+                except Exception:
+                    schedule_context = ""
         def labeled_bridge_section(key: str, title: str, content: str) -> str:
             return render_prompt_sections(
                 [


### PR DESCRIPTION
## 概述

修复在 `_proactive_chat_prompt_fragment` 与 Proactive Chat 联动时，未遵循 `include_schedule_in_messages` 开关导致生活片段候选被无条件硬编码注入提示词的问题。

## 关联 Issue

Fixes #218

## 改动说明

在获取并格式化 `schedule_context` 前，增加 `if bool(runtime_persona_setting(self, "include_schedule_in_messages", True)):` 判断：
- 开启状态（默认）：保持原有逻辑不变，正常获取并格式化当前生活片段候选。
- 关闭状态：`schedule_context` 保持为空，不会向 Proactive Chat 联动提示词中强行注入生活片段，避免模型在生成主动问候时受到日程/梦境素材干扰输出生硬播报或呓语。

## 测试验证

- 在关闭 `include_schedule_in_messages` 时，主动消息提示词不再包含 `proactive_chat.schedule` 块。
- 在保持开启时，原有日程候选注入行为完全不受影响。
