### PR TITLE
fix: 表情授权轮生图执行期闸与开关联动

### DIFF
--- a/main.py
+++ b/main.py
@@ -12902,8 +12902,19 @@ class PrivateCompanionPlugin(
                 ensure_ascii=False,
             )
         reaction_authorization = self._reaction_expression_authorization(event)
-        if reaction_authorization and not self._photo_generation_instruction_matches(
-            getattr(event, "message_str", "")
+        allow_photo_on_reaction_turns = bool(
+            runtime_persona_setting(
+                self,
+                'allow_generate_photo_on_reaction_turns',
+                False,
+            )
+        )
+        if (
+            reaction_authorization
+            and not allow_photo_on_reaction_turns
+            and not self._photo_generation_instruction_matches(
+                getattr(event, "message_str", "")
+            )
         ):
             return json.dumps(
                 {

--- a/tests/test_smart_imagechat_integration.py
+++ b/tests/test_smart_imagechat_integration.py
@@ -2690,6 +2690,69 @@ class SmartImageChatIntegrationTests(unittest.IsolatedAsyncioTestCase):
             [tool.name for tool in explicit_with_photo_on.func_tool.tools],
         )
 
+    async def test_reaction_turn_photo_execution_gate_follows_toggle(self) -> None:
+        # The execution-time gate inside pc_generate_photo used to skip every
+        # authorized reaction turn without an explicit request, even when the
+        # opt-in switch kept the tool in the declaration.  With the switch on,
+        # the gate must let the call through to the real implementation (whose
+        # quota/permission guards still run); with the switch off, the legacy
+        # skip behavior stays intact.
+        api = _FakeSmartImageAPI(self.image_path)
+        generated_photo = AsyncMock(
+            return_value='{"status":"success","success":true,"sent":true}'
+        )
+
+        # Switch OFF: legacy skip.
+        harness_off = _ReactionHarness(api)
+        harness_off.enable_reaction_experiment()
+        harness_off.allow_generate_photo_on_reaction_turns = False
+        harness_off._pc_generate_photo_impl = generated_photo
+        event_off = _FakeEvent()
+        event_off.message_str = "普通闲聊"
+        module = SimpleNamespace(get_smart_imagechat_api=lambda: api)
+        with patch(
+            "astrbot_plugin_private_companion.llm_tool_actions.get_reaction_asset_library",
+            return_value=module,
+        ):
+            self.assertTrue(
+                await harness_off._preauthorize_reaction_expression_prompt(event_off)
+            )
+            payload_off = json.loads(
+                await PrivateCompanionPlugin.pc_generate_photo(
+                    harness_off,
+                    event_off,
+                    prompt="看看你",
+                    kind="selfie",
+                )
+            )
+        self.assertEqual("skipped", payload_off["status"])
+        generated_photo.assert_not_awaited()
+
+        # Switch ON: the execution gate lets the request reach the real impl.
+        harness_on = _ReactionHarness(api)
+        harness_on.enable_reaction_experiment()
+        harness_on.allow_generate_photo_on_reaction_turns = True
+        harness_on._pc_generate_photo_impl = generated_photo
+        event_on = _FakeEvent()
+        event_on.message_str = "普通闲聊"
+        with patch(
+            "astrbot_plugin_private_companion.llm_tool_actions.get_reaction_asset_library",
+            return_value=module,
+        ):
+            self.assertTrue(
+                await harness_on._preauthorize_reaction_expression_prompt(event_on)
+            )
+            payload_on = json.loads(
+                await PrivateCompanionPlugin.pc_generate_photo(
+                    harness_on,
+                    event_on,
+                    prompt="看看你",
+                    kind="selfie",
+                )
+            )
+        self.assertEqual("success", payload_on["status"])
+        generated_photo.assert_awaited_once()
+
     def test_failed_media_followup_keeps_current_media_tool_available(self) -> None:
         message = (
             "我重启了，你再试试发过来，不要生成新图，"


### PR DESCRIPTION
## 修复了什么

生产实例实测（PR #221 合入并部署后）暴露第二层拦截：`allow_generate_photo_on_reaction_turns` 开启后，`pc_generate_photo` 已出现在请求工具声明中，模型成功调用并传入正确参数，但工具执行时仍被跳过：

```json
{"status": "skipped", "message": "本轮没有显式生图请求，继续自然文字回复即可。"}
```

图片未产出，模型只能回文字（"自拍工具还是超时没有响应"）。

根因：`pc_generate_photo` 工具实现内部还有一道**执行期闸**——只要存在表情授权（`reaction_authorization`）且用户消息未命中显式生图关键词表，就直接 skip。PR #212 当初只放开了声明裁剪与提示词，没有同步这道闸，导致"工具看得见、调得起、但被拒执行"。

## 怎么修复

执行期闸（`main.py` `pc_generate_photo`）读取 `allow_generate_photo_on_reaction_turns` 开关：

- **开关开启**：授权轮放行到 `_pc_generate_photo_impl`——其内部权限/配额守卫（用户请求总闸、`enable_photo_text_action`、`natural_language_photo_generation_mode`、每日额度、内容边界）照常执行，不绕过任何既有约束；
- **开关关闭（默认）**：保持原 skip 行为不变，存量用户零影响。

三层一致性补齐：声明裁剪（PR #212）→ 提示词联动（PR #212）→ 执行期闸（本 PR）都尊重同一个开关。

## 已经验证了什么

- 新增回归测试 `test_reaction_turn_photo_execution_gate_follows_toggle`：
  - 开关关闭时，授权轮调用仍返回 `skipped` 且不会触发生成实现；
  - 开关开启时，调用成功到达生成实现并返回 `success`。
- 相关回归 152 项通过：`test_smart_imagechat_integration`、`test_user_requested_photo_generation`、`test_photo_tool_delivery_contract`。
- `git diff --check` 通过，无行尾 churn。
- 生产实例已手动覆盖 `main.py`（远程已备份到 `bak_toggle_fix_20260906\`），修复版等待用户自行重启验证。
