### PR TITLE
fix: accept short explicit NAI parameter blocks

### DIFF
--- a/photo_nai_params.py
+++ b/photo_nai_params.py
@@ -50,13 +50,20 @@ def extract_user_photo_nai_params(text: Any) -> str:
     candidate = str(text or "")
     if not candidate:
         return ""
-    match = re.search(r"masterpiece[\s,，]*best\s+quality\b", candidate, flags=re.I)
+    # These tokens are strong NAI signals and avoid treating ordinary prose as tags.
+    match = re.search(
+        r"(?:masterpiece[\s,，]*best\s+quality\b|score[_\s-]?\d(?:\.\d+)?\b|rating[_\s-]?(?:safe|questionable|explicit)\b)",
+        candidate,
+        flags=re.I,
+    )
     if not match:
         return ""
     block = candidate[match.start():]
     block = re.split(r"[\n\r。！？!?]", block, maxsplit=1)[0]
     block = re.sub(r"\s+", " ", block.replace("\uFF0C", ",")).strip(" ,")
-    return block if len(re.split(r",\s*", block)) >= 8 else ""
+    # A short, explicit tag block is still valid; the prompt contract controls
+    # what may be retained, so do not discard it using an arbitrary tag count.
+    return block if len(_split_tags(block)) >= 2 else ""
 
 
 def cache_user_photo_nai_params(

--- a/tests/test_photo_nai_params.py
+++ b/tests/test_photo_nai_params.py
@@ -27,6 +27,14 @@ class PhotoNaiParamsTests(unittest.TestCase):
             "masterpiece, best quality, 1girl, green hair, sitting, bedroom, soft light, detailed eyes",
         )
 
+    def test_extracts_short_explicit_nai_block(self) -> None:
+        text = "masterpiece, best quality, portrait"
+        self.assertEqual(extract_user_photo_nai_params(text), text)
+
+    def test_extracts_score_marker_without_quality_pair(self) -> None:
+        text = "score_9, score_8_up, 1girl"
+        self.assertEqual(extract_user_photo_nai_params(text), text)
+
     def test_cached_params_expire(self) -> None:
         user = {"last_photo_nai_params": "masterpiece, best quality", "last_photo_nai_params_at": 100.0}
         self.assertEqual(recent_cached_photo_nai_params(user, now=100 + 60), "masterpiece, best quality")


### PR DESCRIPTION
PR #230 introduced request-scoped NAI parameter pass-through but required a fixed masterpiece/best quality marker and at least eight comma-separated tags. This follow-up keeps NAI-only merging while accepting strong score/rating markers and shorter explicit tag blocks. Added regression coverage for short blocks and score markers. Validation: 9 focused unittest cases pass.