### PR TITLE
fix: avoid empty user history entries for proactive archives

### DIFF
--- a/proactive_message.py
+++ b/proactive_message.py
@@ -18778,18 +18778,34 @@ class ProactiveMessageMixin(FinalResponsePersistenceMixin):
             return False
         for attempt in range(4):
             try:
-                safe_user_prompt = "" if self._proactive_archive_context_text(user_prompt) else str(user_prompt or "").strip()
+                archive_context_only = self._proactive_archive_context_text(user_prompt)
+                safe_user_prompt = str(user_prompt or "").strip()
                 user_msg_obj = UserMessageSegment(content=safe_user_prompt)
                 assistant_msg_obj = AssistantMessageSegment(content=visible_assistant_response)
                 async def _write():
                     conv_id = await self._ensure_conversation_id_for_umo(umo, title="Private Companion 主动消息")
                     if not conv_id:
                         return False
-                    await self.context.conversation_manager.add_message_pair(
-                        cid=conv_id,
-                        user_message=user_msg_obj,
-                        assistant_message=assistant_msg_obj,
-                    )
+                    conversation_manager = self.context.conversation_manager
+                    if archive_context_only:
+                        conversation = await conversation_manager.get_conversation(umo, conv_id)
+                        if conversation is None:
+                            return False
+                        raw_history = getattr(conversation, "history", "[]")
+                        if isinstance(raw_history, str):
+                            history = json.loads(raw_history or "[]")
+                        elif isinstance(raw_history, list):
+                            history = list(raw_history)
+                        else:
+                            history = []
+                        history.append(assistant_msg_obj.model_dump())
+                        await conversation_manager.update_conversation(umo, conv_id, history=history)
+                    else:
+                        await conversation_manager.add_message_pair(
+                            cid=conv_id,
+                            user_message=user_msg_obj,
+                            assistant_message=assistant_msg_obj,
+                        )
                     return True
 
                 written = await self._conversation_db_operation("archive_proactive_message", _write)

--- a/tests/test_final_response_persistence.py
+++ b/tests/test_final_response_persistence.py
@@ -632,7 +632,14 @@ class FinalResponsePersistenceTests(unittest.IsolatedAsyncioTestCase):
             ["user", "assistant"],
             [item["role"] for item in harness.conversation_manager.history[-2:]],
         )
-        self.assertEqual("", harness.conversation_manager.history[-2]["content"])
+        self.assertEqual("真实用户消息", harness.conversation_manager.history[-2]["content"])
+        self.assertTrue(
+            all(
+                item.get("content")
+                for item in harness.conversation_manager.history
+                if item.get("role") == "user"
+            )
+        )
         self.assertEqual(["实际发出的主动消息"], captured)
 
     async def test_livingmemory_prefers_plugin_public_handler_when_available(self):


### PR DESCRIPTION
## 修复
主动消息使用内部承接占位或投递回执作为归档上下文时，不再构造空的 user 消息。现在会在同一会话历史中只追加实际发送的 assistant 内容；普通主动消息仍维持 user-assistant 成对归档。

## 关联 Issue
Closes #226

## 验证
- tests/test_final_response_persistence.py -k 'proactive_placeholder or proactive_official_history'
- AstrBot bundled Python 3.12
- git diff --check