### PR TITLE
修复周期状态缺失导致的 SQLite 增量保存重试

### DIFF
--- a/daily_state.py
+++ b/daily_state.py
@@ -3520,7 +3520,7 @@ class DailyStateMixin(DailyStateTickMixin):
                     state["weather"] = self._weather_summary_text(weather)
                     return state
                 async with self._data_lock:
-                    deleted_sections = self._cleanup_expired_conditions() or set()
+                    deleted_sections = set(self._cleanup_expired_conditions() or ())
                     self._ensure_time_based_hunger_condition()
                     state = self._compose_state_from_conditions(weather)
                     existing_state = self.data.get("daily_state")
@@ -3531,6 +3531,11 @@ class DailyStateMixin(DailyStateTickMixin):
                             "state_conditions",
                             "body_cycle_state",
                         } - set(deleted_sections)
+                        if "body_cycle_state" in self.data:
+                            deleted_sections.discard("body_cycle_state")
+                            save_sections.add("body_cycle_state")
+                        else:
+                            save_sections.discard("body_cycle_state")
                         self._save_data_sync(
                             sections=save_sections,
                             deleted_sections=deleted_sections,
@@ -3565,7 +3570,7 @@ class DailyStateMixin(DailyStateTickMixin):
 
             needs_generation = force or self.data.get("state_generated_day") != today
             if not needs_generation:
-                deleted_sections = self._cleanup_expired_conditions() or set()
+                deleted_sections = set(self._cleanup_expired_conditions() or ())
                 self._ensure_time_based_hunger_condition()
                 state = self._compose_state_from_conditions(weather)
                 self.data["daily_state"] = state
@@ -3575,6 +3580,11 @@ class DailyStateMixin(DailyStateTickMixin):
                     "body_cycle_state",
                     "hunger_window_attempts",
                 } - set(deleted_sections)
+                if "body_cycle_state" in self.data:
+                    deleted_sections.discard("body_cycle_state")
+                    save_sections.add("body_cycle_state")
+                else:
+                    save_sections.discard("body_cycle_state")
                 self._save_data_sync(
                     sections=save_sections,
                     deleted_sections=deleted_sections,
@@ -3591,9 +3601,9 @@ class DailyStateMixin(DailyStateTickMixin):
         async with self._data_lock:
             deleted_sections: set[str] = set()
             if not force and self.data.get("state_generated_day") == generation_day:
-                deleted_sections = self._cleanup_expired_conditions() or set()
+                deleted_sections = set(self._cleanup_expired_conditions() or ())
             else:
-                deleted_sections = self._cleanup_expired_conditions() or set()
+                deleted_sections = set(self._cleanup_expired_conditions() or ())
                 if force:
                     self.data["state_conditions"] = []
                 dream_pick = deferred_updates.get("dream_pick")
@@ -3627,6 +3637,11 @@ class DailyStateMixin(DailyStateTickMixin):
                 "body_cycle_state",
                 "hunger_window_attempts",
             } - set(deleted_sections)
