### PR TITLE
WIP: 表情表达选图准确性（向量领先排序、描述回传、发送前视觉复核）+ 主动消息随机冲动修补

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -13006,7 +13006,8 @@
         "description": "发送前视觉复核表情包",
         "type": "string",
         "options": ["off", "embedding", "always"],
-        "hint": "发送前让视觉模型看一眼选中的表情包：embedding=仅当命中完全依赖向量相似度时复核；always=每次都复核；off=关闭。复核结果会随工具返回给聊天模型，不贴合则不发送。主动消息的低延迟路径不复核。",
+        "labels": ["关闭", "仅向量主导选图时复核", "每次都复核"],
+        "hint": "发送前让视觉模型看一眼选中的表情包：embedding=仅当本次选图由向量相似度主导时复核；always=每次都复核；off=关闭。复核结果会随工具返回给聊天模型，不贴合则不发送。主动消息的低延迟路径不复核。",
         "default": "embedding",
         "condition": {
           "enable_reaction_expression_experiment": true

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -12975,7 +12975,7 @@
       "reaction_expression_embedding_score_threshold": {
         "description": "表情语义相似度阈值",
         "type": "float",
-        "hint": "低于该相似度的素材不会获得语义加分。建议 0.35-0.55；过高可能漏掉隐含表达，过低会增加误召回。",
+        "hint": "最佳候选的相似度低于该值时，本轮不按向量排序而回退关键词匹配。语义加分按本轮相似度分布相对排序（最佳=满分，中位=0），因此该阈值只是兜底。建议 0.35-0.55。",
         "default": 0.42,
         "slider": {
           "min": 0,
@@ -12990,16 +12990,26 @@
       "reaction_expression_embedding_weight": {
         "description": "表情语义加权分",
         "type": "float",
-        "hint": "语义相似度在现有关键词、情绪和偏好排序中的软加分。建议 0.35-0.75，不会单独决定是否发送。",
-        "default": 0.55,
+        "hint": "向量领先时最佳候选获得的加分；此时关键词命中只在同簇内做微调（上限 0.5）。建议 1.0-2.0；低于 0.8 时关键词重新占主导。不会单独决定是否发送。",
+        "default": 1.5,
         "slider": {
           "min": 0,
-          "max": 1.5,
+          "max": 3,
           "step": 0.05
         },
         "condition": {
           "enable_reaction_expression_experiment": true,
           "reaction_expression_embedding_enabled": true
+        }
+      },
+      "reaction_expression_vision_verify_mode": {
+        "description": "发送前视觉复核表情包",
+        "type": "string",
+        "options": ["off", "embedding", "always"],
+        "hint": "发送前让视觉模型看一眼选中的表情包：embedding=仅当命中完全依赖向量相似度时复核；always=每次都复核；off=关闭。复核结果会随工具返回给聊天模型，不贴合则不发送。主动消息的低延迟路径不复核。",
+        "default": "embedding",
+        "condition": {
+          "enable_reaction_expression_experiment": true
         }
       },
       "reaction_expression_embedding_backfill_enabled": {

--- a/dreaming.py
+++ b/dreaming.py
@@ -521,7 +521,7 @@ def build_dream_memory_fragments(plugin, count: int = 8) -> list[str]:
             _single_line(yesterday.get("summary"), 100),
         ):
             cleaned = _clean_dream_fragment_text(candidate)
-            if cleaned and "无明确" not in candidate and _dream_fragment_is_useful(cleaned):
+            if cleaned and "无明确" not in candidate and "暂无" not in candidate and _dream_fragment_is_useful(cleaned):
                 fragments.append(cleaned)
         residues = yesterday.get("residues", [])
         if isinstance(residues, list):

--- a/llm_tool_actions.py
+++ b/llm_tool_actions.py
@@ -6466,7 +6466,9 @@ class LlmToolActionsMixin:
         snapshot_caption = "；".join(
             part
             for part in (
-                f"图片画面：{_single_line(lookup.get('description'), 200)}" if lookup.get("description") else "",
+                f"图片画面：{_single_line(lookup.get('description') or lookup.get('image_description'), 200)}"
+                if lookup.get("description") or lookup.get("image_description")
+                else "",
                 f"图库标签：{'、'.join(tags[:8])}" if tags else "",
                 f"表达需求：{need}" if need else "",
                 f"选图依据：{match_reason}" if match_reason else "",
@@ -7319,7 +7321,10 @@ class LlmToolActionsMixin:
         verify_mode = _single_line(
             runtime_persona_setting(self, "reaction_expression_vision_verify_mode", "embedding"), 20
         ).lower()
-        if send_image and not low_latency and (
+        # The automatic tag path prepares the image here (send=False,
+        # internal_attachment=True) and delivers it after the text, so it needs
+        # the same pre-send check as a direct tool send.
+        if (send_image or internal_attachment) and not low_latency and (
             verify_mode == "always"
             or (verify_mode == "embedding" and lookup.get("match_basis") == "embedding")
         ):
@@ -7393,7 +7398,9 @@ class LlmToolActionsMixin:
         snapshot_caption = "；".join(
             part
             for part in (
-                f"图片画面：{_single_line(lookup.get('description'), 200)}" if lookup.get("description") else "",
+                f"图片画面：{_single_line(lookup.get('description') or lookup.get('image_description'), 200)}"
+                if lookup.get("description") or lookup.get("image_description")
+                else "",
                 f"图库标签：{'、'.join(tags[:8])}" if tags else "",
                 f"表达需求：{need}" if need else "",
                 f"选图依据：{match_reason}" if match_reason else "",

--- a/llm_tool_actions.py
+++ b/llm_tool_actions.py
@@ -161,6 +161,7 @@ _REACTION_LOG_DECISIONS = frozenset(
 _REACTION_LOG_REASONS = frozenset(
     {
         "allowed",
+        "vision_rejected",
         "experiment_disabled",
         "provider_unavailable",
         "private_disabled",
@@ -6967,6 +6968,14 @@ class LlmToolActionsMixin:
             cache[asset_id] = description
         fit_value = payload.get("fit")
         fit = fit_value if isinstance(fit_value, bool) else str(fit_value).strip().lower() in {"true", "1", "yes", "是"}
+        logger.info(
+            "表情包视觉复核: fit=%s asset=%s need=%s 描述=%s 原因=%s",
+            fit,
+            asset_id[:12],
+            _single_line(query_text, 80),
+            description,
+            _single_line(payload.get("reason"), 120),
+        )
         return {
             "fit": fit,
             "description": description or known,

--- a/llm_tool_actions.py
+++ b/llm_tool_actions.py
@@ -1398,9 +1398,9 @@ class LlmToolActionsMixin:
             return True
         if re.search(
             r"(?:把|将|给|帮我|麻烦)?(?:这张|那张|刚才的|上面的|改好的)?"
-            r"(?:图|图片|照片|成图).{0,8}(?:发|传|给|贴|丢)(?:出来|过来|给我|我)?"
+            r"(?:图|图片|照片|成图|表情包|表情|贴纸|反应图|梗图).{0,8}(?:发|传|给|贴|丢)(?:出来|过来|给我|我)?"
             r"|(?:发|传|给|贴|丢).{0,8}(?:这张|那张|刚才的|上面的|改好的)?"
-            r"(?:图|图片|照片|成图)",
+            r"(?:图|图片|照片|成图|表情包|表情|贴纸|反应图|梗图)",
             compact,
             flags=re.I,
         ):
@@ -1411,7 +1411,7 @@ class LlmToolActionsMixin:
         # image anchor, a recent-result anchor, and an actual send instruction.
         has_media_anchor = bool(
             re.search(
-                r"(?:图|图片|照片|成图|图像|画面|这张|那张|这一张|那一张)",
+                r"(?:图|图片|照片|成图|图像|画面|表情包|贴纸|反应图|梗图|这张|那张|这一张|那一张)",
                 compact,
                 flags=re.I,
             )
@@ -6466,6 +6466,7 @@ class LlmToolActionsMixin:
         snapshot_caption = "；".join(
             part
             for part in (
+                f"图片画面：{_single_line(lookup.get('description'), 200)}" if lookup.get("description") else "",
                 f"图库标签：{'、'.join(tags[:8])}" if tags else "",
                 f"表达需求：{need}" if need else "",
                 f"选图依据：{match_reason}" if match_reason else "",
@@ -6903,6 +6904,74 @@ class LlmToolActionsMixin:
         )
         return True
 
+    async def _reaction_expression_vision_verify(
+        self,
+        event: AstrMessageEvent,
+        library: Any,
+        lookup: dict[str, Any],
+        query_text: str,
+        lookup_context: str,
+    ) -> dict[str, Any] | None:
+        """Let a vision-capable model look at the chosen meme before it is sent.
+
+        Returns ``{"fit": bool, "description": str}`` or ``None`` when no
+        vision provider is usable (the caller then trusts the metadata match).
+        """
+        asset_id = _single_line(lookup.get("asset_id"), 64)
+        if not asset_id or library is None:
+            return None
+        # ponytail: in-memory per-asset description cache; persist into the catalog if restarts matter
+        cache = getattr(self, "_reaction_vision_description_cache", None)
+        if not isinstance(cache, dict):
+            cache = {}
+            setattr(self, "_reaction_vision_description_cache", cache)
+        umo = _single_line(getattr(event, "unified_msg_origin", ""), 160)
+        provider_id, provider_source, _prompt, provider = self._select_private_image_visual_provider(umo)
+        if provider is None or not self._can_run_llm_task(provider_id, task="reaction_vision_verify"):
+            return None
+        image = await asyncio.to_thread(library.get_analysis_image_data, asset_id, max_edge=512)
+        if not image or not image.get("data_url"):
+            return None
+        known = _single_line(cache.get(asset_id), 300)
+        prompt = (
+            "你是聊天机器人的眼睛。我准备用这张表情包回应下面的对话，请先看图再判断它是否贴合。\n"
+            f"检索需求：{query_text}\n"
+            + (f"对话语境：{lookup_context}\n" if lookup_context else "")
+            + (f"已知描述：{known}\n" if known else "")
+            + "只输出 JSON：{\"fit\": true/false, \"description\": \"一句话描述图里的内容和情绪（30字内）\", \"reason\": \"贴合或不贴合的原因（20字内）\"}"
+        )
+        started = time.time()
+        try:
+            result = await asyncio.wait_for(
+                provider.text_chat(prompt=prompt, image_urls=[image["data_url"]], max_tokens=120),
+                timeout=8.0,
+            )
+            raw_text = str(getattr(result, "completion_text", result) or "").strip()
+            payload = self._extract_json_payload(raw_text)
+            if not isinstance(payload, dict) or "fit" not in payload:
+                raise ValueError("vision verify returned no fit field")
+            self._record_llm_usage(
+                provider_id=provider_id, task="reaction_vision_verify", prompt=prompt,
+                completion=raw_text, resp=result, elapsed_ms=int((time.time() - started) * 1000),
+                success=True, budget_exempt=True,
+            )
+            self._clear_private_image_provider_failure(provider_id, provider_source)
+        except Exception as exc:
+            self._mark_private_image_provider_failure(provider_id, provider_source, exc, task="reaction_vision_verify")
+            logger.debug("表情包视觉复核失败: provider=%s error_type=%s", provider_id, type(exc).__name__)
+            return None
+        description = _single_line(payload.get("description"), 300)
+        if description:
+            cache[asset_id] = description
+        fit_value = payload.get("fit")
+        fit = fit_value if isinstance(fit_value, bool) else str(fit_value).strip().lower() in {"true", "1", "yes", "是"}
+        return {
+            "fit": fit,
+            "description": description or known,
+            "reason": _single_line(payload.get("reason"), 120),
+            "provider_id": provider_id,
+        }
+
     async def _pc_find_reaction_image_impl(
         self,
         event: AstrMessageEvent,
@@ -7246,6 +7315,49 @@ class LlmToolActionsMixin:
             match_basis=self._reaction_expression_match_basis(lookup),
         )
 
+        vision_review: dict[str, Any] | None = None
+        verify_mode = _single_line(
+            runtime_persona_setting(self, "reaction_expression_vision_verify_mode", "embedding"), 20
+        ).lower()
+        if send_image and not low_latency and (
+            verify_mode == "always"
+            or (verify_mode == "embedding" and lookup.get("match_basis") == "embedding")
+        ):
+            vision_review = await self._reaction_expression_vision_verify(
+                event, library, lookup, query_text, lookup_context
+            )
+            if vision_review is not None and not vision_review.get("fit"):
+                self._log_reaction_expression_event(
+                    event,
+                    stage="lookup",
+                    decision="miss",
+                    reason="vision_rejected",
+                    scope=scope,
+                    status="not_found",
+                    found=False,
+                    sent=False,
+                    image_id=lookup.get("image_id"),
+                    confidence=lookup.get("confidence"),
+                    cache_hit=cache_hit,
+                    latency_ms=lookup_latency_ms,
+                    match_basis=self._reaction_expression_match_basis(lookup),
+                )
+                return json.dumps(
+                    {
+                        "status": "not_found",
+                        "success": False,
+                        "found": False,
+                        "sent": False,
+                        "message": "候选表情包经视觉复核后不贴合当前语境，未发送",
+                        "image_description": _single_line(vision_review.get("description"), 300),
+                        "reason": _single_line(vision_review.get("reason"), 120),
+                        "cache_hit": cache_hit,
+                        "lookup_latency_ms": lookup_latency_ms,
+                        "must_not_claim_sent": True,
+                    },
+                    ensure_ascii=False,
+                )
+
         sent = False
         delivery: dict[str, Any] = {}
         visible_caption = self._sanitize_photo_tool_caption(caption, limit=120)
@@ -7281,6 +7393,7 @@ class LlmToolActionsMixin:
         snapshot_caption = "；".join(
             part
             for part in (
+                f"图片画面：{_single_line(lookup.get('description'), 200)}" if lookup.get("description") else "",
                 f"图库标签：{'、'.join(tags[:8])}" if tags else "",
                 f"表达需求：{need}" if need else "",
                 f"选图依据：{match_reason}" if match_reason else "",
@@ -7381,6 +7494,12 @@ class LlmToolActionsMixin:
             "need": need,
             "reason": match_reason,
             "confidence": _safe_float(lookup.get("confidence"), 0.0, 0.0, 1.0),
+            "image_description": _single_line(
+                (vision_review or {}).get("description")
+                or getattr(self, "_reaction_vision_description_cache", {}).get(_single_line(lookup.get("asset_id"), 64))
+                or lookup.get("description"),
+                300,
+            ),
             "delivery": _single_line(delivery.get("destination"), 40),
             "cache_hit": cache_hit,
             "lookup_latency_ms": lookup_latency_ms,

--- a/proactive.py
+++ b/proactive.py
@@ -3351,7 +3351,7 @@ class ProactiveMixin(UserRestGateMixin):
         context = self._random_proactive_impulse_context(user, now=now)
         if not bool(context.get("allowed")):
             return None
-        reason = self._choose_planned_reason()
+        reason, scheduled = self._draw_random_reason_slot(user, now=now, delay_hours=delay_hours)
         if bool(context.get("suggest_soft_reason")) and reason in {"check_in", "state_share"}:
             reason = "quiet_care"
         motive = self._choose_proactive_motive(reason, user)
@@ -3363,13 +3363,6 @@ class ProactiveMixin(UserRestGateMixin):
             motive=motive,
             planned_event=None,
         )
-        scheduled = self._sample_proactive_timestamp(
-            user,
-            now=now,
-            delay_hours=delay_hours,
-            reason=reason,
-        )
-        scheduled = self._move_timestamp_into_reason_window(scheduled, reason, user)
         topic = self._choose_proactive_topic(reason, user)
         emotion_adjustment = self._apply_emotion_to_planned_proactive(
             user,
@@ -3429,6 +3422,32 @@ class ProactiveMixin(UserRestGateMixin):
             impulse["salience"] = min(_safe_float(impulse.get("salience"), 0.4), 0.34)
             impulse["urgency"] = min(_safe_float(impulse.get("urgency"), 0.3), 0.22)
         return self._queue_proactive_impulse(user, impulse)
+
+    def _draw_random_reason_slot(
+        self,
+        user: dict[str, Any],
+        *,
+        now: float,
+        delay_hours: tuple[float, float],
+    ) -> tuple[str, float]:
+        """Pick a reason whose time window is open near the sampled slot.
+
+        Reasons are weighted blind to the clock; an evening draw of a daytime
+        reason (activity_share 10:00-18:30) would otherwise be pushed to the
+        next morning and silence the whole night. Redraw a few times and keep
+        the earliest slot.
+        """
+        horizon = now + max(1.0, _safe_float(delay_hours[1], 1.0, 0.05)) * 3600
+        best: tuple[str, float] | None = None
+        for _ in range(6):
+            reason = self._choose_planned_reason()
+            scheduled = self._sample_proactive_timestamp(user, now=now, delay_hours=delay_hours, reason=reason)
+            scheduled = self._move_timestamp_into_reason_window(scheduled, reason, user)
+            if best is None or scheduled < best[1]:
+                best = (reason, scheduled)
+            if scheduled <= horizon:
+                break
+        return best
 
     def _proactive_window_timezone(self) -> str:
         return (
@@ -3725,10 +3744,30 @@ class ProactiveMixin(UserRestGateMixin):
             for item in self._cleanup_proactive_impulses(user, now=now)
             if isinstance(item, dict) and str(item.get("state") or "queued") in {"queued", "deferred"}
         ]
-        if not active_impulses:
+        if self._random_impulse_slot_open(active_impulses, now=now, delay_hours=delay_hours):
             self._queue_random_proactive_impulse(user, now=now, delay_hours=delay_hours)
         if not self._materialize_best_proactive_impulse(user, now=now):
             self._clear_pending_proactive_plan(user)
+
+    @staticmethod
+    def _random_impulse_slot_open(
+        active_impulses: list[dict[str, Any]],
+        *,
+        now: float,
+        delay_hours: tuple[float, float] | None,
+    ) -> bool:
+        """True when nothing queued/deferred starts before the random-draw horizon.
+
+        Ritual greetings (noon/evening) are queued hours ahead; they must not
+        stop the engine from drawing an ordinary impulse for the gap before them.
+        """
+        high = _safe_float(delay_hours[1], 1.0, 0.05) if delay_hours else 1.0
+        horizon = now + max(0.5, high) * 3600
+        return not any(
+            _safe_float(item.get("window_start_at"), 0) <= horizon
+            for item in active_impulses
+            if isinstance(item, dict)
+        )
 
     def _promote_earlier_daily_greeting_event(
         self,

--- a/proactive_engine.py
+++ b/proactive_engine.py
@@ -3492,7 +3492,7 @@ class ProactiveEngineMixin:
             near_term = [
                 item
                 for item in future
-                if _safe_float(item.get("window_start_at"), earliest_start) <= earliest_start + 90 * 60
+                if _safe_float(item.get("window_start_at"), earliest_start) <= earliest_start + 30 * 60
             ]
             selected = max(
                 near_term,
@@ -9201,6 +9201,8 @@ class ProactiveEngineMixin:
     ) -> dict[str, str]:
         current_item = self._proactive_current_agenda_item()
         current_text = self._format_plan_item_for_prompt(current_item)
+        if current_text.strip(" （）()") in {"", "暂无"}:
+            current_text = ""
         event_text = ""
         if isinstance(planned_event, dict):
             event_text = " ".join(

--- a/reaction_asset_library.py
+++ b/reaction_asset_library.py
@@ -1303,17 +1303,23 @@ class ReactionAssetLibrary:
                 matched_phrases.append(
                     "语义相近：" + "、".join(sorted(shared_semantic_clusters))
                 )
-            embedding_score = embedding_scores.get(item["id"], 0.0)
+            embedding_score = embedding_scores.get(item["id"])
             if embedding_led:
-                embedding_bonus = embedding_factor * max(
-                    -1.0, min(1.0, (embedding_score - embedding_median) / embedding_span)
+                # Assets whose vector is missing or stale (caption re-analysed,
+                # backfill pending) stay neutral rather than being demoted.
+                embedding_bonus = (
+                    embedding_factor * max(-1.0, min(1.0, (embedding_score - embedding_median) / embedding_span))
+                    if embedding_score is not None
+                    else 0.0
                 )
+                embedding_score = embedding_score or 0.0
                 # ponytail: once vectors lead, lexical hits only break ties inside
                 # the matched cluster. A stray tag on a wrong-category asset used
                 # to win outright through the 1.7 phrase bonus.
                 score = min(score, 0.5)
                 semantic_bonus = min(semantic_bonus, 0.3)
             else:
+                embedding_score = embedding_score or 0.0
                 embedding_bonus = (
                     embedding_factor * max(0.0, (embedding_score - embedding_threshold) / max(0.01, 1.0 - embedding_threshold))
                     if embedding_score >= embedding_threshold

--- a/reaction_asset_library.py
+++ b/reaction_asset_library.py
@@ -8,6 +8,7 @@ import json
 import mimetypes
 import os
 import re
+import statistics
 import threading
 import time
 import uuid
@@ -1224,12 +1225,33 @@ class ReactionAssetLibrary:
                     and _single_line(raw.get("embedding_text_hash"), 80) == self.embedding_text_hash(item)
                 )
             }
-        ranked: list[tuple[float, float, dict[str, Any], Path, list[str], float, float]] = []
-        now = time.time()
+        eligible_rows: list[tuple[dict[str, Any], Path]] = []
         for item in candidates:
             path = self._path_for(item)
             if not item["enabled"] or scope_text not in item["scopes"] or path is None or not path.is_file():
                 continue
+            eligible_rows.append((item, path))
+        # Text embeddings of short reaction captions are crowded: every asset
+        # lands at cosine 0.4-0.8 for any query, so an absolute threshold passes
+        # almost the whole catalog and the bonus barely separates assets. Rank
+        # against the query's own distribution instead: the best asset earns
+        # the full weight, the median asset earns nothing and assets well
+        # below the median are demoted by the same amount.
+        embedding_scores: dict[str, float] = {}
+        for item, _path in eligible_rows:
+            candidate_vector = embeddings_by_id.get(item["id"])
+            if embedding_vector and candidate_vector and len(candidate_vector) == len(embedding_vector):
+                embedding_scores[item["id"]] = max(
+                    -1.0,
+                    min(1.0, sum(left * right for left, right in zip(embedding_vector, candidate_vector))),
+                )
+        embedding_top = max(embedding_scores.values(), default=0.0)
+        embedding_led = len(embedding_scores) >= 8 and embedding_top >= embedding_threshold
+        embedding_median = statistics.median(embedding_scores.values()) if embedding_led else 0.0
+        embedding_span = max(0.02, embedding_top - embedding_median)
+        ranked: list[tuple[float, float, dict[str, Any], Path, list[str], float, float, float]] = []
+        now = time.time()
+        for item, path in eligible_rows:
             primary = " ".join(
                 [
                     item["name"],
@@ -1281,18 +1303,22 @@ class ReactionAssetLibrary:
                 matched_phrases.append(
                     "语义相近：" + "、".join(sorted(shared_semantic_clusters))
                 )
-            embedding_score = 0.0
-            candidate_vector = embeddings_by_id.get(item["id"])
-            if embedding_vector and candidate_vector and len(candidate_vector) == len(embedding_vector):
-                embedding_score = max(
-                    -1.0,
-                    min(1.0, sum(left * right for left, right in zip(embedding_vector, candidate_vector))),
+            embedding_score = embedding_scores.get(item["id"], 0.0)
+            if embedding_led:
+                embedding_bonus = embedding_factor * max(
+                    -1.0, min(1.0, (embedding_score - embedding_median) / embedding_span)
                 )
-            embedding_bonus = (
-                embedding_factor * max(0.0, (embedding_score - embedding_threshold) / max(0.01, 1.0 - embedding_threshold))
-                if embedding_score >= embedding_threshold
-                else 0.0
-            )
+                # ponytail: once vectors lead, lexical hits only break ties inside
+                # the matched cluster. A stray tag on a wrong-category asset used
+                # to win outright through the 1.7 phrase bonus.
+                score = min(score, 0.5)
+                semantic_bonus = min(semantic_bonus, 0.3)
+            else:
+                embedding_bonus = (
+                    embedding_factor * max(0.0, (embedding_score - embedding_threshold) / max(0.01, 1.0 - embedding_threshold))
+                    if embedding_score >= embedding_threshold
+                    else 0.0
+                )
             relevance_score = score + semantic_bonus + embedding_bonus
             if embedding_bonus > 0.0 and not matched_phrases:
                 matched_phrases.append("语义相近")
@@ -1316,6 +1342,7 @@ class ReactionAssetLibrary:
                     matched_phrases,
                     learned_bias,
                     embedding_score,
+                    embedding_bonus,
                 )
             )
         if not ranked:
@@ -1328,7 +1355,7 @@ class ReactionAssetLibrary:
         if not eligible:
             return None
         eligible.sort(key=lambda row: (row[0], row[2]["updated_at"]), reverse=True)
-        _selection_score, score, item, path, matched_phrases, learned_bias, embedding_score = eligible[0]
+        _selection_score, score, item, path, matched_phrases, learned_bias, embedding_score, embedding_bonus = eligible[0]
         semantic_match = any(
             phrase.startswith("语义相近：") for phrase in matched_phrases
         )
@@ -1342,6 +1369,8 @@ class ReactionAssetLibrary:
             "found": True,
             "image_id": f"pc-local:{item['id']}",
             "asset_id": item["id"],
+            "name": item["name"],
+            "description": item["description"],
             "path": str(path),
             "tags": [*item["tags"], *item["emotions"], *item["intents"]][:20],
             "need": query_text,
@@ -1349,7 +1378,7 @@ class ReactionAssetLibrary:
             "candidate_queries": candidate_queries,
             "reason": (
                 "本插件素材库按关键词及本地语义近似匹配"
-                if semantic_match and not embedding_score >= embedding_threshold
+                if semantic_match and embedding_bonus <= 0.0
                 else "本插件素材库按候选检索表达、标签、情绪和沟通用途匹配"
                 if matched_phrases
                 else "本插件素材库按标签、情绪和沟通用途匹配"
@@ -1359,9 +1388,9 @@ class ReactionAssetLibrary:
             "embedding_score": round(embedding_score, 4) if embedding_score else 0.0,
             "match_basis": (
                 "embedding"
-                if embedding_score >= embedding_threshold and not semantic_match and score < 0.28
+                if embedding_bonus > 0.0 and embedding_bonus >= score - embedding_bonus
                 else "hybrid"
-                if embedding_score >= embedding_threshold
+                if embedding_bonus > 0.0
                 else "keyword_semantic"
                 if semantic_match
                 else "keyword"

--- a/tests/test_random_impulse_between_greetings.py
+++ b/tests/test_random_impulse_between_greetings.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import unittest
+
+from astrbot_plugin_private_companion.proactive import ProactiveMixin
+from astrbot_plugin_private_companion.proactive_engine import ProactiveEngineMixin
+
+
+class _TopicHarness(ProactiveEngineMixin):
+    @staticmethod
+    def _proactive_current_agenda_item():
+        return None
+
+    @staticmethod
+    def _format_plan_item_for_prompt(_item) -> str:
+        return "（暂无）"
+
+    @staticmethod
+    def _soften_topic_hook(text: str) -> str:
+        return text
+
+    @staticmethod
+    def _normalize_internal_motive_text(text: str) -> str:
+        return text
+
+
+class RandomImpulseBetweenGreetingsTests(unittest.TestCase):
+    def test_far_future_greeting_does_not_block_random_draw(self) -> None:
+        now = 1_000_000.0
+        evening = [{"state": "queued", "reason": "evening_greeting", "window_start_at": now + 8 * 3600}]
+        soon = [{"state": "queued", "reason": "check_in", "window_start_at": now + 1 * 3600}]
+        self.assertTrue(ProactiveMixin._random_impulse_slot_open(evening, now=now, delay_hours=(1.0, 3.0)))
+        self.assertFalse(ProactiveMixin._random_impulse_slot_open(soon, now=now, delay_hours=(1.0, 3.0)))
+        self.assertTrue(ProactiveMixin._random_impulse_slot_open([], now=now, delay_hours=None))
+
+    def test_agenda_placeholder_is_not_a_photo_topic(self) -> None:
+        patch = _TopicHarness()._photo_text_plan_field_patch(reason="background_schedule")
+        self.assertEqual(patch["topic"], "手边这一小段")
+        self.assertNotIn("暂无", patch["motive"])
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class _DrawHarness(ProactiveMixin):
+    def __init__(self, reasons: list[str]) -> None:
+        self._reasons = list(reasons)
+
+    def _choose_planned_reason(self) -> str:
+        return self._reasons.pop(0)
+
+    @staticmethod
+    def _sample_proactive_timestamp(_user, *, now, delay_hours, reason=""):
+        return now + 3600.0
+
+    @staticmethod
+    def _move_timestamp_into_reason_window(ts, reason, _user=None):
+        return ts + 14 * 3600 if reason == "activity_share" else ts
+
+
+class RandomReasonSlotTests(unittest.TestCase):
+    def test_daytime_reason_at_night_is_redrawn(self) -> None:
+        now = 1_000_000.0
+        reason, slot = _DrawHarness(["activity_share", "quiet_care", "check_in"])._draw_random_reason_slot(
+            {}, now=now, delay_hours=(1.0, 3.0)
+        )
+        self.assertEqual(reason, "quiet_care")
+        self.assertEqual(slot, now + 3600.0)
+
+    def test_keeps_earliest_when_every_draw_is_far(self) -> None:
+        now = 1_000_000.0
+        reason, slot = _DrawHarness(["activity_share"] * 6)._draw_random_reason_slot({}, now=now, delay_hours=(1.0, 3.0))
+        self.assertEqual(reason, "activity_share")
+        self.assertEqual(slot, now + 15 * 3600.0)

--- a/tests/test_reaction_asset_library.py
+++ b/tests/test_reaction_asset_library.py
@@ -300,6 +300,41 @@ class ReactionAssetLibraryTests(unittest.TestCase):
         self.assertIsNone(self.library.find("不开心", scope="private"))
         self.assertIsNone(self.library.find("查询天气", scope="private"))
 
+    def test_find_lets_embedding_cluster_outrank_stray_lexical_tag(self) -> None:
+        # Nine assets sit close to the query vector; one far-away asset carries
+        # the literal query as a tag. The vector cluster must win the pick.
+        cluster = []
+        for index in range(9):
+            cluster.append(
+                self.library.import_blobs(
+                    [(f"angry{index}.png", PNG_BYTES + bytes([index]))],
+                    metadata={"emotions": ["angry"]},
+                )["items"][0]
+            )
+        stray = self.library.import_blobs(
+            [("stray.png", PNG_BYTES + b"stray")],
+            metadata={"tags": ["傲娇吐槽", "性暗示"], "emotions": ["color"]},
+        )["items"][0]
+        rows = [
+            {"id": item["id"], "vector": [1.0, 0.02 * index], "text_hash": self.library.embedding_text_hash(item)}
+            for index, item in enumerate(cluster)
+        ]
+        rows.append({"id": stray["id"], "vector": [0.6, 0.8], "text_hash": self.library.embedding_text_hash(stray)})
+        self.assertEqual(10, self.library.upsert_embeddings("test-embedding", rows))
+
+        keyword_only = self.library.find("傲娇吐槽")
+        embedded = self.library.find(
+            "傲娇吐槽",
+            embedding_query=[1.0, 0.0],
+            embedding_provider_id="test-embedding",
+            embedding_weight=1.5,
+        )
+
+        self.assertEqual(f"pc-local:{stray['id']}", keyword_only["image_id"])
+        self.assertIn(embedded["asset_id"], {item["id"] for item in cluster})
+        self.assertEqual("embedding", embedded["match_basis"])
+        self.assertIn("description", embedded)
+
     def test_find_softly_rotates_recently_used_equally_relevant_assets(self) -> None:
         first = self.library.import_blobs(
             [("开心一号.png", PNG_BYTES)],


### PR DESCRIPTION
> WIP / 讨论用。这些改动在我的实例（6.4.5b + Acacia 人格）上跑了几天，现移植到 main。是否合并、怎么拆，都听作者意见。

关联 Issue：#224

## 表情表达准确性（主要内容）

- `reaction_asset_library.find()`：向量分改为按本轮查询自身的相似度分布相对排序（最佳=满分、中位=0、明显低于中位=负分）。原来 0.42 的绝对阈值让 396 张里 379–395 张全部过线，加分几乎没有区分度；关键词命中（+1.7）则能让一个错类素材上的杂标签胜出。向量领先时关键词分封顶 0.5、本地语义簇分封顶 0.3，只做同簇内微调。
- `find()` 结果新增 `name/description`；`llm_tool_actions` 把描述写进发送后 `last_photo_share_snapshot`（`图片画面：…`）和工具返回的 `image_description`，模型追问时不再靠标签臆造。
- `match_basis` 改为：向量加分 ≥ 词法分 → `embedding`，否则 `hybrid`/`keyword_semantic`/`keyword`。
- `_conf_schema`：`reaction_expression_embedding_weight` 默认 0.55 → 1.5，滑条上限 3；两个 hint 改写。
- 新增 `reaction_expression_vision_verify_mode`（off/embedding/always）：非低延迟路径下，命中依赖向量时先让视觉模型看图判断贴合再发；不贴合则不发并把描述返回给模型。描述缓存目前只在内存里。
- `_current_media_delivery_instruction_matches`：「把表情包/贴纸/反应图发出来」这类显式请求也算 explicit media request，否则 glm-5.3-flash 在实验授权轮会去乱调其它工具。
- 测试：`test_find_lets_embedding_cluster_outrank_stray_lexical_tag`。

## 顺带移植的其它本地修补（可拆出去）

- `proactive.py`：随机冲动的 reason 在开放的时间窗内抽取（`_draw_random_reason_slot`）；远期的仪式问候不再阻止抽取当下的随机冲动（`_random_impulse_slot_open`）。之前晚间会因为抽到白天 reason 被推到次日早上而整夜沉默。附 `test_random_impulse_between_greetings.py`。
- `proactive_engine.py`：近期冲动窗口 90→30 分钟；日程文本为「暂无」时不注入提示词。
- `dreaming.py`：梦境素材跳过「暂无」占位。

## 说明

- 仓库里 `llm_tool_actions.py`/`proactive*.py`/`_conf_schema.json` 是 CRLF/LF 混排；本 PR 新增行按各文件多数行尾处理，`git diff` 无整文件换行噪音。
- 数据侧配套（不在 PR 内）：用页面「自动识别」把语义包描述重跑一遍以去掉 `以当前分类“X”…为主体：` 模板，并停用 `color` 分类。
