### PR TITLE
修复主动消息 TTS 归档正文丢失

### DIFF
--- a/final_response_persistence.py
+++ b/final_response_persistence.py
@@ -702,7 +702,24 @@ def collect_proactive_delivery(
         except BaseException:
             coordinator._reset_context(ledger)
             raise
-        return coordinator.finish_proactive(ledger, outcome)
+        outcome = coordinator.finish_proactive(ledger, outcome)
+        # TTS 会把可见正文除首块外的部分放到后台异步补发。主链返回时
+        # confirmed_chains 只含首块，finish_proactive 据此覆盖出的
+        # delivered_text 会丢掉消息尾部（例如承诺的后半句）。
+        # 当整轮已判定 complete 时，改回用发送前的原始全文归档。
+        original_text = str(args[0] or "").strip() if args else ""
+        if (
+            original_text
+            and getattr(outcome, "complete", False)
+            and str(getattr(outcome, "delivered_text", "") or "").strip()
+            != original_text
+        ):
+            try:
+                outcome = replace(outcome, delivered_text=original_text)
+            except (TypeError, ValueError):
+                # outcome 不是 dataclass 或字段缺失时保持原样
+                pass
+        return outcome
 
     return wrapped
 

--- a/tests/test_final_response_persistence.py
+++ b/tests/test_final_response_persistence.py
@@ -6,6 +6,7 @@ import json
 import unittest
 from dataclasses import dataclass
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 from astrbot.api.message_components import Image, Plain
@@ -102,11 +103,35 @@ class _ActiveOutcome:
     delivered_chain: tuple = ()
 
 
+@dataclass(frozen=True)
+class _CompleteActiveOutcome:
+    delivered: bool
+    complete: bool
+    delivered_text: str = ""
+    delivery_umo: str = ""
+    delivered_chain: tuple = ()
+
+
 class _ActiveCollector(FinalResponsePersistenceMixin):
     @collect_proactive_delivery
     async def send(self, umo: str) -> _ActiveOutcome:
         self._confirm_outbound_delivery(umo, [Plain("平台实际收到的主动回复")])
         return _ActiveOutcome(True, delivered_text="审核后的候选回复")
+
+
+class _FullTextActiveCollector(FinalResponsePersistenceMixin):
+    def __init__(self, *, complete: bool, confirmed_chain: list[Any]) -> None:
+        self.complete = complete
+        self.confirmed_chain = confirmed_chain
+
+    @collect_proactive_delivery
+    async def send(self, umo: str, text: str) -> _CompleteActiveOutcome:
+        self._confirm_outbound_delivery(umo, self.confirmed_chain)
+        return _CompleteActiveOutcome(
+            delivered=bool(self.confirmed_chain),
+            complete=self.complete,
+            delivered_text="审核后的候选回复",
+        )
 
 
 class _Registry:
@@ -1025,6 +1050,49 @@ class FinalResponsePersistenceTests(unittest.IsolatedAsyncioTestCase):
             "平台实际收到的主动回复",
             outcome.delivered_chain[0].text,
         )
+
+    async def test_proactive_collector_restores_original_text_after_complete_tts_delivery(self):
+        outcome = await _FullTextActiveCollector(
+            complete=True,
+            confirmed_chain=[Plain("首块正文")],
+        ).send(UMO, "首块正文尾部承诺")
+
+        self.assertTrue(outcome.complete)
+        self.assertEqual("首块正文尾部承诺", outcome.delivered_text)
+        self.assertEqual(("首块正文",), tuple(item.text for item in outcome.delivered_chain))
+
+    async def test_proactive_collector_keeps_confirmed_prefix_after_partial_delivery(self):
+        outcome = await _FullTextActiveCollector(
+            complete=False,
+            confirmed_chain=[Plain("首块正文")],
+        ).send(UMO, "首块正文尾部承诺")
+
+        self.assertFalse(outcome.complete)
+        self.assertEqual("首块正文", outcome.delivered_text)
+
+    async def test_proactive_collector_keeps_equal_text_for_single_segment_delivery(self):
+        outcome = await _FullTextActiveCollector(
+            complete=True,
+            confirmed_chain=[Plain("单段全文")],
+        ).send(UMO, "单段全文")
+
+        self.assertEqual("单段全文", outcome.delivered_text)
+
+    async def test_proactive_collector_only_replaces_text_and_preserves_media_chain(self):
+        collector = _FullTextActiveCollector(
+            complete=True,
+            confirmed_chain=[Plain("首块正文"), Image(file="image.png")],
+        )
+        outcome = await collector.send(UMO, "首块正文尾部承诺")
+
+        self.assertEqual("首块正文尾部承诺", outcome.delivered_text)
+        self.assertIsInstance(outcome.delivered_chain[1], Image)
+        archived = collector._delivered_assistant_text_from_chain(
+            outcome.delivered_chain,
+            fallback_text=outcome.delivered_text,
+        )
+        self.assertIn("首块正文尾部承诺", archived)
+        self.assertIn('<pc_history_media images="1" />', archived)
 
     async def test_streaming_response_persists_only_confirmed_stream_chunks(self):
         plugin = PrivateCompanionPlugin.__new__(PrivateCompanionPlugin)


### PR DESCRIPTION
## 修复了什么

修复主动消息启用 TTS 分块时归档正文不完整的问题。首块随主链发送、其余正文由后台任务补发时，主链返回阶段的 `confirmed_chains` 只有首块，原实现会据此覆盖 `delivered_text`，导致后半段承诺同时从会话历史和长期记忆中丢失。

## 怎么修复

在 `collect_proactive_delivery` 完成既有确认链处理后读取发送前的原始正文（位置参数 `args[0]`）。仅当整轮 `complete=True` 且确认链拼出的文本与原始正文不一致时，使用 `dataclasses.replace` 回填 `delivered_text`。

- 部分送达或失败（`complete=False`）继续按真实确认内容归档。
- 单段、合并转发等本来已完整的文本不改变。
- 只替换文本字段，已确认的媒体链和媒体归档标记保持不变。
- 非 dataclass 返回值或缺少目标字段时保持原有结果。

## 已验证

- AstrBot 自带 Python 3.12：`tests/test_final_response_persistence.py -k proactive_collector`，5 passed。
- `tests/test_overall_debug_regressions.py`，24 passed。
- CI 对应测试集：41 passed、36 passed；`scripts/ci_static_checks.py` 架构与产物检查通过。
- 相关测试组合共 174 passed；其中 1 个既有断言失败，原因是上游近期将 `tts_enabled` 默认值改为 `False`，不涉及本次改动。
- 全量测试收集仍受既有 `tests/test_relationship_violation_penalty.py` 顶层相对导入错误影响，未改动该问题。

