### PR TITLE
fix: 修复表情授权轮生图开关只写分组键导致运行时读到旧默认值

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -3501,6 +3501,12 @@
     "default": "温柔日常,奇幻,恐怖,追逐,悬疑,荒诞,怀旧,暧昧春梦",
     "invisible": true
   },
+  "allow_generate_photo_on_reaction_turns": {
+    "description": "Legacy flat config: 表情表达授权轮保留生图工具",
+    "type": "bool",
+    "default": false,
+    "invisible": true
+  },
   "enable_photo_text_action": {
     "description": "Legacy flat config: 允许主动拍照/生图",
     "type": "bool",

--- a/page_api.py
+++ b/page_api.py
@@ -25632,6 +25632,14 @@ class PrivateCompanionPageApi(
         if key in {"page_font_family", "page_theme"}:
             self._set_schema_compat_value(config, key, value)
             return
+        if key == "allow_generate_photo_on_reaction_turns":
+            # Keep the grouped schema entry and the hidden legacy flat key in
+            # sync: the runtime reads the flat attribute injected by AstrBot,
+            # while the visible config page renders the grouped entry.  A
+            # one-sided write leaves a stale flat False that silently disables
+            # the opt-in switch after a reload.
+            self._set_schema_compat_value(config, key, value)
+            return
         updated_existing = _set_into_config(config, key, value, allow_flat_fallback=False)
         updated_group = self._set_schema_group_config_value(config, key, value, create_group=True)
         if updated_existing or updated_group:

--- a/plugin_bootstrap.py
+++ b/plugin_bootstrap.py
@@ -1403,15 +1403,6 @@ def _initialize_photo_and_expression_config(self: Any, c: Any) -> None:
         "allow_generate_photo_on_reaction_turns",
         False,
     )
-    # 自愈存量分叉：早期版本只写分组键，配置文件可能残留 AstrBot 注入的
-    # 顶层扁平默认 false。把当前生效值同步回所有同名位置，保证重启后
-    # 运行时属性与配置文件一致，避免“面板已开启但开关仍不生效”。
-    _set_into_config(
-        c,
-        "allow_generate_photo_on_reaction_turns",
-        self.allow_generate_photo_on_reaction_turns,
-        allow_flat_fallback=False,
-    )
     self.command_photo_generation_max_daily = self._cfg_int(c, "command_photo_generation_max_daily", -1, -1, 100)
     self.photo_generation_trace_max_size_kb = self._cfg_int(
         c,

--- a/plugin_bootstrap.py
+++ b/plugin_bootstrap.py
@@ -1398,6 +1398,20 @@ def _initialize_photo_and_expression_config(self: Any, c: Any) -> None:
         "enable_user_requested_photo_generation",
         True,
     )
+    self.allow_generate_photo_on_reaction_turns = self._cfg_bool(
+        c,
+        "allow_generate_photo_on_reaction_turns",
+        False,
+    )
+    # 自愈存量分叉：早期版本只写分组键，配置文件可能残留 AstrBot 注入的
+    # 顶层扁平默认 false。把当前生效值同步回所有同名位置，保证重启后
+    # 运行时属性与配置文件一致，避免“面板已开启但开关仍不生效”。
+    _set_into_config(
+        c,
+        "allow_generate_photo_on_reaction_turns",
+        self.allow_generate_photo_on_reaction_turns,
+        allow_flat_fallback=False,
+    )
     self.command_photo_generation_max_daily = self._cfg_int(c, "command_photo_generation_max_daily", -1, -1, 100)
     self.photo_generation_trace_max_size_kb = self._cfg_int(
         c,

--- a/tests/test_config_group_authority.py
+++ b/tests/test_config_group_authority.py
@@ -847,6 +847,54 @@ class ConfigGroupAuthorityTests(unittest.TestCase):
                 )
             self.assertIn('placeholder: "-1（不限量）"', script)
 
+    def test_reaction_turn_photo_toggle_keeps_grouped_and_flat_values_in_sync(self):
+        schema = json.loads((ROOT / "_conf_schema.json").read_text(encoding="utf-8"))
+        # The opt-in key must carry both a visible grouped entry and a hidden
+        # legacy flat entry: the runtime reads the flat attribute injected by
+        # AstrBot while the config page renders the grouped entry.  A missing
+        # flat entry leaves a stale default false behind and silently disables
+        # the switch after a reload.
+        legacy = schema["allow_generate_photo_on_reaction_turns"]
+        grouped = schema["photo_action_config"]["items"][
+            "allow_generate_photo_on_reaction_turns"
+        ]
+        self.assertFalse(legacy["default"])
+        self.assertTrue(legacy["invisible"])
+        self.assertFalse(grouped["default"])
+        self.assertEqual(grouped["condition"]["enable_reaction_expression_experiment"], True)
+
+        with tempfile.TemporaryDirectory() as folder:
+            config_path = Path(folder) / "private_companion_config.json"
+            config = AstrBotConfig(str(config_path), schema=schema)
+            # Reproduce the stale fork observed in production: the grouped
+            # entry says True while the flat entry keeps the old default False.
+            config["photo_action_config"] = {
+                "allow_generate_photo_on_reaction_turns": True,
+            }
+            config["allow_generate_photo_on_reaction_turns"] = False
+            plugin = SimpleNamespace(config=config)
+            api = PrivateCompanionPageApi.__new__(PrivateCompanionPageApi)
+            api.plugin = plugin
+            api._schema_key_index_cache = None
+
+            api._apply_config_value("allow_generate_photo_on_reaction_turns", True)
+
+            self.assertTrue(
+                config["photo_action_config"]["allow_generate_photo_on_reaction_turns"]
+            )
+            self.assertTrue(config["allow_generate_photo_on_reaction_turns"])
+
+            # Runtime projection must follow the grouped value when the flat
+            # value is stale, via the bootstrap initializer's grouped-first
+            # read plus the self-healing sync.
+            self.assertTrue(
+                PrivateCompanionPlugin._cfg_bool(
+                    config,
+                    "allow_generate_photo_on_reaction_turns",
+                    False,
+                )
+            )
+
     def test_empty_photo_scope_selection_remains_explicitly_disabled(self):
         api = PrivateCompanionPageApi(None)
         self.assertEqual([], api._normalize_setting_value("photo_generation_allowed_scopes", []))


### PR DESCRIPTION
## 修复了什么

生产环境实测（AstrBot 6.5.6 生产实例）：用户在陪伴面板开启 `allow_generate_photo_on_reaction_turns` 后，bot 依然看不到 `pc_generate_photo` 工具，表情授权轮继续裁剪该工具。

排查生产实例配置文件 `astrbot_plugin_private_companion_config.json` 发现同一开关存在**两个不一致的值**：

- 顶层扁平键 `allow_generate_photo_on_reaction_turns = false`
- 分组键 `photo_action_config.allow_generate_photo_on_reaction_turns = true`

运行时 `get_persona_setting` 读取 AstrBot 注入的**顶层扁平属性**（非多人格模式下直接 `object.__getattribute__(self, key)`），读到 `false`，于是开关在运行态从未生效。其余前置条件（表情实验开启、触发概率 1.0、用户请求生图开关开启、生图总开关开启、tool_first 模式）均已满足，仅此键分叉导致失败。

## 怎么修复（根因有两层）

1. **`_conf_schema.json` 缺顶层 legacy 扁平条目**：新键只登记在 `photo_action_config` 分组里，没有像 `enable_photo_text_action` 等同类键那样补一个 `invisible` 的顶层扁平条目。AstrBot 不会把该键作为顶层属性维护，配置文件残留 schema 默认值 `false`。→ 补登记顶层 legacy 扁平条目（bool、默认 false、invisible）。
2. **`plugin_bootstrap.py` 缺启动初始化**：同类键（如 `enable_user_requested_photo_generation`）都有 `self.xxx = self._cfg_bool(...)` 初始化，新键没有，运行时属性缺失时直接回退默认 `false`。→ 补初始化，并加**自愈同步**：把生效值（分组优先读取）写回所有同名位置，存量分叉配置下次启动自动收敛。

另外 `page_api.py` 的 `_set_config_value` 对该键改走 compat 双写路径（分组 + 顶层同步），保存时不再产生新的分叉，与 `_set_schema_compat_value` 既有惯例一致。

## 已经验证了什么

- 新增回归测试 `test_reaction_turn_photo_toggle_keeps_grouped_and_flat_values_in_sync`：精确复现生产环境“顶层 false / 分组 true”分叉场景，断言保存后两边一致、运行时投影为 true。
- 相关回归 207 项通过：`test_config_group_authority`、`test_config_schema_i18n`、`test_smart_imagechat_integration`、`test_user_requested_photo_generation`、`test_photo_scope_runtime`、`test_command_photo_quota`、`test_image_model_config_ui`、`test_release_layout`、`test_persona_config`。
- `git diff --check` 通过，无行尾 churn。
- `test_feature_config_ui_ownership::test_visible_feature_cards_are_saveable` 失败为上游既有问题（`enable_group_social_context` 不在 `_allowed_feature_keys`），已在干净 `upstream/main` 基线复现，与本次改动无关。
- 生产实例应急处置：已备份并手动把生产配置文件的两个位置都改为 true（`..._config.json.bak_toggle_fix_20260906`），但 6.5.6 运行时缺初始化代码，**需本次修复合入并更新插件后重启才会真正生效**。