+            if "body_cycle_state" in self.data:
+                deleted_sections.discard("body_cycle_state")
+                save_sections.add("body_cycle_state")
+            else:
+                save_sections.discard("body_cycle_state")
             self._save_data_sync(
                 sections=save_sections,
                 deleted_sections=deleted_sections,

--- a/tests/test_daily_state_generation_safety.py
+++ b/tests/test_daily_state_generation_safety.py
@@ -72,6 +72,52 @@ class _StateHarness(DailyStateMixin):
         self.save_count += 1
 
 
+class _CyclePersistenceHarness(_StateHarness):
+    """Small harness for asserting the daily-state save contract."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.cleanup_results: list[set[str]] = []
+        self.rebuild_body_cycle = False
+        self.compose_count = 0
+        self.save_requests: list[dict[str, set[str]]] = []
+
+    def _cleanup_expired_conditions(self) -> set[str]:
+        result = self.cleanup_results.pop(0) if self.cleanup_results else set()
+        if "body_cycle_state" in result:
+            self.data.pop("body_cycle_state", None)
+        return set(result)
+
+    async def _generate_state_conditions(
+        self,
+        _weather=None,
+        *,
+        deferred_state_updates=None,
+    ):
+        if self.rebuild_body_cycle and isinstance(deferred_state_updates, dict):
+            deferred_state_updates["body_cycle_conditions"] = [
+                {"id": "rebuilt", "kind": "body_cycle"}
+            ]
+        return []
+
+    def _compose_state_from_conditions(self, _weather=None):
+        self.compose_count += 1
+        return {
+            "date": "2026-07-23",
+            "conditions": deepcopy(self.data.get("state_conditions", [])),
+            "refresh": self.compose_count,
+        }
+
+    def _save_data_sync(self, **kwargs) -> None:
+        self.save_count += 1
+        self.save_requests.append(
+            {
+                "sections": set(kwargs.get("sections") or ()),
+                "deleted_sections": set(kwargs.get("deleted_sections") or ()),
+            }
+        )
+
+
 class _DiaryHarness(DailyStateMixin):
     def __init__(self) -> None:
         self._data_lock = asyncio.Lock()
@@ -116,6 +162,81 @@ class _DiaryHarness(DailyStateMixin):
 
 
 class DailyStateGenerationSafetyTests(unittest.IsolatedAsyncioTestCase):
+    async def test_cycle_cleanup_emits_tombstone_once_without_stale_changed_section(self) -> None:
+        harness = _CyclePersistenceHarness()
+        harness.data.update(
+            {
+                "daily_state": {"date": "2026-07-23"},
+                "state_generated_day": "2026-07-23",
+                "body_cycle_state": {"cycle_anchor_ts": 1},
+            }
+        )
+        harness.cleanup_results = [{"body_cycle_state"}, set()]
+
+        with patch("astrbot_plugin_private_companion.daily_state._today_key", return_value="2026-07-23"):
+            await harness._ensure_daily_state_once()
+            await harness._ensure_daily_state_once()
+
+        self.assertEqual(2, len(harness.save_requests))
+        first, second = harness.save_requests
+        self.assertNotIn("body_cycle_state", first["sections"])
+        self.assertEqual({"body_cycle_state"}, first["deleted_sections"])
+        self.assertNotIn("body_cycle_state", second["sections"])
+        self.assertEqual(set(), second["deleted_sections"])
+
+    async def test_passive_fast_cycle_cleanup_does_not_reintroduce_missing_section(self) -> None:
+        harness = _CyclePersistenceHarness()
+        harness.data.update(
+            {
+                "daily_state": {"date": "2026-07-23", "refresh": 0},
+                "daily_weather": {"date": "2026-07-23", "prompt": "晴"},
+                "body_cycle_state": {"cycle_anchor_ts": 1},
+            }
+        )
+        harness.cleanup_results = [{"body_cycle_state"}, set()]
+
+        with patch("astrbot_plugin_private_companion.daily_state._today_key", return_value="2026-07-23"):
+            await harness._ensure_daily_state_once(passive_fast=True)
+            await harness._ensure_daily_state_once(passive_fast=True)
+
+        self.assertEqual(2, len(harness.save_requests))
+        first, second = harness.save_requests
+        self.assertNotIn("body_cycle_state", first["sections"])
+        self.assertEqual({"body_cycle_state"}, first["deleted_sections"])
+        self.assertNotIn("body_cycle_state", second["sections"])
+        self.assertEqual(set(), second["deleted_sections"])
+
+    async def test_force_cycle_refresh_keeps_missing_section_out_of_final_changed_set(self) -> None:
+        harness = _CyclePersistenceHarness()
+        harness.data["body_cycle_state"] = {"cycle_anchor_ts": 1}
+        harness.cleanup_results = [{"body_cycle_state"}, set()]
+
+        with patch("astrbot_plugin_private_companion.daily_state._today_key", return_value="2026-07-23"):
+            await harness._ensure_daily_state_once(force=True)
+            await harness._ensure_daily_state_once(force=True)
+
+        self.assertEqual(2, len(harness.save_requests))
+        first, second = harness.save_requests
+        self.assertNotIn("body_cycle_state", first["sections"])
+        self.assertEqual({"body_cycle_state"}, first["deleted_sections"])
+        self.assertNotIn("body_cycle_state", second["sections"])
+        self.assertEqual(set(), second["deleted_sections"])
+
+    async def test_rebuilt_cycle_state_supersedes_cleanup_tombstone(self) -> None:
+        harness = _CyclePersistenceHarness()
+        harness.data["body_cycle_state"] = {"cycle_anchor_ts": 1}
+        harness.cleanup_results = [{"body_cycle_state"}]
+        harness.rebuild_body_cycle = True
+
+        with patch("astrbot_plugin_private_companion.daily_state._today_key", return_value="2026-07-23"):
+            await harness._ensure_daily_state_once(force=True)
+
+        self.assertEqual(1, len(harness.save_requests))
+        request = harness.save_requests[0]
+        self.assertIn("body_cycle_state", request["sections"])
+        self.assertEqual(set(), request["deleted_sections"])
+        self.assertEqual("rebuilt", harness.data["body_cycle_state"]["id"])
+
     async def test_passive_fast_discards_cached_period_when_humanized_states_disabled(self) -> None:
         harness = _StateHarness()
         harness.enable_humanized_states = False


### PR DESCRIPTION
## 修复了什么

修复 `body_cycle_state` 在周期条件清理后的 SQLite 增量保存异常。清理已删除该 section 后，日状态的三个保存分支仍可能把缺失的 key 标记为 changed，清除尚未落盘的 tombstone，最终触发 `missing dirty sections without explicit tombstones` 并进入重复重试。

## 怎么修复

- 在 passive-fast、无需重新生成和生成后的最终保存路径中，根据内存快照是否仍有 `body_cycle_state` 归一化 changed/deleted 集合。
- section 缺失时只保留本次真实 tombstone，不再提交缺失的 changed payload；section 被重建时移除 tombstone 并提交 live payload。
- 保留核心 writer、SQLite revision 和缺失 dirty section 保护逻辑不变。
- 增加四个合成夹具回归测试，覆盖三条保存路径、二次刷新以及重建覆盖删除标记。

## 已验证

- `pytest tests/test_daily_state_generation_safety.py tests/test_advanced_cycle_strategy.py tests/test_incremental_persistence_storage.py tests/test_incremental_persistence_callsites.py -q`：107 passed，60 个子测试通过。
- `pytest tests/test_daily_state_generation_safety.py -q`：18 passed。
- `scripts/ci_static_checks.py --package astrbot_plugin_private_companion --import-module main`：`architecture and artifact checks passed`。
- `py_compile` 和 `git diff --check` 通过。
- writer 全量测试中 37 passed；另有 4 个既有 JSON/Persona sanitizer 测试失败，与本次改动无关，未修改相关代码。