### PR TITLE
refactor(ui): 重构陪伴面板信息层级，优化提示词与配置交互，修复未安装扩展白屏问题

### DIFF
--- a/pages/companion-panel/app.js
+++ b/pages/companion-panel/app.js
@@ -579,10 +579,10 @@ function syncProviderConfigModeControls() {
   });
   const hint = document.getElementById("providerConfigModeHint");
   if (hint) {
-    const tokenCostHint = "插件功能通常会携带较多动态上下文，Token 缓存命中率可能较低，请结合调用频率和预算合理规划模型。";
+    const tokenCostHint = "每次调用可能附带日程、记忆等资料，因此缓存不一定命中；请留意调用频率和 Token 花费。";
     hint.textContent = quick
-      ? `${tokenCostHint} 快速配置显示通用场景模型；插件识图、资料归档视觉和通用嵌入模型各自独立。`
-      : `${tokenCostHint} 精准配置显示各任务单独 Provider；独立识图与通用嵌入不会跟随文本模型改写。`;
+      ? `先为常用任务选模型即可。图片识别、资料归档识图和向量模型需要单独设置。${tokenCostHint}`
+      : `为每一种任务单独选模型服务。修改文字模型不会改动独立识图和向量模型。${tokenCostHint}`;
   }
 }
 
@@ -6016,9 +6016,9 @@ function loadOptionalClassicScript(relativePath, retry = 0) {
 
 const optionalModuleLoaders = {
   providerTree: [
-    () => loadOptionalClassicScript("./js/panels/provider-tree.js?v=20260804-reading-archive-capability-v1&manual=provider-input-v2&layout=v2&vision-state=v1", 0),
-    () => loadOptionalClassicScript("./js/panels/provider-tree.js?v=20260804-reading-archive-capability-v1&manual=provider-input-v2&layout=v2&vision-state=v1", 1),
-    () => loadOptionalClassicScript("./js/panels/provider-tree.js?v=20260804-reading-archive-capability-v1&manual=provider-input-v2&layout=v2&vision-state=v1", 2),
+    () => loadOptionalClassicScript("./js/panels/provider-tree.js?v=20260804-reading-archive-capability-v1&manual=provider-input-v2&layout=v2&vision-state=v1&studio=20260912-v1", 0),
+    () => loadOptionalClassicScript("./js/panels/provider-tree.js?v=20260804-reading-archive-capability-v1&manual=provider-input-v2&layout=v2&vision-state=v1&studio=20260912-v1", 1),
+    () => loadOptionalClassicScript("./js/panels/provider-tree.js?v=20260804-reading-archive-capability-v1&manual=provider-input-v2&layout=v2&vision-state=v1&studio=20260912-v1", 2),
   ],
   qzonePanel: [
     () => loadOptionalClassicScript("./js/panels/qzone-panel.js?v=20260810-qzone-classic-loader-v1", 0),
@@ -8063,8 +8063,8 @@ function selectTaskPrompt(taskKey) {
   state.selectedTaskPromptKey = next.task_key;
   state.taskPromptDraft = String(next.custom_prompt || "");
   renderTaskPrompts();
-  if (window.matchMedia?.("(max-width: 700px)")?.matches) {
-    $("#promptsEditor")?.scrollIntoView({ behavior: "smooth", block: "start" });
+  if (getComputedStyle($("#promptsRoot")).gridTemplateColumns.trim().split(/\s+/).length === 1) {
+    $("#promptsEditor")?.scrollIntoView({ behavior: window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ? "auto" : "smooth", block: "start" });
   }
 }
 
@@ -12239,7 +12239,7 @@ function renderCompanionPluginTerminal() {
         <p>${escapeHtml(entry.detail)}</p>
         <small>${escapeHtml(entry.note)}</small>
       </div>
-      <button type="button" class="dashboard-companion-plugin-action" data-jump-tab="${escapeHtml(entry.tab)}" ${entry.key === "image" && !entry.status.installed ? "disabled" : ""}>${escapeHtml(entry.action)}</button>
+      <button type="button" class="dashboard-companion-plugin-action" data-jump-tab="${escapeHtml(entry.tab)}" ${!entry.status?.installed ? 'disabled aria-disabled="true" title="未安装对应扩展插件"' : ""}>${escapeHtml(entry.action)}</button>
     </article>
   `).join("");
 }
@@ -13113,12 +13113,12 @@ function labeledRoleplayValuePresent(text, label) {
 }
 
 const troubleshootingCategories = {
-  all: { label: "全部概览", description: "先看所有正在影响功能的信号", keywords: [] },
-  reply: { label: "回复", description: "没有回复、回复异常或内容被带偏", keywords: ["回复", "llm", "防抖", "沉默", "token", "模型", "注入", "上下文", "群聊"] },
-  proactive: { label: "主动", description: "主动消息没有发出、被延后或被丢弃", keywords: ["主动", "候选", "静默", "冷却", "预约", "人格", "配额", "未回复"] },
+  all: { label: "全部", description: "查看所有检查结果", keywords: [] },
+  reply: { label: "聊天回复", description: "不回复、回复慢，或答非所问", keywords: ["回复", "llm", "防抖", "沉默", "token", "模型", "注入", "上下文", "群聊"] },
+  proactive: { label: "主动消息", description: "没有主动联系，或消息没有发出", keywords: ["主动", "候选", "静默", "冷却", "预约", "人格", "配额", "未回复"] },
   image_generation: { label: "生图", description: "文生图、自拍、参考图或图片下载失败", keywords: ["生图", "图片生成", "文生图", "自拍", "参考图", "comfy", "图像 api", "image"] },
-  image_recognition: { label: "识图", description: "图片识别、视觉模型、转述或窥屏异常", keywords: ["识图", "图片识别", "视觉", "转述", "窥屏", "screen", "vision"] },
-  voice: { label: "语音", description: "TTS 设置、真实语音 Provider 或音频生成失败", keywords: ["tts", "语音", "音频", "朗读", "voice"] },
+  image_recognition: { label: "图片识别", description: "看不懂图片，或屏幕内容识别失败", keywords: ["识图", "图片识别", "视觉", "转述", "窥屏", "screen", "vision"] },
+  voice: { label: "语音", description: "没有声音、音频生成失败或服务配置有误", keywords: ["tts", "语音", "音频", "朗读", "voice"] },
 };
 
 function troubleshootingCategoryInfo(category) {
@@ -13441,14 +13441,14 @@ function renderTroubleshooting() {
   const reasonItems = troubleshootingReasonItems(filteredChecks, filteredEvents, selected);
   renderTroubleshootingSuppressedWarnings(data);
   if (categoriesEl) categoriesEl.innerHTML = troubleshootingCategoryPickerMarkup(category);
-  $("#troubleshootingChecksTitle")?.replaceChildren(document.createTextNode(`${categoryInfo.label}：需要处理的信号`));
-  $("#troubleshootingChainTitle")?.replaceChildren(document.createTextNode(`${categoryInfo.label}：链路与运行状态`));
-  $("#troubleshootingEventsTitle")?.replaceChildren(document.createTextNode(`${categoryInfo.label}：最近问题`));
+  $("#troubleshootingChecksTitle")?.replaceChildren(document.createTextNode(`${categoryInfo.label} · 检查结果`));
+  $("#troubleshootingChainTitle")?.replaceChildren(document.createTextNode(`${categoryInfo.label} · 连接测试`));
+  $("#troubleshootingEventsTitle")?.replaceChildren(document.createTextNode(`${categoryInfo.label} · 最近记录`));
   summaryEl.innerHTML = `
     <section class="troubleshooting-head-card ${escapeHtml(level)}">
       <div>
         <span>${escapeHtml(summary.generated_at || "等待检查")}</span>
-        <b>${escapeHtml(summary.headline || "尚未加载排障信息")}</b>
+        <b>${escapeHtml(studioDiagnosticTitle(summary.headline) || "还没有检查结果")}</b>
         <small>${escapeHtml(troubleshootingSummaryText(counts, summary))}</small>
       </div>
       <button type="button" data-troubleshooting-refresh>重新检查</button>
@@ -13460,18 +13460,18 @@ function renderTroubleshooting() {
       </button>
     `).join("")}
     ${troubleshootingProactiveIntensityMarkup(data.proactive_intensity || state.overview?.proactive_intensity || {})}
-    <section class="troubleshooting-reasons">
-      <header>
-        <b>${escapeHtml(selected === "all" ? `近 2 小时${categoryInfo.label}待处理原因` : `${troubleshootingLevelLabel(selected)}原因`)}</b>
-        <span>${escapeHtml(selected === "all" ? "只展示近期需要处理的错误和警告；普通信息可点信息查看" : "筛选同时作用于常见问题检查和最近问题")}</span>
-      </header>
-      ${reasonItems.length ? reasonItems.map((item) => `
+    <details class="troubleshooting-reasons studio-reason-details">
+      <summary>
+        <b>${escapeHtml(selected === "all" ? `近 2 小时的问题摘要` : `${troubleshootingLevelLabel(selected)}原因`)}</b>
+        <span>${escapeHtml(selected === "all" ? "展开查看错误和警告；详细结果见下方" : "按当前条件筛选；详细结果见下方")}</span>
+      </summary>
+      <div class="studio-reason-body">${reasonItems.length ? reasonItems.map((item) => `
         <button type="button" class="${escapeHtml(item.level || "info")}" ${item.jump ? `data-jump-tab="${escapeHtml(item.jump)}"` : ""}>
           <b>${escapeHtml(item.title || "-")}</b>
           <span>${escapeHtml(item.text || "")}</span>
         </button>
-      `).join("") : `<div class="empty small">${escapeHtml(selected === "all" ? "暂无需要处理的原因" : "这个筛选下暂无原因")}</div>`}
-    </section>
+      `).join("") : `<div class="empty small">${escapeHtml(selected === "all" ? "暂无需要处理的原因" : "这个筛选下暂无原因")}</div>`}</div>
+    </details>
   `;
   document.querySelectorAll("[data-troubleshooting-filter]").forEach((button) => {
     button.classList.toggle("is-active", button.dataset.troubleshootingFilter === selected);
@@ -13673,12 +13673,13 @@ function troubleshootingCheckMarkup(item) {
     <section class="troubleshooting-check ${escapeHtml(level)}">
       <div class="troubleshooting-check-icon">${escapeHtml(level === "ok" ? "✓" : level === "error" ? "!" : level === "warn" ? "!" : "i")}</div>
       <div>
-        <b>${escapeHtml(item.title || "-")}</b>
-        <p>${escapeHtml(item.text || "")}</p>
+        <b title="${escapeHtml(item.title || "")}">${escapeHtml(studioDiagnosticTitle(item.title) || "-")}</b>
+        <p>${escapeHtml(studioDiagnosticExplanation(item) || item.text || "")}</p>
+        ${studioDiagnosticExplanation(item) && item.text ? `<details class="studio-check-original"><summary>原始检查说明</summary><p>${escapeHtml(item.text)}</p></details>` : ""}
         ${item.action ? `<small>${escapeHtml(item.action)}</small>` : ""}
       </div>
       <div class="troubleshooting-check-actions">
-        ${item.jump ? `<button type="button" data-jump-tab="${escapeHtml(item.jump)}">查看</button>` : ""}
+        ${item.jump ? `<button type="button" data-jump-tab="${escapeHtml(item.jump)}">${escapeHtml(studioDiagnosticDestination(item.jump))} ↗</button>` : ""}
         ${troubleshootingSuppressionButtonMarkup(item, "常见检查")}
       </div>
     </section>
@@ -13692,12 +13693,12 @@ function troubleshootingEventMarkup(item) {
         <span>${escapeHtml(item.source || "事件")}</span>
         <small>${escapeHtml(item.time || "")}</small>
       </header>
-      <b>${escapeHtml(item.title || "-")}</b>
+      <b title="${escapeHtml(item.title || "")}">${escapeHtml(studioDiagnosticTitle(item.title) || "-")}</b>
       ${item.detail ? `<p>${escapeHtml(item.detail)}</p>` : ""}
       <footer>
         ${item.action ? `<span>${escapeHtml(item.action)}</span>` : ""}
         <div class="troubleshooting-event-actions">
-          ${item.jump ? `<button type="button" data-jump-tab="${escapeHtml(item.jump)}">查看</button>` : ""}
+          ${item.jump ? `<button type="button" data-jump-tab="${escapeHtml(item.jump)}">${escapeHtml(studioDiagnosticDestination(item.jump))} ↗</button>` : ""}
           ${troubleshootingSuppressionButtonMarkup(item, item.source || "最近问题")}
         </div>
       </footer>
@@ -17080,13 +17081,13 @@ async function renderUserDetail(forceFetch = false) {
       </label>
       <button type="submit">保存</button>
       </form>
-    <div class="visual-strip">
+    <details class="studio-user-metrics"><summary>更多互动统计 <small>关系、主动次数、片段、待续话题与习惯</small></summary><div class="visual-strip">
       ${miniStat("关系阶段", detail.relationship_stage || detail.relationship_intimacy?.phase?.label || "初识")}
       ${scoreGauge("今日主动", detail.sent_today || 0, 0, proactiveGaugeMax(detail.sent_today, detail.effective_daily_limit, detail.effective_daily_limit_unlimited, state.overview?.private?.max_daily_messages || 8))}
       ${miniStat("片段", detail.dialogue_episode_count || (detail.dialogue_episodes || []).length)}
       ${miniStat("未完话头", Array.isArray(detail.open_loops) ? activeOpenLoopItems(detail.open_loops).length : (detail.open_loop_count || 0))}
       ${miniStat("习惯", detail.habit_count || detail.behavior_habits?.items?.length || 0)}
-    </div>
+    </div></details>
       ${detailBlock("最近对话", "", [["用户消息", detail.last_user_message || ""], ["陪伴回复", detail.last_companion_message || ""]])}
       ${renderOpenLoopBlock(detail)}
     </section>
@@ -23387,7 +23388,10 @@ function renderProactiveCandidates() {
   const listTruncated = Boolean(data.list_truncated);
   const taskData = state.overview?.proactive_tasks || {};
   const runtime = taskData.runtime || {};
-  $("#proactiveSummary").innerHTML = [
+  $("#proactiveSummary").innerHTML = `
+    <div class="studio-proactive-lead"><span>待发送 <b>${escapeHtml(pendingTotal)}</b></span><span>已发送 <b>${escapeHtml(counts.sent || 0)}</b></span><span>调度检查 <b>${runtime.healthy ? "正常" : "待确认"}</b></span></div>
+    <details class="studio-proactive-metrics" ${studioDisclosureIsOpen("proactive-metrics") ? "open" : ""} data-studio-disclosure="proactive-metrics"><summary>完整统计与调度状态 <small>新增、合并、拦截及执行记录</small></summary><div class="studio-metric-list">
+${[
     proactiveSummaryCard("今日新增", data.today_record_total || 0, `候选池现有 ${formatNumber(data.pool_record_total || totalRecords)} 条`),
     proactiveSummaryCard("今日合并", data.today_merge_trigger_count || 0, "同一来源或相近候选合并次数"),
     proactiveSummaryCard("今日拦截", data.today_blocked_record_total || 0, "按实际拦截记录统计"),
@@ -23397,7 +23401,9 @@ function renderProactiveCandidates() {
     proactiveSummaryCard("被拦截", counts.blocked || 0, "同类拦截已合并计数"),
     proactiveSummaryCard("执行审计", taskData.audit_total || 0, `${Object.keys(taskData.audit_status_counts || {}).length || 0} 类结果`),
     proactiveSummaryCard("循环状态", runtime.healthy ? "正常" : "待确认", runtime.last_tick_started_ts ? `最近 ${runtime.last_tick_started}` : "尚无心跳"),
-  ].join("");
+  ].join("")}
+    </div></details>`;
+  studioBindDisclosures($("#proactiveSummary"));
   $("#proactiveSourceChart").innerHTML = donutChart(sourceCounts, {
     emptyText: "暂无来源数据",
     labelFormatter: (label) => sourceLabels[label] || proactiveCandidateSourceLabel(label),
@@ -23435,7 +23441,7 @@ function renderProactiveCandidates() {
           <div class="toolbar">
             <span class="badge">${escapeHtml(repeat > 1 ? `${status} x${repeat}` : status)}</span>
             <button type="button" class="danger-outline" data-proactive-candidate-delete="${escapeHtml(item.id || "")}" data-proactive-user-id="${escapeHtml(item.user_id || "")}">删除</button>
-            <button type="button" class="danger-outline" data-proactive-candidate-prune="${escapeHtml(item.user_id || "")}" data-proactive-prune-keep="160">删一点</button>
+            <button type="button" class="danger-outline" data-proactive-candidate-prune="${escapeHtml(item.user_id || "")}" data-proactive-prune-keep="160" title="保留最近 160 条，清理更早的记录">清理旧记录</button>
           </div>
         </div>
         <p>${escapeHtml(item.motive || "暂无动机记录")}</p>
@@ -28080,22 +28086,23 @@ function renderFeatureSwitches() {
       ? proactiveIntensityCommonSettingCard(overviewSettings, intensity)
       : "";
     return `
-      <section class="feature-switch-group">
-        <header>
+      <details class="feature-switch-group studio-feature-group" data-studio-feature-group="${escapeHtml(group.title)}" ${studioFeatureGroupOpen(group.title) ? "open" : ""}>
+        <summary>
           <div>
             <b>${escapeHtml(group.title)}</b>
             <span>${escapeHtml(group.note || "")}</span>
           </div>
-          <small>${escapeHtml(groupMeta)}</small>
-        </header>
+          <small>已开启 ${escapeHtml(groupMeta)}</small>
+        </summary>
         <div class="feature-switch-list">
           ${prefix}
           ${visibleKeys.map((key) => featureSwitchItem(key)).join("")}
         </div>
-      </section>
+      </details>
     `;
   }).filter(Boolean).join("");
   $("#featureFlags").innerHTML = board || `<div class="feature-filter-empty"><b>没有匹配的功能开关</b><span>可以调整领域、作用阶段、状态或搜索词。</span><button type="button" data-feature-filter-reset>清除筛选</button></div>`;
+  studioBindFeatureGroups();
   document.querySelectorAll("[data-feature-key]").forEach((input) => {
     input.addEventListener("change", () => {
       state.featureDraft[input.dataset.featureKey] = input.checked;
@@ -28121,7 +28128,7 @@ function renderFeatureSwitches() {
       renderFeatureSwitches();
     };
     card.addEventListener("click", (event) => {
-      if (event.target.closest("button, input, label, select, textarea, a")) return;
+      if (event.target.closest("button, input, label, select, textarea, a, summary, .studio-feature-notes")) return;
       openDetail();
     });
   });
@@ -28512,10 +28519,9 @@ function featureSwitchItem(key) {
       <div class="feature-switch-body">
         <button type="button" class="feature-switch-text" data-feature-open="${escapeHtml(key)}">
           <b>${escapeHtml(featureLabel(key))}</b>
-          <small>${escapeHtml(featurePublicKey(key))}</small>
           <span class="feature-open-hint">查看配置 <span aria-hidden="true">›</span></span>
         </button>
-        <div class="feature-stage-tags" aria-label="作用阶段">${imageUse ? `<span class="feature-image-use">${escapeHtml(imageUse)}</span>` : ""}${stageTags}</div>
+        <details class="studio-feature-notes"><summary>配置键与作用阶段</summary><code>${escapeHtml(featurePublicKey(key))}</code><div class="feature-stage-tags" aria-label="作用阶段">${imageUse ? `<span class="feature-image-use">${escapeHtml(imageUse)}</span>` : ""}${stageTags}</div></details>
         <div class="feature-switch-meta">
           <span class="feature-state-text">${escapeHtml(stateText)}</span>
           ${sourceBadge}
@@ -39441,8 +39447,19 @@ function switchTab(tabName) {
   // Calendar is part of the observation workspace now. Keep old deep links
   // and bookmarks working by redirecting the retired tab to that workspace.
   if (tabName === "calendar") tabName = "memory";
-  if (tabName === "enable_experimental_bluetooth_wakeup") tabName = "reality";
   tabName = tabName === "modules" ? "config" : (opensSocialLearning ? "learning" : (opensDailyReview ? "experimental" : (tabName || "dashboard")));
+  if (tabName === "creative" && !contentCompanionInstalled()) {
+    showToast("尚未安装创作扩展，请在插件市场安装后使用", "warn");
+    return;
+  }
+  if (tabName === "reality" && !realityCompanionInstalled()) {
+    showToast("尚未安装现实触及扩展，请在插件市场安装后使用", "warn");
+    return;
+  }
+  if (tabName === "image" && !imageCompanionInstalled()) {
+    showToast("尚未安装生图扩展，请在插件市场安装后使用", "warn");
+    return;
+  }
   if (opensSocialLearning) state.learningSection = "social";
   if (opensDailyReview) state.experimentalSubpage = "daily-review";
   if (tabName !== state.activeTab && hasUnsavedChanges()) {
@@ -40035,7 +40052,7 @@ document.addEventListener("change", (event) => {
 
 document.addEventListener("click", async (event) => {
   const target = event.target instanceof Element ? event.target.closest("[data-jump-tab]") : null;
-  if (!target) return;
+  if (!target || target.disabled || target.getAttribute("aria-disabled") === "true") return;
   state.setupGuideOpen = false;
   clearSetupGuideProactivePoll();
   renderSetupGuideOverlay();
@@ -41642,3 +41659,189 @@ async function bootstrapPage() {
 }
 
 void bootstrapPage();
+
+/* Companion Studio: presentation enhancements only. All navigation goes through
+ * existing tab clicks / switchTab(), including dirty-form checks and lazy loads. */
+(function initializeCompanionStudio() {
+  if (!document.body.classList.contains("companion-studio")) return;
+  const nav = document.querySelector(".annotations");
+  const dialog = document.getElementById("studioCommand");
+  const input = document.getElementById("studioCommandInput");
+  const results = document.getElementById("studioCommandResults");
+  const descriptions = {
+    dashboard: "今日状态、陪伴概况与运行信息", roleplay: "角色设定、世界观、衣柜与关系资料",
+    private: "陪伴对象、用户资料与私聊关系", group: "群聊成员、互动与观察",
+    learning: "表达学习、社交知识与反应素材", memory: "日程、时间轴、记忆与生活观察",
+    proactive: "主动互动、候选消息与策略", creative: "书架、日记、创作与空间",
+    image: "图像生成与运行状态", tokens: "用量、预算与消耗分析",
+    troubleshooting: "诊断、连接检查与故障排查", config: "功能开关、人格配置与行为设置",
+    models: "模型路由、Provider、语音与图像服务", experimental: "实验能力与每日巡视",
+    prompts: "任务提示词、附加指令与默认恢复", reality: "现实触及与外部设备",
+  };
+  let returnFocus = null;
+  const visibleTabs = () => [...nav.querySelectorAll(".tab[data-tab]")].filter(tab => !tab.hidden && getComputedStyle(tab).display !== "none");
+  function renderSearch() {
+    const query = input.value.trim().toLocaleLowerCase();
+    results.replaceChildren();
+    visibleTabs().filter(tab => `${tab.textContent} ${descriptions[tab.dataset.tab] || ""}`.toLocaleLowerCase().includes(query)).forEach(tab => {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "studio-command-result";
+      const icon = document.createElement("span");
+      icon.textContent = tab.querySelector("i")?.textContent || "↗";
+      icon.setAttribute("aria-hidden", "true");
+      const copy = document.createElement("div");
+      const title = document.createElement("b");
+      title.textContent = tab.querySelector("span")?.textContent || tab.dataset.tab;
+      const hint = document.createElement("small");
+      hint.textContent = descriptions[tab.dataset.tab] || "打开功能页面";
+      copy.append(title, hint);
+      button.append(icon, copy);
+      button.addEventListener("click", () => { dialog.close(); tab.click(); });
+      results.append(button);
+    });
+    if (!results.childElementCount) {
+      const empty = document.createElement("p");
+      empty.className = "studio-search-empty";
+      empty.textContent = "没有找到相关功能，试试「配置」或「日程」。";
+      results.append(empty);
+    }
+  }
+  function openSearch() {
+    if (dialog.open) return;
+    // Do not cover a pending confirmation or another feature's modal dialog.
+    if (document.querySelector("dialog[open]")) return;
+    returnFocus = document.activeElement;
+    input.value = "";
+    renderSearch();
+    dialog.showModal();
+    input.focus();
+  }
+  document.getElementById("studioFindBtn").addEventListener("click", openSearch);
+  document.getElementById("studioCommandClose").addEventListener("click", () => dialog.close());
+  dialog.addEventListener("close", () => returnFocus?.focus?.({ preventScroll: true }));
+  dialog.addEventListener("click", event => {
+    if (event.target !== dialog) return;
+    const rect = dialog.getBoundingClientRect();
+    if (event.clientX < rect.left || event.clientX > rect.right || event.clientY < rect.top || event.clientY > rect.bottom) dialog.close();
+  });
+  input.addEventListener("input", renderSearch);
+  dialog.addEventListener("keydown", event => {
+    const buttons = [...results.querySelectorAll("button")];
+    const index = buttons.indexOf(document.activeElement);
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      if (event.key === "ArrowUp" && index <= 0) input.focus();
+      else buttons[Math.min(buttons.length - 1, Math.max(0, index + (event.key === "ArrowDown" ? 1 : -1)))]?.focus();
+    } else if (event.key === "Enter" && event.target === input) {
+      event.preventDefault(); buttons[0]?.click();
+    }
+  });
+  document.addEventListener("keydown", event => {
+    if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+      event.preventDefault(); if (dialog.open) dialog.close(); else openSearch();
+    }
+    const stat = event.target.closest?.(".stat[data-jump-tab]");
+    if (stat && (event.key === "Enter" || event.key === " ")) { event.preventDefault(); stat.click(); }
+  });
+  let activeName = "";
+  function syncNavigation() {
+    const tabs = [...nav.querySelectorAll(".tab[data-tab]")];
+    const active = tabs.find(tab => tab.classList.contains("is-active"));
+    tabs.forEach(tab => {
+      if (tab === active) tab.setAttribute("aria-current", "page");
+      else tab.removeAttribute("aria-current");
+      tab.setAttribute("aria-controls", `panel-${tab.dataset.tab}`);
+    });
+    if (!active || activeName === active.dataset.tab) return;
+    activeName = active.dataset.tab;
+    document.getElementById("studioPageTitle").textContent = active.querySelector("span")?.textContent || "总览";
+    document.querySelector(".studio-skip").href = `#panel-${activeName}`;
+    if (window.matchMedia("(min-width: 681px)").matches) {
+      const top = active.offsetTop;
+      if (top < nav.scrollTop || top + active.offsetHeight > nav.scrollTop + nav.clientHeight) {
+        nav.scrollTo({ top: Math.max(0, top - nav.clientHeight / 2), behavior: "auto" });
+      }
+    }
+  }
+  new MutationObserver(syncNavigation).observe(nav, { subtree: true, attributes: true, attributeFilter: ["class", "hidden"] });
+  syncNavigation();
+  function enhanceStats(root) {
+    root.querySelectorAll(".stat[data-jump-tab]").forEach(stat => {
+      stat.tabIndex = 0;
+      stat.setAttribute("role", "button");
+      stat.setAttribute("aria-label", `${stat.textContent.trim()}，查看详情`);
+    });
+  }
+  ["stats", "configStats"].forEach(id => {
+    const root = document.getElementById(id);
+    if (!root) return;
+    new MutationObserver(() => enhanceStats(root)).observe(root, { childList: true });
+    enhanceStats(root);
+  });
+  document.querySelectorAll(".layout > .panel").forEach(panel => { panel.tabIndex = -1; });
+})();
+
+/* Plain-language labels only; raw diagnostic data, filters and action keys remain unchanged. */
+function studioDiagnosticTitle(title) {
+  const labels = {
+    "有可关注项": "有几项需要确认",
+    "主动消息没有私聊对象": "还没有设置私聊对象",
+    "主动带图当前不可用": "主动消息暂时不能附图",
+    "Token 预算未阻塞": "Token 预算正常",
+    "TTS 强化未开启": "未启用语音增强",
+    "SQLite WAL 检查通过": "数据库读写检查通过",
+    "近期模型调用无待处理失败": "近期没有待处理的模型错误",
+  };
+  return labels[String(title || "")] || String(title || "");
+}
+function studioDiagnosticDestination(tab) {
+  const labels = { private: "设置陪伴对象", tokens: "查看用量", config: "打开设置", models: "模型设置", image: "图片设置", proactive: "主动消息设置", group: "群聊设置", memory: "查看日程", troubleshooting: "查看详情" };
+  return labels[tab] || "打开相关页面";
+}
+
+function studioDiagnosticExplanation(item) {
+  const explanations = {
+    "主动消息没有私聊对象": "还没有启用的陪伴对象，所以暂时不会发送主动私聊消息。",
+    "主动带图当前不可用": "主动消息暂时不能附图。请检查图片服务、用量限制，以及陪伴对象的权限。",
+    "TTS 强化未开启": "语音增强已关闭。请勿要求模型输出 TTS 标签；如果仍有标签，发送前会清理。",
+  };
+  return explanations[String(item?.title || "")] || "";
+}
+
+/* Studio v3: native disclosures preserve mounted controls and existing events.
+ * In-memory UI preferences only. Never write configuration or infer feature state. */
+function studioFeatureFilterActive() {
+  return Boolean(document.getElementById("featureFilter")?.value.trim())
+    || [state.featureDomainFilter, state.featureStageFilter, state.featureStatusFilter].some(value => value && value !== "all");
+}
+function studioDisclosureIsOpen(key) { return Boolean(studioDisclosureIsOpen.values?.get(key)); }
+function studioBindDisclosures(root) {
+  root?.querySelectorAll("details[data-studio-disclosure]").forEach(node => {
+    if (node.dataset.studioBound) return;
+    node.dataset.studioBound = "1";
+    node.addEventListener("toggle", () => {
+      if (!node.isConnected) return;
+      studioDisclosureIsOpen.values ||= new Map();
+      studioDisclosureIsOpen.values.set(node.dataset.studioDisclosure, node.open);
+    });
+  });
+}
+function studioFeatureGroupOpen(title) {
+  return studioFeatureFilterActive() || studioDisclosureIsOpen("feature:" + title);
+}
+function studioBindFeatureGroups() {
+  document.querySelectorAll("details[data-studio-feature-group]").forEach(node => {
+    const revealedByFilter = studioFeatureFilterActive();
+    node.querySelector(":scope > summary")?.addEventListener("click", () => {
+      if (revealedByFilter) return;
+      studioDisclosureIsOpen.values ||= new Map();
+      studioDisclosureIsOpen.values.set("feature:" + node.dataset.studioFeatureGroup, !node.open);
+    });
+    node.addEventListener("toggle", () => {
+      if (!node.isConnected || revealedByFilter || studioFeatureFilterActive()) return;
+      studioDisclosureIsOpen.values ||= new Map();
+      studioDisclosureIsOpen.values.set("feature:" + node.dataset.studioFeatureGroup, node.open);
+    });
+  });
+}

--- a/pages/companion-panel/app.js
+++ b/pages/companion-panel/app.js
@@ -8063,7 +8063,8 @@ function selectTaskPrompt(taskKey) {
   state.selectedTaskPromptKey = next.task_key;
   state.taskPromptDraft = String(next.custom_prompt || "");
   renderTaskPrompts();
-  if (getComputedStyle($("#promptsRoot")).gridTemplateColumns.trim().split(/\s+/).length === 1) {
+  const promptsRoot = $("#promptsRoot");
+  if (promptsRoot && getComputedStyle(promptsRoot).gridTemplateColumns.trim().split(/\s+/).length === 1) {
     $("#promptsEditor")?.scrollIntoView({ behavior: window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ? "auto" : "smooth", block: "start" });
   }
 }
@@ -41697,7 +41698,7 @@ void bootstrapPage();
       hint.textContent = descriptions[tab.dataset.tab] || "打开功能页面";
       copy.append(title, hint);
       button.append(icon, copy);
-      button.addEventListener("click", () => { dialog.close(); tab.click(); });
+      button.addEventListener("click", () => { returnFocus = tab; dialog.close(); tab.click(); });
       results.append(button);
     });
     if (!results.childElementCount) {

--- a/pages/companion-panel/css/polish.css
+++ b/pages/companion-panel/css/polish.css
@@ -5309,3 +5309,702 @@ code,
     flex-basis: calc(50% - 3px);
   }
 }
+
+/* ==========================================================================
+   Companion Studio / 2026-09 — presentation-only redesign.
+   Deliberately last: legacy component layouts and visibility contracts remain.
+   All palette variants still use the original appearance selector.
+   ========================================================================== */
+:root {
+  --studio-bg: #f7f8f4;
+  --studio-sidebar: #f0f3ed;
+  --studio-hero: #edf1e7;
+  --radius: 18px;
+  --radius-sm: 10px;
+  --shadow: 0 8px 32px rgba(35, 57, 43, .035);
+  --shadow-soft: 0 2px 10px rgba(35, 57, 43, .025);
+}
+:root[data-theme="classic"], :root:not([data-theme]) {
+  --bg: #f7f8f4; --panel: #fff; --surface: #f6f8f3;
+  --surface-strong: #e9eee4; --ink: #293d33; --muted: #748074;
+  --line: #dce3d7; --line-soft: #e9ede4;
+  --accent: #53755b; --accent-strong: #34543e; --accent-soft: #e6eddf;
+  --blue: #648371; --blue-soft: #e6ede5;
+  --red: #bf7366; --red-soft: #f6e9e5;
+  --gold: #a78d56; --gold-soft: #f6f0e1;
+  --cv-line: #dce3d7; --cv-line-soft: #e9ede4;
+}
+:root[data-theme]:not([data-theme="classic"]) {
+  --studio-bg: var(--bg); --studio-sidebar: var(--surface);
+  --studio-hero: color-mix(in srgb, var(--accent-soft) 45%, var(--panel));
+}
+html:has(body.companion-studio) { background: var(--studio-bg) !important; scrollbar-gutter: auto; }
+body.companion-studio { background: var(--studio-bg) !important; color: var(--ink); font-weight: 400; font-size: 14px; line-height: 1.65; }
+html[data-page-font="original"] body.companion-studio { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif !important; }
+body.companion-studio::before, body.companion-studio::after { content: none !important; }
+.companion-studio .shell { width: 100% !important; max-width: 1800px !important; margin: 0 auto !important; padding: 0 42px 48px 270px !important; }
+.companion-studio .layout { display: block !important; background: none !important; border: 0 !important; box-shadow: none !important; border-radius: 0 !important; overflow: visible !important; backdrop-filter: none !important; }
+.companion-studio .panel { padding: 28px 0 !important; background: transparent !important; border: 0 !important; box-shadow: none !important; min-width: 0; }
+.companion-studio .panel::before, .companion-studio .panel::after { content: none !important; }
+.companion-studio .panel:not(.is-active):not(.is-leaving) { display: none !important; }
+.companion-studio [hidden] { display: none !important; }
+/* Quiet, persistent application header */
+.companion-studio .folio { display: flex !important; align-items: center !important; gap: 18px !important; min-height: 102px !important; margin: 0 !important; padding: 20px 0 !important; border: 0 !important; border-bottom: 1px solid var(--line) !important; background: transparent !important; box-shadow: none !important; border-radius: 0 !important; backdrop-filter: none !important; }
+.companion-studio .folio::before, .companion-studio .folio::after, .companion-studio .folio-meta::before, .companion-studio .folio-meta::after { content: none !important; }
+.companion-studio .folio-meta { flex: 1; min-width: 0; padding: 0 !important; display: block !important; background: none !important; border: 0 !important; }
+.companion-studio .folio-heading { display: flex !important; flex-wrap: wrap; gap: 12px 28px; align-items: center; justify-content: space-between; }
+.companion-studio .folio-eyebrow { font-size: 10px !important; letter-spacing: 2px !important; font-weight: 400 !important; color: var(--muted) !important; margin-bottom: 6px; }
+.companion-studio .folio-title { font-size: 19px !important; line-height: 1.6 !important; letter-spacing: -.4px !important; font-weight: 600 !important; margin: 0 !important; }
+.studio-header-slash { color: #b8c2b6; margin: 0 12px; font-weight: 300; }
+#studioPageTitle { font-size: 14px; font-weight: 400; color: var(--muted); }
+.companion-studio .folio-persona-context { display: grid; gap: 4px; }
+.companion-studio #subtitle { margin: 0 !important; font-size: 12px !important; color: var(--muted) !important; max-width: 36ch; }
+.companion-studio .folio-plate { width: 46px !important; height: 46px !important; min-height: 0 !important; flex: 0 0 46px; border-radius: 50% !important; border: 0 !important; padding: 0 !important; background: var(--accent-soft) !important; overflow: hidden; }
+.companion-studio .folio-plate:not(:has(img[src]:not([src=""]))) { display: none !important; }
+.companion-studio .folio-plate::before, .companion-studio .folio-plate::after { content: none !important; }
+.companion-studio .daily-outfit-logo { width: 100% !important; height: 100% !important; max-height: none !important; object-fit: cover !important; }
+.companion-studio .folio-tools { display: flex !important; flex-direction: row !important; gap: 10px !important; padding: 0 !important; width: auto !important; border: 0 !important; background: none !important; }
+.companion-studio .seal, .companion-studio .setup-guide-entry { position: relative !important; min-height: 40px !important; height: 40px !important; border: 1px solid var(--line) !important; border-radius: 10px !important; background: var(--panel) !important; color: var(--ink) !important; box-shadow: none !important; font-size: 12px !important; font-weight: 500 !important; padding: 0 14px !important; }
+.companion-studio .seal { width: 40px !important; padding: 0 !important; transform: none !important; }
+.companion-studio .seal-mark { font-size: 22px !important; }
+.companion-studio .seal small { display: none; }
+.companion-studio .setup-guide-badge { box-shadow: none !important; background: var(--accent) !important; font-size: 9px !important; min-width: 16px !important; height: 16px !important; line-height: 16px !important; }
+/* Navigation: every existing tab remains the original clickable node. */
+.companion-studio .annotations { position: fixed !important; inset: 0 auto 0 0 !important; width: 226px !important; height: 100dvh !important; display: flex !important; flex-direction: column !important; align-items: stretch !important; gap: 4px !important; padding: 28px 18px 22px !important; border: 0 !important; border-right: 1px solid var(--line-soft) !important; background: var(--studio-sidebar) !important; border-radius: 0 !important; overflow-y: auto !important; overflow-x: hidden !important; z-index: 30 !important; box-shadow: none !important; backdrop-filter: none !important; scrollbar-width: thin; }
+.companion-studio .annot-axis, .companion-studio .annotations::before, .companion-studio .annotations::after { display: none !important; }
+.studio-brand { display: flex; align-items: center; gap: 10px; padding: 1px 6px 28px; flex-shrink: 0; }
+.studio-brand-mark { width: 36px; height: 36px; background: var(--accent); color: #fff; border-radius: 12px; font-size: 33px; line-height: 36px; text-align: center; }
+.studio-brand b { display: block; font-size: 15px; letter-spacing: -.3px; font-weight: 600; }
+.studio-brand small { display: block; font-size: 7px; letter-spacing: 1.6px; color: var(--muted); margin-top: 3px; }
+.companion-studio .studio-find { display: flex; justify-content: space-between; align-items: center; gap: 6px; padding: 10px 11px !important; width: 100%; background: color-mix(in srgb, var(--panel) 62%, transparent) !important; color: var(--muted) !important; border: 1px solid var(--line) !important; border-radius: 9px !important; font-size: 11px !important; font-weight: 400 !important; margin-bottom: 12px; }
+.studio-find kbd { font: inherit; font-size: 9px; opacity: .75; }
+.studio-nav-label { padding: 17px 14px 7px; font-size: 10px; letter-spacing: 1.4px; color: var(--muted); }
+.companion-studio .annotations .tab { display: flex !important; flex-direction: row !important; align-items: center !important; gap: 14px !important; width: 100% !important; min-width: 0 !important; min-height: 40px !important; padding: 10px 15px !important; margin: 0 !important; border: 0 !important; border-radius: 9px !important; background: transparent !important; color: var(--muted) !important; box-shadow: none !important; font-size: 13px !important; font-weight: 450 !important; transform: none !important; flex-shrink: 0; }
+.companion-studio .annotations .tab i { display: inline-grid; place-items: center; width: 19px; font-size: 19px !important; font-style: normal; font-family: system-ui, sans-serif; font-weight: 400 !important; color: inherit !important; line-height: 1; }
+.companion-studio .annotations .tab span { font-size: inherit !important; font-weight: inherit !important; }
+.companion-studio .annotations .tab:hover { background: var(--accent-soft) !important; color: var(--accent-strong) !important; }
+.companion-studio .annotations .tab.is-active { background: var(--accent) !important; color: white !important; font-weight: 500 !important; }
+.companion-studio .annotations .tab::before, .companion-studio .annotations .tab::after { content: none !important; }
+.companion-studio .annotations .tab[hidden] { display: none !important; }
+.studio-nav-foot { margin-top: auto; padding: 28px 12px 0; font-size: 10px; color: var(--muted); }
+.studio-nav-foot > span { color: var(--accent); margin-right: 5px; }
+.studio-nav-foot small { display: block; margin-top: 8px; font-size: 7px; letter-spacing: 1.6px; opacity: .7; }
+/* Home: invitation, four compact signals, then two calm columns. */
+.companion-studio .section-head { gap: 18px !important; margin: 0 0 24px !important; padding: 0 0 20px !important; border-bottom: 1px solid var(--line-soft) !important; background: transparent !important; }
+.companion-studio .section-head h2 { font-size: 23px !important; font-weight: 600 !important; letter-spacing: -.5px; }
+.companion-studio .section-head h2::before, .companion-studio .section-head h2::after { content: none !important; }
+.companion-studio .section-desc { color: var(--muted) !important; font-size: 12px !important; line-height: 1.8 !important; margin-top: 7px !important; font-weight: 400 !important; }
+.companion-studio .dashboard-overview-head { border: 0 !important; padding: 0 !important; margin-bottom: 24px !important; }
+.companion-studio #exportSnapshotBtn { color: var(--muted) !important; background: transparent !important; border: 1px solid var(--line) !important; box-shadow: none !important; font-size: 11px !important; padding: 9px 14px !important; border-radius: 8px !important; }
+.studio-welcome { position: relative; isolation: isolate; display: flex; align-items: center; min-height: 280px; padding: 34px 38px; border: 1px solid color-mix(in srgb, var(--line) 55%, transparent); border-radius: 19px; background: var(--studio-hero); overflow: hidden; }
+.studio-welcome-copy { position: relative; z-index: 1; }
+.studio-kicker { display: flex; align-items: center; gap: 8px; color: var(--accent); font-size: 8px; letter-spacing: 2px; font-weight: 600; }
+.studio-kicker > span { width: 5px; height: 5px; border-radius: 50%; background: var(--accent); }
+.companion-studio .studio-welcome h2 { margin: 18px 0 12px !important; font-size: clamp(25px, 2.4vw, 37px) !important; font-weight: 500 !important; line-height: 1.5 !important; letter-spacing: 1px; color: var(--accent-strong); }
+.studio-welcome p { font-size: 12px; color: var(--muted); }
+.studio-welcome-actions { display: flex; align-items: center; flex-wrap: wrap; gap: 19px; margin-top: 25px; }
+.companion-studio .studio-primary { background: var(--accent) !important; color: #fff !important; border: 0 !important; border-radius: 9px !important; padding: 11px 17px !important; font-size: 12px !important; font-weight: 500 !important; box-shadow: none !important; }
+.studio-primary > span { margin-left: 13px; }
+.companion-studio .studio-text-button { border: 0 !important; background: none !important; color: var(--accent-strong) !important; font-size: 11px !important; font-weight: 400 !important; padding: 8px 0 !important; box-shadow: none !important; }
+.studio-text-button > span { margin-left: 6px; }
+.studio-art { position: absolute; right: 20px; bottom: 15px; width: 41%; max-width: 370px; z-index: -1; }
+.studio-art-caption { position: absolute; bottom: 17px; right: 55px; font-size: 7px; color: var(--accent); letter-spacing: 2px; opacity: .65; }
+.studio-metrics-label { display: flex; justify-content: space-between; align-items: center; margin: 28px 2px 12px; font-size: 12px; font-weight: 500; }
+.studio-metrics-label small { font-size: 10px; color: var(--muted); font-weight: 400; }
+.companion-studio #stats { display: grid !important; grid-template-columns: repeat(4, minmax(0, 1fr)) !important; gap: 12px !important; margin: 0 0 28px !important; }
+.companion-studio .stat { border: 1px solid var(--line-soft) !important; border-radius: 12px !important; padding: 20px 17px !important; background: var(--panel) !important; box-shadow: none !important; }
+.companion-studio .stat::before, .companion-studio .stat::after { content: none !important; }
+.companion-studio .stat b { font-size: clamp(14px, 1.5vw, 21px) !important; font-weight: 550 !important; letter-spacing: -.5px; margin: 5px 0 8px !important; line-height: 1.4; }
+.companion-studio .stat span { display: block; color: var(--muted) !important; font-size: 10px !important; line-height: 1.6; }
+.companion-studio .stat:hover { border-color: var(--accent) !important; background: var(--surface) !important; }
+.companion-studio .dashboard-life-desk { display: grid !important; grid-template-columns: minmax(0, 1fr) minmax(0, 1.13fr) !important; gap: 20px !important; align-items: start !important; margin: 0 !important; }
+.companion-studio .dashboard-life-column { display: grid !important; grid-template-columns: minmax(0,1fr) !important; gap: 20px !important; min-width: 0; }
+.companion-studio .life-desk-card { position: relative; border: 1px solid var(--line-soft) !important; border-radius: 15px !important; padding: 23px !important; background: var(--panel) !important; box-shadow: none !important; overflow: hidden; }
+.companion-studio .life-desk-card::before, .companion-studio .life-desk-card::after { content: none !important; }
+.companion-studio .life-desk-card-head { display: flex; justify-content: space-between; gap: 12px !important; align-items: center; margin-bottom: 22px !important; padding: 0 !important; border: 0 !important; }
+.companion-studio .life-desk-card-head h3 { font-size: 16px !important; font-weight: 550 !important; color: var(--ink) !important; }
+.companion-studio .life-desk-card-head > div { gap: 9px !important; }
+.companion-studio .life-desk-dot { width: 6px !important; height: 6px !important; background: #a1b18e !important; box-shadow: none !important; }
+.companion-studio .life-desk-card-head small { font-size: 9px !important; color: var(--muted) !important; font-weight: 400 !important; }
+.companion-studio .life-fact-grid { display: grid !important; grid-template-columns: repeat(2, minmax(0, 1fr)) !important; gap: 0 22px !important; }
+.companion-studio .life-fact-item { border: 0 !important; border-bottom: 1px solid var(--line-soft) !important; padding: 13px 0 !important; min-height: 0 !important; border-radius: 0 !important; background: transparent !important; box-shadow: none !important; }
+.companion-studio .life-fact-item:nth-last-child(-n+2) { border-bottom: 0 !important; }
+.companion-studio .life-fact-item > span { font-size: 10px !important; color: var(--muted) !important; font-weight: 400 !important; }
+.companion-studio .life-fact-item > b { font-size: 12px !important; color: var(--ink) !important; font-weight: 500 !important; margin-top: 5px; line-height: 1.65 !important; }
+.companion-studio .life-desk-link { padding: 5px 9px !important; border: 1px solid var(--line-soft) !important; color: var(--accent) !important; background: var(--surface) !important; border-radius: 7px !important; font-size: 10px !important; font-weight: 450 !important; box-shadow: none !important; }
+.companion-studio .life-timeline-preview { min-height: 230px !important; max-height: none !important; padding: 0 !important; overflow: visible !important; }
+.companion-studio .life-timeline-row { background: transparent !important; border: 0 !important; border-bottom: 1px solid var(--line-soft) !important; border-radius: 0 !important; padding: 16px 4px !important; margin: 0 !important; box-shadow: none !important; }
+.companion-studio .life-timeline-row.is-current { background: var(--surface) !important; border-radius: 10px !important; padding: 16px 12px !important; border: 1px solid var(--line-soft) !important; }
+.companion-studio .life-timeline-content b { font-size: 13px !important; font-weight: 500 !important; }
+.companion-studio .life-timeline-content p { font-size: 11px !important; line-height: 1.8 !important; }
+.companion-studio .life-current-activity { border: 0 !important; background: var(--surface) !important; border-radius: 10px !important; padding: 16px !important; }
+.companion-studio .life-current-activity b { font-size: 15px !important; font-weight: 500 !important; }
+.companion-studio .life-state-grid { gap: 14px !important; }
+.companion-studio .life-state-grid > div { border: 0 !important; background: transparent !important; padding: 6px 0 !important; }
+.companion-studio .life-state-grid b { font-size: 12px !important; font-weight: 500 !important; }
+.companion-studio .life-energy-track { height: 4px !important; margin: 20px 0 !important; background: var(--accent-soft) !important; }
+.companion-studio .life-energy-track i { background: var(--accent) !important; }
+.companion-studio .life-empty { display: grid; place-content: center; text-align: center; min-height: 150px; border: 0 !important; border-radius: 10px !important; background: var(--surface) !important; color: var(--muted) !important; font-size: 12px !important; }
+.companion-studio .dashboard-secondary { margin-top: 30px !important; display: grid; gap: 12px !important; }
+.studio-section-label { font-size: 14px; margin: 0 2px 3px; }
+.studio-section-label small { font-size: 11px; color: var(--muted); margin-left: 12px; }
+.companion-studio .dashboard-disclosure { border: 1px solid var(--line-soft) !important; border-radius: 12px !important; background: var(--panel) !important; box-shadow: none !important; overflow: hidden; }
+.companion-studio .dashboard-disclosure > summary { padding: 20px 23px !important; background: transparent !important; cursor: pointer; }
+.companion-studio .dashboard-disclosure > summary b { font-size: 13px !important; font-weight: 500 !important; }
+.companion-studio .dashboard-disclosure > summary small { font-size: 11px !important; color: var(--muted); font-weight: 400 !important; }
+.companion-studio .dashboard-disclosure[open] > summary { border-bottom: 1px solid var(--line-soft); }
+.companion-studio .studio-memory-disclosure .dashboard-life-column-right { padding: 20px; grid-template-columns: repeat(2, minmax(0,1fr)) !important; }
+.companion-studio .studio-terminal-disclosure { margin-top: 12px; }
+.companion-studio .dashboard-companion-terminal { border: 0 !important; box-shadow: none !important; background: transparent !important; margin: 0 !important; padding: 24px !important; }
+.companion-studio .dashboard-companion-terminal h2 { font-size: 18px !important; }
+/* Shared visual system. Component-specific grids and behavior are untouched. */
+.companion-studio :is(.module-card,.dashboard-strategy-card,.dashboard-chart-card,.dashboard-insight-card,.dashboard-activity-card,.qzone-card,.config-persona-selector,.config-persona-top-row > article,.persona-import-panel,.world-knowledge-brief,.proactive-summary,.prompts-catalog,.prompts-editor,.memory-view-card,.feature-card,.config-overview-card,.learning-card) { border-color: var(--line-soft) !important; border-radius: 14px !important; background: var(--panel) !important; box-shadow: none !important; }
+.companion-studio :is(.module-card,.feature-card,.dashboard-strategy-card,.dashboard-chart-card,.dashboard-insight-card,.dashboard-activity-card)::before,
+.companion-studio :is(.module-card,.feature-card,.dashboard-strategy-card,.dashboard-chart-card,.dashboard-insight-card,.dashboard-activity-card)::after { content: none !important; }
+.companion-studio .module-card { padding: 24px !important; margin-bottom: 20px; }
+.companion-studio :is(.module-card-head,.persona-card-head) { margin-bottom: 20px !important; }
+.companion-studio :is(.module-card-head,.persona-card-head) :is(h2,h3) { font-weight: 550 !important; font-size: 18px !important; }
+.companion-studio :is(.module-card-head,.persona-card-head) :is(p,.section-desc) { font-size: 12px !important; font-weight: 400 !important; line-height: 1.8 !important; }
+.companion-studio :is(input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="color"]),select,textarea) { border-radius: 9px !important; border-color: var(--line) !important; background-color: var(--panel); color: var(--ink); box-shadow: none; font-size: 13px; }
+.companion-studio :is(input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="color"]),select) { min-height: 40px; }
+.companion-studio textarea { padding: 13px !important; line-height: 1.8 !important; }
+.companion-studio :is(input,select,textarea):focus { outline: 2px solid color-mix(in srgb,var(--accent) 40%,transparent) !important; outline-offset: 2px; }
+.companion-studio :is(button,[role="button"],a,summary,input,select,textarea):focus-visible { outline: 2px solid var(--accent) !important; outline-offset: 3px !important; }
+.companion-studio button { font-family: inherit; border-radius: 9px; transition: background .15s ease, border-color .15s ease; }
+.companion-studio button:disabled { opacity: .5; cursor: not-allowed; }
+.companion-studio :is(.primary-button,.module-form button[type="submit"],#saveFeaturesBtn) { background: var(--accent) !important; color: #fff !important; border: 1px solid var(--accent) !important; box-shadow: none !important; border-radius: 9px !important; }
+.companion-studio :is(.secondary-button,.ghost-button) { background: var(--panel) !important; color: var(--accent-strong) !important; border-color: var(--line) !important; border-radius: 9px !important; box-shadow: none !important; }
+.companion-studio :is(.module-badge,.world-save-state,.prompts-custom-badge) { border-color: var(--line-soft) !important; background: var(--accent-soft) !important; color: var(--accent-strong) !important; border-radius: 6px !important; font-weight: 500 !important; }
+.companion-studio :is(th,td) { padding: 14px 16px; border-color: var(--line-soft) !important; }
+.companion-studio th { background: var(--surface) !important; color: var(--muted); font-weight: 500; }
+.companion-studio .feature-save-actions { border: 1px solid var(--line) !important; border-radius: 14px !important; background: var(--panel) !important; box-shadow: 0 8px 35px #293d3320 !important; }
+/* Search dialog: navigates by clicking the existing tab, preserving dirty guards. */
+.studio-command { width: min(540px, calc(100vw - 32px)); max-height: 80dvh; padding: 24px; margin: 12vh auto auto; border: 1px solid var(--line); border-radius: 20px; background: var(--panel); color: var(--ink); box-shadow: 0 25px 90px #14291a30; }
+.studio-command::backdrop { background: #20362655; backdrop-filter: blur(5px); }
+.studio-command-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 18px; }
+.studio-command-head h2 { font-size: 19px; font-weight: 550; }
+.studio-command-head button { width: 32px; height: 32px; border: 0; background: var(--surface); color: var(--muted); font-size: 22px; }
+#studioCommandInput { width: 100%; padding: 12px 14px; }
+.studio-command-results { display: grid; gap: 4px; margin-top: 16px; max-height: 42dvh; overflow-y: auto; }
+.companion-studio .studio-command-result { display: flex; gap: 12px; align-items: center; width: 100%; padding: 12px; background: transparent; color: var(--ink); border: 0; border-radius: 9px; text-align: left; }
+.studio-command-result > span { color: var(--accent); font-size: 20px; }
+.studio-command-result b { font-size: 13px; font-weight: 500; }
+.studio-command-result small { display: block; font-size: 10px; color: var(--muted); margin-top: 2px; }
+.companion-studio .studio-command-result:hover, .companion-studio .studio-command-result:focus { background: var(--surface); }
+.studio-command-help { margin-top: 18px; font-size: 10px; color: var(--muted); }
+.studio-search-empty { padding: 24px 10px; color: var(--muted); font-size: 12px; text-align: center; }
+.studio-skip { position: fixed; top: -100px; left: 240px; z-index: 100; padding: 12px; background: var(--panel); color: var(--accent); }
+.studio-skip:focus { top: 10px; }
+@media (min-width: 1800px) { .companion-studio .annotations { left: max(0px, calc((100vw - 1800px) / 2)) !important; } }
+@media (max-width: 1180px) {
+  .companion-studio .shell { padding-left: 218px !important; padding-right: 28px !important; }
+  .companion-studio .annotations { width: 190px !important; padding: 24px 12px !important; }
+  .studio-brand { gap: 7px; padding-left: 3px; }
+  .studio-brand b { font-size: 13px; }
+  .studio-brand-mark { width: 30px; height: 32px; font-size: 28px; line-height: 32px; }
+  .studio-welcome { padding: 28px; }
+  .studio-art { width: 36%; right: 0; }
+  .studio-art-caption { right: 25px; font-size: 6px; }
+  .companion-studio .folio-persona-context { max-width: 28ch; }
+  .companion-studio .life-desk-card { padding: 19px !important; }
+  .companion-studio .life-desk-card-head { flex-wrap: wrap; }
+}
+@media (max-width: 960px) {
+  .companion-studio .shell { padding-left: 196px !important; padding-right: 22px !important; }
+  .companion-studio .annotations { width: 174px !important; padding: 22px 10px !important; }
+  .studio-find kbd { display: none; }
+  .studio-brand small { font-size: 6px; letter-spacing: 1px; }
+  .companion-studio .folio-heading { gap: 5px; }
+  .companion-studio .folio-persona-context { text-align: left; max-width: none; }
+  .studio-welcome h2 { font-size: 27px !important; }
+  .studio-art { opacity: .4; right: -15px; width: 44%; }
+  .studio-art-caption { display: none; }
+  .companion-studio #stats { grid-template-columns: repeat(2,minmax(0,1fr)) !important; }
+  .companion-studio .stat b { font-size: 18px !important; }
+  .companion-studio .dashboard-life-desk { grid-template-columns: minmax(0,1fr) !important; }
+  .companion-studio .studio-memory-disclosure .dashboard-life-column-right { grid-template-columns: minmax(0,1fr) !important; }
+}
+@media (max-width: 680px) {
+  .companion-studio .shell { padding: 0 18px 28px !important; }
+  .companion-studio .folio { min-height: 85px !important; gap: 10px !important; padding: 18px 0 !important; }
+  .companion-studio .folio-title { font-size: 16px !important; }
+  .companion-studio .folio-eyebrow { font-size: 8px !important; }
+  .companion-studio .folio-tools { gap: 5px !important; }
+  .companion-studio .setup-guide-entry { font-size: 10px !important; padding: 0 10px !important; }
+  .companion-studio #subtitle { font-size: 10px !important; }
+  .companion-studio .folio-plate { width: 30px !important; height: 30px !important; flex-basis: 30px !important; }
+  .studio-header-slash { margin: 0 7px; }
+  #studioPageTitle { font-size: 11px; }
+  .companion-studio .annotations { position: sticky !important; top: 0 !important; width: calc(100% + 36px) !important; height: auto !important; margin: 0 -18px !important; padding: 10px 18px !important; flex-direction: row !important; gap: 5px !important; overflow-x: auto !important; overflow-y: hidden !important; border-bottom: 1px solid var(--line-soft) !important; z-index: 30 !important; }
+  .studio-brand, .studio-nav-label, .studio-nav-foot { display: none; }
+  .companion-studio .annotations .tab { flex: 0 0 auto !important; width: auto !important; min-height: 36px !important; padding: 8px 12px !important; gap: 6px !important; font-size: 12px !important; }
+  .companion-studio .annotations .tab i { font-size: 15px !important; width: 15px; }
+  .companion-studio .studio-find { flex: 0 0 auto; width: auto; margin: 0 5px 0 0; padding: 6px 10px !important; }
+  .companion-studio .panel { padding: 22px 0 !important; }
+  .companion-studio .section-head h2 { font-size: 21px !important; }
+  .studio-welcome { min-height: 264px; padding: 26px 24px; }
+  .companion-studio .studio-welcome h2 { font-size: 27px !important; }
+  .studio-welcome p { font-size: 11px; max-width: 220px; }
+  .studio-welcome-actions { gap: 10px 18px; margin-top: 22px; }
+  .studio-art { width: 180px; bottom: 30px; right: -56px; opacity: .23; }
+  .studio-kicker { font-size: 7px; letter-spacing: 1.4px; }
+  .companion-studio #stats { gap: 10px !important; margin-bottom: 20px !important; }
+  .companion-studio .stat { padding: 15px !important; }
+  .companion-studio .stat b { font-size: 16px !important; }
+  .companion-studio .stat span { font-size: 9px !important; }
+  .companion-studio .dashboard-life-desk { gap: 16px !important; }
+  .companion-studio .module-card { padding: 16px !important; }
+  .companion-studio .dashboard-disclosure > summary { padding: 17px !important; }
+  .companion-studio .dashboard-disclosure > summary small { font-size: 10px !important; }
+  .studio-metrics-label small { font-size: 9px; }
+  .studio-command { margin-top: 7vh; padding: 20px; }
+  .studio-skip { left: 18px; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .companion-studio *, .companion-studio *::before, .companion-studio *::after { scroll-behavior: auto !important; animation-duration: .01ms !important; transition-duration: .01ms !important; }
+}
+.companion-studio .life-desk-empty { display: grid; place-content: center; min-height: 210px; text-align: center; border: 0 !important; border-radius: 10px !important; background: var(--surface) !important; color: var(--muted) !important; font-size: 12px !important; }
+.companion-studio #dashboardTimelinePreview .life-desk-empty::before { content: '◷'; font-size: 30px; color: var(--accent); opacity: .45; margin-bottom: 12px; }
+.companion-studio #dashboardTimelinePreview .life-desk-empty::after { content: '日程同步后，会在这里留下足迹'; font-size: 10px; margin-top: 7px; opacity: .8; }
+/* Balance the home grid: current state becomes a compact, full-width strip. */
+.companion-studio .dashboard-life-desk > .dashboard-life-column-left,
+.companion-studio .dashboard-life-desk > .dashboard-life-column-main { display: contents !important; }
+.companion-studio .life-desk-today { grid-column: 1; grid-row: 1; }
+.companion-studio .life-desk-timeline { grid-column: 2; grid-row: 1; height: 100%; }
+.companion-studio .life-desk-current { grid-column: 1 / -1; grid-row: 2; }
+.companion-studio .life-current-state { display: grid !important; grid-template-columns: minmax(0,1fr) minmax(0,1.4fr) !important; gap: 8px 30px !important; }
+.companion-studio .life-current-activity { grid-column: 1; grid-row: 1 / 3; align-content: center; }
+.companion-studio .life-current-state > .life-energy-track { grid-column: 2; margin: 6px 0 4px !important; }
+.companion-studio .life-current-state > .life-state-grid { grid-column: 2; grid-template-columns: repeat(3,minmax(0,1fr)) !important; gap: 8px 18px !important; }
+.companion-studio .life-state-grid span { font-size: 10px !important; font-weight: 400 !important; color: var(--muted) !important; }
+.companion-studio .setup-guide-entry { width: auto !important; min-width: 94px !important; white-space: nowrap !important; word-break: keep-all !important; }
+@media(max-width: 960px) {
+  .companion-studio .life-desk-today { grid-column: 1; grid-row: 1; }
+  .companion-studio .life-desk-timeline { grid-column: 1; grid-row: 2; }
+  .companion-studio .life-desk-current { grid-column: 1; grid-row: 3; }
+  .companion-studio .life-current-state { grid-template-columns: minmax(0,1fr) !important; }
+  .companion-studio .life-current-activity { grid-column: 1; grid-row: auto; }
+  .companion-studio .life-current-state > .life-energy-track { grid-column: 1; margin: 12px 0 !important; }
+  .companion-studio .life-current-state > .life-state-grid { grid-column: 1; }
+}
+@media(max-width: 680px) {
+  .companion-studio .folio .folio-tools { flex-direction: row !important; flex-wrap: nowrap !important; align-items: center; }
+  .companion-studio .folio .folio-tools button { flex-shrink: 0; }
+  .companion-studio .folio .folio-tools .setup-guide-entry { min-width: 72px !important; }
+  .companion-studio .dashboard-overview-head { flex-direction: row !important; align-items: center !important; }
+  .companion-studio .dashboard-overview-head > .actions { width: auto !important; flex: 0 0 auto !important; }
+  .companion-studio #exportSnapshotBtn { width: auto !important; font-size: 9px !important; padding: 7px 10px !important; }
+  .companion-studio .life-current-state > .life-state-grid { grid-template-columns: repeat(2,minmax(0,1fr)) !important; }
+  .companion-studio .studio-find { position: static; background: var(--panel) !important; }
+}
+/* Configuration and model editors share the same quiet surfaces. */
+.companion-studio :is(.config-fold-panel,.config-persona-stats-panel,.proactive-mode-card,.provider-config-mode-card,.provider-toolbar,.provider-card,.persona-card) {
+  background: var(--panel) !important; border: 1px solid var(--line-soft) !important; border-radius: 14px !important; box-shadow: none !important;
+}
+.companion-studio :is(.config-fold-panel,.proactive-mode-card,.provider-card,.persona-card)::before,
+.companion-studio :is(.config-fold-panel,.proactive-mode-card,.provider-card,.persona-card)::after { content: none !important; }
+.companion-studio .config-fold-summary { padding: 24px !important; background: transparent !important; }
+.companion-studio .config-fold-heading h2 { font-size: 18px !important; font-weight: 550 !important; }
+.companion-studio .config-fold-heading h2::before { content: none !important; }
+.companion-studio .proactive-mode-card { padding: 23px !important; }
+.companion-studio .proactive-mode-card :is(h3,h4) { font-size: 17px !important; font-weight: 550 !important; }
+.companion-studio .proactive-mode-card.off { border-left: 1px solid var(--line-soft) !important; }
+.companion-studio .provider-tree-grid { grid-template-columns: repeat(2,minmax(0,1fr)) !important; gap: 20px !important; }
+.companion-studio .provider-card { padding: 23px !important; }
+.companion-studio .provider-tree-node { margin-bottom: 15px !important; }
+.companion-studio .provider-tree-title { font-size: 17px !important; font-weight: 550 !important; }
+.companion-studio .provider-tree-body { gap: 14px !important; }
+.companion-studio .provider-tree-preview { font-size: 12px !important; line-height: 1.8 !important; }
+.companion-studio .provider-current { padding: 13px !important; border: 0 !important; background: var(--surface) !important; border-radius: 9px !important; }
+.companion-studio .provider-current b { font-weight: 500 !important; font-size: 12px !important; }
+.companion-studio :is(.provider-config-mode-card,.provider-toolbar) { padding: 20px !important; margin-bottom: 20px !important; }
+.companion-studio :is(.provider-toolbar-actions,.provider-row) button { padding: 10px 15px !important; border: 1px solid var(--line) !important; background: var(--panel) !important; color: var(--accent-strong) !important; border-radius: 9px !important; font-size: 12px !important; font-weight: 500 !important; box-shadow: none !important; }
+.companion-studio #saveProvidersBtn { background: var(--accent) !important; color: white !important; border-color: var(--accent) !important; }
+.companion-studio .provider-guide { margin-top: 12px !important; padding: 14px !important; background: var(--surface) !important; border: 0 !important; border-radius: 8px !important; line-height: 1.8 !important; }
+.studio-provider-guide { border-top: 1px solid var(--line-soft); padding-top: 12px; }
+.studio-provider-guide > summary { color: var(--accent); font-size: 11px; cursor: pointer; }
+.companion-studio .feature-save-actions { top: auto !important; bottom: max(20px,env(safe-area-inset-bottom)) !important; left: auto !important; right: 30px !important; width: auto !important; max-width: calc(100vw - 260px); transform: none !important; display: flex !important; align-items: center !important; gap: 16px !important; padding: 12px 18px !important; }
+.companion-studio .feature-save-actions[hidden] { display: none !important; }
+.companion-studio .feature-save-actions button { width: auto !important; min-width: 0 !important; padding: 8px 14px !important; font-size: 12px !important; }
+.companion-studio .feature-save-state { font-size: 11px !important; font-weight: 400 !important; }
+.companion-studio #panel-config { padding-bottom: 105px !important; }
+@media(max-width: 960px) { .companion-studio .provider-tree-grid { grid-template-columns: minmax(0,1fr) !important; } }
+@media(max-width: 680px) {
+  .companion-studio .feature-save-actions { left: 12px !important; right: 12px !important; bottom: max(12px,env(safe-area-inset-bottom)) !important; max-width: none; gap: 8px !important; flex-wrap: wrap; justify-content: flex-end; padding: 12px !important; }
+  .companion-studio .feature-save-state { margin-right: auto; }
+  .companion-studio :is(.provider-card,.config-fold-summary,.proactive-mode-card) { padding: 18px !important; }
+}
+
+/* Companion Studio v2 — internal components, not just the application shell.
+   Keep visibility/data attributes under the existing controllers. */
+.companion-studio .panel button:not([class]),
+.companion-studio :is(.actions,.inline-form) > button {
+  appearance: none; font: inherit; font-size: 12px; font-weight: 500;
+  min-height: 36px; padding: 8px 13px; line-height: 1.5;
+  border: 1px solid var(--line); border-radius: 8px;
+  background: var(--panel); color: var(--accent-strong); box-shadow: none;
+  cursor: pointer;
+}
+.companion-studio .panel button:not([class]):hover:not(:disabled) { background: var(--surface); border-color: var(--accent); }
+.companion-studio .panel button:not([class]):disabled { cursor: not-allowed; }
+/* A sticky toolbar was covering the model cards while scrolling. Keep it in flow. */
+.companion-studio .provider-toolbar {
+  position: static !important; inset: auto !important; z-index: auto !important;
+  transform: none !important; backdrop-filter: none !important;
+  padding: 14px 18px !important; min-height: 0 !important;
+}
+.companion-studio .provider-tree-grid { align-items: start !important; grid-auto-rows: auto !important; }
+.companion-studio .provider-card { align-self: start !important; height: auto !important; min-height: 0 !important; }
+.companion-studio .provider-card .provider-tree-preview { margin: 0 0 12px; min-height: 0 !important; }
+.companion-studio .provider-tree-node { align-items: flex-start !important; gap: 12px !important; }
+.companion-studio .provider-badge { font-size: 10px !important; font-weight: 400 !important; padding: 4px 8px !important; border: 1px solid var(--line) !important; border-radius: 6px !important; }
+.companion-studio .provider-tag { font-weight: 400 !important; border-radius: 5px !important; }
+.companion-studio .provider-row { flex-wrap: wrap; }
+.companion-studio .provider-row .hint { font-size: 10px; overflow-wrap: anywhere; }
+.companion-studio .studio-welcome { min-height: 220px; }
+.companion-studio .studio-welcome h2 { font-size: clamp(24px,2.1vw,32px) !important; }
+/* Diagnostics: compact summary, readable full-width rows, one page scrollbar. */
+.companion-studio #panel-troubleshooting { --diag-ink: var(--ink); --diag-signal: var(--accent); }
+.companion-studio .troubleshooting-page { display: grid !important; gap: 22px !important; }
+.companion-studio .diagnostic-masthead { background: transparent !important; border: 0 !important; border-bottom: 1px solid var(--line) !important; border-radius: 0 !important; box-shadow: none !important; padding: 0 0 24px !important; align-items: center; }
+.companion-studio .diagnostic-kicker { font: inherit; font-size: 11px !important; font-weight: 400 !important; color: var(--muted) !important; }
+.companion-studio .diagnostic-masthead h2 { font-size: 25px !important; font-weight: 600 !important; line-height: 1.5 !important; margin: 5px 0 8px !important; }
+.companion-studio .diagnostic-masthead p { font-size: 13px !important; }
+.companion-studio #refreshTroubleshootingBtn { border: 1px solid var(--accent) !important; background: var(--accent) !important; color: white !important; padding: 9px 17px !important; border-radius: 9px !important; box-shadow: none !important; }
+.companion-studio .diagnostic-live-dot { font-size: 11px; }
+.companion-studio .diagnostic-live-dot i { background: var(--muted); box-shadow: none; width: 5px; height: 5px; }
+.companion-studio .diagnostic-problem-picker { grid-template-columns: 1fr !important; padding: 20px !important; gap: 16px !important; border: 1px solid var(--line-soft) !important; background: var(--panel) !important; border-radius: 13px !important; box-shadow: none !important; }
+.companion-studio .diagnostic-problem-picker > div:first-child { display: flex; flex-wrap: wrap; gap: 6px 12px; align-items: baseline; }
+.companion-studio .diagnostic-problem-picker > div:first-child > span { color: var(--muted); font-size: 10px; font-weight: 400; }
+.companion-studio .diagnostic-problem-picker h3 { font-size: 16px !important; font-weight: 550 !important; }
+.companion-studio .diagnostic-problem-picker p { font-size: 12px !important; }
+.companion-studio .diagnostic-category-list { display: grid !important; grid-template-columns: repeat(auto-fit,minmax(135px,1fr)) !important; gap: 8px !important; }
+.companion-studio .diagnostic-category { min-height: 84px !important; border: 1px solid var(--line-soft) !important; background: var(--surface) !important; border-radius: 9px !important; padding: 12px !important; box-shadow: none !important; transform: none !important; align-content: start; }
+.companion-studio .diagnostic-category b { font-size: 13px !important; font-weight: 550 !important; }
+.companion-studio .diagnostic-category span { font-size: 11px !important; line-height: 1.6 !important; font-weight: 400 !important; }
+.companion-studio .diagnostic-category.is-active { background: var(--accent-soft) !important; border-color: var(--accent) !important; }
+.companion-studio .troubleshooting-summary { display: grid !important; grid-template-columns: minmax(210px,2fr) repeat(4,minmax(0,1fr)) !important; gap: 10px !important; align-items: stretch !important; }
+.companion-studio .troubleshooting-head-card { border: 1px solid var(--line-soft) !important; background: var(--panel) !important; padding: 17px !important; border-radius: 11px !important; box-shadow: none !important; flex-wrap: wrap; gap: 10px; }
+.companion-studio .troubleshooting-head-card b { font-size: 18px !important; font-weight: 550 !important; line-height: 1.5 !important; }
+.companion-studio .troubleshooting-head-card small { font-size: 11px !important; }
+.companion-studio .troubleshooting-head-card > div > span { font-size: 10px !important; }
+.companion-studio .troubleshooting-count { min-height: 95px !important; padding: 15px 8px !important; border: 1px solid var(--line-soft) !important; border-radius: 11px !important; background: var(--panel) !important; box-shadow: none !important; }
+.companion-studio .troubleshooting-count b { font-size: 25px !important; font-weight: 550 !important; line-height: 1.4 !important; }
+.companion-studio .troubleshooting-count span { font-size: 12px !important; font-weight: 400 !important; }
+.companion-studio .troubleshooting-count.is-active { border-color: var(--accent) !important; background: var(--surface) !important; }
+.companion-studio .studio-reason-details { display: block !important; grid-column: 1 / -1; padding: 0 !important; background: var(--panel) !important; border: 1px solid var(--line-soft) !important; border-radius: 10px !important; box-shadow: none !important; }
+.companion-studio .studio-reason-details > summary { display: flex; align-items: center; gap: 12px; padding: 14px 18px; cursor: pointer; list-style: none; }
+.companion-studio .studio-reason-details > summary::after { content: '+'; margin-left: auto; font-size: 18px; color: var(--accent); }
+.companion-studio .studio-reason-details[open] > summary::after { content: '−'; }
+.companion-studio .studio-reason-details > summary b { font-size: 12px; font-weight: 500; }
+.companion-studio .studio-reason-details > summary span { font-size: 11px; color: var(--muted); }
+.companion-studio .studio-reason-body { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 10px; padding: 0 18px 18px; }
+.companion-studio .studio-reason-body button { text-align: left; padding: 14px; border-color: var(--line-soft); }
+.companion-studio .studio-reason-body button b { display: block; margin-bottom: 6px; font-size: 13px; }
+.companion-studio .studio-reason-body button span { font-size: 12px; color: var(--muted); font-weight: 400; }
+.companion-studio :is(.diagnostic-priority-zone,.diagnostic-live-lane,.diagnostic-event-lane,.diagnostic-runtime-card,.diagnostic-evidence-drawer) { border: 1px solid var(--line-soft) !important; border-radius: 13px !important; box-shadow: none !important; background: var(--panel) !important; padding: 22px !important; }
+.companion-studio .diagnostic-zone-head { align-items: center !important; flex-wrap: wrap; gap: 14px !important; margin: 0 0 20px !important; }
+.companion-studio .diagnostic-zone-head h3 { font-size: 18px !important; font-weight: 550 !important; margin-top: 3px !important; }
+.companion-studio .diagnostic-zone-head > div > span { font-size: 10px !important; font-weight: 400 !important; color: var(--muted); }
+.companion-studio .diagnostic-filter { border: 1px solid var(--line-soft) !important; padding: 3px !important; border-radius: 9px !important; background: var(--surface) !important; gap: 2px !important; }
+.companion-studio .diagnostic-filter button { border: 0 !important; background: transparent; border-radius: 6px !important; padding: 6px 12px !important; min-height: 32px !important; font-size: 12px !important; font-weight: 400 !important; }
+.companion-studio .diagnostic-filter button.is-active { background: var(--accent) !important; color: white !important; }
+.companion-studio #troubleshootingChecks { display: grid !important; grid-template-columns: minmax(0,1fr) !important; gap: 0 !important; max-height: none !important; height: auto !important; overflow: visible !important; padding: 0 !important; align-items: start !important; }
+.companion-studio .troubleshooting-check { display: grid !important; grid-template-columns: 30px minmax(0,1fr) !important; gap: 6px 14px !important; align-items: start !important; border: 0 !important; border-bottom: 1px solid var(--line-soft) !important; border-radius: 0 !important; padding: 20px 0 !important; min-height: 0 !important; height: auto !important; background: transparent !important; box-shadow: none !important; }
+.companion-studio .troubleshooting-check:last-child { border-bottom: 0 !important; }
+.companion-studio .troubleshooting-check-icon { grid-column: 1; grid-row: 1 / 3; width: 28px !important; height: 28px !important; font-size: 15px !important; margin-top: 1px; box-shadow: none !important; }
+.companion-studio .troubleshooting-check > div:nth-child(2) { grid-column: 2; min-width: 0; }
+.companion-studio .troubleshooting-check b { font-size: 14px !important; font-weight: 550 !important; line-height: 1.6 !important; }
+.companion-studio .troubleshooting-check p { font-size: 13px !important; line-height: 1.9 !important; margin: 5px 0 !important; color: var(--muted); overflow-wrap: anywhere; }
+.companion-studio .troubleshooting-check small { display: block; font-size: 12px !important; font-weight: 400 !important; line-height: 1.8; color: var(--ink); }
+.companion-studio .troubleshooting-check-actions { grid-column: 2 !important; justify-content: flex-start !important; margin-top: 5px; gap: 8px !important; }
+.companion-studio :is(.troubleshooting-check-actions,.troubleshooting-event-actions) button { appearance: none !important; min-height: 32px !important; font-size: 11px !important; font-weight: 500 !important; padding: 6px 11px !important; border: 1px solid var(--line) !important; border-radius: 7px !important; background: var(--surface) !important; color: var(--accent-strong) !important; box-shadow: none !important; }
+.companion-studio .diagnostic-warning-suppress { background: transparent !important; color: var(--warn) !important; }
+.companion-studio .diagnostic-main-grid { grid-template-columns: minmax(0,1fr) !important; gap: 20px !important; }
+.companion-studio .diagnostic-events { max-height: none !important; overflow: visible !important; padding: 0 !important; }
+.companion-studio .troubleshooting-event { background: var(--surface) !important; border-color: var(--line-soft) !important; padding: 18px !important; box-shadow: none !important; border-radius: 9px !important; }
+.companion-studio .diagnostic-runtime-stack { gap: 14px !important; }
+.companion-studio .diagnostic-runtime-card { background: var(--surface) !important; padding: 17px !important; }
+.companion-studio .diagnostic-runtime-card h3 { font-weight: 550 !important; }
+.companion-studio .diagnostic-evidence-drawer { padding: 0 !important; }
+.companion-studio .diagnostic-evidence-drawer > summary { padding: 19px 22px !important; }
+.companion-studio .diagnostic-evidence-drawer > summary span { font-weight: 500 !important; font-size: 13px !important; }
+.companion-studio .diagnostic-evidence-drawer > summary small { font-size: 11px !important; }
+@media(min-width: 1200px) {
+  .companion-studio .troubleshooting-check { grid-template-columns: 30px minmax(0,1fr) auto !important; }
+  .companion-studio .troubleshooting-check-actions { grid-column: 3 !important; grid-row: 1; max-width: 210px; justify-content: flex-end !important; }
+}
+@media(max-width: 960px) {
+  .companion-studio .troubleshooting-summary { grid-template-columns: repeat(4,minmax(0,1fr)) !important; }
+  .companion-studio .troubleshooting-head-card { grid-column: 1 / -1; }
+  .companion-studio .studio-reason-body { grid-template-columns: 1fr; }
+}
+@media(max-width: 680px) {
+  .companion-studio .diagnostic-masthead { grid-template-columns: 1fr !important; gap: 16px !important; }
+  .companion-studio .diagnostic-masthead-actions { display: flex; align-items: center; flex-wrap: wrap; justify-content: space-between; }
+  .companion-studio .diagnostic-masthead-actions button { width: auto !important; }
+  .companion-studio .diagnostic-category-list { grid-template-columns: repeat(2,minmax(0,1fr)) !important; }
+  .companion-studio :is(.diagnostic-priority-zone,.diagnostic-live-lane,.diagnostic-event-lane,.diagnostic-problem-picker) { padding: 16px !important; }
+  .companion-studio .diagnostic-zone-head { align-items: flex-start !important; }
+  .companion-studio .diagnostic-filter { flex-wrap: wrap; }
+  .companion-studio .studio-reason-details > summary { align-items: flex-start; flex-wrap: wrap; gap: 6px; }
+  .companion-studio .studio-reason-details > summary span { flex-basis: 85%; }
+  .companion-studio .troubleshooting-count { min-height: 80px !important; padding: 10px 5px !important; }
+  .companion-studio .diagnostic-runtime-stack { grid-template-columns: minmax(0,1fr) !important; }
+  .companion-studio .troubleshooting-check { column-gap: 10px !important; }
+  .companion-studio .troubleshooting-check-actions button { white-space: normal; }
+}
+/* Subpage controls use one consistent treatment, including lazy-rendered content. */
+.companion-studio :is(.models-page-nav,.models-page-heading,.provider-group-head) { background: transparent !important; box-shadow: none !important; }
+.companion-studio :is(.models-page-heading,.provider-group-head) h2 { font-size: 23px; font-weight: 550; }
+.companion-studio :is(.models-subnav,.provider-config-mode,.provider-mode-switch) { border: 1px solid var(--line-soft) !important; background: var(--surface) !important; border-radius: 9px !important; padding: 4px !important; gap: 3px !important; box-shadow: none !important; }
+.companion-studio :is(.models-subnav,.provider-config-mode,.provider-mode-switch) button { appearance: none; border: 0 !important; border-radius: 6px !important; background: transparent !important; color: var(--muted) !important; padding: 9px 13px !important; font-size: 12px !important; font-weight: 500 !important; box-shadow: none !important; }
+.companion-studio :is(.models-subnav,.provider-config-mode,.provider-mode-switch) button.active { background: var(--accent) !important; color: white !important; }
+.companion-studio .models-subnav button::before { content: none !important; }
+.companion-studio .studio-routing-help { margin: 16px 0; border: 1px solid var(--line-soft); border-radius: 10px; background: var(--panel); }
+.companion-studio .studio-routing-help > summary { padding: 15px 18px; font-size: 12px; cursor: pointer; color: var(--accent-strong); }
+.companion-studio .studio-routing-help small { font-size: 11px; color: var(--muted); margin-left: 10px; }
+.companion-studio .studio-routing-help .provider-flow { padding: 18px; margin: 0; border: 0; box-shadow: none; }
+.companion-studio .studio-save-explainer { margin: -6px 0 22px; color: var(--muted); font-size: 11px; line-height: 1.8; }
+.companion-studio :is(.empty,.empty.small) { padding: 24px 18px; background: var(--surface); border: 1px solid var(--line-soft); border-radius: 10px; color: var(--muted); font-size: 12px; font-weight: 400; box-shadow: none; }
+.companion-studio :is(.config-section-nav,.world-outline) { background: var(--surface) !important; box-shadow: none !important; }
+.companion-studio .config-fold-kicker { background: none !important; color: var(--muted) !important; font-weight: 400 !important; font-size: 10px !important; padding: 0 !important; }
+.companion-studio .config-fold-preview > span { border: 0 !important; background: var(--surface) !important; padding: 4px 7px; font-size: 10px; font-weight: 400 !important; }
+.companion-studio .persona-card-head { border: 0 !important; }
+.companion-studio .persona-card { padding: 22px !important; }
+@media(max-width: 680px) { .companion-studio .persona-card { padding: 14px !important; } .companion-studio .studio-routing-help small { display: block; margin-left: 0; margin-top: 5px; } }
+.companion-studio .diagnostic-runtime-stack { align-items: start !important; }
+.companion-studio .diagnostic-runtime-card { height: auto !important; align-self: start !important; }
+.companion-studio .studio-runtime-details { margin-top: 18px; padding-top: 16px; border-top: 1px solid var(--line-soft); }
+.companion-studio .studio-runtime-details:not(:has(#troubleshootingRuntimeStack:not([hidden]))) { display: none; }
+.companion-studio .studio-runtime-details > summary { font-size: 12px; color: var(--accent-strong); cursor: pointer; }
+.companion-studio .studio-runtime-details small { font-size: 11px; color: var(--muted); margin-left: 12px; }
+.companion-studio .studio-check-original { margin: 6px 0; }
+.companion-studio .studio-check-original > summary { font-size: 11px; color: var(--muted); cursor: pointer; }
+.companion-studio .studio-check-original p { background: var(--surface); border-left: 2px solid var(--line); padding: 10px 14px; font-size: 12px !important; }
+.companion-studio .troubleshooting-chain-tests { align-items: start !important; gap: 14px !important; }
+.companion-studio .troubleshooting-chain-test { display: flex !important; flex-direction: column !important; align-items: stretch !important; gap: 14px !important; border: 1px solid var(--line-soft) !important; border-radius: 10px !important; padding: 18px !important; background: var(--surface) !important; box-shadow: none !important; height: auto !important; }
+.companion-studio .troubleshooting-chain-test b { font-size: 14px !important; font-weight: 550 !important; }
+.companion-studio .troubleshooting-chain-test p { font-size: 12px !important; line-height: 1.8 !important; }
+.companion-studio .troubleshooting-chain-test-actions { display: flex !important; justify-content: flex-start; flex-wrap: wrap; gap: 8px; }
+.companion-studio .troubleshooting-chain-test-actions button { min-height: 34px; padding: 8px 13px; border: 1px solid var(--line); border-radius: 8px; background: var(--panel); color: var(--accent-strong); font-size: 12px; white-space: normal; }
+
+/* Studio v3 — an outline and working lists, not a wall of metric cards. */
+.companion-studio .studio-feature-instructions { color: var(--muted); font-size: 12px; margin: 16px 0 10px; }
+.companion-studio .feature-switch-board { display: block !important; padding: 0 !important; border: 0 !important; background: transparent !important; }
+.companion-studio .feature-switch-group { margin: 0 !important; border: 0 !important; border-bottom: 1px solid var(--line) !important; border-radius: 0 !important; background: transparent !important; box-shadow: none !important; overflow: visible !important; }
+.companion-studio .studio-feature-group > summary { display: flex; align-items: center; gap: 18px; padding: 22px 0; list-style: none; cursor: pointer; }
+.companion-studio .studio-feature-group > summary::-webkit-details-marker { display: none; }
+.companion-studio .studio-feature-group > summary::before { content: '›'; width: 15px; flex: 0 0 15px; font-size: 23px; line-height: 1; color: var(--accent); transition: transform .15s; }
+.companion-studio .studio-feature-group[open] > summary::before { transform: rotate(90deg); }
+.companion-studio .studio-feature-group > summary > div { flex: 1; min-width: 0; display: grid; gap: 6px; }
+.companion-studio .studio-feature-group > summary b { font-size: 16px; font-weight: 550; color: var(--ink); }
+.companion-studio .studio-feature-group > summary span { font-size: 12px; font-weight: 400; color: var(--muted); line-height: 1.7; }
+.companion-studio .studio-feature-group > summary small { font-size: 11px; color: var(--muted); flex-shrink: 0; }
+.companion-studio .studio-feature-group > summary:hover b { color: var(--accent); }
+.companion-studio .feature-switch-list { display: block !important; padding: 0 0 12px 33px !important; gap: 0 !important; border-top: 0 !important; }
+.companion-studio .feature-switch-item { display: flex !important; flex-wrap: wrap !important; align-items: flex-start !important; gap: 12px 20px !important; padding: 19px 0 !important; min-height: 0 !important; border: 0 !important; border-top: 1px solid var(--line-soft) !important; border-radius: 0 !important; background: transparent !important; box-shadow: none !important; height: auto !important; }
+.companion-studio .feature-switch-item::before, .companion-studio .feature-switch-item::after { content: none !important; }
+.companion-studio .feature-switch-body { flex: 1 1 220px; min-width: 0; display: flex !important; flex-direction: column !important; gap: 6px !important; order: 0; }
+.companion-studio .feature-switch-item > .feature-toggle-hit { order: 1; flex: 0 0 auto; margin: 5px 0 0 !important; }
+.companion-studio .feature-switch-text { display: flex !important; align-items: baseline !important; flex-wrap: wrap; justify-content: flex-start !important; gap: 8px 18px !important; padding: 0 !important; margin: 0 !important; border: 0 !important; background: transparent !important; border-radius: 0 !important; text-align: left; box-shadow: none !important; width: fit-content !important; }
+.companion-studio .feature-switch-text b { font-size: 14px !important; line-height: 1.7 !important; font-weight: 550 !important; }
+.companion-studio .feature-switch-text small { font-size: 10px !important; color: var(--muted); }
+.companion-studio .feature-open-hint { font-size: 11px !important; font-weight: 400 !important; color: var(--accent) !important; }
+.companion-studio .feature-switch-meta { order: 1; display: flex !important; align-items: baseline !important; gap: 6px 12px !important; flex-wrap: wrap; }
+.companion-studio .feature-state-text { border: 0 !important; background: none !important; border-radius: 0 !important; padding: 0 !important; font-size: 11px !important; font-weight: 400 !important; color: var(--muted) !important; }
+.companion-studio .feature-switch-item.on .feature-state-text { color: var(--accent) !important; }
+.companion-studio .feature-stage-tags { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
+.companion-studio .feature-stage-tags span { border: 0 !important; background: none !important; padding: 0 10px 0 0 !important; color: var(--muted) !important; font-size: 11px !important; font-weight: 400 !important; }
+.companion-studio .feature-toggle-hit input:not(:checked) + .feature-toggle-visual { background: #a4ada3 !important; box-shadow: none !important; }
+.companion-studio .feature-toggle-hit input:disabled + .feature-toggle-visual { opacity: .45; }
+.companion-studio .feature-toggle-hit input:focus-visible + .feature-toggle-visual { outline: 2px solid var(--accent); outline-offset: 4px; }
+.companion-studio .feature-temp-unlock-btn { order: 2; padding: 7px 11px; font-size: 11px; }
+.companion-studio .studio-feature-notes { order: 2; color: var(--muted); margin: 1px 0 0; }
+.companion-studio .studio-feature-notes summary { cursor: pointer; font-size: 10px; width: fit-content; }
+.companion-studio .studio-feature-notes code { display: block; margin: 8px 0; font-size: 11px; overflow-wrap: anywhere; color: var(--muted); }
+.companion-studio .feature-lock-note, .companion-studio .feature-lock-related { color: var(--muted); font-size: 11px !important; line-height: 1.8 !important; }
+.companion-studio .feature-inline-setting-form { display: flex !important; flex-wrap: wrap; align-items: center; gap: 9px; margin: 0 !important; flex: 0 1 300px; min-width: 0; }
+.companion-studio .feature-inline-setting-form select { flex: 1 1 200px; min-width: 0 !important; width: auto !important; }
+.companion-studio .feature-inline-setting-form button { flex: 0 0 auto; min-width: 64px; white-space: nowrap !important; word-break: keep-all !important; }
+/* Configuration categories and summaries become lines in an outline. */
+.companion-studio :is(.config-fold-panel,.config-persona-stats-panel,.feature-config-article,.config-persona-top-row .proactive-mode-card) { background: transparent !important; border: 0 !important; border-bottom: 1px solid var(--line) !important; border-radius: 0 !important; box-shadow: none !important; }
+.companion-studio .config-fold-summary { padding: 22px 0 !important; }
+.companion-studio .config-fold-preview { margin-top: 8px; }
+.companion-studio .config-grid, .companion-studio .config-persona-settings { gap: 22px !important; }
+.companion-studio .feature-config-article { padding: 0 0 95px !important; }
+.companion-studio .feature-config-head { padding: 0 0 14px !important; }
+.companion-studio .feature-switch-summary { display: flex !important; flex-wrap: wrap; gap: 10px 32px !important; padding: 12px 0 !important; margin: 0 0 16px !important; border: 0 !important; background: transparent !important; box-shadow: none !important; }
+.companion-studio .feature-summary-card { display: flex !important; flex-wrap: wrap; align-items: baseline; gap: 6px 10px; border: 0 !important; border-radius: 0 !important; padding: 0 !important; background: transparent !important; box-shadow: none !important; }
+.companion-studio .feature-summary-card b { font-size: 15px !important; font-weight: 550 !important; }
+.companion-studio .feature-summary-card span, .companion-studio .feature-summary-card small { font-size: 11px !important; font-weight: 400 !important; }
+.companion-studio .feature-filter-workspace { border: 0 !important; border-radius: 0 !important; padding: 0 !important; background: none !important; box-shadow: none !important; }
+.companion-studio .feature-filter-topline { padding: 12px 0 !important; }
+.companion-studio .studio-filter-options > summary, .companion-studio .studio-config-stats > summary { cursor: pointer; font-size: 12px; color: var(--accent); padding: 12px 0; }
+.companion-studio .feature-filter-row { background: transparent !important; border: 0 !important; border-top: 1px solid var(--line-soft) !important; padding: 13px 0 !important; }
+.companion-studio .config-persona-top-row { display: block !important; }
+.companion-studio .config-persona-top-row .proactive-mode-card { margin: 0; padding: 18px 0 !important; }
+.companion-studio .config-persona-top-row .proactive-mode-card::before { content: none !important; }
+/* Proactive messages: queue first, statistics and plots on demand. */
+.companion-studio #proactiveSummary { display: block !important; background: transparent !important; padding: 0 !important; box-shadow: none !important; }
+.companion-studio .studio-proactive-lead { display: flex; flex-wrap: wrap; align-items: baseline; gap: 15px 38px; padding: 8px 0 20px; border-bottom: 1px solid var(--line); }
+.companion-studio .studio-proactive-lead span { font-size: 13px; color: var(--muted); }
+.companion-studio .studio-proactive-lead b { font-size: 20px; font-weight: 550; color: var(--ink); margin-left: 10px; }
+.companion-studio :is(.studio-proactive-metrics,.studio-proactive-disclosure,.studio-user-metrics) { border: 0; border-bottom: 1px solid var(--line); border-radius: 0; background: transparent; }
+.companion-studio :is(.studio-proactive-metrics,.studio-proactive-disclosure,.studio-user-metrics) > summary { padding: 18px 0; cursor: pointer; font-size: 13px; font-weight: 500; color: var(--accent-strong); }
+.companion-studio :is(.studio-proactive-metrics,.studio-proactive-disclosure,.studio-user-metrics) > summary small { margin-left: 14px; font-size: 11px; color: var(--muted); font-weight: 400; }
+.companion-studio .studio-metric-list { padding-bottom: 18px; }
+.companion-studio .proactive-summary-card { display: grid !important; grid-template-columns: 145px 110px minmax(0,1fr) !important; align-items: baseline; gap: 12px; padding: 11px 0 !important; border: 0 !important; border-bottom: 1px solid var(--line-soft) !important; border-radius: 0 !important; background: transparent !important; box-shadow: none !important; }
+.companion-studio .proactive-summary-card b { font-size: 15px !important; font-weight: 550 !important; }
+.companion-studio .proactive-summary-card > span { font-size: 12px !important; }
+.companion-studio .proactive-summary-card small { font-size: 11px !important; }
+.companion-studio .proactive-layout { display: block !important; margin: 28px 0 0 !important; }
+.companion-studio .proactive-layout article { border: 0 !important; border-radius: 0 !important; padding: 0 0 22px !important; background: transparent !important; box-shadow: none !important; }
+.companion-studio .proactive-layout article h2 { font-size: 17px; font-weight: 550; }
+.companion-studio .studio-chart-layout { display: block; }
+.companion-studio :is(.proactive-candidate,.proactive-task,.proactive-audit) { border: 0 !important; border-bottom: 1px solid var(--line) !important; border-radius: 0 !important; padding: 20px 0 !important; background: transparent !important; box-shadow: none !important; }
+.companion-studio .proactive-filter-list { display: flex !important; flex-wrap: wrap; gap: 6px !important; }
+.companion-studio .proactive-filter-user { width: auto !important; background: transparent !important; border-radius: 6px !important; box-shadow: none !important; padding: 9px 12px !important; }
+.companion-studio .proactive-filter-user.is-active { background: var(--accent-soft) !important; }
+/* Member workspace: document-style detail and a compact directory; no sticky subnav. */
+.companion-studio .user-workspace { grid-template-columns: minmax(195px,240px) minmax(0,1fr) !important; gap: 28px; border: 0 !important; border-radius: 0 !important; background: transparent !important; box-shadow: none !important; overflow: visible !important; }
+.companion-studio .user-roster { position: static !important; height: auto !important; min-height: 0 !important; max-height: none !important; grid-template-rows: auto auto auto auto !important; background: transparent !important; border: 0 !important; padding: 0 20px 0 0; border-right: 1px solid var(--line) !important; }
+.companion-studio .user-roster-list { min-height: 0 !important; max-height: none !important; overflow: visible !important; padding: 0 !important; }
+.companion-studio .user-roster-head { padding: 0 0 14px !important; }
+.companion-studio .user-roster-head .eyebrow { font-size: 10px; border: 0 !important; background: none !important; padding: 0 !important; }
+.companion-studio .user-roster-head h3 { font-size: 16px !important; font-weight: 550; }
+.companion-studio .user-directory-nav { display: flex !important; margin: 0 0 12px !important; padding: 0 !important; border: 0 !important; border-bottom: 1px solid var(--line) !important; border-radius: 0 !important; background: none !important; }
+.companion-studio .user-directory-nav button { flex: 1; border-radius: 0 !important; border-bottom: 2px solid transparent !important; font-weight: 500 !important; background: none !important; box-shadow: none !important; }
+.companion-studio .user-directory-nav button.is-active { border-bottom-color: var(--accent) !important; }
+.companion-studio .user-roster-item { border: 0 !important; border-bottom: 1px solid var(--line-soft) !important; border-radius: 0 !important; padding: 13px 8px !important; background: transparent !important; box-shadow: none !important; min-height: 0 !important; gap: 10px !important; }
+.companion-studio .user-roster-item.is-selected { background: var(--accent-soft) !important; box-shadow: inset 2px 0 var(--accent) !important; }
+.companion-studio .user-roster-item::before { content: none !important; }
+.companion-studio .user-avatar { width: 30px !important; height: 30px !important; border-radius: 50% !important; font-size: 12px !important; }
+.companion-studio .user-roster-main strong { font-size: 12px !important; }
+.companion-studio .user-roster-id, .companion-studio .user-roster-meta { font-size: 10px !important; }
+.companion-studio .user-roster-footer { border: 0 !important; padding: 16px 0 !important; }
+.companion-studio .user-detail-shell, .companion-studio #userDetail { padding: 0 !important; border: 0 !important; border-radius: 0 !important; background: transparent !important; box-shadow: none !important; }
+.companion-studio .user-detail-tabs { position: static !important; top: auto !important; z-index: auto !important; backdrop-filter: none !important; display: flex !important; flex-wrap: wrap !important; gap: 4px 12px !important; padding: 0 !important; background: transparent !important; overflow: visible !important; border-top: 0 !important; margin: 16px 0 0 !important; }
+.companion-studio .user-detail-tabs button { border-radius: 0 !important; padding: 10px 2px !important; font-size: 12px !important; font-weight: 500 !important; background: none !important; border-bottom: 2px solid transparent !important; transform: none !important; }
+.companion-studio .user-detail-tabs button.is-active { color: var(--accent) !important; border-bottom-color: var(--accent) !important; }
+.companion-studio .user-view-overview { display: block !important; padding: 0 0 18px !important; border: 0 !important; border-radius: 0 !important; background: transparent !important; box-shadow: none !important; }
+.companion-studio .user-view-heading h3 { font-size: 17px !important; font-weight: 550 !important; }
+.companion-studio .user-view-stats { display: flex !important; flex-wrap: wrap; gap: 10px 24px !important; margin-top: 14px; }
+.companion-studio .user-view-stats > span { display: flex !important; gap: 10px; align-items: baseline; min-height: 0 !important; padding: 0 !important; border: 0 !important; background: none !important; border-radius: 0 !important; }
+.companion-studio .user-view-stats b { font-size: 13px !important; font-weight: 500 !important; }
+.companion-studio .user-profile-form { border: 0 !important; border-bottom: 1px solid var(--line) !important; padding: 0 0 20px !important; border-radius: 0 !important; background: none !important; }
+.companion-studio .studio-user-metrics .visual-strip { display: flex !important; flex-wrap: wrap; gap: 15px 32px !important; padding: 10px 0 20px; }
+.companion-studio .studio-user-metrics :is(.mini-stat,.gauge) { display: flex !important; gap: 10px; align-items: center; padding: 0 !important; min-width: 0 !important; border: 0 !important; border-radius: 0 !important; box-shadow: none !important; background: none !important; }
+.companion-studio .studio-user-metrics .mini-stat b { font-size: 15px !important; font-weight: 550 !important; }
+.companion-studio .studio-user-metrics .gauge svg { width: 62px !important; height: 34px !important; }
+.companion-studio .studio-user-metrics :is(.mini-stat,.gauge) > span { font-size: 12px; }
+@media(max-width: 1050px) {
+ .companion-studio .user-workspace { grid-template-columns: minmax(0,1fr) !important; }
+ .companion-studio .user-roster { border: 0 !important; border-bottom: 1px solid var(--line) !important; padding: 0 !important; }
+ .companion-studio .user-roster-list { display: block !important; }
+ .companion-studio .feature-inline-setting-form { flex-basis: 100%; }
+}
+@media(max-width: 680px) {
+ .companion-studio .studio-feature-group > summary { padding: 18px 0; gap: 10px; }
+ .companion-studio .studio-feature-group > summary span { font-size: 11px; }
+ .companion-studio .studio-feature-group > summary small { max-width: 65px; text-align: right; }
+ .companion-studio .feature-switch-list { padding-left: 12px !important; }
+ .companion-studio .feature-switch-body { flex-basis: 170px; }
+ .companion-studio .feature-switch-item { gap: 10px !important; }
+ .companion-studio .feature-switch-text { gap: 5px 12px !important; }
+ .companion-studio .proactive-summary-card { grid-template-columns: minmax(100px,1fr) auto !important; gap: 5px !important; }
+ .companion-studio .proactive-summary-card small { grid-column: 1 / -1; }
+ .companion-studio :is(.studio-proactive-metrics,.studio-proactive-disclosure,.studio-user-metrics) > summary small { display: block; margin: 5px 0 0; }
+ .companion-studio .studio-proactive-lead { gap: 12px 22px; }
+ .companion-studio .studio-proactive-lead b { font-size: 17px; }
+}
+/* Final containment pass: remove surviving legacy frames, stripes and faux cards. */
+.companion-studio .feature-switch-text { min-height: 0 !important; }
+.companion-studio .feature-switch-body { row-gap: 5px !important; }
+.companion-studio .feature-switch-meta { margin: 0 !important; padding: 0 !important; }
+.companion-studio .proactive-records-card { display: block !important; }
+.companion-studio #proactiveCandidateFilters { position: static !important; display: block !important; margin: 14px 0 !important; width: 100% !important; }
+.companion-studio .proactive-filter-summary { display: flex !important; align-items: baseline; flex-wrap: wrap; gap: 8px 15px !important; padding: 10px 0 !important; border: 0 !important; border-radius: 0 !important; background: none !important; box-shadow: none !important; }
+.companion-studio .proactive-filter-summary b { font-size: 13px !important; font-weight: 500 !important; }
+.companion-studio .proactive-filter-summary :is(span,small,em) { font-size: 11px !important; font-style: normal; font-weight: 400; }
+.companion-studio .proactive-filter-list { border-bottom: 1px solid var(--line); padding-bottom: 6px; }
+.companion-studio .proactive-filter-user { display: flex !important; align-items: baseline; gap: 14px !important; border: 0 !important; border-bottom: 2px solid transparent !important; border-radius: 0 !important; }
+.companion-studio .proactive-filter-user.is-active { background: none !important; border-bottom-color: var(--accent) !important; }
+.companion-studio .proactive-filter-user > span { display: flex; flex-wrap: wrap; gap: 10px; align-items: baseline; }
+.companion-studio .proactive-filter-user em { background: none !important; border-radius: 0 !important; padding: 0 !important; min-width: 0 !important; height: auto !important; font-size: 12px; }
+.companion-studio #proactiveCandidateList { padding: 0 !important; }
+.companion-studio .proactive-candidate .danger-outline { border: 1px solid var(--line) !important; padding: 6px 10px !important; border-radius: 5px !important; background: transparent !important; color: var(--danger) !important; box-shadow: none !important; font-size: 11px !important; font-weight: 400 !important; }
+.companion-studio :is(.user-workspace,.user-detail-header,.user-view-overview,.user-detail-shell,.user-view-heading,.user-roster)::before,
+.companion-studio :is(.user-workspace,.user-detail-header,.user-view-overview,.user-detail-shell,.user-view-heading,.user-roster)::after { content: none !important; }
+.companion-studio .user-detail-header { border: 0 !important; border-radius: 0 !important; background: none !important; padding: 0 0 12px !important; box-shadow: none !important; }
+.companion-studio .user-detail-summary { background: none !important; box-shadow: none !important; border: 0 !important; border-radius: 0 !important; padding: 0 !important; }
+.companion-studio .user-detail-avatar { width: 42px !important; height: 42px !important; border-radius: 50% !important; font-size: 17px !important; }
+.companion-studio .user-roster-footer { display: flex !important; flex-wrap: wrap; gap: 8px !important; background: none !important; }
+.companion-studio .user-roster-footer button { font-size: 11px; padding: 8px 10px; }
+.companion-studio .user-roster-name { display: flex; flex-wrap: wrap; }
+.companion-studio .user-roster-name strong { white-space: normal !important; overflow-wrap: anywhere; }
+.companion-studio #userDetail :is(.detail-block,.detail-card,.companion-intimacy-card,.private-dialogue-section,.user-view-overview) { background: none !important; border: 0 !important; border-bottom: 1px solid var(--line) !important; border-radius: 0 !important; box-shadow: none !important; padding: 20px 0 !important; margin: 0 !important; }
+.companion-studio #userDetail :is(.detail-block,.detail-card,.companion-intimacy-card,.private-dialogue-section)::before,
+.companion-studio #userDetail :is(.detail-block,.detail-card,.companion-intimacy-card,.private-dialogue-section)::after,
+.companion-studio #userDetail :is(h2,h3)::before, .companion-studio #userDetail :is(h2,h3)::after { content: none !important; }
+.companion-studio #userDetail :is(.detail-block,.detail-card) :is(h2,h3) { font-size: 16px !important; font-weight: 550 !important; }
+.companion-studio .user-profile-form { margin-top: 16px !important; }
+/* The same document-like surface carries through the home and editor pages. */
+.companion-studio #stats { display: flex !important; flex-wrap: wrap; gap: 16px 36px !important; padding: 16px 0 !important; border-block: 1px solid var(--line); }
+.companion-studio #stats .stat { flex: 1 1 180px; padding: 0 !important; border: 0 !important; border-radius: 0 !important; box-shadow: none !important; background: transparent !important; }
+.companion-studio #stats .stat:hover { color: var(--accent); text-decoration: underline; }
+.companion-studio .studio-welcome { background: transparent !important; border: 0 !important; border-radius: 0 !important; padding: 12px 0 20px !important; }
+.companion-studio .studio-art { opacity: .65; }
+.companion-studio .dashboard-life-desk { display: block !important; }
+.companion-studio .life-desk-card { padding: 24px 0 !important; border: 0 !important; border-bottom: 1px solid var(--line) !important; border-radius: 0 !important; background: transparent !important; box-shadow: none !important; }
+.companion-studio .life-desk-dot { display: none; }
+.companion-studio :is(.module-card,.persona-card,.provider-card) { border-radius: 0 !important; border: 0 !important; border-bottom: 1px solid var(--line) !important; padding: 22px 0 !important; background: transparent !important; box-shadow: none !important; }
+.companion-studio .provider-tree-grid { grid-template-columns: minmax(0,1fr) !important; }
+.companion-studio .world-workspace { padding: 20px !important; }
+.companion-studio .empty { border: 0 !important; border-radius: 0 !important; background: transparent !important; padding: 22px 0 !important; }
+@media(max-width: 680px) { .companion-studio .studio-art { opacity: .12; } .companion-studio .feature-switch-text b { font-size: 13px !important; } .companion-studio .world-workspace { padding: 12px !important; } }
+
+/* Prompt workspace containment: respond to the actual panel width in AstrBot,
+   not merely the outer screen. Keep full labels; only long readers scroll. */
+.companion-studio #panel-prompts { container-name: promptpage; container-type: inline-size; min-width: 0; }
+.companion-studio .prompts-page-head { flex-wrap: wrap; }
+.companion-studio .prompts-scope-note { min-width: 0 !important; max-width: 100%; flex: 0 1 360px; }
+.companion-studio .prompts-workspace { display: grid !important; grid-template-columns: minmax(230px, 280px) minmax(0, 1fr) !important; align-items: start; gap: 24px; min-width: 0; width: 100%; min-height: 0 !important; overflow: visible !important; border: 0 !important; border-radius: 0 !important; background: transparent !important; }
+.companion-studio #panel-prompts :is(.prompts-catalog,.prompts-editor) { width: 100%; min-width: 0 !important; max-width: 100%; min-height: 0 !important; border: 0 !important; border-radius: 0 !important; background: transparent !important; box-shadow: none !important; }
+.companion-studio .prompts-catalog { border-right: 1px solid var(--line) !important; padding-right: 18px; }
+.companion-studio .prompts-catalog-toolbar { min-width: 0; padding: 0 0 14px; }
+.companion-studio .prompts-mode-switch { border-radius: 5px; }
+.companion-studio .prompts-mode-switch button { white-space: normal; overflow-wrap: anywhere; padding: 7px; }
+.companion-studio .prompts-group-nav { display: flex; flex-wrap: wrap !important; overflow: visible !important; min-width: 0; max-width: 100%; padding: 12px 0; gap: 6px; }
+.companion-studio .prompts-group-nav button { flex: 0 1 auto !important; max-width: 100%; white-space: normal !important; overflow-wrap: anywhere; min-height: 30px; line-height: 1.6; padding: 5px 8px; font-weight: 500; border-radius: 5px; }
+.companion-studio .prompts-directory-hint { padding: 9px 0; font-size: 11px; color: var(--muted); line-height: 1.7; }
+.companion-studio .prompts-task-list { min-height: 0 !important; max-height: clamp(220px,48dvh,560px) !important; overflow-y: auto !important; overflow-x: hidden; overscroll-behavior: auto; scrollbar-gutter: stable; padding: 0 6px 0 0; }
+.companion-studio .prompts-task-item { border: 0 !important; border-bottom: 1px solid var(--line-soft) !important; border-radius: 0 !important; padding: 12px 9px !important; background: transparent !important; box-shadow: none !important; min-height: 0; }
+.companion-studio .prompts-task-item.active { background: var(--accent-soft) !important; }
+.companion-studio .prompts-task-item-head { align-items: flex-start; }
+.companion-studio .prompts-task-item b { font-size: 13px; font-weight: 500; line-height: 1.7; white-space: normal; overflow-wrap: anywhere; }
+.companion-studio .prompts-task-state { margin-top: 7px; }
+.companion-studio .prompts-task-item code { white-space: normal !important; overflow: visible !important; text-overflow: clip !important; overflow-wrap: anywhere; line-height: 1.7; font-size: 10px; }
+.companion-studio .prompts-editor-content { display: block !important; width: 100%; min-width: 0; min-height: 0 !important; }
+.companion-studio .prompts-editor-content[hidden] { display: none !important; }
+.companion-studio .prompts-editor-head { flex-wrap: wrap; padding: 0 0 18px; gap: 10px; }
+.companion-studio .prompts-editor-head > div { flex: 1 1 240px; min-width: 0; }
+.companion-studio .prompts-editor-head :is(h3,p) { overflow-wrap: anywhere; white-space: normal; }
+.companion-studio .prompts-editor-head h3 { font-size: 19px; font-weight: 550; line-height: 1.6; }
+.companion-studio .prompts-editor-meta { grid-template-columns: minmax(0,1fr) !important; }
+.companion-studio .prompts-editor-meta > div { grid-column: 1 !important; padding: 12px 0; border: 0 !important; border-bottom: 1px solid var(--line-soft) !important; }
+.companion-studio .prompts-editor-meta :is(dd,code) { min-width: 0; max-width: 100%; white-space: normal; overflow-wrap: anywhere; }
+.companion-studio :is(.prompts-builtin-preview,.prompts-textarea-field) { min-width: 0; padding: 18px 0; }
+.companion-studio .prompts-builtin-preview-head { flex-wrap: wrap; }
+.companion-studio .prompts-builtin-prompt { max-width: 100%; box-sizing: border-box; max-height: 360px; overflow-y: auto; overflow-x: auto; white-space: pre-wrap !important; overflow-wrap: anywhere !important; tab-size: 2; }
+.companion-studio .prompts-textarea-field textarea { box-sizing: border-box; max-width: 100%; min-width: 0; min-height: 240px; resize: vertical; }
+.companion-studio .prompts-editor-boundary { margin: 0 0 18px; }
+.companion-studio .prompts-editor-actions { position: static !important; flex-wrap: wrap; min-width: 0; padding: 16px 0; gap: 12px; }
+.companion-studio .prompts-editor-actions > div { display: flex; flex-wrap: wrap; flex: 0 1 auto; min-width: 0; max-width: 100%; }
+.companion-studio .prompts-editor-actions button { white-space: normal; min-width: 0; max-width: 100%; }
+/* Fallback for browsers without container queries. */
+@media(max-width:1180px) { .companion-studio .prompts-workspace { grid-template-columns: minmax(0,1fr) !important; } .companion-studio .prompts-catalog { border-right: 0 !important; border-bottom: 1px solid var(--line) !important; padding: 0 0 20px; } }
+@supports(container-type:inline-size) {
+ @container promptpage (min-width:901px) { .companion-studio .prompts-workspace { grid-template-columns: minmax(230px,280px) minmax(0,1fr) !important; } .companion-studio .prompts-catalog { border-right: 1px solid var(--line) !important; border-bottom: 0 !important; padding: 0 18px 0 0; } }
+ @container promptpage (max-width:900px) { .companion-studio .prompts-workspace { grid-template-columns: minmax(0,1fr) !important; } .companion-studio .prompts-catalog { border-right: 0 !important; border-bottom: 1px solid var(--line) !important; padding: 0 0 20px; } .companion-studio .prompts-task-list { max-height: 320px !important; } }
+}

--- a/pages/companion-panel/css/polish.css
+++ b/pages/companion-panel/css/polish.css
@@ -5316,21 +5316,21 @@ code,
    All palette variants still use the original appearance selector.
    ========================================================================== */
 :root {
-  --studio-bg: #f7f8f4;
-  --studio-sidebar: #f0f3ed;
+  --studio-bg: #f7f8fa;
+  --studio-sidebar: #f0f3f4;
   --studio-hero: #edf1e7;
-  --radius: 18px;
-  --radius-sm: 10px;
+  --radius: 8px;
+  --radius-sm: 6px;
   --shadow: 0 8px 32px rgba(35, 57, 43, .035);
   --shadow-soft: 0 2px 10px rgba(35, 57, 43, .025);
 }
 :root[data-theme="classic"], :root:not([data-theme]) {
-  --bg: #f7f8f4; --panel: #fff; --surface: #f6f8f3;
-  --surface-strong: #e9eee4; --ink: #293d33; --muted: #748074;
-  --line: #dce3d7; --line-soft: #e9ede4;
+  --bg: #f7f8fa; --panel: #fff; --surface: #f3f5f6;
+  --surface-strong: #e9eef0; --ink: #29353c; --muted: #56636b;
+  --line: #d8dfe3; --line-soft: #e5e9ec;
   --accent: #53755b; --accent-strong: #34543e; --accent-soft: #e6eddf;
-  --blue: #648371; --blue-soft: #e6ede5;
-  --red: #bf7366; --red-soft: #f6e9e5;
+  --blue: #386b9a; --blue-soft: #e7eef7;
+  --red: #a94f51; --red-soft: #f6e9e5;
   --gold: #a78d56; --gold-soft: #f6f0e1;
   --cv-line: #dce3d7; --cv-line-soft: #e9ede4;
 }
@@ -5353,8 +5353,8 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 .companion-studio .folio::before, .companion-studio .folio::after, .companion-studio .folio-meta::before, .companion-studio .folio-meta::after { content: none !important; }
 .companion-studio .folio-meta { flex: 1; min-width: 0; padding: 0 !important; display: block !important; background: none !important; border: 0 !important; }
 .companion-studio .folio-heading { display: flex !important; flex-wrap: wrap; gap: 12px 28px; align-items: center; justify-content: space-between; }
-.companion-studio .folio-eyebrow { font-size: 10px !important; letter-spacing: 2px !important; font-weight: 400 !important; color: var(--muted) !important; margin-bottom: 6px; }
-.companion-studio .folio-title { font-size: 19px !important; line-height: 1.6 !important; letter-spacing: -.4px !important; font-weight: 600 !important; margin: 0 !important; }
+.companion-studio .folio-eyebrow { font-size: 10px !important; letter-spacing: 0 !important; font-weight: 400 !important; color: var(--muted) !important; margin-bottom: 6px; }
+.companion-studio .folio-title { font-size: 19px !important; line-height: 1.6 !important; letter-spacing: 0 !important; font-weight: 600 !important; margin: 0 !important; }
 .studio-header-slash { color: #b8c2b6; margin: 0 12px; font-weight: 300; }
 #studioPageTitle { font-size: 14px; font-weight: 400; color: var(--muted); }
 .companion-studio .folio-persona-context { display: grid; gap: 4px; }
@@ -5364,7 +5364,7 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 .companion-studio .folio-plate::before, .companion-studio .folio-plate::after { content: none !important; }
 .companion-studio .daily-outfit-logo { width: 100% !important; height: 100% !important; max-height: none !important; object-fit: cover !important; }
 .companion-studio .folio-tools { display: flex !important; flex-direction: row !important; gap: 10px !important; padding: 0 !important; width: auto !important; border: 0 !important; background: none !important; }
-.companion-studio .seal, .companion-studio .setup-guide-entry { position: relative !important; min-height: 40px !important; height: 40px !important; border: 1px solid var(--line) !important; border-radius: 10px !important; background: var(--panel) !important; color: var(--ink) !important; box-shadow: none !important; font-size: 12px !important; font-weight: 500 !important; padding: 0 14px !important; }
+.companion-studio .seal, .companion-studio .setup-guide-entry { position: relative !important; min-height: 40px !important; height: 40px !important; border: 1px solid var(--line) !important; border-radius: 8px !important; background: var(--panel) !important; color: var(--ink) !important; box-shadow: none !important; font-size: 12px !important; font-weight: 500 !important; padding: 0 14px !important; }
 .companion-studio .seal { width: 40px !important; padding: 0 !important; transform: none !important; }
 .companion-studio .seal-mark { font-size: 22px !important; }
 .companion-studio .seal small { display: none; }
@@ -5373,13 +5373,13 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 .companion-studio .annotations { position: fixed !important; inset: 0 auto 0 0 !important; width: 226px !important; height: 100dvh !important; display: flex !important; flex-direction: column !important; align-items: stretch !important; gap: 4px !important; padding: 28px 18px 22px !important; border: 0 !important; border-right: 1px solid var(--line-soft) !important; background: var(--studio-sidebar) !important; border-radius: 0 !important; overflow-y: auto !important; overflow-x: hidden !important; z-index: 30 !important; box-shadow: none !important; backdrop-filter: none !important; scrollbar-width: thin; }
 .companion-studio .annot-axis, .companion-studio .annotations::before, .companion-studio .annotations::after { display: none !important; }
 .studio-brand { display: flex; align-items: center; gap: 10px; padding: 1px 6px 28px; flex-shrink: 0; }
-.studio-brand-mark { width: 36px; height: 36px; background: var(--accent); color: #fff; border-radius: 12px; font-size: 33px; line-height: 36px; text-align: center; }
-.studio-brand b { display: block; font-size: 15px; letter-spacing: -.3px; font-weight: 600; }
-.studio-brand small { display: block; font-size: 7px; letter-spacing: 1.6px; color: var(--muted); margin-top: 3px; }
-.companion-studio .studio-find { display: flex; justify-content: space-between; align-items: center; gap: 6px; padding: 10px 11px !important; width: 100%; background: color-mix(in srgb, var(--panel) 62%, transparent) !important; color: var(--muted) !important; border: 1px solid var(--line) !important; border-radius: 9px !important; font-size: 11px !important; font-weight: 400 !important; margin-bottom: 12px; }
+.studio-brand-mark { width: 36px; height: 36px; background: var(--accent); color: #fff; border-radius: 8px; font-size: 33px; line-height: 36px; text-align: center; }
+.studio-brand b { display: block; font-size: 15px; letter-spacing: 0; font-weight: 600; }
+.studio-brand small { display: block; font-size: 7px; letter-spacing: 0; color: var(--muted); margin-top: 3px; }
+.companion-studio .studio-find { display: flex; justify-content: space-between; align-items: center; gap: 6px; padding: 10px 11px !important; width: 100%; background: color-mix(in srgb, var(--panel) 62%, transparent) !important; color: var(--muted) !important; border: 1px solid var(--line) !important; border-radius: 8px !important; font-size: 11px !important; font-weight: 400 !important; margin-bottom: 12px; }
 .studio-find kbd { font: inherit; font-size: 9px; opacity: .75; }
-.studio-nav-label { padding: 17px 14px 7px; font-size: 10px; letter-spacing: 1.4px; color: var(--muted); }
-.companion-studio .annotations .tab { display: flex !important; flex-direction: row !important; align-items: center !important; gap: 14px !important; width: 100% !important; min-width: 0 !important; min-height: 40px !important; padding: 10px 15px !important; margin: 0 !important; border: 0 !important; border-radius: 9px !important; background: transparent !important; color: var(--muted) !important; box-shadow: none !important; font-size: 13px !important; font-weight: 450 !important; transform: none !important; flex-shrink: 0; }
+.studio-nav-label { padding: 17px 14px 7px; font-size: 10px; letter-spacing: 0; color: var(--muted); }
+.companion-studio .annotations .tab { display: flex !important; flex-direction: row !important; align-items: center !important; gap: 14px !important; width: 100% !important; min-width: 0 !important; min-height: 40px !important; padding: 10px 15px !important; margin: 0 !important; border: 0 !important; border-radius: 8px !important; background: transparent !important; color: var(--muted) !important; box-shadow: none !important; font-size: 13px !important; font-weight: 450 !important; transform: none !important; flex-shrink: 0; }
 .companion-studio .annotations .tab i { display: inline-grid; place-items: center; width: 19px; font-size: 19px !important; font-style: normal; font-family: system-ui, sans-serif; font-weight: 400 !important; color: inherit !important; line-height: 1; }
 .companion-studio .annotations .tab span { font-size: inherit !important; font-weight: inherit !important; }
 .companion-studio .annotations .tab:hover { background: var(--accent-soft) !important; color: var(--accent-strong) !important; }
@@ -5388,38 +5388,38 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 .companion-studio .annotations .tab[hidden] { display: none !important; }
 .studio-nav-foot { margin-top: auto; padding: 28px 12px 0; font-size: 10px; color: var(--muted); }
 .studio-nav-foot > span { color: var(--accent); margin-right: 5px; }
-.studio-nav-foot small { display: block; margin-top: 8px; font-size: 7px; letter-spacing: 1.6px; opacity: .7; }
+.studio-nav-foot small { display: block; margin-top: 8px; font-size: 7px; letter-spacing: 0; opacity: .7; }
 /* Home: invitation, four compact signals, then two calm columns. */
 .companion-studio .section-head { gap: 18px !important; margin: 0 0 24px !important; padding: 0 0 20px !important; border-bottom: 1px solid var(--line-soft) !important; background: transparent !important; }
-.companion-studio .section-head h2 { font-size: 23px !important; font-weight: 600 !important; letter-spacing: -.5px; }
+.companion-studio .section-head h2 { font-size: 23px !important; font-weight: 600 !important; letter-spacing: 0; }
 .companion-studio .section-head h2::before, .companion-studio .section-head h2::after { content: none !important; }
 .companion-studio .section-desc { color: var(--muted) !important; font-size: 12px !important; line-height: 1.8 !important; margin-top: 7px !important; font-weight: 400 !important; }
 .companion-studio .dashboard-overview-head { border: 0 !important; padding: 0 !important; margin-bottom: 24px !important; }
 .companion-studio #exportSnapshotBtn { color: var(--muted) !important; background: transparent !important; border: 1px solid var(--line) !important; box-shadow: none !important; font-size: 11px !important; padding: 9px 14px !important; border-radius: 8px !important; }
-.studio-welcome { position: relative; isolation: isolate; display: flex; align-items: center; min-height: 280px; padding: 34px 38px; border: 1px solid color-mix(in srgb, var(--line) 55%, transparent); border-radius: 19px; background: var(--studio-hero); overflow: hidden; }
+.studio-welcome { position: relative; isolation: isolate; display: flex; align-items: center; min-height: 280px; padding: 34px 38px; border: 1px solid color-mix(in srgb, var(--line) 55%, transparent); border-radius: 8px; background: var(--studio-hero); overflow: hidden; }
 .studio-welcome-copy { position: relative; z-index: 1; }
-.studio-kicker { display: flex; align-items: center; gap: 8px; color: var(--accent); font-size: 8px; letter-spacing: 2px; font-weight: 600; }
+.studio-kicker { display: flex; align-items: center; gap: 8px; color: var(--accent); font-size: 8px; letter-spacing: 0; font-weight: 600; }
 .studio-kicker > span { width: 5px; height: 5px; border-radius: 50%; background: var(--accent); }
-.companion-studio .studio-welcome h2 { margin: 18px 0 12px !important; font-size: clamp(25px, 2.4vw, 37px) !important; font-weight: 500 !important; line-height: 1.5 !important; letter-spacing: 1px; color: var(--accent-strong); }
+.companion-studio .studio-welcome h2 { margin: 18px 0 12px !important; font-size: 28px !important; font-weight: 500 !important; line-height: 1.5 !important; letter-spacing: 0; color: var(--accent-strong); }
 .studio-welcome p { font-size: 12px; color: var(--muted); }
 .studio-welcome-actions { display: flex; align-items: center; flex-wrap: wrap; gap: 19px; margin-top: 25px; }
-.companion-studio .studio-primary { background: var(--accent) !important; color: #fff !important; border: 0 !important; border-radius: 9px !important; padding: 11px 17px !important; font-size: 12px !important; font-weight: 500 !important; box-shadow: none !important; }
+.companion-studio .studio-primary { background: var(--accent) !important; color: #fff !important; border: 0 !important; border-radius: 8px !important; padding: 11px 17px !important; font-size: 12px !important; font-weight: 500 !important; box-shadow: none !important; }
 .studio-primary > span { margin-left: 13px; }
 .companion-studio .studio-text-button { border: 0 !important; background: none !important; color: var(--accent-strong) !important; font-size: 11px !important; font-weight: 400 !important; padding: 8px 0 !important; box-shadow: none !important; }
 .studio-text-button > span { margin-left: 6px; }
 .studio-art { position: absolute; right: 20px; bottom: 15px; width: 41%; max-width: 370px; z-index: -1; }
-.studio-art-caption { position: absolute; bottom: 17px; right: 55px; font-size: 7px; color: var(--accent); letter-spacing: 2px; opacity: .65; }
+.studio-art-caption { position: absolute; bottom: 17px; right: 55px; font-size: 7px; color: var(--accent); letter-spacing: 0; opacity: .65; }
 .studio-metrics-label { display: flex; justify-content: space-between; align-items: center; margin: 28px 2px 12px; font-size: 12px; font-weight: 500; }
 .studio-metrics-label small { font-size: 10px; color: var(--muted); font-weight: 400; }
 .companion-studio #stats { display: grid !important; grid-template-columns: repeat(4, minmax(0, 1fr)) !important; gap: 12px !important; margin: 0 0 28px !important; }
-.companion-studio .stat { border: 1px solid var(--line-soft) !important; border-radius: 12px !important; padding: 20px 17px !important; background: var(--panel) !important; box-shadow: none !important; }
+.companion-studio .stat { border: 1px solid var(--line-soft) !important; border-radius: 8px !important; padding: 20px 17px !important; background: var(--panel) !important; box-shadow: none !important; }
 .companion-studio .stat::before, .companion-studio .stat::after { content: none !important; }
-.companion-studio .stat b { font-size: clamp(14px, 1.5vw, 21px) !important; font-weight: 550 !important; letter-spacing: -.5px; margin: 5px 0 8px !important; line-height: 1.4; }
+.companion-studio .stat b { font-size: 18px !important; font-weight: 550 !important; letter-spacing: 0; margin: 5px 0 8px !important; line-height: 1.4; }
 .companion-studio .stat span { display: block; color: var(--muted) !important; font-size: 10px !important; line-height: 1.6; }
 .companion-studio .stat:hover { border-color: var(--accent) !important; background: var(--surface) !important; }
 .companion-studio .dashboard-life-desk { display: grid !important; grid-template-columns: minmax(0, 1fr) minmax(0, 1.13fr) !important; gap: 20px !important; align-items: start !important; margin: 0 !important; }
 .companion-studio .dashboard-life-column { display: grid !important; grid-template-columns: minmax(0,1fr) !important; gap: 20px !important; min-width: 0; }
-.companion-studio .life-desk-card { position: relative; border: 1px solid var(--line-soft) !important; border-radius: 15px !important; padding: 23px !important; background: var(--panel) !important; box-shadow: none !important; overflow: hidden; }
+.companion-studio .life-desk-card { position: relative; border: 1px solid var(--line-soft) !important; border-radius: 8px !important; padding: 23px !important; background: var(--panel) !important; box-shadow: none !important; overflow: hidden; }
 .companion-studio .life-desk-card::before, .companion-studio .life-desk-card::after { content: none !important; }
 .companion-studio .life-desk-card-head { display: flex; justify-content: space-between; gap: 12px !important; align-items: center; margin-bottom: 22px !important; padding: 0 !important; border: 0 !important; }
 .companion-studio .life-desk-card-head h3 { font-size: 16px !important; font-weight: 550 !important; color: var(--ink) !important; }
@@ -5434,21 +5434,21 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 .companion-studio .life-desk-link { padding: 5px 9px !important; border: 1px solid var(--line-soft) !important; color: var(--accent) !important; background: var(--surface) !important; border-radius: 7px !important; font-size: 10px !important; font-weight: 450 !important; box-shadow: none !important; }
 .companion-studio .life-timeline-preview { min-height: 230px !important; max-height: none !important; padding: 0 !important; overflow: visible !important; }
 .companion-studio .life-timeline-row { background: transparent !important; border: 0 !important; border-bottom: 1px solid var(--line-soft) !important; border-radius: 0 !important; padding: 16px 4px !important; margin: 0 !important; box-shadow: none !important; }
-.companion-studio .life-timeline-row.is-current { background: var(--surface) !important; border-radius: 10px !important; padding: 16px 12px !important; border: 1px solid var(--line-soft) !important; }
+.companion-studio .life-timeline-row.is-current { background: var(--surface) !important; border-radius: 8px !important; padding: 16px 12px !important; border: 1px solid var(--line-soft) !important; }
 .companion-studio .life-timeline-content b { font-size: 13px !important; font-weight: 500 !important; }
 .companion-studio .life-timeline-content p { font-size: 11px !important; line-height: 1.8 !important; }
-.companion-studio .life-current-activity { border: 0 !important; background: var(--surface) !important; border-radius: 10px !important; padding: 16px !important; }
+.companion-studio .life-current-activity { border: 0 !important; background: var(--surface) !important; border-radius: 8px !important; padding: 16px !important; }
 .companion-studio .life-current-activity b { font-size: 15px !important; font-weight: 500 !important; }
 .companion-studio .life-state-grid { gap: 14px !important; }
 .companion-studio .life-state-grid > div { border: 0 !important; background: transparent !important; padding: 6px 0 !important; }
 .companion-studio .life-state-grid b { font-size: 12px !important; font-weight: 500 !important; }
 .companion-studio .life-energy-track { height: 4px !important; margin: 20px 0 !important; background: var(--accent-soft) !important; }
 .companion-studio .life-energy-track i { background: var(--accent) !important; }
-.companion-studio .life-empty { display: grid; place-content: center; text-align: center; min-height: 150px; border: 0 !important; border-radius: 10px !important; background: var(--surface) !important; color: var(--muted) !important; font-size: 12px !important; }
+.companion-studio .life-empty { display: grid; place-content: center; text-align: center; min-height: 150px; border: 0 !important; border-radius: 8px !important; background: var(--surface) !important; color: var(--muted) !important; font-size: 12px !important; }
 .companion-studio .dashboard-secondary { margin-top: 30px !important; display: grid; gap: 12px !important; }
 .studio-section-label { font-size: 14px; margin: 0 2px 3px; }
 .studio-section-label small { font-size: 11px; color: var(--muted); margin-left: 12px; }
-.companion-studio .dashboard-disclosure { border: 1px solid var(--line-soft) !important; border-radius: 12px !important; background: var(--panel) !important; box-shadow: none !important; overflow: hidden; }
+.companion-studio .dashboard-disclosure { border: 1px solid var(--line-soft) !important; border-radius: 8px !important; background: var(--panel) !important; box-shadow: none !important; overflow: hidden; }
 .companion-studio .dashboard-disclosure > summary { padding: 20px 23px !important; background: transparent !important; cursor: pointer; }
 .companion-studio .dashboard-disclosure > summary b { font-size: 13px !important; font-weight: 500 !important; }
 .companion-studio .dashboard-disclosure > summary small { font-size: 11px !important; color: var(--muted); font-weight: 400 !important; }
@@ -5458,35 +5458,35 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 .companion-studio .dashboard-companion-terminal { border: 0 !important; box-shadow: none !important; background: transparent !important; margin: 0 !important; padding: 24px !important; }
 .companion-studio .dashboard-companion-terminal h2 { font-size: 18px !important; }
 /* Shared visual system. Component-specific grids and behavior are untouched. */
-.companion-studio :is(.module-card,.dashboard-strategy-card,.dashboard-chart-card,.dashboard-insight-card,.dashboard-activity-card,.qzone-card,.config-persona-selector,.config-persona-top-row > article,.persona-import-panel,.world-knowledge-brief,.proactive-summary,.prompts-catalog,.prompts-editor,.memory-view-card,.feature-card,.config-overview-card,.learning-card) { border-color: var(--line-soft) !important; border-radius: 14px !important; background: var(--panel) !important; box-shadow: none !important; }
+.companion-studio :is(.module-card,.dashboard-strategy-card,.dashboard-chart-card,.dashboard-insight-card,.dashboard-activity-card,.qzone-card,.config-persona-selector,.config-persona-top-row > article,.persona-import-panel,.world-knowledge-brief,.proactive-summary,.prompts-catalog,.prompts-editor,.memory-view-card,.feature-card,.config-overview-card,.learning-card) { border-color: var(--line-soft) !important; border-radius: 8px !important; background: var(--panel) !important; box-shadow: none !important; }
 .companion-studio :is(.module-card,.feature-card,.dashboard-strategy-card,.dashboard-chart-card,.dashboard-insight-card,.dashboard-activity-card)::before,
 .companion-studio :is(.module-card,.feature-card,.dashboard-strategy-card,.dashboard-chart-card,.dashboard-insight-card,.dashboard-activity-card)::after { content: none !important; }
 .companion-studio .module-card { padding: 24px !important; margin-bottom: 20px; }
 .companion-studio :is(.module-card-head,.persona-card-head) { margin-bottom: 20px !important; }
 .companion-studio :is(.module-card-head,.persona-card-head) :is(h2,h3) { font-weight: 550 !important; font-size: 18px !important; }
 .companion-studio :is(.module-card-head,.persona-card-head) :is(p,.section-desc) { font-size: 12px !important; font-weight: 400 !important; line-height: 1.8 !important; }
-.companion-studio :is(input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="color"]),select,textarea) { border-radius: 9px !important; border-color: var(--line) !important; background-color: var(--panel); color: var(--ink); box-shadow: none; font-size: 13px; }
+.companion-studio :is(input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="color"]),select,textarea) { border-radius: 8px !important; border-color: var(--line) !important; background-color: var(--panel); color: var(--ink); box-shadow: none; font-size: 13px; }
 .companion-studio :is(input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="color"]),select) { min-height: 40px; }
 .companion-studio textarea { padding: 13px !important; line-height: 1.8 !important; }
 .companion-studio :is(input,select,textarea):focus { outline: 2px solid color-mix(in srgb,var(--accent) 40%,transparent) !important; outline-offset: 2px; }
 .companion-studio :is(button,[role="button"],a,summary,input,select,textarea):focus-visible { outline: 2px solid var(--accent) !important; outline-offset: 3px !important; }
-.companion-studio button { font-family: inherit; border-radius: 9px; transition: background .15s ease, border-color .15s ease; }
+.companion-studio button { font-family: inherit; border-radius: 8px; transition: background .15s ease, border-color .15s ease; }
 .companion-studio button:disabled { opacity: .5; cursor: not-allowed; }
-.companion-studio :is(.primary-button,.module-form button[type="submit"],#saveFeaturesBtn) { background: var(--accent) !important; color: #fff !important; border: 1px solid var(--accent) !important; box-shadow: none !important; border-radius: 9px !important; }
-.companion-studio :is(.secondary-button,.ghost-button) { background: var(--panel) !important; color: var(--accent-strong) !important; border-color: var(--line) !important; border-radius: 9px !important; box-shadow: none !important; }
+.companion-studio :is(.primary-button,.module-form button[type="submit"],#saveFeaturesBtn) { background: var(--accent) !important; color: #fff !important; border: 1px solid var(--accent) !important; box-shadow: none !important; border-radius: 8px !important; }
+.companion-studio :is(.secondary-button,.ghost-button) { background: var(--panel) !important; color: var(--accent-strong) !important; border-color: var(--line) !important; border-radius: 8px !important; box-shadow: none !important; }
 .companion-studio :is(.module-badge,.world-save-state,.prompts-custom-badge) { border-color: var(--line-soft) !important; background: var(--accent-soft) !important; color: var(--accent-strong) !important; border-radius: 6px !important; font-weight: 500 !important; }
 .companion-studio :is(th,td) { padding: 14px 16px; border-color: var(--line-soft) !important; }
 .companion-studio th { background: var(--surface) !important; color: var(--muted); font-weight: 500; }
-.companion-studio .feature-save-actions { border: 1px solid var(--line) !important; border-radius: 14px !important; background: var(--panel) !important; box-shadow: 0 8px 35px #293d3320 !important; }
+.companion-studio .feature-save-actions { border: 1px solid var(--line) !important; border-radius: 8px !important; background: var(--panel) !important; box-shadow: 0 8px 35px #293d3320 !important; }
 /* Search dialog: navigates by clicking the existing tab, preserving dirty guards. */
-.studio-command { width: min(540px, calc(100vw - 32px)); max-height: 80dvh; padding: 24px; margin: 12vh auto auto; border: 1px solid var(--line); border-radius: 20px; background: var(--panel); color: var(--ink); box-shadow: 0 25px 90px #14291a30; }
+.studio-command { width: min(540px, calc(100vw - 32px)); max-height: 80dvh; padding: 24px; margin: 12vh auto auto; border: 1px solid var(--line); border-radius: 8px; background: var(--panel); color: var(--ink); box-shadow: 0 25px 90px #14291a30; }
 .studio-command::backdrop { background: #20362655; backdrop-filter: blur(5px); }
 .studio-command-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 18px; }
 .studio-command-head h2 { font-size: 19px; font-weight: 550; }
 .studio-command-head button { width: 32px; height: 32px; border: 0; background: var(--surface); color: var(--muted); font-size: 22px; }
 #studioCommandInput { width: 100%; padding: 12px 14px; }
 .studio-command-results { display: grid; gap: 4px; margin-top: 16px; max-height: 42dvh; overflow-y: auto; }
-.companion-studio .studio-command-result { display: flex; gap: 12px; align-items: center; width: 100%; padding: 12px; background: transparent; color: var(--ink); border: 0; border-radius: 9px; text-align: left; }
+.companion-studio .studio-command-result { display: flex; gap: 12px; align-items: center; width: 100%; padding: 12px; background: transparent; color: var(--ink); border: 0; border-radius: 8px; text-align: left; }
 .studio-command-result > span { color: var(--accent); font-size: 20px; }
 .studio-command-result b { font-size: 13px; font-weight: 500; }
 .studio-command-result small { display: block; font-size: 10px; color: var(--muted); margin-top: 2px; }
@@ -5513,7 +5513,7 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
   .companion-studio .shell { padding-left: 196px !important; padding-right: 22px !important; }
   .companion-studio .annotations { width: 174px !important; padding: 22px 10px !important; }
   .studio-find kbd { display: none; }
-  .studio-brand small { font-size: 6px; letter-spacing: 1px; }
+  .studio-brand small { font-size: 6px; letter-spacing: 0; }
   .companion-studio .folio-heading { gap: 5px; }
   .companion-studio .folio-persona-context { text-align: left; max-width: none; }
   .studio-welcome h2 { font-size: 27px !important; }
@@ -5547,7 +5547,7 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
   .studio-welcome p { font-size: 11px; max-width: 220px; }
   .studio-welcome-actions { gap: 10px 18px; margin-top: 22px; }
   .studio-art { width: 180px; bottom: 30px; right: -56px; opacity: .23; }
-  .studio-kicker { font-size: 7px; letter-spacing: 1.4px; }
+  .studio-kicker { font-size: 7px; letter-spacing: 0; }
   .companion-studio #stats { gap: 10px !important; margin-bottom: 20px !important; }
   .companion-studio .stat { padding: 15px !important; }
   .companion-studio .stat b { font-size: 16px !important; }
@@ -5563,7 +5563,7 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 @media (prefers-reduced-motion: reduce) {
   .companion-studio *, .companion-studio *::before, .companion-studio *::after { scroll-behavior: auto !important; animation-duration: .01ms !important; transition-duration: .01ms !important; }
 }
-.companion-studio .life-desk-empty { display: grid; place-content: center; min-height: 210px; text-align: center; border: 0 !important; border-radius: 10px !important; background: var(--surface) !important; color: var(--muted) !important; font-size: 12px !important; }
+.companion-studio .life-desk-empty { display: grid; place-content: center; min-height: 210px; text-align: center; border: 0 !important; border-radius: 8px !important; background: var(--surface) !important; color: var(--muted) !important; font-size: 12px !important; }
 .companion-studio #dashboardTimelinePreview .life-desk-empty::before { content: '◷'; font-size: 30px; color: var(--accent); opacity: .45; margin-bottom: 12px; }
 .companion-studio #dashboardTimelinePreview .life-desk-empty::after { content: '日程同步后，会在这里留下足迹'; font-size: 10px; margin-top: 7px; opacity: .8; }
 /* Balance the home grid: current state becomes a compact, full-width strip. */
@@ -5599,7 +5599,7 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 }
 /* Configuration and model editors share the same quiet surfaces. */
 .companion-studio :is(.config-fold-panel,.config-persona-stats-panel,.proactive-mode-card,.provider-config-mode-card,.provider-toolbar,.provider-card,.persona-card) {
-  background: var(--panel) !important; border: 1px solid var(--line-soft) !important; border-radius: 14px !important; box-shadow: none !important;
+  background: var(--panel) !important; border: 1px solid var(--line-soft) !important; border-radius: 8px !important; box-shadow: none !important;
 }
 .companion-studio :is(.config-fold-panel,.proactive-mode-card,.provider-card,.persona-card)::before,
 .companion-studio :is(.config-fold-panel,.proactive-mode-card,.provider-card,.persona-card)::after { content: none !important; }
@@ -5615,10 +5615,10 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 .companion-studio .provider-tree-title { font-size: 17px !important; font-weight: 550 !important; }
 .companion-studio .provider-tree-body { gap: 14px !important; }
 .companion-studio .provider-tree-preview { font-size: 12px !important; line-height: 1.8 !important; }
-.companion-studio .provider-current { padding: 13px !important; border: 0 !important; background: var(--surface) !important; border-radius: 9px !important; }
+.companion-studio .provider-current { padding: 13px !important; border: 0 !important; background: var(--surface) !important; border-radius: 8px !important; }
 .companion-studio .provider-current b { font-weight: 500 !important; font-size: 12px !important; }
 .companion-studio :is(.provider-config-mode-card,.provider-toolbar) { padding: 20px !important; margin-bottom: 20px !important; }
-.companion-studio :is(.provider-toolbar-actions,.provider-row) button { padding: 10px 15px !important; border: 1px solid var(--line) !important; background: var(--panel) !important; color: var(--accent-strong) !important; border-radius: 9px !important; font-size: 12px !important; font-weight: 500 !important; box-shadow: none !important; }
+.companion-studio :is(.provider-toolbar-actions,.provider-row) button { padding: 10px 15px !important; border: 1px solid var(--line) !important; background: var(--panel) !important; color: var(--accent-strong) !important; border-radius: 8px !important; font-size: 12px !important; font-weight: 500 !important; box-shadow: none !important; }
 .companion-studio #saveProvidersBtn { background: var(--accent) !important; color: white !important; border-color: var(--accent) !important; }
 .companion-studio .provider-guide { margin-top: 12px !important; padding: 14px !important; background: var(--surface) !important; border: 0 !important; border-radius: 8px !important; line-height: 1.8 !important; }
 .studio-provider-guide { border-top: 1px solid var(--line-soft); padding-top: 12px; }
@@ -5662,7 +5662,7 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 .companion-studio .provider-row { flex-wrap: wrap; }
 .companion-studio .provider-row .hint { font-size: 10px; overflow-wrap: anywhere; }
 .companion-studio .studio-welcome { min-height: 220px; }
-.companion-studio .studio-welcome h2 { font-size: clamp(24px,2.1vw,32px) !important; }
+.companion-studio .studio-welcome h2 { font-size: 28px !important; }
 /* Diagnostics: compact summary, readable full-width rows, one page scrollbar. */
 .companion-studio #panel-troubleshooting { --diag-ink: var(--ink); --diag-signal: var(--accent); }
 .companion-studio .troubleshooting-page { display: grid !important; gap: 22px !important; }
@@ -5670,29 +5670,29 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 .companion-studio .diagnostic-kicker { font: inherit; font-size: 11px !important; font-weight: 400 !important; color: var(--muted) !important; }
 .companion-studio .diagnostic-masthead h2 { font-size: 25px !important; font-weight: 600 !important; line-height: 1.5 !important; margin: 5px 0 8px !important; }
 .companion-studio .diagnostic-masthead p { font-size: 13px !important; }
-.companion-studio #refreshTroubleshootingBtn { border: 1px solid var(--accent) !important; background: var(--accent) !important; color: white !important; padding: 9px 17px !important; border-radius: 9px !important; box-shadow: none !important; }
+.companion-studio #refreshTroubleshootingBtn { border: 1px solid var(--accent) !important; background: var(--accent) !important; color: white !important; padding: 9px 17px !important; border-radius: 8px !important; box-shadow: none !important; }
 .companion-studio .diagnostic-live-dot { font-size: 11px; }
 .companion-studio .diagnostic-live-dot i { background: var(--muted); box-shadow: none; width: 5px; height: 5px; }
-.companion-studio .diagnostic-problem-picker { grid-template-columns: 1fr !important; padding: 20px !important; gap: 16px !important; border: 1px solid var(--line-soft) !important; background: var(--panel) !important; border-radius: 13px !important; box-shadow: none !important; }
+.companion-studio .diagnostic-problem-picker { grid-template-columns: 1fr !important; padding: 20px !important; gap: 16px !important; border: 1px solid var(--line-soft) !important; background: var(--panel) !important; border-radius: 8px !important; box-shadow: none !important; }
 .companion-studio .diagnostic-problem-picker > div:first-child { display: flex; flex-wrap: wrap; gap: 6px 12px; align-items: baseline; }
 .companion-studio .diagnostic-problem-picker > div:first-child > span { color: var(--muted); font-size: 10px; font-weight: 400; }
 .companion-studio .diagnostic-problem-picker h3 { font-size: 16px !important; font-weight: 550 !important; }
 .companion-studio .diagnostic-problem-picker p { font-size: 12px !important; }
 .companion-studio .diagnostic-category-list { display: grid !important; grid-template-columns: repeat(auto-fit,minmax(135px,1fr)) !important; gap: 8px !important; }
-.companion-studio .diagnostic-category { min-height: 84px !important; border: 1px solid var(--line-soft) !important; background: var(--surface) !important; border-radius: 9px !important; padding: 12px !important; box-shadow: none !important; transform: none !important; align-content: start; }
+.companion-studio .diagnostic-category { min-height: 84px !important; border: 1px solid var(--line-soft) !important; background: var(--surface) !important; border-radius: 8px !important; padding: 12px !important; box-shadow: none !important; transform: none !important; align-content: start; }
 .companion-studio .diagnostic-category b { font-size: 13px !important; font-weight: 550 !important; }
 .companion-studio .diagnostic-category span { font-size: 11px !important; line-height: 1.6 !important; font-weight: 400 !important; }
 .companion-studio .diagnostic-category.is-active { background: var(--accent-soft) !important; border-color: var(--accent) !important; }
 .companion-studio .troubleshooting-summary { display: grid !important; grid-template-columns: minmax(210px,2fr) repeat(4,minmax(0,1fr)) !important; gap: 10px !important; align-items: stretch !important; }
-.companion-studio .troubleshooting-head-card { border: 1px solid var(--line-soft) !important; background: var(--panel) !important; padding: 17px !important; border-radius: 11px !important; box-shadow: none !important; flex-wrap: wrap; gap: 10px; }
+.companion-studio .troubleshooting-head-card { border: 1px solid var(--line-soft) !important; background: var(--panel) !important; padding: 17px !important; border-radius: 8px !important; box-shadow: none !important; flex-wrap: wrap; gap: 10px; }
 .companion-studio .troubleshooting-head-card b { font-size: 18px !important; font-weight: 550 !important; line-height: 1.5 !important; }
 .companion-studio .troubleshooting-head-card small { font-size: 11px !important; }
 .companion-studio .troubleshooting-head-card > div > span { font-size: 10px !important; }
-.companion-studio .troubleshooting-count { min-height: 95px !important; padding: 15px 8px !important; border: 1px solid var(--line-soft) !important; border-radius: 11px !important; background: var(--panel) !important; box-shadow: none !important; }
+.companion-studio .troubleshooting-count { min-height: 95px !important; padding: 15px 8px !important; border: 1px solid var(--line-soft) !important; border-radius: 8px !important; background: var(--panel) !important; box-shadow: none !important; }
 .companion-studio .troubleshooting-count b { font-size: 25px !important; font-weight: 550 !important; line-height: 1.4 !important; }
 .companion-studio .troubleshooting-count span { font-size: 12px !important; font-weight: 400 !important; }
 .companion-studio .troubleshooting-count.is-active { border-color: var(--accent) !important; background: var(--surface) !important; }
-.companion-studio .studio-reason-details { display: block !important; grid-column: 1 / -1; padding: 0 !important; background: var(--panel) !important; border: 1px solid var(--line-soft) !important; border-radius: 10px !important; box-shadow: none !important; }
+.companion-studio .studio-reason-details { display: block !important; grid-column: 1 / -1; padding: 0 !important; background: var(--panel) !important; border: 1px solid var(--line-soft) !important; border-radius: 8px !important; box-shadow: none !important; }
 .companion-studio .studio-reason-details > summary { display: flex; align-items: center; gap: 12px; padding: 14px 18px; cursor: pointer; list-style: none; }
 .companion-studio .studio-reason-details > summary::after { content: '+'; margin-left: auto; font-size: 18px; color: var(--accent); }
 .companion-studio .studio-reason-details[open] > summary::after { content: '−'; }
@@ -5702,11 +5702,11 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 .companion-studio .studio-reason-body button { text-align: left; padding: 14px; border-color: var(--line-soft); }
 .companion-studio .studio-reason-body button b { display: block; margin-bottom: 6px; font-size: 13px; }
 .companion-studio .studio-reason-body button span { font-size: 12px; color: var(--muted); font-weight: 400; }
-.companion-studio :is(.diagnostic-priority-zone,.diagnostic-live-lane,.diagnostic-event-lane,.diagnostic-runtime-card,.diagnostic-evidence-drawer) { border: 1px solid var(--line-soft) !important; border-radius: 13px !important; box-shadow: none !important; background: var(--panel) !important; padding: 22px !important; }
+.companion-studio :is(.diagnostic-priority-zone,.diagnostic-live-lane,.diagnostic-event-lane,.diagnostic-runtime-card,.diagnostic-evidence-drawer) { border: 1px solid var(--line-soft) !important; border-radius: 8px !important; box-shadow: none !important; background: var(--panel) !important; padding: 22px !important; }
 .companion-studio .diagnostic-zone-head { align-items: center !important; flex-wrap: wrap; gap: 14px !important; margin: 0 0 20px !important; }
 .companion-studio .diagnostic-zone-head h3 { font-size: 18px !important; font-weight: 550 !important; margin-top: 3px !important; }
 .companion-studio .diagnostic-zone-head > div > span { font-size: 10px !important; font-weight: 400 !important; color: var(--muted); }
-.companion-studio .diagnostic-filter { border: 1px solid var(--line-soft) !important; padding: 3px !important; border-radius: 9px !important; background: var(--surface) !important; gap: 2px !important; }
+.companion-studio .diagnostic-filter { border: 1px solid var(--line-soft) !important; padding: 3px !important; border-radius: 8px !important; background: var(--surface) !important; gap: 2px !important; }
 .companion-studio .diagnostic-filter button { border: 0 !important; background: transparent; border-radius: 6px !important; padding: 6px 12px !important; min-height: 32px !important; font-size: 12px !important; font-weight: 400 !important; }
 .companion-studio .diagnostic-filter button.is-active { background: var(--accent) !important; color: white !important; }
 .companion-studio #troubleshootingChecks { display: grid !important; grid-template-columns: minmax(0,1fr) !important; gap: 0 !important; max-height: none !important; height: auto !important; overflow: visible !important; padding: 0 !important; align-items: start !important; }
@@ -5722,7 +5722,7 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 .companion-studio .diagnostic-warning-suppress { background: transparent !important; color: var(--warn) !important; }
 .companion-studio .diagnostic-main-grid { grid-template-columns: minmax(0,1fr) !important; gap: 20px !important; }
 .companion-studio .diagnostic-events { max-height: none !important; overflow: visible !important; padding: 0 !important; }
-.companion-studio .troubleshooting-event { background: var(--surface) !important; border-color: var(--line-soft) !important; padding: 18px !important; box-shadow: none !important; border-radius: 9px !important; }
+.companion-studio .troubleshooting-event { background: var(--surface) !important; border-color: var(--line-soft) !important; padding: 18px !important; box-shadow: none !important; border-radius: 8px !important; }
 .companion-studio .diagnostic-runtime-stack { gap: 14px !important; }
 .companion-studio .diagnostic-runtime-card { background: var(--surface) !important; padding: 17px !important; }
 .companion-studio .diagnostic-runtime-card h3 { font-weight: 550 !important; }
@@ -5757,16 +5757,16 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 /* Subpage controls use one consistent treatment, including lazy-rendered content. */
 .companion-studio :is(.models-page-nav,.models-page-heading,.provider-group-head) { background: transparent !important; box-shadow: none !important; }
 .companion-studio :is(.models-page-heading,.provider-group-head) h2 { font-size: 23px; font-weight: 550; }
-.companion-studio :is(.models-subnav,.provider-config-mode,.provider-mode-switch) { border: 1px solid var(--line-soft) !important; background: var(--surface) !important; border-radius: 9px !important; padding: 4px !important; gap: 3px !important; box-shadow: none !important; }
+.companion-studio :is(.models-subnav,.provider-config-mode,.provider-mode-switch) { border: 1px solid var(--line-soft) !important; background: var(--surface) !important; border-radius: 8px !important; padding: 4px !important; gap: 3px !important; box-shadow: none !important; }
 .companion-studio :is(.models-subnav,.provider-config-mode,.provider-mode-switch) button { appearance: none; border: 0 !important; border-radius: 6px !important; background: transparent !important; color: var(--muted) !important; padding: 9px 13px !important; font-size: 12px !important; font-weight: 500 !important; box-shadow: none !important; }
 .companion-studio :is(.models-subnav,.provider-config-mode,.provider-mode-switch) button.active { background: var(--accent) !important; color: white !important; }
 .companion-studio .models-subnav button::before { content: none !important; }
-.companion-studio .studio-routing-help { margin: 16px 0; border: 1px solid var(--line-soft); border-radius: 10px; background: var(--panel); }
+.companion-studio .studio-routing-help { margin: 16px 0; border: 1px solid var(--line-soft); border-radius: 8px; background: var(--panel); }
 .companion-studio .studio-routing-help > summary { padding: 15px 18px; font-size: 12px; cursor: pointer; color: var(--accent-strong); }
 .companion-studio .studio-routing-help small { font-size: 11px; color: var(--muted); margin-left: 10px; }
 .companion-studio .studio-routing-help .provider-flow { padding: 18px; margin: 0; border: 0; box-shadow: none; }
 .companion-studio .studio-save-explainer { margin: -6px 0 22px; color: var(--muted); font-size: 11px; line-height: 1.8; }
-.companion-studio :is(.empty,.empty.small) { padding: 24px 18px; background: var(--surface); border: 1px solid var(--line-soft); border-radius: 10px; color: var(--muted); font-size: 12px; font-weight: 400; box-shadow: none; }
+.companion-studio :is(.empty,.empty.small) { padding: 24px 18px; background: var(--surface); border: 1px solid var(--line-soft); border-radius: 8px; color: var(--muted); font-size: 12px; font-weight: 400; box-shadow: none; }
 .companion-studio :is(.config-section-nav,.world-outline) { background: var(--surface) !important; box-shadow: none !important; }
 .companion-studio .config-fold-kicker { background: none !important; color: var(--muted) !important; font-weight: 400 !important; font-size: 10px !important; padding: 0 !important; }
 .companion-studio .config-fold-preview > span { border: 0 !important; background: var(--surface) !important; padding: 4px 7px; font-size: 10px; font-weight: 400 !important; }
@@ -5783,7 +5783,7 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 .companion-studio .studio-check-original > summary { font-size: 11px; color: var(--muted); cursor: pointer; }
 .companion-studio .studio-check-original p { background: var(--surface); border-left: 2px solid var(--line); padding: 10px 14px; font-size: 12px !important; }
 .companion-studio .troubleshooting-chain-tests { align-items: start !important; gap: 14px !important; }
-.companion-studio .troubleshooting-chain-test { display: flex !important; flex-direction: column !important; align-items: stretch !important; gap: 14px !important; border: 1px solid var(--line-soft) !important; border-radius: 10px !important; padding: 18px !important; background: var(--surface) !important; box-shadow: none !important; height: auto !important; }
+.companion-studio .troubleshooting-chain-test { display: flex !important; flex-direction: column !important; align-items: stretch !important; gap: 14px !important; border: 1px solid var(--line-soft) !important; border-radius: 8px !important; padding: 18px !important; background: var(--surface) !important; box-shadow: none !important; height: auto !important; }
 .companion-studio .troubleshooting-chain-test b { font-size: 14px !important; font-weight: 550 !important; }
 .companion-studio .troubleshooting-chain-test p { font-size: 12px !important; line-height: 1.8 !important; }
 .companion-studio .troubleshooting-chain-test-actions { display: flex !important; justify-content: flex-start; flex-wrap: wrap; gap: 8px; }
@@ -5987,7 +5987,7 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 .companion-studio .prompts-task-item code { white-space: normal !important; overflow: visible !important; text-overflow: clip !important; overflow-wrap: anywhere; line-height: 1.7; font-size: 10px; }
 .companion-studio .prompts-editor-content { display: block !important; width: 100%; min-width: 0; min-height: 0 !important; }
 .companion-studio .prompts-editor-content[hidden] { display: none !important; }
-.companion-studio .prompts-editor-head { flex-wrap: wrap; padding: 0 0 18px; gap: 10px; }
+.companion-studio .prompts-editor-head { flex-direction: row !important; flex-wrap: wrap; padding: 0 0 18px; gap: 10px; }
 .companion-studio .prompts-editor-head > div { flex: 1 1 240px; min-width: 0; }
 .companion-studio .prompts-editor-head :is(h3,p) { overflow-wrap: anywhere; white-space: normal; }
 .companion-studio .prompts-editor-head h3 { font-size: 19px; font-weight: 550; line-height: 1.6; }
@@ -6007,4 +6007,17 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 @supports(container-type:inline-size) {
  @container promptpage (min-width:901px) { .companion-studio .prompts-workspace { grid-template-columns: minmax(230px,280px) minmax(0,1fr) !important; } .companion-studio .prompts-catalog { border-right: 1px solid var(--line) !important; border-bottom: 0 !important; padding: 0 18px 0 0; } }
  @container promptpage (max-width:900px) { .companion-studio .prompts-workspace { grid-template-columns: minmax(0,1fr) !important; } .companion-studio .prompts-catalog { border-right: 0 !important; border-bottom: 1px solid var(--line) !important; padding: 0 0 20px; } .companion-studio .prompts-task-list { max-height: 320px !important; } }
+}
+
+.companion-studio #providerSummary { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0 24px; }
+.companion-studio .provider-summary-card { min-width: 0; border: 0; border-bottom: 1px solid var(--line); border-radius: 0; padding: 12px 0; background: transparent; box-shadow: none; }
+.companion-studio .provider-summary-card b { font-size: 16px; overflow-wrap: anywhere; }
+@media (max-width: 680px) {
+  .companion-studio .annotations { max-width: none !important; }
+  .companion-studio .studio-find { position: sticky; left: 0; z-index: 1; display: inline-flex !important; flex: 0 0 40px; width: 40px !important; height: 40px; justify-content: center; padding: 0 !important; margin: 0; background: var(--studio-sidebar) !important; }
+  .companion-studio .studio-find .studio-find-label { display: none; }
+  .companion-studio #promptsEditor { scroll-margin-top: 80px; }
+}
+@media (max-width: 700px) {
+  .companion-studio .prompts-scope-note { flex-basis: auto; }
 }

--- a/pages/companion-panel/index.html
+++ b/pages/companion-panel/index.html
@@ -163,7 +163,7 @@
   </style>
   <link rel="stylesheet" href="./css/header-tools.css?v=20260713-font-options" />
   <link rel="stylesheet" href="./css/qzone-mobile.css?v=20260711-qzone-image-preview" />
-  <link rel="stylesheet" href="./css/polish.css?v=20260810-responsive-containment-v1&amp;world=20260811-responsive-v2&amp;config=multi-persona-summary-v2&amp;mobile=20260829-overflow-v1" />
+  <link rel="stylesheet" href="./css/polish.css?v=20260810-responsive-containment-v1&amp;world=20260811-responsive-v2&amp;config=multi-persona-summary-v2&amp;mobile=20260829-overflow-v1&amp;studio=20260912-v4" />
   <script>
     (function () {
       try {
@@ -208,7 +208,8 @@
     })();
   </script>
 </head>
-<body>
+<body class="companion-studio">
+  <a class="studio-skip" href="#panel-dashboard">跳到主要内容</a>
   <section class="asset-load-fallback" role="status" aria-live="polite">
     <div class="asset-load-fallback__content">
       <div class="asset-load-fallback__state" aria-hidden="true"></div>
@@ -226,8 +227,8 @@
       <div class="folio-meta">
         <div class="folio-heading">
           <div>
-            <div class="folio-eyebrow"><b>●</b> PRIVATE COMPANION</div>
-            <h1 class="folio-title">陪伴面板</h1>
+            <div class="folio-eyebrow">你的专属陪伴空间</div>
+            <h1 class="folio-title">陪伴面板 <span class="studio-header-slash">/</span> <span id="studioPageTitle">总览</span></h1>
           </div>
           <div class="folio-persona-context">
             <label id="pagePersonaSelector" class="page-persona-selector" for="pagePersonaSelect" hidden>
@@ -237,7 +238,7 @@
             <p id="subtitle">读取运行态中...</p>
           </div>
         </div>
-        <div class="folio-stats" id="stats"></div>
+
       </div>
 
       <div class="folio-plate" aria-label="今日穿搭">
@@ -255,35 +256,64 @@
 
     <section class="layout">
       <nav class="annotations" aria-label="视图">
+        <div class="studio-brand"><span class="studio-brand-mark" aria-hidden="true">✳</span><div><b>伴 · Companion</b><small>PRIVATE COMPANION</small></div></div>
+        <button type="button" class="studio-find" id="studioFindBtn"><span>⌕ &nbsp; 查找功能</span><kbd>⌘ K</kbd></button>
         <div class="annot-axis" aria-hidden="true"></div>
-        <button class="tab is-active" data-tab="dashboard"><i>01</i><span>总览</span></button>
-        <button class="tab" data-tab="roleplay"><i>02</i><span>世界知识</span></button>
-        <button class="tab" data-tab="private"><i>03</i><span>用户</span></button>
-        <button class="tab" data-tab="group"><i>04</i><span>群聊</span></button>
-        <button class="tab" data-tab="learning"><i>05</i><span>学习</span></button>
-        <button class="tab" data-tab="memory"><i>06</i><span>观察</span></button>
-        <button class="tab" data-tab="proactive"><i>07</i><span>主动</span></button>
-        <button class="tab" data-tab="creative" hidden><i>08</i><span>创作</span></button>
-        <button class="tab" data-tab="image" hidden><i>09</i><span>生图</span></button>
-        <button class="tab" data-tab="tokens"><i>10</i><span>Token</span></button>
-        <button class="tab" data-tab="troubleshooting"><i>11</i><span>排障</span></button>
-        <button class="tab" data-tab="config"><i>12</i><span>配置</span></button>
-        <button class="tab" data-tab="models"><i>13</i><span>模型</span></button>
-        <button class="tab" data-tab="experimental"><i>14</i><span>实验</span></button>
-        <button class="tab" data-tab="prompts"><i>15</i><span>提示词</span></button>
-        <button class="tab" data-tab="reality" hidden><i>16</i><span>现实触及</span></button>
+        <div class="studio-nav-label">日常陪伴</div>
+        <button class="tab is-active" data-tab="dashboard"><i>◫</i><span>总览</span></button>
+        <button class="tab" data-tab="roleplay"><i>◎</i><span>角色与背景</span></button>
+        <button class="tab" data-tab="private"><i>♧</i><span>陪伴对象</span></button>
+        <button class="tab" data-tab="group"><i>♧</i><span>群聊</span></button>
+        <div class="studio-nav-label">理解与成长</div>
+        <button class="tab" data-tab="learning"><i>✧</i><span>学习</span></button>
+        <button class="tab" data-tab="memory"><i>◷</i><span>日程与记忆</span></button>
+        <button class="tab" data-tab="proactive"><i>↗</i><span>主动消息</span></button>
+        <button class="tab" data-tab="creative" hidden><i>✎</i><span>创作</span></button>
+        <button class="tab" data-tab="image" hidden><i>▧</i><span>生图</span></button>
+        <div class="studio-nav-label">管理与调校</div>
+        <button class="tab" data-tab="tokens"><i>◴</i><span>用量统计</span></button>
+        <button class="tab" data-tab="troubleshooting"><i>⊙</i><span>检查与修复</span></button>
+        <button class="tab" data-tab="config"><i>⚙</i><span>功能设置</span></button>
+        <button class="tab" data-tab="models"><i>◇</i><span>模型服务</span></button>
+        <button class="tab" data-tab="experimental"><i>⚗</i><span>实验</span></button>
+        <button class="tab" data-tab="prompts"><i>≡</i><span>提示词</span></button>
+        <button class="tab" data-tab="reality" hidden><i>⌁</i><span>现实触及</span></button>
+        <div class="studio-nav-foot"><span>✧</span> 让陪伴，回归日常。<small>POWERED BY ASTRBOT</small></div>
       </nav>
 
       <section class="panel dashboard-overview is-active" id="panel-dashboard">
         <div class="section-head dashboard-overview-head">
           <div>
             <h2>今日概览</h2>
-            <p class="section-desc">日程、状态、主动与记忆集中在这里；配置和诊断按需展开。</p>
+            <p class="section-desc">今天的点滴，都在这里。</p>
           </div>
           <div class="actions compact">
             <button id="exportSnapshotBtn" type="button">导出快照</button>
           </div>
         </div>
+
+        <section class="studio-welcome" aria-labelledby="studioWelcomeTitle">
+          <div class="studio-welcome-copy"><span class="studio-kicker"><span></span> OUR EVERYDAY, TOGETHER</span>
+            <h2 id="studioWelcomeTitle">今天，TA 过得怎么样？</h2>
+            <p>看看当前状态和日程；要调整行为，去左侧设置。</p>
+            <div class="studio-welcome-actions"><button type="button" data-jump-tab="memory" class="studio-primary">看看 TA 的一天 <span>↗</span></button><button type="button" data-setup-guide-open class="studio-text-button">初次见面？开始配置 <span>→</span></button></div>
+          </div>
+          <svg class="studio-art" viewBox="0 0 400 280" fill="none" aria-hidden="true">
+            <circle cx="224" cy="135" r="108" fill="#e0e7d9"/><circle cx="224" cy="135" r="84" stroke="#c8d3c1" stroke-dasharray="3 7"/>
+            <ellipse cx="218" cy="240" rx="142" ry="14" fill="#d2ddce" opacity=".55"/>
+            <path d="M117 212c-32-29-40-66-29-102 34 7 59 39 53 80" fill="#809b7d"/><path d="M124 213c-4-43 10-75 44-92 17 35 3 67-44 92Z" fill="#a5b99c"/><path d="M122 218 99 139m24 70 32-65" stroke="#526f57" stroke-width="2"/>
+            <path d="M98 202h58l-8 34h-42z" fill="#ede7d9"/><path d="M98 203h58" stroke="#d7d0bd" stroke-width="4"/>
+            <rect x="182" y="185" width="113" height="48" rx="12" fill="#567761"/><rect x="189" y="179" width="110" height="44" rx="10" fill="#f8f5ea"/><path d="M202 190h77m-77 8h77m-77 8h62" stroke="#d9d9c8" stroke-width="2"/>
+            <rect x="170" y="163" width="118" height="21" rx="6" fill="#a7b693"/><path d="M182 173h91" stroke="#eff1de" stroke-width="2"/>
+            <path d="M206 102h57v39c0 20-57 20-57 0z" fill="#fdfbf3"/><ellipse cx="234.5" cy="103" rx="28.5" ry="8" fill="#dad4bc"/><ellipse cx="234.5" cy="104" rx="23" ry="5" fill="#aa8963"/><path d="M264 111h8c23 0 18 30-8 25" stroke="#fdfbf3" stroke-width="9"/>
+            <path d="M225 83c-12-12 13-18 2-32m17 34c-12-12 13-18 2-32" stroke="#fffdf5" stroke-width="3" stroke-linecap="round"/>
+            <path d="m309 64 4 10 11 3-11 4-4 11-3-11-11-4 11-3z" fill="#82946d"/><circle cx="162" cy="65" r="5" fill="#c2a577"/>
+            <path d="m325 172 3 7 7 3-7 2-3 8-2-8-8-2 8-3z" fill="#bda779"/>
+          </svg>
+          <span class="studio-art-caption">A LITTLE CLOSER, EVERY DAY</span>
+        </section>
+        <div class="studio-metrics-label"><span>运行概况</span><small>点击指标，查看详情 ↗</small></div>
+        <div class="folio-stats" id="stats" aria-label="运行概况"></div>
         <section class="dashboard-life-desk" aria-label="今日生活工作台">
           <aside class="dashboard-life-column dashboard-life-column-left">
             <article class="life-desk-card life-desk-today">
@@ -314,7 +344,11 @@
             </article>
           </section>
 
-          <aside class="dashboard-life-column dashboard-life-column-right">
+
+        </section>
+        <section class="dashboard-secondary" aria-label="更多运行信息">
+          <div class="studio-section-label">更多信息 <small>需要时展开查看。</small></div>
+          <details class="dashboard-disclosure studio-memory-disclosure"><summary><span><b>动态、记忆与运行能力</b><small>近期动向、记忆概况与能力状态</small></span></summary>          <aside class="dashboard-life-column dashboard-life-column-right">
             <article class="life-desk-card life-desk-memory">
               <div class="life-desk-card-head">
                 <div><span class="life-desk-dot"></span><h3>动态与记忆</h3></div>
@@ -336,9 +370,7 @@
               </div>
               <div id="dashboardCapabilitySummary" class="life-capability-list"></div>
             </article>
-          </aside>
-        </section>
-        <section class="dashboard-secondary" aria-label="更多运行信息">
+          </aside></details>
           <details class="dashboard-disclosure">
             <summary>
               <span><b>互动与主动</b><small>私聊、群聊和长线主动策略</small></span>
@@ -387,7 +419,7 @@
             </div>
           </details>
         </section>
-        <section class="dashboard-companion-terminal" aria-labelledby="dashboardCompanionTerminalTitle">
+        <details class="dashboard-disclosure studio-terminal-disclosure"><summary><span><b>扩展连接与诊断</b><small>陪伴系插件发现状态、检查与终端入口</small></span></summary>        <section class="dashboard-companion-terminal" aria-labelledby="dashboardCompanionTerminalTitle">
           <header class="dashboard-companion-terminal-head">
             <div>
               <span class="dashboard-kicker">连接检查</span>
@@ -402,14 +434,14 @@
           </header>
           <div id="dashboardCompanionTerminalSummary" class="dashboard-companion-terminal-summary" aria-live="polite"></div>
           <div id="dashboardCompanionTerminalList" class="dashboard-companion-terminal-list"></div>
-        </section>
+        </section></details>
       </section>
 
       <section class="panel" id="panel-roleplay">
         <div class="section-head">
           <div>
             <h2>世界知识</h2>
-            <span class="muted">整理角色和世界背景，作为陪伴行为的稳定参考。</span>
+            <span class="muted">告诉 TA 自己是谁、生活在哪里，以及与你的关系。</span>
           </div>
           <div class="world-page-actions">
             <span class="world-save-state" id="worldSaveState">已同步</span>
@@ -482,7 +514,7 @@
           </aside>
           <div class="module-card-head">
             <div>
-              <h2>世界知识工作台</h2>
+              <h2>角色与背景资料</h2>
               <span class="section-desc">把角色资料、世界观和用户关系整理成插件可引用的背景材料；不会覆盖 AstrBot 主人格。</span>
             </div>
             <span class="module-badge">知识</span>
@@ -1235,12 +1267,22 @@ QQ空间 = 公开札记
 
       <section class="panel" id="panel-proactive">
         <div class="section-head">
-          <h2>今日主动候选</h2>
-          <span class="muted">统一候选池、去重、配额与调度结果</span>
+          <h2>主动消息记录</h2>
+          <span class="muted">先看待发送和已发送消息；需要追查原因时，再展开统计与执行记录。</span>
         </div>
         <div id="proactiveSummary" class="proactive-summary"></div>
         <div class="proactive-layout">
-          <article>
+          <article class="wide proactive-records-card">
+            <h2>消息列表</h2>
+            <div id="proactiveCandidateFilters" class="proactive-filters"></div>
+            <div id="proactiveCandidateList" class="proactive-candidates"></div>
+          </article>
+          <details class="studio-proactive-disclosure"><summary>执行记录 <small>查看任务安排、发送过程与结果</small></summary>          <article class="wide">
+            <h2>主动任务记录</h2>
+            <div id="proactiveTaskList" class="proactive-tasks"></div>
+          </article>
+</details>
+          <details class="studio-proactive-disclosure"><summary>来源与状态分布 <small>按来源和处理状态查看统计图</small></summary><div class="studio-chart-layout">          <article>
             <h2>来源分布</h2>
             <div id="proactiveSourceChart" class="chart-box"></div>
           </article>
@@ -1248,15 +1290,7 @@ QQ空间 = 公开札记
             <h2>状态分布</h2>
             <div id="proactiveStatusChart" class="chart-box"></div>
           </article>
-          <article class="wide">
-            <h2>主动任务记录</h2>
-            <div id="proactiveTaskList" class="proactive-tasks"></div>
-          </article>
-          <article class="wide proactive-records-card">
-            <h2>候选记录</h2>
-            <div id="proactiveCandidateFilters" class="proactive-filters"></div>
-            <div id="proactiveCandidateList" class="proactive-candidates"></div>
-          </article>
+</div></details>
         </div>
       </section>
 
@@ -1471,21 +1505,21 @@ QQ空间 = 公开札记
         <div class="subpage troubleshooting-page">
           <header class="diagnostic-masthead">
             <div>
-              <span class="diagnostic-kicker">SYSTEM / SIGNAL / EVIDENCE</span>
-              <h2>排障指挥台</h2>
-              <p>先选择遇到的问题，再按对应链路查看检查、证据与测试结果。</p>
+              <span class="diagnostic-kicker">遇到问题，从这里查起</span>
+              <h2>检查与修复</h2>
+              <p>先选问题类型，再查看原因。检查不会自动修改你的配置。</p>
             </div>
             <div class="diagnostic-masthead-actions">
-              <button id="refreshTroubleshootingBtn" type="button">执行检查</button>
-              <span class="diagnostic-live-dot"><i></i> 运行态快照</span>
+              <button id="refreshTroubleshootingBtn" type="button">重新检查</button>
+              <span class="diagnostic-live-dot"><i></i> 最近一次检查结果</span>
             </div>
           </header>
 
           <section class="diagnostic-problem-picker" aria-labelledby="troubleshootingProblemTitle">
             <div>
-              <span>从问题开始</span>
-              <h3 id="troubleshootingProblemTitle">你遇到了什么问题？</h3>
-              <p>选择后只保留相关的检查、事件、链路测试与排查说明。</p>
+              <span>选择范围</span>
+              <h3 id="troubleshootingProblemTitle">哪里不正常？</h3>
+              <p>选一类，就只看这一类的检查结果。</p>
             </div>
             <div id="troubleshootingCategories" class="diagnostic-category-list" role="tablist" aria-label="问题类型"></div>
           </section>
@@ -1495,8 +1529,8 @@ QQ空间 = 公开札记
           <section class="diagnostic-priority-zone">
             <div class="diagnostic-zone-head">
               <div>
-                <span>优先队列</span>
-                <h3 id="troubleshootingChecksTitle">需要处理的信号</h3>
+                <span>逐项检查</span>
+                <h3 id="troubleshootingChecksTitle">检查结果</h3>
               </div>
               <div class="troubleshooting-filter diagnostic-filter" role="group" aria-label="问题筛选">
                 <button type="button" data-troubleshooting-filter="all" class="is-active">全部</button>
@@ -1518,12 +1552,13 @@ QQ空间 = 公开札记
           <div class="diagnostic-main-grid">
             <section class="diagnostic-live-lane">
               <div class="diagnostic-zone-head compact">
-                <div><span>实时验证</span><h3 id="troubleshootingChainTitle">链路与运行状态</h3></div>
+                <div><span>需要时再测试</span><h3 id="troubleshootingChainTitle">连接测试</h3></div>
               </div>
               <div id="troubleshootingChainTests" class="troubleshooting-chain-tests"></div>
+              <details class="studio-runtime-details"><summary>数据库、用户隔离与消息合并 <small>展开查看底层运行状态</small></summary>
               <div id="troubleshootingRuntimeStack" class="diagnostic-runtime-stack">
                 <article class="diagnostic-runtime-card">
-                  <div class="diagnostic-card-head"><h3>统一身份与隔离</h3><span>REQ-041</span></div>
+                  <div class="diagnostic-card-head"><h3>用户身份与数据隔离</h3><span>REQ-041</span></div>
                   <div id="troubleshootingReq041" class="troubleshooting-sqlite"></div>
                 </article>
                 <article class="diagnostic-runtime-card">
@@ -1531,29 +1566,29 @@ QQ空间 = 公开札记
                   <div id="troubleshootingSqlite" class="troubleshooting-sqlite"></div>
                 </article>
                 <article class="diagnostic-runtime-card">
-                  <div class="diagnostic-card-head"><h3>消息收口追踪</h3><span>防抖</span></div>
+                  <div class="diagnostic-card-head"><h3>消息合并记录</h3><span>防抖</span></div>
                   <div id="troubleshootingDebounceTrace" class="troubleshooting-debounce-trace"></div>
                 </article>
-              </div>
+              </div></details>
             </section>
 
             <aside class="diagnostic-event-lane">
               <div class="diagnostic-zone-head compact">
-                <div><span>事件时间线</span><h3 id="troubleshootingEventsTitle">最近问题</h3></div>
+                <div><span>按时间查看</span><h3 id="troubleshootingEventsTitle">最近记录</h3></div>
               </div>
               <div id="troubleshootingEvents" class="troubleshooting-events diagnostic-events"></div>
             </aside>
           </div>
 
           <details class="diagnostic-evidence-drawer">
-            <summary><span>证据与深度排查</span><small>提示词注入、常见问题和运行诊断</small></summary>
+            <summary><span>日志与详细说明</span><small>检查正常但仍有问题？展开查看原始记录</small></summary>
             <div class="diagnostic-evidence-body">
               <article class="troubleshooting-injection-panel">
-                <div><h2>最近注入内容</h2><span class="muted">用于排查污染、错时、TTS 规则和上下文串线</span></div>
+                <div><h2>最近加入对话的上下文</h2><span class="muted">检查是否加进了错误的人物资料、时间信息或语音规则。</span></div>
                 <div id="troubleshootingPromptInjections" class="troubleshooting-prompt-injections"></div>
               </article>
               <article class="troubleshooting-diagnostics-panel">
-                <div><h2>运行诊断</h2><span class="muted">从配置、目标用户、群聊开关和运行态中整理出的诊断项</span></div>
+                <div><h2>运行诊断</h2><span class="muted">查看当前配置、陪伴对象、群聊开关是否符合运行条件。</span></div>
                 <div id="diagnosticPanel" class="diagnostic-list"></div>
               </article>
               <article class="troubleshooting-faq-panel">
@@ -1617,8 +1652,8 @@ QQ空间 = 公开札记
         <header class="config-page-intro">
           <div>
             <span class="config-page-kicker">配置中心</span>
-            <h2>配置工作台</h2>
-            <p>基础维护、运行节奏与功能生命周期集中管理。</p>
+            <h2>插件设置</h2>
+            <p>管理陪伴对象、模型服务和功能开关。改完后记得保存。</p>
           </div>
           <nav class="config-section-nav" aria-label="配置区域">
             <button type="button" data-config-section-target="config-common-settings">通用设置</button>
@@ -1630,7 +1665,7 @@ QQ空间 = 公开札记
           <details class="config-fold-panel config-common-settings" id="config-common-settings">
             <summary class="config-fold-summary">
               <div class="config-fold-heading">
-                <span class="config-fold-kicker">配置工作台</span>
+                <span class="config-fold-kicker">插件设置</span>
                 <h2>通用设置</h2>
                 <p>多人格拓扑、AstrBot 路由状态、群聊范围、数据维护与页面外观。</p>
                 <span class="config-fold-preview" aria-label="包含的配置范围">
@@ -1886,7 +1921,7 @@ QQ空间 = 公开札记
                 </div>
                 <span id="configPersonaStatsSource" class="muted">统计随人格选择更新</span>
               </header>
-              <div class="folio-stats config-stats" id="configStats"></div>
+              <details class="studio-config-stats"><summary>查看当前人格的运行统计</summary><div class="folio-stats config-stats" id="configStats"></div></details>
             </section>
           </section>
 
@@ -1970,6 +2005,7 @@ QQ空间 = 公开札记
                 </label>
                 <button id="enableSafeFeaturesBtn" type="button">启用基础安全项</button>
               </div>
+              <details class="studio-filter-options"><summary>按分类、阶段或状态筛选</summary>
               <section class="feature-filter-row" aria-labelledby="featureDomainLabel">
                 <div class="feature-filter-label">
                   <b id="featureDomainLabel">功能领域</b>
@@ -1990,8 +2026,9 @@ QQ空间 = 公开札记
                   <small>快速核对</small>
                 </div>
                 <div id="featureStatusFilters" class="feature-filter-options" role="group" aria-label="当前状态"></div>
-              </section>
+              </section></details>
             </div>
+            <p class="studio-feature-instructions">点击分组展开。右侧开关控制启停，点击功能名称调整参数；更改后请保存。</p>
             <div class="feature-switch-board" id="featureFlags"></div>
           </article>
           </section>
@@ -2057,7 +2094,7 @@ QQ空间 = 公开札记
         <div class="section-head models-page-head">
           <div class="models-page-heading">
             <h2>模型配置</h2>
-            <span class="muted">任务分流、语音合成与生图后端</span>
+            <span class="muted">设置文字、语音和图片任务使用的模型服务。</span>
           </div>
           <nav class="models-subnav" aria-label="模型配置分类" role="tablist">
             <button id="modelsProvidersTab" type="button" class="active" data-index="01" data-models-section="providers" role="tab" aria-controls="modelsProviderPane" aria-selected="true">任务模型</button>
@@ -2070,13 +2107,13 @@ QQ空间 = 公开札记
           <div id="llmStreamingCard"></div>
           <div id="deepseekPeakCard"></div>
           <div id="modelReplacementCard"></div>
-          <div id="providerFlow" class="provider-flow"></div>
+          <details class="studio-routing-help"><summary>查看模型调用关系 <small>不确定某个任务会用哪个模型？在这里查看。</small></summary><div id="providerFlow" class="provider-flow"></div></details>
           <div class="provider-config-mode-card">
             <div>
-              <b>模型配置模式</b>
+              <b>选择配置方式</b>
               <span id="providerConfigModeHint">插件功能通常会携带较多动态上下文，Token 缓存命中率可能较低，请结合调用频率和预算合理规划模型。</span>
             </div>
-            <div class="provider-config-mode" aria-label="模型配置模式">
+            <div class="provider-config-mode" aria-label="选择配置方式">
               <button type="button" data-provider-config-mode="quick" class="active">快速配置</button>
               <button type="button" data-provider-config-mode="precision">精准配置</button>
             </div>
@@ -2093,9 +2130,10 @@ QQ空间 = 公开札记
             </div>
             <div class="provider-toolbar-actions">
               <button id="testAllProvidersBtn" type="button">测试全部模型</button>
-              <button id="saveProvidersBtn" type="button">保存并覆盖两套模型配置</button>
+              <button id="saveProvidersBtn" type="button" title="保存当前填写的模型设置，同时覆盖快速配置和精准配置">保存两套配置</button>
             </div>
           </div>
+          <p class="studio-save-explainer">保存会同时覆盖快速配置和精准配置；测试只检查连接，不会保存修改。</p>
           <form id="providerForm" class="provider-groups"></form>
         </div>
         <div id="modelsTtsPane" class="tts-model-pane" data-models-pane="tts" role="tabpanel" aria-labelledby="modelsTtsTab" hidden>
@@ -2204,7 +2242,7 @@ QQ空间 = 公开札记
         <div class="section-head prompts-page-head">
           <div>
             <h2>任务提示词</h2>
-            <p class="section-desc">统一管理插件内部任务模型的附加指令，包括工具结果转述、日程、复核、群聊、视觉等任务。</p>
+            <p class="section-desc">为日程、群聊、识图等任务补充要求。这里不会修改主聊天人格。</p>
           </div>
           <div class="prompts-scope-note" role="note">
             <b>作用范围</b>
@@ -2225,7 +2263,8 @@ QQ空间 = 公开札记
               </div>
             </div>
             <nav id="promptsGroupNav" class="prompts-group-nav" aria-label="任务分组"></nav>
-            <div id="promptsTaskList" class="prompts-task-list" role="list" aria-label="任务提示词"></div>
+            <p class="prompts-directory-hint" id="promptsDirectoryHint">任务较多时可在目录内滚动，或用上方搜索定位。选择任务后，在编辑区查看完整内容。</p>
+            <div id="promptsTaskList" class="prompts-task-list" role="list" aria-label="任务提示词" aria-describedby="promptsDirectoryHint" tabindex="0"></div>
           </aside>
 
           <section id="promptsEditor" class="prompts-editor" aria-labelledby="promptsEditorTitle">
@@ -2286,6 +2325,12 @@ QQ空间 = 公开札记
     <button id="saveFeaturesBtn" type="button">保存功能开关</button>
   </div>
 
+  <dialog id="studioCommand" class="studio-command" aria-labelledby="studioCommandTitle">
+    <div class="studio-command-head"><h2 id="studioCommandTitle">你想做什么？</h2><button type="button" id="studioCommandClose" aria-label="关闭功能搜索">×</button></div>
+    <input id="studioCommandInput" type="search" placeholder="搜索功能，例如：日程、模型、提示词…" aria-label="搜索功能" autocomplete="off" />
+    <div id="studioCommandResults" class="studio-command-results"></div>
+    <p class="studio-command-help">↑ ↓ 选择 · Enter 打开 · Esc 关闭</p>
+  </dialog>
   <div id="setupGuideOverlayRoot"></div>
 
   <div id="bookshelfCoverPreview" class="bookshelf-cover-preview" hidden aria-hidden="true">
@@ -2318,6 +2363,6 @@ QQ空间 = 公开札记
   <!-- Loaded on demand by app.js through AstrBot's relative dynamic-import rewriting:
        ./js/panels/provider-tree.js?v=20260804-reading-archive-capability-v1&amp;manual=provider-input-v2&amp;layout=v2&amp;vision-state=v1
        ./js/panels/qzone-panel.js?v=20260810-qzone-classic-loader-v1 -->
-  <script src="./app.js?v=20260809-proactive-tts-external-ability-photo-fixed-v1&amp;build=20260810-reference-upload-v2&amp;page=lazy-classic-loader-v1&amp;scope=photo-scope-quota-v1&amp;touch=reality-redesign-rt2-v4&amp;memory-source=memory-companion-v2&amp;user-create=profile-v1&amp;relationship-role-photo=pr125-v1&amp;camera-runtime-scope=v1&amp;config=multi-persona-summary-v2&amp;troubleshooting=persona-routing-lifecycle-v1&amp;content-visibility=v1&amp;migration-notice=v4&amp;component-order=v1&amp;layout=model-routing-v2&amp;persona-style-batch-recovery=v1&amp;preset-save=v1&amp;directory-nav=v2&amp;mihome=external-runtime-v2&amp;terminal=plugin-check-v1&amp;diagnostic-layout=v2&amp;prompts=task-editor-v2&amp;release=6.4.4f&amp;vision-state=v1"></script>
+  <script src="./app.js?v=20260809-proactive-tts-external-ability-photo-fixed-v1&amp;build=20260810-reference-upload-v2&amp;page=lazy-classic-loader-v1&amp;scope=photo-scope-quota-v1&amp;touch=reality-redesign-rt2-v4&amp;memory-source=memory-companion-v2&amp;user-create=profile-v1&amp;relationship-role-photo=pr125-v1&amp;camera-runtime-scope=v1&amp;config=multi-persona-summary-v2&amp;troubleshooting=persona-routing-lifecycle-v1&amp;content-visibility=v1&amp;migration-notice=v4&amp;component-order=v1&amp;layout=model-routing-v2&amp;persona-style-batch-recovery=v1&amp;preset-save=v1&amp;directory-nav=v2&amp;mihome=external-runtime-v2&amp;terminal=plugin-check-v1&amp;diagnostic-layout=v2&amp;prompts=task-editor-v2&amp;release=6.4.4f&amp;vision-state=v1&amp;studio=20260912-v4"></script>
 </body>
 </html>

--- a/pages/companion-panel/index.html
+++ b/pages/companion-panel/index.html
@@ -257,7 +257,7 @@
     <section class="layout">
       <nav class="annotations" aria-label="视图">
         <div class="studio-brand"><span class="studio-brand-mark" aria-hidden="true">✳</span><div><b>伴 · Companion</b><small>PRIVATE COMPANION</small></div></div>
-        <button type="button" class="studio-find" id="studioFindBtn"><span>⌕ &nbsp; 查找功能</span><kbd>⌘ K</kbd></button>
+        <button type="button" class="studio-find" id="studioFindBtn" aria-label="查找功能" title="查找功能"><span aria-hidden="true">⌕</span><span class="studio-find-label">查找功能</span></button>
         <div class="annot-axis" aria-hidden="true"></div>
         <div class="studio-nav-label">日常陪伴</div>
         <button class="tab is-active" data-tab="dashboard"><i>◫</i><span>总览</span></button>
@@ -292,27 +292,7 @@
           </div>
         </div>
 
-        <section class="studio-welcome" aria-labelledby="studioWelcomeTitle">
-          <div class="studio-welcome-copy"><span class="studio-kicker"><span></span> OUR EVERYDAY, TOGETHER</span>
-            <h2 id="studioWelcomeTitle">今天，TA 过得怎么样？</h2>
-            <p>看看当前状态和日程；要调整行为，去左侧设置。</p>
-            <div class="studio-welcome-actions"><button type="button" data-jump-tab="memory" class="studio-primary">看看 TA 的一天 <span>↗</span></button><button type="button" data-setup-guide-open class="studio-text-button">初次见面？开始配置 <span>→</span></button></div>
-          </div>
-          <svg class="studio-art" viewBox="0 0 400 280" fill="none" aria-hidden="true">
-            <circle cx="224" cy="135" r="108" fill="#e0e7d9"/><circle cx="224" cy="135" r="84" stroke="#c8d3c1" stroke-dasharray="3 7"/>
-            <ellipse cx="218" cy="240" rx="142" ry="14" fill="#d2ddce" opacity=".55"/>
-            <path d="M117 212c-32-29-40-66-29-102 34 7 59 39 53 80" fill="#809b7d"/><path d="M124 213c-4-43 10-75 44-92 17 35 3 67-44 92Z" fill="#a5b99c"/><path d="M122 218 99 139m24 70 32-65" stroke="#526f57" stroke-width="2"/>
-            <path d="M98 202h58l-8 34h-42z" fill="#ede7d9"/><path d="M98 203h58" stroke="#d7d0bd" stroke-width="4"/>
-            <rect x="182" y="185" width="113" height="48" rx="12" fill="#567761"/><rect x="189" y="179" width="110" height="44" rx="10" fill="#f8f5ea"/><path d="M202 190h77m-77 8h77m-77 8h62" stroke="#d9d9c8" stroke-width="2"/>
-            <rect x="170" y="163" width="118" height="21" rx="6" fill="#a7b693"/><path d="M182 173h91" stroke="#eff1de" stroke-width="2"/>
-            <path d="M206 102h57v39c0 20-57 20-57 0z" fill="#fdfbf3"/><ellipse cx="234.5" cy="103" rx="28.5" ry="8" fill="#dad4bc"/><ellipse cx="234.5" cy="104" rx="23" ry="5" fill="#aa8963"/><path d="M264 111h8c23 0 18 30-8 25" stroke="#fdfbf3" stroke-width="9"/>
-            <path d="M225 83c-12-12 13-18 2-32m17 34c-12-12 13-18 2-32" stroke="#fffdf5" stroke-width="3" stroke-linecap="round"/>
-            <path d="m309 64 4 10 11 3-11 4-4 11-3-11-11-4 11-3z" fill="#82946d"/><circle cx="162" cy="65" r="5" fill="#c2a577"/>
-            <path d="m325 172 3 7 7 3-7 2-3 8-2-8-8-2 8-3z" fill="#bda779"/>
-          </svg>
-          <span class="studio-art-caption">A LITTLE CLOSER, EVERY DAY</span>
-        </section>
-        <div class="studio-metrics-label"><span>运行概况</span><small>点击指标，查看详情 ↗</small></div>
+        <div class="studio-metrics-label"><span>运行概况</span><button type="button" data-jump-tab="memory" class="studio-text-button">日程与记忆 <span aria-hidden="true">↗</span></button></div>
         <div class="folio-stats" id="stats" aria-label="运行概况"></div>
         <section class="dashboard-life-desk" aria-label="今日生活工作台">
           <aside class="dashboard-life-column dashboard-life-column-left">

--- a/pages/companion-panel/js/panels/provider-tree.js
+++ b/pages/companion-panel/js/panels/provider-tree.js
@@ -126,6 +126,7 @@ window.PrivateCompanionProviderTree = (() => {
     const preference = providerPreferenceMeta[guide.preference || ""];
     const impact = providerPassiveImpactMeta[guide.passiveImpact || ""];
     return `
+      <details class="studio-provider-guide"><summary>模型用途与选择建议</summary>
       <span class="provider-guide">
         <span><b>用途</b>${escapeHtml(guide.purpose)}</span>
         <span><b>适合</b>${escapeHtml(guide.fit)}</span>
@@ -134,6 +135,7 @@ window.PrivateCompanionProviderTree = (() => {
         ${guide.note ? `<span><b>注意</b>${escapeHtml(guide.note)}</span>` : ""}
         <span><b>回退</b>${escapeHtml(guide.fallback)}</span>
       </span>
+      </details>
     `;
   }
 

--- a/pages/陪伴面板/app.js
+++ b/pages/陪伴面板/app.js
@@ -579,10 +579,10 @@ function syncProviderConfigModeControls() {
   });
   const hint = document.getElementById("providerConfigModeHint");
   if (hint) {
-    const tokenCostHint = "插件功能通常会携带较多动态上下文，Token 缓存命中率可能较低，请结合调用频率和预算合理规划模型。";
+    const tokenCostHint = "每次调用可能附带日程、记忆等资料，因此缓存不一定命中；请留意调用频率和 Token 花费。";
     hint.textContent = quick
-      ? `${tokenCostHint} 快速配置显示通用场景模型；插件识图、资料归档视觉和通用嵌入模型各自独立。`
-      : `${tokenCostHint} 精准配置显示各任务单独 Provider；独立识图与通用嵌入不会跟随文本模型改写。`;
+      ? `先为常用任务选模型即可。图片识别、资料归档识图和向量模型需要单独设置。${tokenCostHint}`
+      : `为每一种任务单独选模型服务。修改文字模型不会改动独立识图和向量模型。${tokenCostHint}`;
   }
 }
 
@@ -6016,9 +6016,9 @@ function loadOptionalClassicScript(relativePath, retry = 0) {
 
 const optionalModuleLoaders = {
   providerTree: [
-    () => loadOptionalClassicScript("./js/panels/provider-tree.js?v=20260804-reading-archive-capability-v1&manual=provider-input-v2&layout=v2&vision-state=v1", 0),
-    () => loadOptionalClassicScript("./js/panels/provider-tree.js?v=20260804-reading-archive-capability-v1&manual=provider-input-v2&layout=v2&vision-state=v1", 1),
-    () => loadOptionalClassicScript("./js/panels/provider-tree.js?v=20260804-reading-archive-capability-v1&manual=provider-input-v2&layout=v2&vision-state=v1", 2),
+    () => loadOptionalClassicScript("./js/panels/provider-tree.js?v=20260804-reading-archive-capability-v1&manual=provider-input-v2&layout=v2&vision-state=v1&studio=20260912-v1", 0),
+    () => loadOptionalClassicScript("./js/panels/provider-tree.js?v=20260804-reading-archive-capability-v1&manual=provider-input-v2&layout=v2&vision-state=v1&studio=20260912-v1", 1),
+    () => loadOptionalClassicScript("./js/panels/provider-tree.js?v=20260804-reading-archive-capability-v1&manual=provider-input-v2&layout=v2&vision-state=v1&studio=20260912-v1", 2),
   ],
   qzonePanel: [
     () => loadOptionalClassicScript("./js/panels/qzone-panel.js?v=20260810-qzone-classic-loader-v1", 0),
@@ -8063,8 +8063,8 @@ function selectTaskPrompt(taskKey) {
   state.selectedTaskPromptKey = next.task_key;
   state.taskPromptDraft = String(next.custom_prompt || "");
   renderTaskPrompts();
-  if (window.matchMedia?.("(max-width: 700px)")?.matches) {
-    $("#promptsEditor")?.scrollIntoView({ behavior: "smooth", block: "start" });
+  if (getComputedStyle($("#promptsRoot")).gridTemplateColumns.trim().split(/\s+/).length === 1) {
+    $("#promptsEditor")?.scrollIntoView({ behavior: window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ? "auto" : "smooth", block: "start" });
   }
 }
 
@@ -12239,7 +12239,7 @@ function renderCompanionPluginTerminal() {
         <p>${escapeHtml(entry.detail)}</p>
         <small>${escapeHtml(entry.note)}</small>
       </div>
-      <button type="button" class="dashboard-companion-plugin-action" data-jump-tab="${escapeHtml(entry.tab)}" ${entry.key === "image" && !entry.status.installed ? "disabled" : ""}>${escapeHtml(entry.action)}</button>
+      <button type="button" class="dashboard-companion-plugin-action" data-jump-tab="${escapeHtml(entry.tab)}" ${!entry.status?.installed ? 'disabled aria-disabled="true" title="未安装对应扩展插件"' : ""}>${escapeHtml(entry.action)}</button>
     </article>
   `).join("");
 }
@@ -13113,12 +13113,12 @@ function labeledRoleplayValuePresent(text, label) {
 }
 
 const troubleshootingCategories = {
-  all: { label: "全部概览", description: "先看所有正在影响功能的信号", keywords: [] },
-  reply: { label: "回复", description: "没有回复、回复异常或内容被带偏", keywords: ["回复", "llm", "防抖", "沉默", "token", "模型", "注入", "上下文", "群聊"] },
-  proactive: { label: "主动", description: "主动消息没有发出、被延后或被丢弃", keywords: ["主动", "候选", "静默", "冷却", "预约", "人格", "配额", "未回复"] },
+  all: { label: "全部", description: "查看所有检查结果", keywords: [] },
+  reply: { label: "聊天回复", description: "不回复、回复慢，或答非所问", keywords: ["回复", "llm", "防抖", "沉默", "token", "模型", "注入", "上下文", "群聊"] },
+  proactive: { label: "主动消息", description: "没有主动联系，或消息没有发出", keywords: ["主动", "候选", "静默", "冷却", "预约", "人格", "配额", "未回复"] },
   image_generation: { label: "生图", description: "文生图、自拍、参考图或图片下载失败", keywords: ["生图", "图片生成", "文生图", "自拍", "参考图", "comfy", "图像 api", "image"] },
-  image_recognition: { label: "识图", description: "图片识别、视觉模型、转述或窥屏异常", keywords: ["识图", "图片识别", "视觉", "转述", "窥屏", "screen", "vision"] },
-  voice: { label: "语音", description: "TTS 设置、真实语音 Provider 或音频生成失败", keywords: ["tts", "语音", "音频", "朗读", "voice"] },
+  image_recognition: { label: "图片识别", description: "看不懂图片，或屏幕内容识别失败", keywords: ["识图", "图片识别", "视觉", "转述", "窥屏", "screen", "vision"] },
+  voice: { label: "语音", description: "没有声音、音频生成失败或服务配置有误", keywords: ["tts", "语音", "音频", "朗读", "voice"] },
 };
 
 function troubleshootingCategoryInfo(category) {
@@ -13441,14 +13441,14 @@ function renderTroubleshooting() {
   const reasonItems = troubleshootingReasonItems(filteredChecks, filteredEvents, selected);
   renderTroubleshootingSuppressedWarnings(data);
   if (categoriesEl) categoriesEl.innerHTML = troubleshootingCategoryPickerMarkup(category);
-  $("#troubleshootingChecksTitle")?.replaceChildren(document.createTextNode(`${categoryInfo.label}：需要处理的信号`));
-  $("#troubleshootingChainTitle")?.replaceChildren(document.createTextNode(`${categoryInfo.label}：链路与运行状态`));
-  $("#troubleshootingEventsTitle")?.replaceChildren(document.createTextNode(`${categoryInfo.label}：最近问题`));
+  $("#troubleshootingChecksTitle")?.replaceChildren(document.createTextNode(`${categoryInfo.label} · 检查结果`));
+  $("#troubleshootingChainTitle")?.replaceChildren(document.createTextNode(`${categoryInfo.label} · 连接测试`));
+  $("#troubleshootingEventsTitle")?.replaceChildren(document.createTextNode(`${categoryInfo.label} · 最近记录`));
   summaryEl.innerHTML = `
     <section class="troubleshooting-head-card ${escapeHtml(level)}">
       <div>
         <span>${escapeHtml(summary.generated_at || "等待检查")}</span>
-        <b>${escapeHtml(summary.headline || "尚未加载排障信息")}</b>
+        <b>${escapeHtml(studioDiagnosticTitle(summary.headline) || "还没有检查结果")}</b>
         <small>${escapeHtml(troubleshootingSummaryText(counts, summary))}</small>
       </div>
       <button type="button" data-troubleshooting-refresh>重新检查</button>
@@ -13460,18 +13460,18 @@ function renderTroubleshooting() {
       </button>
     `).join("")}
     ${troubleshootingProactiveIntensityMarkup(data.proactive_intensity || state.overview?.proactive_intensity || {})}
-    <section class="troubleshooting-reasons">
-      <header>
-        <b>${escapeHtml(selected === "all" ? `近 2 小时${categoryInfo.label}待处理原因` : `${troubleshootingLevelLabel(selected)}原因`)}</b>
-        <span>${escapeHtml(selected === "all" ? "只展示近期需要处理的错误和警告；普通信息可点信息查看" : "筛选同时作用于常见问题检查和最近问题")}</span>
-      </header>
-      ${reasonItems.length ? reasonItems.map((item) => `
+    <details class="troubleshooting-reasons studio-reason-details">
+      <summary>
+        <b>${escapeHtml(selected === "all" ? `近 2 小时的问题摘要` : `${troubleshootingLevelLabel(selected)}原因`)}</b>
+        <span>${escapeHtml(selected === "all" ? "展开查看错误和警告；详细结果见下方" : "按当前条件筛选；详细结果见下方")}</span>
+      </summary>
+      <div class="studio-reason-body">${reasonItems.length ? reasonItems.map((item) => `
         <button type="button" class="${escapeHtml(item.level || "info")}" ${item.jump ? `data-jump-tab="${escapeHtml(item.jump)}"` : ""}>
           <b>${escapeHtml(item.title || "-")}</b>
           <span>${escapeHtml(item.text || "")}</span>
         </button>
-      `).join("") : `<div class="empty small">${escapeHtml(selected === "all" ? "暂无需要处理的原因" : "这个筛选下暂无原因")}</div>`}
-    </section>
+      `).join("") : `<div class="empty small">${escapeHtml(selected === "all" ? "暂无需要处理的原因" : "这个筛选下暂无原因")}</div>`}</div>
+    </details>
   `;
   document.querySelectorAll("[data-troubleshooting-filter]").forEach((button) => {
     button.classList.toggle("is-active", button.dataset.troubleshootingFilter === selected);
@@ -13673,12 +13673,13 @@ function troubleshootingCheckMarkup(item) {
     <section class="troubleshooting-check ${escapeHtml(level)}">
       <div class="troubleshooting-check-icon">${escapeHtml(level === "ok" ? "✓" : level === "error" ? "!" : level === "warn" ? "!" : "i")}</div>
       <div>
-        <b>${escapeHtml(item.title || "-")}</b>
-        <p>${escapeHtml(item.text || "")}</p>
+        <b title="${escapeHtml(item.title || "")}">${escapeHtml(studioDiagnosticTitle(item.title) || "-")}</b>
+        <p>${escapeHtml(studioDiagnosticExplanation(item) || item.text || "")}</p>
+        ${studioDiagnosticExplanation(item) && item.text ? `<details class="studio-check-original"><summary>原始检查说明</summary><p>${escapeHtml(item.text)}</p></details>` : ""}
         ${item.action ? `<small>${escapeHtml(item.action)}</small>` : ""}
       </div>
       <div class="troubleshooting-check-actions">
-        ${item.jump ? `<button type="button" data-jump-tab="${escapeHtml(item.jump)}">查看</button>` : ""}
+        ${item.jump ? `<button type="button" data-jump-tab="${escapeHtml(item.jump)}">${escapeHtml(studioDiagnosticDestination(item.jump))} ↗</button>` : ""}
         ${troubleshootingSuppressionButtonMarkup(item, "常见检查")}
       </div>
     </section>
@@ -13692,12 +13693,12 @@ function troubleshootingEventMarkup(item) {
         <span>${escapeHtml(item.source || "事件")}</span>
         <small>${escapeHtml(item.time || "")}</small>
       </header>
-      <b>${escapeHtml(item.title || "-")}</b>
+      <b title="${escapeHtml(item.title || "")}">${escapeHtml(studioDiagnosticTitle(item.title) || "-")}</b>
       ${item.detail ? `<p>${escapeHtml(item.detail)}</p>` : ""}
       <footer>
         ${item.action ? `<span>${escapeHtml(item.action)}</span>` : ""}
         <div class="troubleshooting-event-actions">
-          ${item.jump ? `<button type="button" data-jump-tab="${escapeHtml(item.jump)}">查看</button>` : ""}
+          ${item.jump ? `<button type="button" data-jump-tab="${escapeHtml(item.jump)}">${escapeHtml(studioDiagnosticDestination(item.jump))} ↗</button>` : ""}
           ${troubleshootingSuppressionButtonMarkup(item, item.source || "最近问题")}
         </div>
       </footer>
@@ -17080,13 +17081,13 @@ async function renderUserDetail(forceFetch = false) {
       </label>
       <button type="submit">保存</button>
       </form>
-    <div class="visual-strip">
+    <details class="studio-user-metrics"><summary>更多互动统计 <small>关系、主动次数、片段、待续话题与习惯</small></summary><div class="visual-strip">
       ${miniStat("关系阶段", detail.relationship_stage || detail.relationship_intimacy?.phase?.label || "初识")}
       ${scoreGauge("今日主动", detail.sent_today || 0, 0, proactiveGaugeMax(detail.sent_today, detail.effective_daily_limit, detail.effective_daily_limit_unlimited, state.overview?.private?.max_daily_messages || 8))}
       ${miniStat("片段", detail.dialogue_episode_count || (detail.dialogue_episodes || []).length)}
       ${miniStat("未完话头", Array.isArray(detail.open_loops) ? activeOpenLoopItems(detail.open_loops).length : (detail.open_loop_count || 0))}
       ${miniStat("习惯", detail.habit_count || detail.behavior_habits?.items?.length || 0)}
-    </div>
+    </div></details>
       ${detailBlock("最近对话", "", [["用户消息", detail.last_user_message || ""], ["陪伴回复", detail.last_companion_message || ""]])}
       ${renderOpenLoopBlock(detail)}
     </section>
@@ -23387,7 +23388,10 @@ function renderProactiveCandidates() {
   const listTruncated = Boolean(data.list_truncated);
   const taskData = state.overview?.proactive_tasks || {};
   const runtime = taskData.runtime || {};
-  $("#proactiveSummary").innerHTML = [
+  $("#proactiveSummary").innerHTML = `
+    <div class="studio-proactive-lead"><span>待发送 <b>${escapeHtml(pendingTotal)}</b></span><span>已发送 <b>${escapeHtml(counts.sent || 0)}</b></span><span>调度检查 <b>${runtime.healthy ? "正常" : "待确认"}</b></span></div>
+    <details class="studio-proactive-metrics" ${studioDisclosureIsOpen("proactive-metrics") ? "open" : ""} data-studio-disclosure="proactive-metrics"><summary>完整统计与调度状态 <small>新增、合并、拦截及执行记录</small></summary><div class="studio-metric-list">
+${[
     proactiveSummaryCard("今日新增", data.today_record_total || 0, `候选池现有 ${formatNumber(data.pool_record_total || totalRecords)} 条`),
     proactiveSummaryCard("今日合并", data.today_merge_trigger_count || 0, "同一来源或相近候选合并次数"),
     proactiveSummaryCard("今日拦截", data.today_blocked_record_total || 0, "按实际拦截记录统计"),
@@ -23397,7 +23401,9 @@ function renderProactiveCandidates() {
     proactiveSummaryCard("被拦截", counts.blocked || 0, "同类拦截已合并计数"),
     proactiveSummaryCard("执行审计", taskData.audit_total || 0, `${Object.keys(taskData.audit_status_counts || {}).length || 0} 类结果`),
     proactiveSummaryCard("循环状态", runtime.healthy ? "正常" : "待确认", runtime.last_tick_started_ts ? `最近 ${runtime.last_tick_started}` : "尚无心跳"),
-  ].join("");
+  ].join("")}
+    </div></details>`;
+  studioBindDisclosures($("#proactiveSummary"));
   $("#proactiveSourceChart").innerHTML = donutChart(sourceCounts, {
     emptyText: "暂无来源数据",
     labelFormatter: (label) => sourceLabels[label] || proactiveCandidateSourceLabel(label),
@@ -23435,7 +23441,7 @@ function renderProactiveCandidates() {
           <div class="toolbar">
             <span class="badge">${escapeHtml(repeat > 1 ? `${status} x${repeat}` : status)}</span>
             <button type="button" class="danger-outline" data-proactive-candidate-delete="${escapeHtml(item.id || "")}" data-proactive-user-id="${escapeHtml(item.user_id || "")}">删除</button>
-            <button type="button" class="danger-outline" data-proactive-candidate-prune="${escapeHtml(item.user_id || "")}" data-proactive-prune-keep="160">删一点</button>
+            <button type="button" class="danger-outline" data-proactive-candidate-prune="${escapeHtml(item.user_id || "")}" data-proactive-prune-keep="160" title="保留最近 160 条，清理更早的记录">清理旧记录</button>
           </div>
         </div>
         <p>${escapeHtml(item.motive || "暂无动机记录")}</p>
@@ -28080,22 +28086,23 @@ function renderFeatureSwitches() {
       ? proactiveIntensityCommonSettingCard(overviewSettings, intensity)
       : "";
     return `
-      <section class="feature-switch-group">
-        <header>
+      <details class="feature-switch-group studio-feature-group" data-studio-feature-group="${escapeHtml(group.title)}" ${studioFeatureGroupOpen(group.title) ? "open" : ""}>
+        <summary>
           <div>
             <b>${escapeHtml(group.title)}</b>
             <span>${escapeHtml(group.note || "")}</span>
           </div>
-          <small>${escapeHtml(groupMeta)}</small>
-        </header>
+          <small>已开启 ${escapeHtml(groupMeta)}</small>
+        </summary>
         <div class="feature-switch-list">
           ${prefix}
           ${visibleKeys.map((key) => featureSwitchItem(key)).join("")}
         </div>
-      </section>
+      </details>
     `;
   }).filter(Boolean).join("");
   $("#featureFlags").innerHTML = board || `<div class="feature-filter-empty"><b>没有匹配的功能开关</b><span>可以调整领域、作用阶段、状态或搜索词。</span><button type="button" data-feature-filter-reset>清除筛选</button></div>`;
+  studioBindFeatureGroups();
   document.querySelectorAll("[data-feature-key]").forEach((input) => {
     input.addEventListener("change", () => {
       state.featureDraft[input.dataset.featureKey] = input.checked;
@@ -28121,7 +28128,7 @@ function renderFeatureSwitches() {
       renderFeatureSwitches();
     };
     card.addEventListener("click", (event) => {
-      if (event.target.closest("button, input, label, select, textarea, a")) return;
+      if (event.target.closest("button, input, label, select, textarea, a, summary, .studio-feature-notes")) return;
       openDetail();
     });
   });
@@ -28512,10 +28519,9 @@ function featureSwitchItem(key) {
       <div class="feature-switch-body">
         <button type="button" class="feature-switch-text" data-feature-open="${escapeHtml(key)}">
           <b>${escapeHtml(featureLabel(key))}</b>
-          <small>${escapeHtml(featurePublicKey(key))}</small>
           <span class="feature-open-hint">查看配置 <span aria-hidden="true">›</span></span>
         </button>
-        <div class="feature-stage-tags" aria-label="作用阶段">${imageUse ? `<span class="feature-image-use">${escapeHtml(imageUse)}</span>` : ""}${stageTags}</div>
+        <details class="studio-feature-notes"><summary>配置键与作用阶段</summary><code>${escapeHtml(featurePublicKey(key))}</code><div class="feature-stage-tags" aria-label="作用阶段">${imageUse ? `<span class="feature-image-use">${escapeHtml(imageUse)}</span>` : ""}${stageTags}</div></details>
         <div class="feature-switch-meta">
           <span class="feature-state-text">${escapeHtml(stateText)}</span>
           ${sourceBadge}
@@ -39441,8 +39447,19 @@ function switchTab(tabName) {
   // Calendar is part of the observation workspace now. Keep old deep links
   // and bookmarks working by redirecting the retired tab to that workspace.
   if (tabName === "calendar") tabName = "memory";
-  if (tabName === "enable_experimental_bluetooth_wakeup") tabName = "reality";
   tabName = tabName === "modules" ? "config" : (opensSocialLearning ? "learning" : (opensDailyReview ? "experimental" : (tabName || "dashboard")));
+  if (tabName === "creative" && !contentCompanionInstalled()) {
+    showToast("尚未安装创作扩展，请在插件市场安装后使用", "warn");
+    return;
+  }
+  if (tabName === "reality" && !realityCompanionInstalled()) {
+    showToast("尚未安装现实触及扩展，请在插件市场安装后使用", "warn");
+    return;
+  }
+  if (tabName === "image" && !imageCompanionInstalled()) {
+    showToast("尚未安装生图扩展，请在插件市场安装后使用", "warn");
+    return;
+  }
   if (opensSocialLearning) state.learningSection = "social";
   if (opensDailyReview) state.experimentalSubpage = "daily-review";
   if (tabName !== state.activeTab && hasUnsavedChanges()) {
@@ -40035,7 +40052,7 @@ document.addEventListener("change", (event) => {
 
 document.addEventListener("click", async (event) => {
   const target = event.target instanceof Element ? event.target.closest("[data-jump-tab]") : null;
-  if (!target) return;
+  if (!target || target.disabled || target.getAttribute("aria-disabled") === "true") return;
   state.setupGuideOpen = false;
   clearSetupGuideProactivePoll();
   renderSetupGuideOverlay();
@@ -41642,3 +41659,189 @@ async function bootstrapPage() {
 }
 
 void bootstrapPage();
+
+/* Companion Studio: presentation enhancements only. All navigation goes through
+ * existing tab clicks / switchTab(), including dirty-form checks and lazy loads. */
+(function initializeCompanionStudio() {
+  if (!document.body.classList.contains("companion-studio")) return;
+  const nav = document.querySelector(".annotations");
+  const dialog = document.getElementById("studioCommand");
+  const input = document.getElementById("studioCommandInput");
+  const results = document.getElementById("studioCommandResults");
+  const descriptions = {
+    dashboard: "今日状态、陪伴概况与运行信息", roleplay: "角色设定、世界观、衣柜与关系资料",
+    private: "陪伴对象、用户资料与私聊关系", group: "群聊成员、互动与观察",
+    learning: "表达学习、社交知识与反应素材", memory: "日程、时间轴、记忆与生活观察",
+    proactive: "主动互动、候选消息与策略", creative: "书架、日记、创作与空间",
+    image: "图像生成与运行状态", tokens: "用量、预算与消耗分析",
+    troubleshooting: "诊断、连接检查与故障排查", config: "功能开关、人格配置与行为设置",
+    models: "模型路由、Provider、语音与图像服务", experimental: "实验能力与每日巡视",
+    prompts: "任务提示词、附加指令与默认恢复", reality: "现实触及与外部设备",
+  };
+  let returnFocus = null;
+  const visibleTabs = () => [...nav.querySelectorAll(".tab[data-tab]")].filter(tab => !tab.hidden && getComputedStyle(tab).display !== "none");
+  function renderSearch() {
+    const query = input.value.trim().toLocaleLowerCase();
+    results.replaceChildren();
+    visibleTabs().filter(tab => `${tab.textContent} ${descriptions[tab.dataset.tab] || ""}`.toLocaleLowerCase().includes(query)).forEach(tab => {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "studio-command-result";
+      const icon = document.createElement("span");
+      icon.textContent = tab.querySelector("i")?.textContent || "↗";
+      icon.setAttribute("aria-hidden", "true");
+      const copy = document.createElement("div");
+      const title = document.createElement("b");
+      title.textContent = tab.querySelector("span")?.textContent || tab.dataset.tab;
+      const hint = document.createElement("small");
+      hint.textContent = descriptions[tab.dataset.tab] || "打开功能页面";
+      copy.append(title, hint);
+      button.append(icon, copy);
+      button.addEventListener("click", () => { dialog.close(); tab.click(); });
+      results.append(button);
+    });
+    if (!results.childElementCount) {
+      const empty = document.createElement("p");
+      empty.className = "studio-search-empty";
+      empty.textContent = "没有找到相关功能，试试「配置」或「日程」。";
+      results.append(empty);
+    }
+  }
+  function openSearch() {
+    if (dialog.open) return;
+    // Do not cover a pending confirmation or another feature's modal dialog.
+    if (document.querySelector("dialog[open]")) return;
+    returnFocus = document.activeElement;
+    input.value = "";
+    renderSearch();
+    dialog.showModal();
+    input.focus();
+  }
+  document.getElementById("studioFindBtn").addEventListener("click", openSearch);
+  document.getElementById("studioCommandClose").addEventListener("click", () => dialog.close());
+  dialog.addEventListener("close", () => returnFocus?.focus?.({ preventScroll: true }));
+  dialog.addEventListener("click", event => {
+    if (event.target !== dialog) return;
+    const rect = dialog.getBoundingClientRect();
+    if (event.clientX < rect.left || event.clientX > rect.right || event.clientY < rect.top || event.clientY > rect.bottom) dialog.close();
+  });
+  input.addEventListener("input", renderSearch);
+  dialog.addEventListener("keydown", event => {
+    const buttons = [...results.querySelectorAll("button")];
+    const index = buttons.indexOf(document.activeElement);
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      if (event.key === "ArrowUp" && index <= 0) input.focus();
+      else buttons[Math.min(buttons.length - 1, Math.max(0, index + (event.key === "ArrowDown" ? 1 : -1)))]?.focus();
+    } else if (event.key === "Enter" && event.target === input) {
+      event.preventDefault(); buttons[0]?.click();
+    }
+  });
+  document.addEventListener("keydown", event => {
+    if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+      event.preventDefault(); if (dialog.open) dialog.close(); else openSearch();
+    }
+    const stat = event.target.closest?.(".stat[data-jump-tab]");
+    if (stat && (event.key === "Enter" || event.key === " ")) { event.preventDefault(); stat.click(); }
+  });
+  let activeName = "";
+  function syncNavigation() {
+    const tabs = [...nav.querySelectorAll(".tab[data-tab]")];
+    const active = tabs.find(tab => tab.classList.contains("is-active"));
+    tabs.forEach(tab => {
+      if (tab === active) tab.setAttribute("aria-current", "page");
+      else tab.removeAttribute("aria-current");
+      tab.setAttribute("aria-controls", `panel-${tab.dataset.tab}`);
+    });
+    if (!active || activeName === active.dataset.tab) return;
+    activeName = active.dataset.tab;
+    document.getElementById("studioPageTitle").textContent = active.querySelector("span")?.textContent || "总览";
+    document.querySelector(".studio-skip").href = `#panel-${activeName}`;
+    if (window.matchMedia("(min-width: 681px)").matches) {
+      const top = active.offsetTop;
+      if (top < nav.scrollTop || top + active.offsetHeight > nav.scrollTop + nav.clientHeight) {
+        nav.scrollTo({ top: Math.max(0, top - nav.clientHeight / 2), behavior: "auto" });
+      }
+    }
+  }
+  new MutationObserver(syncNavigation).observe(nav, { subtree: true, attributes: true, attributeFilter: ["class", "hidden"] });
+  syncNavigation();
+  function enhanceStats(root) {
+    root.querySelectorAll(".stat[data-jump-tab]").forEach(stat => {
+      stat.tabIndex = 0;
+      stat.setAttribute("role", "button");
+      stat.setAttribute("aria-label", `${stat.textContent.trim()}，查看详情`);
+    });
+  }
+  ["stats", "configStats"].forEach(id => {
+    const root = document.getElementById(id);
+    if (!root) return;
+    new MutationObserver(() => enhanceStats(root)).observe(root, { childList: true });
+    enhanceStats(root);
+  });
+  document.querySelectorAll(".layout > .panel").forEach(panel => { panel.tabIndex = -1; });
+})();
+
+/* Plain-language labels only; raw diagnostic data, filters and action keys remain unchanged. */
+function studioDiagnosticTitle(title) {
+  const labels = {
+    "有可关注项": "有几项需要确认",
+    "主动消息没有私聊对象": "还没有设置私聊对象",
+    "主动带图当前不可用": "主动消息暂时不能附图",
+    "Token 预算未阻塞": "Token 预算正常",
+    "TTS 强化未开启": "未启用语音增强",
+    "SQLite WAL 检查通过": "数据库读写检查通过",
+    "近期模型调用无待处理失败": "近期没有待处理的模型错误",
+  };
+  return labels[String(title || "")] || String(title || "");
+}
+function studioDiagnosticDestination(tab) {
+  const labels = { private: "设置陪伴对象", tokens: "查看用量", config: "打开设置", models: "模型设置", image: "图片设置", proactive: "主动消息设置", group: "群聊设置", memory: "查看日程", troubleshooting: "查看详情" };
+  return labels[tab] || "打开相关页面";
+}
+
+function studioDiagnosticExplanation(item) {
+  const explanations = {
+    "主动消息没有私聊对象": "还没有启用的陪伴对象，所以暂时不会发送主动私聊消息。",
+    "主动带图当前不可用": "主动消息暂时不能附图。请检查图片服务、用量限制，以及陪伴对象的权限。",
+    "TTS 强化未开启": "语音增强已关闭。请勿要求模型输出 TTS 标签；如果仍有标签，发送前会清理。",
+  };
+  return explanations[String(item?.title || "")] || "";
+}
+
+/* Studio v3: native disclosures preserve mounted controls and existing events.
+ * In-memory UI preferences only. Never write configuration or infer feature state. */
+function studioFeatureFilterActive() {
+  return Boolean(document.getElementById("featureFilter")?.value.trim())
+    || [state.featureDomainFilter, state.featureStageFilter, state.featureStatusFilter].some(value => value && value !== "all");
+}
+function studioDisclosureIsOpen(key) { return Boolean(studioDisclosureIsOpen.values?.get(key)); }
+function studioBindDisclosures(root) {
+  root?.querySelectorAll("details[data-studio-disclosure]").forEach(node => {
+    if (node.dataset.studioBound) return;
+    node.dataset.studioBound = "1";
+    node.addEventListener("toggle", () => {
+      if (!node.isConnected) return;
+      studioDisclosureIsOpen.values ||= new Map();
+      studioDisclosureIsOpen.values.set(node.dataset.studioDisclosure, node.open);
+    });
+  });
+}
+function studioFeatureGroupOpen(title) {
+  return studioFeatureFilterActive() || studioDisclosureIsOpen("feature:" + title);
+}
+function studioBindFeatureGroups() {
+  document.querySelectorAll("details[data-studio-feature-group]").forEach(node => {
+    const revealedByFilter = studioFeatureFilterActive();
+    node.querySelector(":scope > summary")?.addEventListener("click", () => {
+      if (revealedByFilter) return;
+      studioDisclosureIsOpen.values ||= new Map();
+      studioDisclosureIsOpen.values.set("feature:" + node.dataset.studioFeatureGroup, !node.open);
+    });
+    node.addEventListener("toggle", () => {
+      if (!node.isConnected || revealedByFilter || studioFeatureFilterActive()) return;
+      studioDisclosureIsOpen.values ||= new Map();
+      studioDisclosureIsOpen.values.set("feature:" + node.dataset.studioFeatureGroup, node.open);
+    });
+  });
+}

--- a/pages/陪伴面板/app.js
+++ b/pages/陪伴面板/app.js
@@ -8063,7 +8063,8 @@ function selectTaskPrompt(taskKey) {
   state.selectedTaskPromptKey = next.task_key;
   state.taskPromptDraft = String(next.custom_prompt || "");
   renderTaskPrompts();
-  if (getComputedStyle($("#promptsRoot")).gridTemplateColumns.trim().split(/\s+/).length === 1) {
+  const promptsRoot = $("#promptsRoot");
+  if (promptsRoot && getComputedStyle(promptsRoot).gridTemplateColumns.trim().split(/\s+/).length === 1) {
     $("#promptsEditor")?.scrollIntoView({ behavior: window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ? "auto" : "smooth", block: "start" });
   }
 }
@@ -41697,7 +41698,7 @@ void bootstrapPage();
       hint.textContent = descriptions[tab.dataset.tab] || "打开功能页面";
       copy.append(title, hint);
       button.append(icon, copy);
-      button.addEventListener("click", () => { dialog.close(); tab.click(); });
+      button.addEventListener("click", () => { returnFocus = tab; dialog.close(); tab.click(); });
       results.append(button);
     });
     if (!results.childElementCount) {

--- a/pages/陪伴面板/css/polish.css
+++ b/pages/陪伴面板/css/polish.css
@@ -5309,3 +5309,702 @@ code,
     flex-basis: calc(50% - 3px);
   }
 }
+
+/* ==========================================================================
+   Companion Studio / 2026-09 — presentation-only redesign.
+   Deliberately last: legacy component layouts and visibility contracts remain.
+   All palette variants still use the original appearance selector.
+   ========================================================================== */
+:root {
+  --studio-bg: #f7f8f4;
+  --studio-sidebar: #f0f3ed;
+  --studio-hero: #edf1e7;
+  --radius: 18px;
+  --radius-sm: 10px;
+  --shadow: 0 8px 32px rgba(35, 57, 43, .035);
+  --shadow-soft: 0 2px 10px rgba(35, 57, 43, .025);
+}
+:root[data-theme="classic"], :root:not([data-theme]) {
+  --bg: #f7f8f4; --panel: #fff; --surface: #f6f8f3;
+  --surface-strong: #e9eee4; --ink: #293d33; --muted: #748074;
+  --line: #dce3d7; --line-soft: #e9ede4;
+  --accent: #53755b; --accent-strong: #34543e; --accent-soft: #e6eddf;
+  --blue: #648371; --blue-soft: #e6ede5;
+  --red: #bf7366; --red-soft: #f6e9e5;
+  --gold: #a78d56; --gold-soft: #f6f0e1;
+  --cv-line: #dce3d7; --cv-line-soft: #e9ede4;
+}
+:root[data-theme]:not([data-theme="classic"]) {
+  --studio-bg: var(--bg); --studio-sidebar: var(--surface);
+  --studio-hero: color-mix(in srgb, var(--accent-soft) 45%, var(--panel));
+}
+html:has(body.companion-studio) { background: var(--studio-bg) !important; scrollbar-gutter: auto; }
+body.companion-studio { background: var(--studio-bg) !important; color: var(--ink); font-weight: 400; font-size: 14px; line-height: 1.65; }
+html[data-page-font="original"] body.companion-studio { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif !important; }
+body.companion-studio::before, body.companion-studio::after { content: none !important; }
+.companion-studio .shell { width: 100% !important; max-width: 1800px !important; margin: 0 auto !important; padding: 0 42px 48px 270px !important; }
+.companion-studio .layout { display: block !important; background: none !important; border: 0 !important; box-shadow: none !important; border-radius: 0 !important; overflow: visible !important; backdrop-filter: none !important; }
+.companion-studio .panel { padding: 28px 0 !important; background: transparent !important; border: 0 !important; box-shadow: none !important; min-width: 0; }
+.companion-studio .panel::before, .companion-studio .panel::after { content: none !important; }
+.companion-studio .panel:not(.is-active):not(.is-leaving) { display: none !important; }
+.companion-studio [hidden] { display: none !important; }
+/* Quiet, persistent application header */
+.companion-studio .folio { display: flex !important; align-items: center !important; gap: 18px !important; min-height: 102px !important; margin: 0 !important; padding: 20px 0 !important; border: 0 !important; border-bottom: 1px solid var(--line) !important; background: transparent !important; box-shadow: none !important; border-radius: 0 !important; backdrop-filter: none !important; }
+.companion-studio .folio::before, .companion-studio .folio::after, .companion-studio .folio-meta::before, .companion-studio .folio-meta::after { content: none !important; }
+.companion-studio .folio-meta { flex: 1; min-width: 0; padding: 0 !important; display: block !important; background: none !important; border: 0 !important; }
+.companion-studio .folio-heading { display: flex !important; flex-wrap: wrap; gap: 12px 28px; align-items: center; justify-content: space-between; }
+.companion-studio .folio-eyebrow { font-size: 10px !important; letter-spacing: 2px !important; font-weight: 400 !important; color: var(--muted) !important; margin-bottom: 6px; }
+.companion-studio .folio-title { font-size: 19px !important; line-height: 1.6 !important; letter-spacing: -.4px !important; font-weight: 600 !important; margin: 0 !important; }
+.studio-header-slash { color: #b8c2b6; margin: 0 12px; font-weight: 300; }
+#studioPageTitle { font-size: 14px; font-weight: 400; color: var(--muted); }
+.companion-studio .folio-persona-context { display: grid; gap: 4px; }
+.companion-studio #subtitle { margin: 0 !important; font-size: 12px !important; color: var(--muted) !important; max-width: 36ch; }
+.companion-studio .folio-plate { width: 46px !important; height: 46px !important; min-height: 0 !important; flex: 0 0 46px; border-radius: 50% !important; border: 0 !important; padding: 0 !important; background: var(--accent-soft) !important; overflow: hidden; }
+.companion-studio .folio-plate:not(:has(img[src]:not([src=""]))) { display: none !important; }
+.companion-studio .folio-plate::before, .companion-studio .folio-plate::after { content: none !important; }
+.companion-studio .daily-outfit-logo { width: 100% !important; height: 100% !important; max-height: none !important; object-fit: cover !important; }
+.companion-studio .folio-tools { display: flex !important; flex-direction: row !important; gap: 10px !important; padding: 0 !important; width: auto !important; border: 0 !important; background: none !important; }
+.companion-studio .seal, .companion-studio .setup-guide-entry { position: relative !important; min-height: 40px !important; height: 40px !important; border: 1px solid var(--line) !important; border-radius: 10px !important; background: var(--panel) !important; color: var(--ink) !important; box-shadow: none !important; font-size: 12px !important; font-weight: 500 !important; padding: 0 14px !important; }
+.companion-studio .seal { width: 40px !important; padding: 0 !important; transform: none !important; }
+.companion-studio .seal-mark { font-size: 22px !important; }
+.companion-studio .seal small { display: none; }
+.companion-studio .setup-guide-badge { box-shadow: none !important; background: var(--accent) !important; font-size: 9px !important; min-width: 16px !important; height: 16px !important; line-height: 16px !important; }
+/* Navigation: every existing tab remains the original clickable node. */
+.companion-studio .annotations { position: fixed !important; inset: 0 auto 0 0 !important; width: 226px !important; height: 100dvh !important; display: flex !important; flex-direction: column !important; align-items: stretch !important; gap: 4px !important; padding: 28px 18px 22px !important; border: 0 !important; border-right: 1px solid var(--line-soft) !important; background: var(--studio-sidebar) !important; border-radius: 0 !important; overflow-y: auto !important; overflow-x: hidden !important; z-index: 30 !important; box-shadow: none !important; backdrop-filter: none !important; scrollbar-width: thin; }
+.companion-studio .annot-axis, .companion-studio .annotations::before, .companion-studio .annotations::after { display: none !important; }
+.studio-brand { display: flex; align-items: center; gap: 10px; padding: 1px 6px 28px; flex-shrink: 0; }
+.studio-brand-mark { width: 36px; height: 36px; background: var(--accent); color: #fff; border-radius: 12px; font-size: 33px; line-height: 36px; text-align: center; }
+.studio-brand b { display: block; font-size: 15px; letter-spacing: -.3px; font-weight: 600; }
+.studio-brand small { display: block; font-size: 7px; letter-spacing: 1.6px; color: var(--muted); margin-top: 3px; }
+.companion-studio .studio-find { display: flex; justify-content: space-between; align-items: center; gap: 6px; padding: 10px 11px !important; width: 100%; background: color-mix(in srgb, var(--panel) 62%, transparent) !important; color: var(--muted) !important; border: 1px solid var(--line) !important; border-radius: 9px !important; font-size: 11px !important; font-weight: 400 !important; margin-bottom: 12px; }
+.studio-find kbd { font: inherit; font-size: 9px; opacity: .75; }
+.studio-nav-label { padding: 17px 14px 7px; font-size: 10px; letter-spacing: 1.4px; color: var(--muted); }
+.companion-studio .annotations .tab { display: flex !important; flex-direction: row !important; align-items: center !important; gap: 14px !important; width: 100% !important; min-width: 0 !important; min-height: 40px !important; padding: 10px 15px !important; margin: 0 !important; border: 0 !important; border-radius: 9px !important; background: transparent !important; color: var(--muted) !important; box-shadow: none !important; font-size: 13px !important; font-weight: 450 !important; transform: none !important; flex-shrink: 0; }
+.companion-studio .annotations .tab i { display: inline-grid; place-items: center; width: 19px; font-size: 19px !important; font-style: normal; font-family: system-ui, sans-serif; font-weight: 400 !important; color: inherit !important; line-height: 1; }
+.companion-studio .annotations .tab span { font-size: inherit !important; font-weight: inherit !important; }
+.companion-studio .annotations .tab:hover { background: var(--accent-soft) !important; color: var(--accent-strong) !important; }
+.companion-studio .annotations .tab.is-active { background: var(--accent) !important; color: white !important; font-weight: 500 !important; }
+.companion-studio .annotations .tab::before, .companion-studio .annotations .tab::after { content: none !important; }
+.companion-studio .annotations .tab[hidden] { display: none !important; }
+.studio-nav-foot { margin-top: auto; padding: 28px 12px 0; font-size: 10px; color: var(--muted); }
+.studio-nav-foot > span { color: var(--accent); margin-right: 5px; }
+.studio-nav-foot small { display: block; margin-top: 8px; font-size: 7px; letter-spacing: 1.6px; opacity: .7; }
+/* Home: invitation, four compact signals, then two calm columns. */
+.companion-studio .section-head { gap: 18px !important; margin: 0 0 24px !important; padding: 0 0 20px !important; border-bottom: 1px solid var(--line-soft) !important; background: transparent !important; }
+.companion-studio .section-head h2 { font-size: 23px !important; font-weight: 600 !important; letter-spacing: -.5px; }
+.companion-studio .section-head h2::before, .companion-studio .section-head h2::after { content: none !important; }
+.companion-studio .section-desc { color: var(--muted) !important; font-size: 12px !important; line-height: 1.8 !important; margin-top: 7px !important; font-weight: 400 !important; }
+.companion-studio .dashboard-overview-head { border: 0 !important; padding: 0 !important; margin-bottom: 24px !important; }
+.companion-studio #exportSnapshotBtn { color: var(--muted) !important; background: transparent !important; border: 1px solid var(--line) !important; box-shadow: none !important; font-size: 11px !important; padding: 9px 14px !important; border-radius: 8px !important; }
+.studio-welcome { position: relative; isolation: isolate; display: flex; align-items: center; min-height: 280px; padding: 34px 38px; border: 1px solid color-mix(in srgb, var(--line) 55%, transparent); border-radius: 19px; background: var(--studio-hero); overflow: hidden; }
+.studio-welcome-copy { position: relative; z-index: 1; }
+.studio-kicker { display: flex; align-items: center; gap: 8px; color: var(--accent); font-size: 8px; letter-spacing: 2px; font-weight: 600; }
+.studio-kicker > span { width: 5px; height: 5px; border-radius: 50%; background: var(--accent); }
+.companion-studio .studio-welcome h2 { margin: 18px 0 12px !important; font-size: clamp(25px, 2.4vw, 37px) !important; font-weight: 500 !important; line-height: 1.5 !important; letter-spacing: 1px; color: var(--accent-strong); }
+.studio-welcome p { font-size: 12px; color: var(--muted); }
+.studio-welcome-actions { display: flex; align-items: center; flex-wrap: wrap; gap: 19px; margin-top: 25px; }
+.companion-studio .studio-primary { background: var(--accent) !important; color: #fff !important; border: 0 !important; border-radius: 9px !important; padding: 11px 17px !important; font-size: 12px !important; font-weight: 500 !important; box-shadow: none !important; }
+.studio-primary > span { margin-left: 13px; }
+.companion-studio .studio-text-button { border: 0 !important; background: none !important; color: var(--accent-strong) !important; font-size: 11px !important; font-weight: 400 !important; padding: 8px 0 !important; box-shadow: none !important; }
+.studio-text-button > span { margin-left: 6px; }
+.studio-art { position: absolute; right: 20px; bottom: 15px; width: 41%; max-width: 370px; z-index: -1; }
+.studio-art-caption { position: absolute; bottom: 17px; right: 55px; font-size: 7px; color: var(--accent); letter-spacing: 2px; opacity: .65; }
+.studio-metrics-label { display: flex; justify-content: space-between; align-items: center; margin: 28px 2px 12px; font-size: 12px; font-weight: 500; }
+.studio-metrics-label small { font-size: 10px; color: var(--muted); font-weight: 400; }
+.companion-studio #stats { display: grid !important; grid-template-columns: repeat(4, minmax(0, 1fr)) !important; gap: 12px !important; margin: 0 0 28px !important; }
+.companion-studio .stat { border: 1px solid var(--line-soft) !important; border-radius: 12px !important; padding: 20px 17px !important; background: var(--panel) !important; box-shadow: none !important; }
+.companion-studio .stat::before, .companion-studio .stat::after { content: none !important; }
+.companion-studio .stat b { font-size: clamp(14px, 1.5vw, 21px) !important; font-weight: 550 !important; letter-spacing: -.5px; margin: 5px 0 8px !important; line-height: 1.4; }
+.companion-studio .stat span { display: block; color: var(--muted) !important; font-size: 10px !important; line-height: 1.6; }
+.companion-studio .stat:hover { border-color: var(--accent) !important; background: var(--surface) !important; }
+.companion-studio .dashboard-life-desk { display: grid !important; grid-template-columns: minmax(0, 1fr) minmax(0, 1.13fr) !important; gap: 20px !important; align-items: start !important; margin: 0 !important; }
+.companion-studio .dashboard-life-column { display: grid !important; grid-template-columns: minmax(0,1fr) !important; gap: 20px !important; min-width: 0; }
+.companion-studio .life-desk-card { position: relative; border: 1px solid var(--line-soft) !important; border-radius: 15px !important; padding: 23px !important; background: var(--panel) !important; box-shadow: none !important; overflow: hidden; }
+.companion-studio .life-desk-card::before, .companion-studio .life-desk-card::after { content: none !important; }
+.companion-studio .life-desk-card-head { display: flex; justify-content: space-between; gap: 12px !important; align-items: center; margin-bottom: 22px !important; padding: 0 !important; border: 0 !important; }
+.companion-studio .life-desk-card-head h3 { font-size: 16px !important; font-weight: 550 !important; color: var(--ink) !important; }
+.companion-studio .life-desk-card-head > div { gap: 9px !important; }
+.companion-studio .life-desk-dot { width: 6px !important; height: 6px !important; background: #a1b18e !important; box-shadow: none !important; }
+.companion-studio .life-desk-card-head small { font-size: 9px !important; color: var(--muted) !important; font-weight: 400 !important; }
+.companion-studio .life-fact-grid { display: grid !important; grid-template-columns: repeat(2, minmax(0, 1fr)) !important; gap: 0 22px !important; }
+.companion-studio .life-fact-item { border: 0 !important; border-bottom: 1px solid var(--line-soft) !important; padding: 13px 0 !important; min-height: 0 !important; border-radius: 0 !important; background: transparent !important; box-shadow: none !important; }
+.companion-studio .life-fact-item:nth-last-child(-n+2) { border-bottom: 0 !important; }
+.companion-studio .life-fact-item > span { font-size: 10px !important; color: var(--muted) !important; font-weight: 400 !important; }
+.companion-studio .life-fact-item > b { font-size: 12px !important; color: var(--ink) !important; font-weight: 500 !important; margin-top: 5px; line-height: 1.65 !important; }
+.companion-studio .life-desk-link { padding: 5px 9px !important; border: 1px solid var(--line-soft) !important; color: var(--accent) !important; background: var(--surface) !important; border-radius: 7px !important; font-size: 10px !important; font-weight: 450 !important; box-shadow: none !important; }
+.companion-studio .life-timeline-preview { min-height: 230px !important; max-height: none !important; padding: 0 !important; overflow: visible !important; }
+.companion-studio .life-timeline-row { background: transparent !important; border: 0 !important; border-bottom: 1px solid var(--line-soft) !important; border-radius: 0 !important; padding: 16px 4px !important; margin: 0 !important; box-shadow: none !important; }
+.companion-studio .life-timeline-row.is-current { background: var(--surface) !important; border-radius: 10px !important; padding: 16px 12px !important; border: 1px solid var(--line-soft) !important; }
+.companion-studio .life-timeline-content b { font-size: 13px !important; font-weight: 500 !important; }
+.companion-studio .life-timeline-content p { font-size: 11px !important; line-height: 1.8 !important; }
+.companion-studio .life-current-activity { border: 0 !important; background: var(--surface) !important; border-radius: 10px !important; padding: 16px !important; }
+.companion-studio .life-current-activity b { font-size: 15px !important; font-weight: 500 !important; }
+.companion-studio .life-state-grid { gap: 14px !important; }
+.companion-studio .life-state-grid > div { border: 0 !important; background: transparent !important; padding: 6px 0 !important; }
+.companion-studio .life-state-grid b { font-size: 12px !important; font-weight: 500 !important; }
+.companion-studio .life-energy-track { height: 4px !important; margin: 20px 0 !important; background: var(--accent-soft) !important; }
+.companion-studio .life-energy-track i { background: var(--accent) !important; }
+.companion-studio .life-empty { display: grid; place-content: center; text-align: center; min-height: 150px; border: 0 !important; border-radius: 10px !important; background: var(--surface) !important; color: var(--muted) !important; font-size: 12px !important; }
+.companion-studio .dashboard-secondary { margin-top: 30px !important; display: grid; gap: 12px !important; }
+.studio-section-label { font-size: 14px; margin: 0 2px 3px; }
+.studio-section-label small { font-size: 11px; color: var(--muted); margin-left: 12px; }
+.companion-studio .dashboard-disclosure { border: 1px solid var(--line-soft) !important; border-radius: 12px !important; background: var(--panel) !important; box-shadow: none !important; overflow: hidden; }
+.companion-studio .dashboard-disclosure > summary { padding: 20px 23px !important; background: transparent !important; cursor: pointer; }
+.companion-studio .dashboard-disclosure > summary b { font-size: 13px !important; font-weight: 500 !important; }
+.companion-studio .dashboard-disclosure > summary small { font-size: 11px !important; color: var(--muted); font-weight: 400 !important; }
+.companion-studio .dashboard-disclosure[open] > summary { border-bottom: 1px solid var(--line-soft); }
+.companion-studio .studio-memory-disclosure .dashboard-life-column-right { padding: 20px; grid-template-columns: repeat(2, minmax(0,1fr)) !important; }
+.companion-studio .studio-terminal-disclosure { margin-top: 12px; }
+.companion-studio .dashboard-companion-terminal { border: 0 !important; box-shadow: none !important; background: transparent !important; margin: 0 !important; padding: 24px !important; }
+.companion-studio .dashboard-companion-terminal h2 { font-size: 18px !important; }
+/* Shared visual system. Component-specific grids and behavior are untouched. */
+.companion-studio :is(.module-card,.dashboard-strategy-card,.dashboard-chart-card,.dashboard-insight-card,.dashboard-activity-card,.qzone-card,.config-persona-selector,.config-persona-top-row > article,.persona-import-panel,.world-knowledge-brief,.proactive-summary,.prompts-catalog,.prompts-editor,.memory-view-card,.feature-card,.config-overview-card,.learning-card) { border-color: var(--line-soft) !important; border-radius: 14px !important; background: var(--panel) !important; box-shadow: none !important; }
+.companion-studio :is(.module-card,.feature-card,.dashboard-strategy-card,.dashboard-chart-card,.dashboard-insight-card,.dashboard-activity-card)::before,
+.companion-studio :is(.module-card,.feature-card,.dashboard-strategy-card,.dashboard-chart-card,.dashboard-insight-card,.dashboard-activity-card)::after { content: none !important; }
+.companion-studio .module-card { padding: 24px !important; margin-bottom: 20px; }
+.companion-studio :is(.module-card-head,.persona-card-head) { margin-bottom: 20px !important; }
+.companion-studio :is(.module-card-head,.persona-card-head) :is(h2,h3) { font-weight: 550 !important; font-size: 18px !important; }
+.companion-studio :is(.module-card-head,.persona-card-head) :is(p,.section-desc) { font-size: 12px !important; font-weight: 400 !important; line-height: 1.8 !important; }
+.companion-studio :is(input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="color"]),select,textarea) { border-radius: 9px !important; border-color: var(--line) !important; background-color: var(--panel); color: var(--ink); box-shadow: none; font-size: 13px; }
+.companion-studio :is(input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="color"]),select) { min-height: 40px; }
+.companion-studio textarea { padding: 13px !important; line-height: 1.8 !important; }
+.companion-studio :is(input,select,textarea):focus { outline: 2px solid color-mix(in srgb,var(--accent) 40%,transparent) !important; outline-offset: 2px; }
+.companion-studio :is(button,[role="button"],a,summary,input,select,textarea):focus-visible { outline: 2px solid var(--accent) !important; outline-offset: 3px !important; }
+.companion-studio button { font-family: inherit; border-radius: 9px; transition: background .15s ease, border-color .15s ease; }
+.companion-studio button:disabled { opacity: .5; cursor: not-allowed; }
+.companion-studio :is(.primary-button,.module-form button[type="submit"],#saveFeaturesBtn) { background: var(--accent) !important; color: #fff !important; border: 1px solid var(--accent) !important; box-shadow: none !important; border-radius: 9px !important; }
+.companion-studio :is(.secondary-button,.ghost-button) { background: var(--panel) !important; color: var(--accent-strong) !important; border-color: var(--line) !important; border-radius: 9px !important; box-shadow: none !important; }
+.companion-studio :is(.module-badge,.world-save-state,.prompts-custom-badge) { border-color: var(--line-soft) !important; background: var(--accent-soft) !important; color: var(--accent-strong) !important; border-radius: 6px !important; font-weight: 500 !important; }
+.companion-studio :is(th,td) { padding: 14px 16px; border-color: var(--line-soft) !important; }
+.companion-studio th { background: var(--surface) !important; color: var(--muted); font-weight: 500; }
+.companion-studio .feature-save-actions { border: 1px solid var(--line) !important; border-radius: 14px !important; background: var(--panel) !important; box-shadow: 0 8px 35px #293d3320 !important; }
+/* Search dialog: navigates by clicking the existing tab, preserving dirty guards. */
+.studio-command { width: min(540px, calc(100vw - 32px)); max-height: 80dvh; padding: 24px; margin: 12vh auto auto; border: 1px solid var(--line); border-radius: 20px; background: var(--panel); color: var(--ink); box-shadow: 0 25px 90px #14291a30; }
+.studio-command::backdrop { background: #20362655; backdrop-filter: blur(5px); }
+.studio-command-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 18px; }
+.studio-command-head h2 { font-size: 19px; font-weight: 550; }
+.studio-command-head button { width: 32px; height: 32px; border: 0; background: var(--surface); color: var(--muted); font-size: 22px; }
+#studioCommandInput { width: 100%; padding: 12px 14px; }
+.studio-command-results { display: grid; gap: 4px; margin-top: 16px; max-height: 42dvh; overflow-y: auto; }
+.companion-studio .studio-command-result { display: flex; gap: 12px; align-items: center; width: 100%; padding: 12px; background: transparent; color: var(--ink); border: 0; border-radius: 9px; text-align: left; }
+.studio-command-result > span { color: var(--accent); font-size: 20px; }
+.studio-command-result b { font-size: 13px; font-weight: 500; }
+.studio-command-result small { display: block; font-size: 10px; color: var(--muted); margin-top: 2px; }
+.companion-studio .studio-command-result:hover, .companion-studio .studio-command-result:focus { background: var(--surface); }
+.studio-command-help { margin-top: 18px; font-size: 10px; color: var(--muted); }
+.studio-search-empty { padding: 24px 10px; color: var(--muted); font-size: 12px; text-align: center; }
+.studio-skip { position: fixed; top: -100px; left: 240px; z-index: 100; padding: 12px; background: var(--panel); color: var(--accent); }
+.studio-skip:focus { top: 10px; }
+@media (min-width: 1800px) { .companion-studio .annotations { left: max(0px, calc((100vw - 1800px) / 2)) !important; } }
+@media (max-width: 1180px) {
+  .companion-studio .shell { padding-left: 218px !important; padding-right: 28px !important; }
+  .companion-studio .annotations { width: 190px !important; padding: 24px 12px !important; }
+  .studio-brand { gap: 7px; padding-left: 3px; }
+  .studio-brand b { font-size: 13px; }
+  .studio-brand-mark { width: 30px; height: 32px; font-size: 28px; line-height: 32px; }
+  .studio-welcome { padding: 28px; }
+  .studio-art { width: 36%; right: 0; }
+  .studio-art-caption { right: 25px; font-size: 6px; }
+  .companion-studio .folio-persona-context { max-width: 28ch; }
+  .companion-studio .life-desk-card { padding: 19px !important; }
+  .companion-studio .life-desk-card-head { flex-wrap: wrap; }
+}
+@media (max-width: 960px) {
+  .companion-studio .shell { padding-left: 196px !important; padding-right: 22px !important; }
+  .companion-studio .annotations { width: 174px !important; padding: 22px 10px !important; }
+  .studio-find kbd { display: none; }
+  .studio-brand small { font-size: 6px; letter-spacing: 1px; }
+  .companion-studio .folio-heading { gap: 5px; }
+  .companion-studio .folio-persona-context { text-align: left; max-width: none; }
+  .studio-welcome h2 { font-size: 27px !important; }
+  .studio-art { opacity: .4; right: -15px; width: 44%; }
+  .studio-art-caption { display: none; }
+  .companion-studio #stats { grid-template-columns: repeat(2,minmax(0,1fr)) !important; }
+  .companion-studio .stat b { font-size: 18px !important; }
+  .companion-studio .dashboard-life-desk { grid-template-columns: minmax(0,1fr) !important; }
+  .companion-studio .studio-memory-disclosure .dashboard-life-column-right { grid-template-columns: minmax(0,1fr) !important; }
+}
+@media (max-width: 680px) {
+  .companion-studio .shell { padding: 0 18px 28px !important; }
+  .companion-studio .folio { min-height: 85px !important; gap: 10px !important; padding: 18px 0 !important; }
+  .companion-studio .folio-title { font-size: 16px !important; }
+  .companion-studio .folio-eyebrow { font-size: 8px !important; }
+  .companion-studio .folio-tools { gap: 5px !important; }
+  .companion-studio .setup-guide-entry { font-size: 10px !important; padding: 0 10px !important; }
+  .companion-studio #subtitle { font-size: 10px !important; }
+  .companion-studio .folio-plate { width: 30px !important; height: 30px !important; flex-basis: 30px !important; }
+  .studio-header-slash { margin: 0 7px; }
+  #studioPageTitle { font-size: 11px; }
+  .companion-studio .annotations { position: sticky !important; top: 0 !important; width: calc(100% + 36px) !important; height: auto !important; margin: 0 -18px !important; padding: 10px 18px !important; flex-direction: row !important; gap: 5px !important; overflow-x: auto !important; overflow-y: hidden !important; border-bottom: 1px solid var(--line-soft) !important; z-index: 30 !important; }
+  .studio-brand, .studio-nav-label, .studio-nav-foot { display: none; }
+  .companion-studio .annotations .tab { flex: 0 0 auto !important; width: auto !important; min-height: 36px !important; padding: 8px 12px !important; gap: 6px !important; font-size: 12px !important; }
+  .companion-studio .annotations .tab i { font-size: 15px !important; width: 15px; }
+  .companion-studio .studio-find { flex: 0 0 auto; width: auto; margin: 0 5px 0 0; padding: 6px 10px !important; }
+  .companion-studio .panel { padding: 22px 0 !important; }
+  .companion-studio .section-head h2 { font-size: 21px !important; }
+  .studio-welcome { min-height: 264px; padding: 26px 24px; }
+  .companion-studio .studio-welcome h2 { font-size: 27px !important; }
+  .studio-welcome p { font-size: 11px; max-width: 220px; }
+  .studio-welcome-actions { gap: 10px 18px; margin-top: 22px; }
+  .studio-art { width: 180px; bottom: 30px; right: -56px; opacity: .23; }
+  .studio-kicker { font-size: 7px; letter-spacing: 1.4px; }
+  .companion-studio #stats { gap: 10px !important; margin-bottom: 20px !important; }
+  .companion-studio .stat { padding: 15px !important; }
+  .companion-studio .stat b { font-size: 16px !important; }
+  .companion-studio .stat span { font-size: 9px !important; }
+  .companion-studio .dashboard-life-desk { gap: 16px !important; }
+  .companion-studio .module-card { padding: 16px !important; }
+  .companion-studio .dashboard-disclosure > summary { padding: 17px !important; }
+  .companion-studio .dashboard-disclosure > summary small { font-size: 10px !important; }
+  .studio-metrics-label small { font-size: 9px; }
+  .studio-command { margin-top: 7vh; padding: 20px; }
+  .studio-skip { left: 18px; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .companion-studio *, .companion-studio *::before, .companion-studio *::after { scroll-behavior: auto !important; animation-duration: .01ms !important; transition-duration: .01ms !important; }
+}
+.companion-studio .life-desk-empty { display: grid; place-content: center; min-height: 210px; text-align: center; border: 0 !important; border-radius: 10px !important; background: var(--surface) !important; color: var(--muted) !important; font-size: 12px !important; }
+.companion-studio #dashboardTimelinePreview .life-desk-empty::before { content: '◷'; font-size: 30px; color: var(--accent); opacity: .45; margin-bottom: 12px; }
+.companion-studio #dashboardTimelinePreview .life-desk-empty::after { content: '日程同步后，会在这里留下足迹'; font-size: 10px; margin-top: 7px; opacity: .8; }
+/* Balance the home grid: current state becomes a compact, full-width strip. */
+.companion-studio .dashboard-life-desk > .dashboard-life-column-left,
+.companion-studio .dashboard-life-desk > .dashboard-life-column-main { display: contents !important; }
+.companion-studio .life-desk-today { grid-column: 1; grid-row: 1; }
+.companion-studio .life-desk-timeline { grid-column: 2; grid-row: 1; height: 100%; }
+.companion-studio .life-desk-current { grid-column: 1 / -1; grid-row: 2; }
+.companion-studio .life-current-state { display: grid !important; grid-template-columns: minmax(0,1fr) minmax(0,1.4fr) !important; gap: 8px 30px !important; }
+.companion-studio .life-current-activity { grid-column: 1; grid-row: 1 / 3; align-content: center; }
+.companion-studio .life-current-state > .life-energy-track { grid-column: 2; margin: 6px 0 4px !important; }
+.companion-studio .life-current-state > .life-state-grid { grid-column: 2; grid-template-columns: repeat(3,minmax(0,1fr)) !important; gap: 8px 18px !important; }
+.companion-studio .life-state-grid span { font-size: 10px !important; font-weight: 400 !important; color: var(--muted) !important; }
+.companion-studio .setup-guide-entry { width: auto !important; min-width: 94px !important; white-space: nowrap !important; word-break: keep-all !important; }
+@media(max-width: 960px) {
+  .companion-studio .life-desk-today { grid-column: 1; grid-row: 1; }
+  .companion-studio .life-desk-timeline { grid-column: 1; grid-row: 2; }
+  .companion-studio .life-desk-current { grid-column: 1; grid-row: 3; }
+  .companion-studio .life-current-state { grid-template-columns: minmax(0,1fr) !important; }
+  .companion-studio .life-current-activity { grid-column: 1; grid-row: auto; }
+  .companion-studio .life-current-state > .life-energy-track { grid-column: 1; margin: 12px 0 !important; }
+  .companion-studio .life-current-state > .life-state-grid { grid-column: 1; }
+}
+@media(max-width: 680px) {
+  .companion-studio .folio .folio-tools { flex-direction: row !important; flex-wrap: nowrap !important; align-items: center; }
+  .companion-studio .folio .folio-tools button { flex-shrink: 0; }
+  .companion-studio .folio .folio-tools .setup-guide-entry { min-width: 72px !important; }
+  .companion-studio .dashboard-overview-head { flex-direction: row !important; align-items: center !important; }
+  .companion-studio .dashboard-overview-head > .actions { width: auto !important; flex: 0 0 auto !important; }
+  .companion-studio #exportSnapshotBtn { width: auto !important; font-size: 9px !important; padding: 7px 10px !important; }
+  .companion-studio .life-current-state > .life-state-grid { grid-template-columns: repeat(2,minmax(0,1fr)) !important; }
+  .companion-studio .studio-find { position: static; background: var(--panel) !important; }
+}
+/* Configuration and model editors share the same quiet surfaces. */
+.companion-studio :is(.config-fold-panel,.config-persona-stats-panel,.proactive-mode-card,.provider-config-mode-card,.provider-toolbar,.provider-card,.persona-card) {
+  background: var(--panel) !important; border: 1px solid var(--line-soft) !important; border-radius: 14px !important; box-shadow: none !important;
+}
+.companion-studio :is(.config-fold-panel,.proactive-mode-card,.provider-card,.persona-card)::before,
+.companion-studio :is(.config-fold-panel,.proactive-mode-card,.provider-card,.persona-card)::after { content: none !important; }
+.companion-studio .config-fold-summary { padding: 24px !important; background: transparent !important; }
+.companion-studio .config-fold-heading h2 { font-size: 18px !important; font-weight: 550 !important; }
+.companion-studio .config-fold-heading h2::before { content: none !important; }
+.companion-studio .proactive-mode-card { padding: 23px !important; }
+.companion-studio .proactive-mode-card :is(h3,h4) { font-size: 17px !important; font-weight: 550 !important; }
+.companion-studio .proactive-mode-card.off { border-left: 1px solid var(--line-soft) !important; }
+.companion-studio .provider-tree-grid { grid-template-columns: repeat(2,minmax(0,1fr)) !important; gap: 20px !important; }
+.companion-studio .provider-card { padding: 23px !important; }
+.companion-studio .provider-tree-node { margin-bottom: 15px !important; }
+.companion-studio .provider-tree-title { font-size: 17px !important; font-weight: 550 !important; }
+.companion-studio .provider-tree-body { gap: 14px !important; }
+.companion-studio .provider-tree-preview { font-size: 12px !important; line-height: 1.8 !important; }
+.companion-studio .provider-current { padding: 13px !important; border: 0 !important; background: var(--surface) !important; border-radius: 9px !important; }
+.companion-studio .provider-current b { font-weight: 500 !important; font-size: 12px !important; }
+.companion-studio :is(.provider-config-mode-card,.provider-toolbar) { padding: 20px !important; margin-bottom: 20px !important; }
+.companion-studio :is(.provider-toolbar-actions,.provider-row) button { padding: 10px 15px !important; border: 1px solid var(--line) !important; background: var(--panel) !important; color: var(--accent-strong) !important; border-radius: 9px !important; font-size: 12px !important; font-weight: 500 !important; box-shadow: none !important; }
+.companion-studio #saveProvidersBtn { background: var(--accent) !important; color: white !important; border-color: var(--accent) !important; }
+.companion-studio .provider-guide { margin-top: 12px !important; padding: 14px !important; background: var(--surface) !important; border: 0 !important; border-radius: 8px !important; line-height: 1.8 !important; }
+.studio-provider-guide { border-top: 1px solid var(--line-soft); padding-top: 12px; }
+.studio-provider-guide > summary { color: var(--accent); font-size: 11px; cursor: pointer; }
+.companion-studio .feature-save-actions { top: auto !important; bottom: max(20px,env(safe-area-inset-bottom)) !important; left: auto !important; right: 30px !important; width: auto !important; max-width: calc(100vw - 260px); transform: none !important; display: flex !important; align-items: center !important; gap: 16px !important; padding: 12px 18px !important; }
+.companion-studio .feature-save-actions[hidden] { display: none !important; }
+.companion-studio .feature-save-actions button { width: auto !important; min-width: 0 !important; padding: 8px 14px !important; font-size: 12px !important; }
+.companion-studio .feature-save-state { font-size: 11px !important; font-weight: 400 !important; }
+.companion-studio #panel-config { padding-bottom: 105px !important; }
+@media(max-width: 960px) { .companion-studio .provider-tree-grid { grid-template-columns: minmax(0,1fr) !important; } }
+@media(max-width: 680px) {
+  .companion-studio .feature-save-actions { left: 12px !important; right: 12px !important; bottom: max(12px,env(safe-area-inset-bottom)) !important; max-width: none; gap: 8px !important; flex-wrap: wrap; justify-content: flex-end; padding: 12px !important; }
+  .companion-studio .feature-save-state { margin-right: auto; }
+  .companion-studio :is(.provider-card,.config-fold-summary,.proactive-mode-card) { padding: 18px !important; }
+}
+
+/* Companion Studio v2 — internal components, not just the application shell.
+   Keep visibility/data attributes under the existing controllers. */
+.companion-studio .panel button:not([class]),
+.companion-studio :is(.actions,.inline-form) > button {
+  appearance: none; font: inherit; font-size: 12px; font-weight: 500;
+  min-height: 36px; padding: 8px 13px; line-height: 1.5;
+  border: 1px solid var(--line); border-radius: 8px;
+  background: var(--panel); color: var(--accent-strong); box-shadow: none;
+  cursor: pointer;
+}
+.companion-studio .panel button:not([class]):hover:not(:disabled) { background: var(--surface); border-color: var(--accent); }
+.companion-studio .panel button:not([class]):disabled { cursor: not-allowed; }
+/* A sticky toolbar was covering the model cards while scrolling. Keep it in flow. */
+.companion-studio .provider-toolbar {
+  position: static !important; inset: auto !important; z-index: auto !important;
+  transform: none !important; backdrop-filter: none !important;
+  padding: 14px 18px !important; min-height: 0 !important;
+}
+.companion-studio .provider-tree-grid { align-items: start !important; grid-auto-rows: auto !important; }
+.companion-studio .provider-card { align-self: start !important; height: auto !important; min-height: 0 !important; }
+.companion-studio .provider-card .provider-tree-preview { margin: 0 0 12px; min-height: 0 !important; }
+.companion-studio .provider-tree-node { align-items: flex-start !important; gap: 12px !important; }
+.companion-studio .provider-badge { font-size: 10px !important; font-weight: 400 !important; padding: 4px 8px !important; border: 1px solid var(--line) !important; border-radius: 6px !important; }
+.companion-studio .provider-tag { font-weight: 400 !important; border-radius: 5px !important; }
+.companion-studio .provider-row { flex-wrap: wrap; }
+.companion-studio .provider-row .hint { font-size: 10px; overflow-wrap: anywhere; }
+.companion-studio .studio-welcome { min-height: 220px; }
+.companion-studio .studio-welcome h2 { font-size: clamp(24px,2.1vw,32px) !important; }
+/* Diagnostics: compact summary, readable full-width rows, one page scrollbar. */
+.companion-studio #panel-troubleshooting { --diag-ink: var(--ink); --diag-signal: var(--accent); }
+.companion-studio .troubleshooting-page { display: grid !important; gap: 22px !important; }
+.companion-studio .diagnostic-masthead { background: transparent !important; border: 0 !important; border-bottom: 1px solid var(--line) !important; border-radius: 0 !important; box-shadow: none !important; padding: 0 0 24px !important; align-items: center; }
+.companion-studio .diagnostic-kicker { font: inherit; font-size: 11px !important; font-weight: 400 !important; color: var(--muted) !important; }
+.companion-studio .diagnostic-masthead h2 { font-size: 25px !important; font-weight: 600 !important; line-height: 1.5 !important; margin: 5px 0 8px !important; }
+.companion-studio .diagnostic-masthead p { font-size: 13px !important; }
+.companion-studio #refreshTroubleshootingBtn { border: 1px solid var(--accent) !important; background: var(--accent) !important; color: white !important; padding: 9px 17px !important; border-radius: 9px !important; box-shadow: none !important; }
+.companion-studio .diagnostic-live-dot { font-size: 11px; }
+.companion-studio .diagnostic-live-dot i { background: var(--muted); box-shadow: none; width: 5px; height: 5px; }
+.companion-studio .diagnostic-problem-picker { grid-template-columns: 1fr !important; padding: 20px !important; gap: 16px !important; border: 1px solid var(--line-soft) !important; background: var(--panel) !important; border-radius: 13px !important; box-shadow: none !important; }
+.companion-studio .diagnostic-problem-picker > div:first-child { display: flex; flex-wrap: wrap; gap: 6px 12px; align-items: baseline; }
+.companion-studio .diagnostic-problem-picker > div:first-child > span { color: var(--muted); font-size: 10px; font-weight: 400; }
+.companion-studio .diagnostic-problem-picker h3 { font-size: 16px !important; font-weight: 550 !important; }
+.companion-studio .diagnostic-problem-picker p { font-size: 12px !important; }
+.companion-studio .diagnostic-category-list { display: grid !important; grid-template-columns: repeat(auto-fit,minmax(135px,1fr)) !important; gap: 8px !important; }
+.companion-studio .diagnostic-category { min-height: 84px !important; border: 1px solid var(--line-soft) !important; background: var(--surface) !important; border-radius: 9px !important; padding: 12px !important; box-shadow: none !important; transform: none !important; align-content: start; }
+.companion-studio .diagnostic-category b { font-size: 13px !important; font-weight: 550 !important; }
+.companion-studio .diagnostic-category span { font-size: 11px !important; line-height: 1.6 !important; font-weight: 400 !important; }
+.companion-studio .diagnostic-category.is-active { background: var(--accent-soft) !important; border-color: var(--accent) !important; }
+.companion-studio .troubleshooting-summary { display: grid !important; grid-template-columns: minmax(210px,2fr) repeat(4,minmax(0,1fr)) !important; gap: 10px !important; align-items: stretch !important; }
+.companion-studio .troubleshooting-head-card { border: 1px solid var(--line-soft) !important; background: var(--panel) !important; padding: 17px !important; border-radius: 11px !important; box-shadow: none !important; flex-wrap: wrap; gap: 10px; }
+.companion-studio .troubleshooting-head-card b { font-size: 18px !important; font-weight: 550 !important; line-height: 1.5 !important; }
+.companion-studio .troubleshooting-head-card small { font-size: 11px !important; }
+.companion-studio .troubleshooting-head-card > div > span { font-size: 10px !important; }
+.companion-studio .troubleshooting-count { min-height: 95px !important; padding: 15px 8px !important; border: 1px solid var(--line-soft) !important; border-radius: 11px !important; background: var(--panel) !important; box-shadow: none !important; }
+.companion-studio .troubleshooting-count b { font-size: 25px !important; font-weight: 550 !important; line-height: 1.4 !important; }
+.companion-studio .troubleshooting-count span { font-size: 12px !important; font-weight: 400 !important; }
+.companion-studio .troubleshooting-count.is-active { border-color: var(--accent) !important; background: var(--surface) !important; }
+.companion-studio .studio-reason-details { display: block !important; grid-column: 1 / -1; padding: 0 !important; background: var(--panel) !important; border: 1px solid var(--line-soft) !important; border-radius: 10px !important; box-shadow: none !important; }
+.companion-studio .studio-reason-details > summary { display: flex; align-items: center; gap: 12px; padding: 14px 18px; cursor: pointer; list-style: none; }
+.companion-studio .studio-reason-details > summary::after { content: '+'; margin-left: auto; font-size: 18px; color: var(--accent); }
+.companion-studio .studio-reason-details[open] > summary::after { content: '−'; }
+.companion-studio .studio-reason-details > summary b { font-size: 12px; font-weight: 500; }
+.companion-studio .studio-reason-details > summary span { font-size: 11px; color: var(--muted); }
+.companion-studio .studio-reason-body { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 10px; padding: 0 18px 18px; }
+.companion-studio .studio-reason-body button { text-align: left; padding: 14px; border-color: var(--line-soft); }
+.companion-studio .studio-reason-body button b { display: block; margin-bottom: 6px; font-size: 13px; }
+.companion-studio .studio-reason-body button span { font-size: 12px; color: var(--muted); font-weight: 400; }
+.companion-studio :is(.diagnostic-priority-zone,.diagnostic-live-lane,.diagnostic-event-lane,.diagnostic-runtime-card,.diagnostic-evidence-drawer) { border: 1px solid var(--line-soft) !important; border-radius: 13px !important; box-shadow: none !important; background: var(--panel) !important; padding: 22px !important; }
+.companion-studio .diagnostic-zone-head { align-items: center !important; flex-wrap: wrap; gap: 14px !important; margin: 0 0 20px !important; }
+.companion-studio .diagnostic-zone-head h3 { font-size: 18px !important; font-weight: 550 !important; margin-top: 3px !important; }
+.companion-studio .diagnostic-zone-head > div > span { font-size: 10px !important; font-weight: 400 !important; color: var(--muted); }
+.companion-studio .diagnostic-filter { border: 1px solid var(--line-soft) !important; padding: 3px !important; border-radius: 9px !important; background: var(--surface) !important; gap: 2px !important; }
+.companion-studio .diagnostic-filter button { border: 0 !important; background: transparent; border-radius: 6px !important; padding: 6px 12px !important; min-height: 32px !important; font-size: 12px !important; font-weight: 400 !important; }
+.companion-studio .diagnostic-filter button.is-active { background: var(--accent) !important; color: white !important; }
+.companion-studio #troubleshootingChecks { display: grid !important; grid-template-columns: minmax(0,1fr) !important; gap: 0 !important; max-height: none !important; height: auto !important; overflow: visible !important; padding: 0 !important; align-items: start !important; }
+.companion-studio .troubleshooting-check { display: grid !important; grid-template-columns: 30px minmax(0,1fr) !important; gap: 6px 14px !important; align-items: start !important; border: 0 !important; border-bottom: 1px solid var(--line-soft) !important; border-radius: 0 !important; padding: 20px 0 !important; min-height: 0 !important; height: auto !important; background: transparent !important; box-shadow: none !important; }
+.companion-studio .troubleshooting-check:last-child { border-bottom: 0 !important; }
+.companion-studio .troubleshooting-check-icon { grid-column: 1; grid-row: 1 / 3; width: 28px !important; height: 28px !important; font-size: 15px !important; margin-top: 1px; box-shadow: none !important; }
+.companion-studio .troubleshooting-check > div:nth-child(2) { grid-column: 2; min-width: 0; }
+.companion-studio .troubleshooting-check b { font-size: 14px !important; font-weight: 550 !important; line-height: 1.6 !important; }
+.companion-studio .troubleshooting-check p { font-size: 13px !important; line-height: 1.9 !important; margin: 5px 0 !important; color: var(--muted); overflow-wrap: anywhere; }
+.companion-studio .troubleshooting-check small { display: block; font-size: 12px !important; font-weight: 400 !important; line-height: 1.8; color: var(--ink); }
+.companion-studio .troubleshooting-check-actions { grid-column: 2 !important; justify-content: flex-start !important; margin-top: 5px; gap: 8px !important; }
+.companion-studio :is(.troubleshooting-check-actions,.troubleshooting-event-actions) button { appearance: none !important; min-height: 32px !important; font-size: 11px !important; font-weight: 500 !important; padding: 6px 11px !important; border: 1px solid var(--line) !important; border-radius: 7px !important; background: var(--surface) !important; color: var(--accent-strong) !important; box-shadow: none !important; }
+.companion-studio .diagnostic-warning-suppress { background: transparent !important; color: var(--warn) !important; }
+.companion-studio .diagnostic-main-grid { grid-template-columns: minmax(0,1fr) !important; gap: 20px !important; }
+.companion-studio .diagnostic-events { max-height: none !important; overflow: visible !important; padding: 0 !important; }
+.companion-studio .troubleshooting-event { background: var(--surface) !important; border-color: var(--line-soft) !important; padding: 18px !important; box-shadow: none !important; border-radius: 9px !important; }
+.companion-studio .diagnostic-runtime-stack { gap: 14px !important; }
+.companion-studio .diagnostic-runtime-card { background: var(--surface) !important; padding: 17px !important; }
+.companion-studio .diagnostic-runtime-card h3 { font-weight: 550 !important; }
+.companion-studio .diagnostic-evidence-drawer { padding: 0 !important; }
+.companion-studio .diagnostic-evidence-drawer > summary { padding: 19px 22px !important; }
+.companion-studio .diagnostic-evidence-drawer > summary span { font-weight: 500 !important; font-size: 13px !important; }
+.companion-studio .diagnostic-evidence-drawer > summary small { font-size: 11px !important; }
+@media(min-width: 1200px) {
+  .companion-studio .troubleshooting-check { grid-template-columns: 30px minmax(0,1fr) auto !important; }
+  .companion-studio .troubleshooting-check-actions { grid-column: 3 !important; grid-row: 1; max-width: 210px; justify-content: flex-end !important; }
+}
+@media(max-width: 960px) {
+  .companion-studio .troubleshooting-summary { grid-template-columns: repeat(4,minmax(0,1fr)) !important; }
+  .companion-studio .troubleshooting-head-card { grid-column: 1 / -1; }
+  .companion-studio .studio-reason-body { grid-template-columns: 1fr; }
+}
+@media(max-width: 680px) {
+  .companion-studio .diagnostic-masthead { grid-template-columns: 1fr !important; gap: 16px !important; }
+  .companion-studio .diagnostic-masthead-actions { display: flex; align-items: center; flex-wrap: wrap; justify-content: space-between; }
+  .companion-studio .diagnostic-masthead-actions button { width: auto !important; }
+  .companion-studio .diagnostic-category-list { grid-template-columns: repeat(2,minmax(0,1fr)) !important; }
+  .companion-studio :is(.diagnostic-priority-zone,.diagnostic-live-lane,.diagnostic-event-lane,.diagnostic-problem-picker) { padding: 16px !important; }
+  .companion-studio .diagnostic-zone-head { align-items: flex-start !important; }
+  .companion-studio .diagnostic-filter { flex-wrap: wrap; }
+  .companion-studio .studio-reason-details > summary { align-items: flex-start; flex-wrap: wrap; gap: 6px; }
+  .companion-studio .studio-reason-details > summary span { flex-basis: 85%; }
+  .companion-studio .troubleshooting-count { min-height: 80px !important; padding: 10px 5px !important; }
+  .companion-studio .diagnostic-runtime-stack { grid-template-columns: minmax(0,1fr) !important; }
+  .companion-studio .troubleshooting-check { column-gap: 10px !important; }
+  .companion-studio .troubleshooting-check-actions button { white-space: normal; }
+}
+/* Subpage controls use one consistent treatment, including lazy-rendered content. */
+.companion-studio :is(.models-page-nav,.models-page-heading,.provider-group-head) { background: transparent !important; box-shadow: none !important; }
+.companion-studio :is(.models-page-heading,.provider-group-head) h2 { font-size: 23px; font-weight: 550; }
+.companion-studio :is(.models-subnav,.provider-config-mode,.provider-mode-switch) { border: 1px solid var(--line-soft) !important; background: var(--surface) !important; border-radius: 9px !important; padding: 4px !important; gap: 3px !important; box-shadow: none !important; }
+.companion-studio :is(.models-subnav,.provider-config-mode,.provider-mode-switch) button { appearance: none; border: 0 !important; border-radius: 6px !important; background: transparent !important; color: var(--muted) !important; padding: 9px 13px !important; font-size: 12px !important; font-weight: 500 !important; box-shadow: none !important; }
+.companion-studio :is(.models-subnav,.provider-config-mode,.provider-mode-switch) button.active { background: var(--accent) !important; color: white !important; }
+.companion-studio .models-subnav button::before { content: none !important; }
+.companion-studio .studio-routing-help { margin: 16px 0; border: 1px solid var(--line-soft); border-radius: 10px; background: var(--panel); }
+.companion-studio .studio-routing-help > summary { padding: 15px 18px; font-size: 12px; cursor: pointer; color: var(--accent-strong); }
+.companion-studio .studio-routing-help small { font-size: 11px; color: var(--muted); margin-left: 10px; }
+.companion-studio .studio-routing-help .provider-flow { padding: 18px; margin: 0; border: 0; box-shadow: none; }
+.companion-studio .studio-save-explainer { margin: -6px 0 22px; color: var(--muted); font-size: 11px; line-height: 1.8; }
+.companion-studio :is(.empty,.empty.small) { padding: 24px 18px; background: var(--surface); border: 1px solid var(--line-soft); border-radius: 10px; color: var(--muted); font-size: 12px; font-weight: 400; box-shadow: none; }
+.companion-studio :is(.config-section-nav,.world-outline) { background: var(--surface) !important; box-shadow: none !important; }
+.companion-studio .config-fold-kicker { background: none !important; color: var(--muted) !important; font-weight: 400 !important; font-size: 10px !important; padding: 0 !important; }
+.companion-studio .config-fold-preview > span { border: 0 !important; background: var(--surface) !important; padding: 4px 7px; font-size: 10px; font-weight: 400 !important; }
+.companion-studio .persona-card-head { border: 0 !important; }
+.companion-studio .persona-card { padding: 22px !important; }
+@media(max-width: 680px) { .companion-studio .persona-card { padding: 14px !important; } .companion-studio .studio-routing-help small { display: block; margin-left: 0; margin-top: 5px; } }
+.companion-studio .diagnostic-runtime-stack { align-items: start !important; }
+.companion-studio .diagnostic-runtime-card { height: auto !important; align-self: start !important; }
+.companion-studio .studio-runtime-details { margin-top: 18px; padding-top: 16px; border-top: 1px solid var(--line-soft); }
+.companion-studio .studio-runtime-details:not(:has(#troubleshootingRuntimeStack:not([hidden]))) { display: none; }
+.companion-studio .studio-runtime-details > summary { font-size: 12px; color: var(--accent-strong); cursor: pointer; }
+.companion-studio .studio-runtime-details small { font-size: 11px; color: var(--muted); margin-left: 12px; }
+.companion-studio .studio-check-original { margin: 6px 0; }
+.companion-studio .studio-check-original > summary { font-size: 11px; color: var(--muted); cursor: pointer; }
+.companion-studio .studio-check-original p { background: var(--surface); border-left: 2px solid var(--line); padding: 10px 14px; font-size: 12px !important; }
+.companion-studio .troubleshooting-chain-tests { align-items: start !important; gap: 14px !important; }
+.companion-studio .troubleshooting-chain-test { display: flex !important; flex-direction: column !important; align-items: stretch !important; gap: 14px !important; border: 1px solid var(--line-soft) !important; border-radius: 10px !important; padding: 18px !important; background: var(--surface) !important; box-shadow: none !important; height: auto !important; }
+.companion-studio .troubleshooting-chain-test b { font-size: 14px !important; font-weight: 550 !important; }
+.companion-studio .troubleshooting-chain-test p { font-size: 12px !important; line-height: 1.8 !important; }
+.companion-studio .troubleshooting-chain-test-actions { display: flex !important; justify-content: flex-start; flex-wrap: wrap; gap: 8px; }
+.companion-studio .troubleshooting-chain-test-actions button { min-height: 34px; padding: 8px 13px; border: 1px solid var(--line); border-radius: 8px; background: var(--panel); color: var(--accent-strong); font-size: 12px; white-space: normal; }
+
+/* Studio v3 — an outline and working lists, not a wall of metric cards. */
+.companion-studio .studio-feature-instructions { color: var(--muted); font-size: 12px; margin: 16px 0 10px; }
+.companion-studio .feature-switch-board { display: block !important; padding: 0 !important; border: 0 !important; background: transparent !important; }
+.companion-studio .feature-switch-group { margin: 0 !important; border: 0 !important; border-bottom: 1px solid var(--line) !important; border-radius: 0 !important; background: transparent !important; box-shadow: none !important; overflow: visible !important; }
+.companion-studio .studio-feature-group > summary { display: flex; align-items: center; gap: 18px; padding: 22px 0; list-style: none; cursor: pointer; }
+.companion-studio .studio-feature-group > summary::-webkit-details-marker { display: none; }
+.companion-studio .studio-feature-group > summary::before { content: '›'; width: 15px; flex: 0 0 15px; font-size: 23px; line-height: 1; color: var(--accent); transition: transform .15s; }
+.companion-studio .studio-feature-group[open] > summary::before { transform: rotate(90deg); }
+.companion-studio .studio-feature-group > summary > div { flex: 1; min-width: 0; display: grid; gap: 6px; }
+.companion-studio .studio-feature-group > summary b { font-size: 16px; font-weight: 550; color: var(--ink); }
+.companion-studio .studio-feature-group > summary span { font-size: 12px; font-weight: 400; color: var(--muted); line-height: 1.7; }
+.companion-studio .studio-feature-group > summary small { font-size: 11px; color: var(--muted); flex-shrink: 0; }
+.companion-studio .studio-feature-group > summary:hover b { color: var(--accent); }
+.companion-studio .feature-switch-list { display: block !important; padding: 0 0 12px 33px !important; gap: 0 !important; border-top: 0 !important; }
+.companion-studio .feature-switch-item { display: flex !important; flex-wrap: wrap !important; align-items: flex-start !important; gap: 12px 20px !important; padding: 19px 0 !important; min-height: 0 !important; border: 0 !important; border-top: 1px solid var(--line-soft) !important; border-radius: 0 !important; background: transparent !important; box-shadow: none !important; height: auto !important; }
+.companion-studio .feature-switch-item::before, .companion-studio .feature-switch-item::after { content: none !important; }
+.companion-studio .feature-switch-body { flex: 1 1 220px; min-width: 0; display: flex !important; flex-direction: column !important; gap: 6px !important; order: 0; }
+.companion-studio .feature-switch-item > .feature-toggle-hit { order: 1; flex: 0 0 auto; margin: 5px 0 0 !important; }
+.companion-studio .feature-switch-text { display: flex !important; align-items: baseline !important; flex-wrap: wrap; justify-content: flex-start !important; gap: 8px 18px !important; padding: 0 !important; margin: 0 !important; border: 0 !important; background: transparent !important; border-radius: 0 !important; text-align: left; box-shadow: none !important; width: fit-content !important; }
+.companion-studio .feature-switch-text b { font-size: 14px !important; line-height: 1.7 !important; font-weight: 550 !important; }
+.companion-studio .feature-switch-text small { font-size: 10px !important; color: var(--muted); }
+.companion-studio .feature-open-hint { font-size: 11px !important; font-weight: 400 !important; color: var(--accent) !important; }
+.companion-studio .feature-switch-meta { order: 1; display: flex !important; align-items: baseline !important; gap: 6px 12px !important; flex-wrap: wrap; }
+.companion-studio .feature-state-text { border: 0 !important; background: none !important; border-radius: 0 !important; padding: 0 !important; font-size: 11px !important; font-weight: 400 !important; color: var(--muted) !important; }
+.companion-studio .feature-switch-item.on .feature-state-text { color: var(--accent) !important; }
+.companion-studio .feature-stage-tags { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
+.companion-studio .feature-stage-tags span { border: 0 !important; background: none !important; padding: 0 10px 0 0 !important; color: var(--muted) !important; font-size: 11px !important; font-weight: 400 !important; }
+.companion-studio .feature-toggle-hit input:not(:checked) + .feature-toggle-visual { background: #a4ada3 !important; box-shadow: none !important; }
+.companion-studio .feature-toggle-hit input:disabled + .feature-toggle-visual { opacity: .45; }
+.companion-studio .feature-toggle-hit input:focus-visible + .feature-toggle-visual { outline: 2px solid var(--accent); outline-offset: 4px; }
+.companion-studio .feature-temp-unlock-btn { order: 2; padding: 7px 11px; font-size: 11px; }
+.companion-studio .studio-feature-notes { order: 2; color: var(--muted); margin: 1px 0 0; }
+.companion-studio .studio-feature-notes summary { cursor: pointer; font-size: 10px; width: fit-content; }
+.companion-studio .studio-feature-notes code { display: block; margin: 8px 0; font-size: 11px; overflow-wrap: anywhere; color: var(--muted); }
+.companion-studio .feature-lock-note, .companion-studio .feature-lock-related { color: var(--muted); font-size: 11px !important; line-height: 1.8 !important; }
+.companion-studio .feature-inline-setting-form { display: flex !important; flex-wrap: wrap; align-items: center; gap: 9px; margin: 0 !important; flex: 0 1 300px; min-width: 0; }
+.companion-studio .feature-inline-setting-form select { flex: 1 1 200px; min-width: 0 !important; width: auto !important; }
+.companion-studio .feature-inline-setting-form button { flex: 0 0 auto; min-width: 64px; white-space: nowrap !important; word-break: keep-all !important; }
+/* Configuration categories and summaries become lines in an outline. */
+.companion-studio :is(.config-fold-panel,.config-persona-stats-panel,.feature-config-article,.config-persona-top-row .proactive-mode-card) { background: transparent !important; border: 0 !important; border-bottom: 1px solid var(--line) !important; border-radius: 0 !important; box-shadow: none !important; }
+.companion-studio .config-fold-summary { padding: 22px 0 !important; }
+.companion-studio .config-fold-preview { margin-top: 8px; }
+.companion-studio .config-grid, .companion-studio .config-persona-settings { gap: 22px !important; }
+.companion-studio .feature-config-article { padding: 0 0 95px !important; }
+.companion-studio .feature-config-head { padding: 0 0 14px !important; }
+.companion-studio .feature-switch-summary { display: flex !important; flex-wrap: wrap; gap: 10px 32px !important; padding: 12px 0 !important; margin: 0 0 16px !important; border: 0 !important; background: transparent !important; box-shadow: none !important; }
+.companion-studio .feature-summary-card { display: flex !important; flex-wrap: wrap; align-items: baseline; gap: 6px 10px; border: 0 !important; border-radius: 0 !important; padding: 0 !important; background: transparent !important; box-shadow: none !important; }
+.companion-studio .feature-summary-card b { font-size: 15px !important; font-weight: 550 !important; }
+.companion-studio .feature-summary-card span, .companion-studio .feature-summary-card small { font-size: 11px !important; font-weight: 400 !important; }
+.companion-studio .feature-filter-workspace { border: 0 !important; border-radius: 0 !important; padding: 0 !important; background: none !important; box-shadow: none !important; }
+.companion-studio .feature-filter-topline { padding: 12px 0 !important; }
+.companion-studio .studio-filter-options > summary, .companion-studio .studio-config-stats > summary { cursor: pointer; font-size: 12px; color: var(--accent); padding: 12px 0; }
+.companion-studio .feature-filter-row { background: transparent !important; border: 0 !important; border-top: 1px solid var(--line-soft) !important; padding: 13px 0 !important; }
+.companion-studio .config-persona-top-row { display: block !important; }
+.companion-studio .config-persona-top-row .proactive-mode-card { margin: 0; padding: 18px 0 !important; }
+.companion-studio .config-persona-top-row .proactive-mode-card::before { content: none !important; }
+/* Proactive messages: queue first, statistics and plots on demand. */
+.companion-studio #proactiveSummary { display: block !important; background: transparent !important; padding: 0 !important; box-shadow: none !important; }
+.companion-studio .studio-proactive-lead { display: flex; flex-wrap: wrap; align-items: baseline; gap: 15px 38px; padding: 8px 0 20px; border-bottom: 1px solid var(--line); }
+.companion-studio .studio-proactive-lead span { font-size: 13px; color: var(--muted); }
+.companion-studio .studio-proactive-lead b { font-size: 20px; font-weight: 550; color: var(--ink); margin-left: 10px; }
+.companion-studio :is(.studio-proactive-metrics,.studio-proactive-disclosure,.studio-user-metrics) { border: 0; border-bottom: 1px solid var(--line); border-radius: 0; background: transparent; }
+.companion-studio :is(.studio-proactive-metrics,.studio-proactive-disclosure,.studio-user-metrics) > summary { padding: 18px 0; cursor: pointer; font-size: 13px; font-weight: 500; color: var(--accent-strong); }
+.companion-studio :is(.studio-proactive-metrics,.studio-proactive-disclosure,.studio-user-metrics) > summary small { margin-left: 14px; font-size: 11px; color: var(--muted); font-weight: 400; }
+.companion-studio .studio-metric-list { padding-bottom: 18px; }
+.companion-studio .proactive-summary-card { display: grid !important; grid-template-columns: 145px 110px minmax(0,1fr) !important; align-items: baseline; gap: 12px; padding: 11px 0 !important; border: 0 !important; border-bottom: 1px solid var(--line-soft) !important; border-radius: 0 !important; background: transparent !important; box-shadow: none !important; }
+.companion-studio .proactive-summary-card b { font-size: 15px !important; font-weight: 550 !important; }
+.companion-studio .proactive-summary-card > span { font-size: 12px !important; }
+.companion-studio .proactive-summary-card small { font-size: 11px !important; }
+.companion-studio .proactive-layout { display: block !important; margin: 28px 0 0 !important; }
+.companion-studio .proactive-layout article { border: 0 !important; border-radius: 0 !important; padding: 0 0 22px !important; background: transparent !important; box-shadow: none !important; }
+.companion-studio .proactive-layout article h2 { font-size: 17px; font-weight: 550; }
+.companion-studio .studio-chart-layout { display: block; }
+.companion-studio :is(.proactive-candidate,.proactive-task,.proactive-audit) { border: 0 !important; border-bottom: 1px solid var(--line) !important; border-radius: 0 !important; padding: 20px 0 !important; background: transparent !important; box-shadow: none !important; }
+.companion-studio .proactive-filter-list { display: flex !important; flex-wrap: wrap; gap: 6px !important; }
+.companion-studio .proactive-filter-user { width: auto !important; background: transparent !important; border-radius: 6px !important; box-shadow: none !important; padding: 9px 12px !important; }
+.companion-studio .proactive-filter-user.is-active { background: var(--accent-soft) !important; }
+/* Member workspace: document-style detail and a compact directory; no sticky subnav. */
+.companion-studio .user-workspace { grid-template-columns: minmax(195px,240px) minmax(0,1fr) !important; gap: 28px; border: 0 !important; border-radius: 0 !important; background: transparent !important; box-shadow: none !important; overflow: visible !important; }
+.companion-studio .user-roster { position: static !important; height: auto !important; min-height: 0 !important; max-height: none !important; grid-template-rows: auto auto auto auto !important; background: transparent !important; border: 0 !important; padding: 0 20px 0 0; border-right: 1px solid var(--line) !important; }
+.companion-studio .user-roster-list { min-height: 0 !important; max-height: none !important; overflow: visible !important; padding: 0 !important; }
+.companion-studio .user-roster-head { padding: 0 0 14px !important; }
+.companion-studio .user-roster-head .eyebrow { font-size: 10px; border: 0 !important; background: none !important; padding: 0 !important; }
+.companion-studio .user-roster-head h3 { font-size: 16px !important; font-weight: 550; }
+.companion-studio .user-directory-nav { display: flex !important; margin: 0 0 12px !important; padding: 0 !important; border: 0 !important; border-bottom: 1px solid var(--line) !important; border-radius: 0 !important; background: none !important; }
+.companion-studio .user-directory-nav button { flex: 1; border-radius: 0 !important; border-bottom: 2px solid transparent !important; font-weight: 500 !important; background: none !important; box-shadow: none !important; }
+.companion-studio .user-directory-nav button.is-active { border-bottom-color: var(--accent) !important; }
+.companion-studio .user-roster-item { border: 0 !important; border-bottom: 1px solid var(--line-soft) !important; border-radius: 0 !important; padding: 13px 8px !important; background: transparent !important; box-shadow: none !important; min-height: 0 !important; gap: 10px !important; }
+.companion-studio .user-roster-item.is-selected { background: var(--accent-soft) !important; box-shadow: inset 2px 0 var(--accent) !important; }
+.companion-studio .user-roster-item::before { content: none !important; }
+.companion-studio .user-avatar { width: 30px !important; height: 30px !important; border-radius: 50% !important; font-size: 12px !important; }
+.companion-studio .user-roster-main strong { font-size: 12px !important; }
+.companion-studio .user-roster-id, .companion-studio .user-roster-meta { font-size: 10px !important; }
+.companion-studio .user-roster-footer { border: 0 !important; padding: 16px 0 !important; }
+.companion-studio .user-detail-shell, .companion-studio #userDetail { padding: 0 !important; border: 0 !important; border-radius: 0 !important; background: transparent !important; box-shadow: none !important; }
+.companion-studio .user-detail-tabs { position: static !important; top: auto !important; z-index: auto !important; backdrop-filter: none !important; display: flex !important; flex-wrap: wrap !important; gap: 4px 12px !important; padding: 0 !important; background: transparent !important; overflow: visible !important; border-top: 0 !important; margin: 16px 0 0 !important; }
+.companion-studio .user-detail-tabs button { border-radius: 0 !important; padding: 10px 2px !important; font-size: 12px !important; font-weight: 500 !important; background: none !important; border-bottom: 2px solid transparent !important; transform: none !important; }
+.companion-studio .user-detail-tabs button.is-active { color: var(--accent) !important; border-bottom-color: var(--accent) !important; }
+.companion-studio .user-view-overview { display: block !important; padding: 0 0 18px !important; border: 0 !important; border-radius: 0 !important; background: transparent !important; box-shadow: none !important; }
+.companion-studio .user-view-heading h3 { font-size: 17px !important; font-weight: 550 !important; }
+.companion-studio .user-view-stats { display: flex !important; flex-wrap: wrap; gap: 10px 24px !important; margin-top: 14px; }
+.companion-studio .user-view-stats > span { display: flex !important; gap: 10px; align-items: baseline; min-height: 0 !important; padding: 0 !important; border: 0 !important; background: none !important; border-radius: 0 !important; }
+.companion-studio .user-view-stats b { font-size: 13px !important; font-weight: 500 !important; }
+.companion-studio .user-profile-form { border: 0 !important; border-bottom: 1px solid var(--line) !important; padding: 0 0 20px !important; border-radius: 0 !important; background: none !important; }
+.companion-studio .studio-user-metrics .visual-strip { display: flex !important; flex-wrap: wrap; gap: 15px 32px !important; padding: 10px 0 20px; }
+.companion-studio .studio-user-metrics :is(.mini-stat,.gauge) { display: flex !important; gap: 10px; align-items: center; padding: 0 !important; min-width: 0 !important; border: 0 !important; border-radius: 0 !important; box-shadow: none !important; background: none !important; }
+.companion-studio .studio-user-metrics .mini-stat b { font-size: 15px !important; font-weight: 550 !important; }
+.companion-studio .studio-user-metrics .gauge svg { width: 62px !important; height: 34px !important; }
+.companion-studio .studio-user-metrics :is(.mini-stat,.gauge) > span { font-size: 12px; }
+@media(max-width: 1050px) {
+ .companion-studio .user-workspace { grid-template-columns: minmax(0,1fr) !important; }
+ .companion-studio .user-roster { border: 0 !important; border-bottom: 1px solid var(--line) !important; padding: 0 !important; }
+ .companion-studio .user-roster-list { display: block !important; }
+ .companion-studio .feature-inline-setting-form { flex-basis: 100%; }
+}
+@media(max-width: 680px) {
+ .companion-studio .studio-feature-group > summary { padding: 18px 0; gap: 10px; }
+ .companion-studio .studio-feature-group > summary span { font-size: 11px; }
+ .companion-studio .studio-feature-group > summary small { max-width: 65px; text-align: right; }
+ .companion-studio .feature-switch-list { padding-left: 12px !important; }
+ .companion-studio .feature-switch-body { flex-basis: 170px; }
+ .companion-studio .feature-switch-item { gap: 10px !important; }
+ .companion-studio .feature-switch-text { gap: 5px 12px !important; }
+ .companion-studio .proactive-summary-card { grid-template-columns: minmax(100px,1fr) auto !important; gap: 5px !important; }
+ .companion-studio .proactive-summary-card small { grid-column: 1 / -1; }
+ .companion-studio :is(.studio-proactive-metrics,.studio-proactive-disclosure,.studio-user-metrics) > summary small { display: block; margin: 5px 0 0; }
+ .companion-studio .studio-proactive-lead { gap: 12px 22px; }
+ .companion-studio .studio-proactive-lead b { font-size: 17px; }
+}
+/* Final containment pass: remove surviving legacy frames, stripes and faux cards. */
+.companion-studio .feature-switch-text { min-height: 0 !important; }
+.companion-studio .feature-switch-body { row-gap: 5px !important; }
+.companion-studio .feature-switch-meta { margin: 0 !important; padding: 0 !important; }
+.companion-studio .proactive-records-card { display: block !important; }
+.companion-studio #proactiveCandidateFilters { position: static !important; display: block !important; margin: 14px 0 !important; width: 100% !important; }
+.companion-studio .proactive-filter-summary { display: flex !important; align-items: baseline; flex-wrap: wrap; gap: 8px 15px !important; padding: 10px 0 !important; border: 0 !important; border-radius: 0 !important; background: none !important; box-shadow: none !important; }
+.companion-studio .proactive-filter-summary b { font-size: 13px !important; font-weight: 500 !important; }
+.companion-studio .proactive-filter-summary :is(span,small,em) { font-size: 11px !important; font-style: normal; font-weight: 400; }
+.companion-studio .proactive-filter-list { border-bottom: 1px solid var(--line); padding-bottom: 6px; }
+.companion-studio .proactive-filter-user { display: flex !important; align-items: baseline; gap: 14px !important; border: 0 !important; border-bottom: 2px solid transparent !important; border-radius: 0 !important; }
+.companion-studio .proactive-filter-user.is-active { background: none !important; border-bottom-color: var(--accent) !important; }
+.companion-studio .proactive-filter-user > span { display: flex; flex-wrap: wrap; gap: 10px; align-items: baseline; }
+.companion-studio .proactive-filter-user em { background: none !important; border-radius: 0 !important; padding: 0 !important; min-width: 0 !important; height: auto !important; font-size: 12px; }
+.companion-studio #proactiveCandidateList { padding: 0 !important; }
+.companion-studio .proactive-candidate .danger-outline { border: 1px solid var(--line) !important; padding: 6px 10px !important; border-radius: 5px !important; background: transparent !important; color: var(--danger) !important; box-shadow: none !important; font-size: 11px !important; font-weight: 400 !important; }
+.companion-studio :is(.user-workspace,.user-detail-header,.user-view-overview,.user-detail-shell,.user-view-heading,.user-roster)::before,
+.companion-studio :is(.user-workspace,.user-detail-header,.user-view-overview,.user-detail-shell,.user-view-heading,.user-roster)::after { content: none !important; }
+.companion-studio .user-detail-header { border: 0 !important; border-radius: 0 !important; background: none !important; padding: 0 0 12px !important; box-shadow: none !important; }
+.companion-studio .user-detail-summary { background: none !important; box-shadow: none !important; border: 0 !important; border-radius: 0 !important; padding: 0 !important; }
+.companion-studio .user-detail-avatar { width: 42px !important; height: 42px !important; border-radius: 50% !important; font-size: 17px !important; }
+.companion-studio .user-roster-footer { display: flex !important; flex-wrap: wrap; gap: 8px !important; background: none !important; }
+.companion-studio .user-roster-footer button { font-size: 11px; padding: 8px 10px; }
+.companion-studio .user-roster-name { display: flex; flex-wrap: wrap; }
+.companion-studio .user-roster-name strong { white-space: normal !important; overflow-wrap: anywhere; }
+.companion-studio #userDetail :is(.detail-block,.detail-card,.companion-intimacy-card,.private-dialogue-section,.user-view-overview) { background: none !important; border: 0 !important; border-bottom: 1px solid var(--line) !important; border-radius: 0 !important; box-shadow: none !important; padding: 20px 0 !important; margin: 0 !important; }
+.companion-studio #userDetail :is(.detail-block,.detail-card,.companion-intimacy-card,.private-dialogue-section)::before,
+.companion-studio #userDetail :is(.detail-block,.detail-card,.companion-intimacy-card,.private-dialogue-section)::after,
+.companion-studio #userDetail :is(h2,h3)::before, .companion-studio #userDetail :is(h2,h3)::after { content: none !important; }
+.companion-studio #userDetail :is(.detail-block,.detail-card) :is(h2,h3) { font-size: 16px !important; font-weight: 550 !important; }
+.companion-studio .user-profile-form { margin-top: 16px !important; }
+/* The same document-like surface carries through the home and editor pages. */
+.companion-studio #stats { display: flex !important; flex-wrap: wrap; gap: 16px 36px !important; padding: 16px 0 !important; border-block: 1px solid var(--line); }
+.companion-studio #stats .stat { flex: 1 1 180px; padding: 0 !important; border: 0 !important; border-radius: 0 !important; box-shadow: none !important; background: transparent !important; }
+.companion-studio #stats .stat:hover { color: var(--accent); text-decoration: underline; }
+.companion-studio .studio-welcome { background: transparent !important; border: 0 !important; border-radius: 0 !important; padding: 12px 0 20px !important; }
+.companion-studio .studio-art { opacity: .65; }
+.companion-studio .dashboard-life-desk { display: block !important; }
+.companion-studio .life-desk-card { padding: 24px 0 !important; border: 0 !important; border-bottom: 1px solid var(--line) !important; border-radius: 0 !important; background: transparent !important; box-shadow: none !important; }
+.companion-studio .life-desk-dot { display: none; }
+.companion-studio :is(.module-card,.persona-card,.provider-card) { border-radius: 0 !important; border: 0 !important; border-bottom: 1px solid var(--line) !important; padding: 22px 0 !important; background: transparent !important; box-shadow: none !important; }
+.companion-studio .provider-tree-grid { grid-template-columns: minmax(0,1fr) !important; }
+.companion-studio .world-workspace { padding: 20px !important; }
+.companion-studio .empty { border: 0 !important; border-radius: 0 !important; background: transparent !important; padding: 22px 0 !important; }
+@media(max-width: 680px) { .companion-studio .studio-art { opacity: .12; } .companion-studio .feature-switch-text b { font-size: 13px !important; } .companion-studio .world-workspace { padding: 12px !important; } }
+
+/* Prompt workspace containment: respond to the actual panel width in AstrBot,
+   not merely the outer screen. Keep full labels; only long readers scroll. */
+.companion-studio #panel-prompts { container-name: promptpage; container-type: inline-size; min-width: 0; }
+.companion-studio .prompts-page-head { flex-wrap: wrap; }
+.companion-studio .prompts-scope-note { min-width: 0 !important; max-width: 100%; flex: 0 1 360px; }
+.companion-studio .prompts-workspace { display: grid !important; grid-template-columns: minmax(230px, 280px) minmax(0, 1fr) !important; align-items: start; gap: 24px; min-width: 0; width: 100%; min-height: 0 !important; overflow: visible !important; border: 0 !important; border-radius: 0 !important; background: transparent !important; }
+.companion-studio #panel-prompts :is(.prompts-catalog,.prompts-editor) { width: 100%; min-width: 0 !important; max-width: 100%; min-height: 0 !important; border: 0 !important; border-radius: 0 !important; background: transparent !important; box-shadow: none !important; }
+.companion-studio .prompts-catalog { border-right: 1px solid var(--line) !important; padding-right: 18px; }
+.companion-studio .prompts-catalog-toolbar { min-width: 0; padding: 0 0 14px; }
+.companion-studio .prompts-mode-switch { border-radius: 5px; }
+.companion-studio .prompts-mode-switch button { white-space: normal; overflow-wrap: anywhere; padding: 7px; }
+.companion-studio .prompts-group-nav { display: flex; flex-wrap: wrap !important; overflow: visible !important; min-width: 0; max-width: 100%; padding: 12px 0; gap: 6px; }
+.companion-studio .prompts-group-nav button { flex: 0 1 auto !important; max-width: 100%; white-space: normal !important; overflow-wrap: anywhere; min-height: 30px; line-height: 1.6; padding: 5px 8px; font-weight: 500; border-radius: 5px; }
+.companion-studio .prompts-directory-hint { padding: 9px 0; font-size: 11px; color: var(--muted); line-height: 1.7; }
+.companion-studio .prompts-task-list { min-height: 0 !important; max-height: clamp(220px,48dvh,560px) !important; overflow-y: auto !important; overflow-x: hidden; overscroll-behavior: auto; scrollbar-gutter: stable; padding: 0 6px 0 0; }
+.companion-studio .prompts-task-item { border: 0 !important; border-bottom: 1px solid var(--line-soft) !important; border-radius: 0 !important; padding: 12px 9px !important; background: transparent !important; box-shadow: none !important; min-height: 0; }
+.companion-studio .prompts-task-item.active { background: var(--accent-soft) !important; }
+.companion-studio .prompts-task-item-head { align-items: flex-start; }
+.companion-studio .prompts-task-item b { font-size: 13px; font-weight: 500; line-height: 1.7; white-space: normal; overflow-wrap: anywhere; }
+.companion-studio .prompts-task-state { margin-top: 7px; }
+.companion-studio .prompts-task-item code { white-space: normal !important; overflow: visible !important; text-overflow: clip !important; overflow-wrap: anywhere; line-height: 1.7; font-size: 10px; }
+.companion-studio .prompts-editor-content { display: block !important; width: 100%; min-width: 0; min-height: 0 !important; }
+.companion-studio .prompts-editor-content[hidden] { display: none !important; }
+.companion-studio .prompts-editor-head { flex-wrap: wrap; padding: 0 0 18px; gap: 10px; }
+.companion-studio .prompts-editor-head > div { flex: 1 1 240px; min-width: 0; }
+.companion-studio .prompts-editor-head :is(h3,p) { overflow-wrap: anywhere; white-space: normal; }
+.companion-studio .prompts-editor-head h3 { font-size: 19px; font-weight: 550; line-height: 1.6; }
+.companion-studio .prompts-editor-meta { grid-template-columns: minmax(0,1fr) !important; }
+.companion-studio .prompts-editor-meta > div { grid-column: 1 !important; padding: 12px 0; border: 0 !important; border-bottom: 1px solid var(--line-soft) !important; }
+.companion-studio .prompts-editor-meta :is(dd,code) { min-width: 0; max-width: 100%; white-space: normal; overflow-wrap: anywhere; }
+.companion-studio :is(.prompts-builtin-preview,.prompts-textarea-field) { min-width: 0; padding: 18px 0; }
+.companion-studio .prompts-builtin-preview-head { flex-wrap: wrap; }
+.companion-studio .prompts-builtin-prompt { max-width: 100%; box-sizing: border-box; max-height: 360px; overflow-y: auto; overflow-x: auto; white-space: pre-wrap !important; overflow-wrap: anywhere !important; tab-size: 2; }
+.companion-studio .prompts-textarea-field textarea { box-sizing: border-box; max-width: 100%; min-width: 0; min-height: 240px; resize: vertical; }
+.companion-studio .prompts-editor-boundary { margin: 0 0 18px; }
+.companion-studio .prompts-editor-actions { position: static !important; flex-wrap: wrap; min-width: 0; padding: 16px 0; gap: 12px; }
+.companion-studio .prompts-editor-actions > div { display: flex; flex-wrap: wrap; flex: 0 1 auto; min-width: 0; max-width: 100%; }
+.companion-studio .prompts-editor-actions button { white-space: normal; min-width: 0; max-width: 100%; }
+/* Fallback for browsers without container queries. */
+@media(max-width:1180px) { .companion-studio .prompts-workspace { grid-template-columns: minmax(0,1fr) !important; } .companion-studio .prompts-catalog { border-right: 0 !important; border-bottom: 1px solid var(--line) !important; padding: 0 0 20px; } }
+@supports(container-type:inline-size) {
+ @container promptpage (min-width:901px) { .companion-studio .prompts-workspace { grid-template-columns: minmax(230px,280px) minmax(0,1fr) !important; } .companion-studio .prompts-catalog { border-right: 1px solid var(--line) !important; border-bottom: 0 !important; padding: 0 18px 0 0; } }
+ @container promptpage (max-width:900px) { .companion-studio .prompts-workspace { grid-template-columns: minmax(0,1fr) !important; } .companion-studio .prompts-catalog { border-right: 0 !important; border-bottom: 1px solid var(--line) !important; padding: 0 0 20px; } .companion-studio .prompts-task-list { max-height: 320px !important; } }
+}

--- a/pages/陪伴面板/css/polish.css
+++ b/pages/陪伴面板/css/polish.css
@@ -5316,21 +5316,21 @@ code,
    All palette variants still use the original appearance selector.
    ========================================================================== */
 :root {
-  --studio-bg: #f7f8f4;
-  --studio-sidebar: #f0f3ed;
+  --studio-bg: #f7f8fa;
+  --studio-sidebar: #f0f3f4;
   --studio-hero: #edf1e7;
-  --radius: 18px;
-  --radius-sm: 10px;
+  --radius: 8px;
+  --radius-sm: 6px;
   --shadow: 0 8px 32px rgba(35, 57, 43, .035);
   --shadow-soft: 0 2px 10px rgba(35, 57, 43, .025);
 }
 :root[data-theme="classic"], :root:not([data-theme]) {
-  --bg: #f7f8f4; --panel: #fff; --surface: #f6f8f3;
-  --surface-strong: #e9eee4; --ink: #293d33; --muted: #748074;
-  --line: #dce3d7; --line-soft: #e9ede4;
+  --bg: #f7f8fa; --panel: #fff; --surface: #f3f5f6;
+  --surface-strong: #e9eef0; --ink: #29353c; --muted: #56636b;
+  --line: #d8dfe3; --line-soft: #e5e9ec;
   --accent: #53755b; --accent-strong: #34543e; --accent-soft: #e6eddf;
-  --blue: #648371; --blue-soft: #e6ede5;
-  --red: #bf7366; --red-soft: #f6e9e5;
+  --blue: #386b9a; --blue-soft: #e7eef7;
+  --red: #a94f51; --red-soft: #f6e9e5;
   --gold: #a78d56; --gold-soft: #f6f0e1;
   --cv-line: #dce3d7; --cv-line-soft: #e9ede4;
 }
@@ -5353,8 +5353,8 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 .companion-studio .folio::before, .companion-studio .folio::after, .companion-studio .folio-meta::before, .companion-studio .folio-meta::after { content: none !important; }
 .companion-studio .folio-meta { flex: 1; min-width: 0; padding: 0 !important; display: block !important; background: none !important; border: 0 !important; }
 .companion-studio .folio-heading { display: flex !important; flex-wrap: wrap; gap: 12px 28px; align-items: center; justify-content: space-between; }
-.companion-studio .folio-eyebrow { font-size: 10px !important; letter-spacing: 2px !important; font-weight: 400 !important; color: var(--muted) !important; margin-bottom: 6px; }
-.companion-studio .folio-title { font-size: 19px !important; line-height: 1.6 !important; letter-spacing: -.4px !important; font-weight: 600 !important; margin: 0 !important; }
+.companion-studio .folio-eyebrow { font-size: 10px !important; letter-spacing: 0 !important; font-weight: 400 !important; color: var(--muted) !important; margin-bottom: 6px; }
+.companion-studio .folio-title { font-size: 19px !important; line-height: 1.6 !important; letter-spacing: 0 !important; font-weight: 600 !important; margin: 0 !important; }
 .studio-header-slash { color: #b8c2b6; margin: 0 12px; font-weight: 300; }
 #studioPageTitle { font-size: 14px; font-weight: 400; color: var(--muted); }
 .companion-studio .folio-persona-context { display: grid; gap: 4px; }
@@ -5364,7 +5364,7 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 .companion-studio .folio-plate::before, .companion-studio .folio-plate::after { content: none !important; }
 .companion-studio .daily-outfit-logo { width: 100% !important; height: 100% !important; max-height: none !important; object-fit: cover !important; }
 .companion-studio .folio-tools { display: flex !important; flex-direction: row !important; gap: 10px !important; padding: 0 !important; width: auto !important; border: 0 !important; background: none !important; }
-.companion-studio .seal, .companion-studio .setup-guide-entry { position: relative !important; min-height: 40px !important; height: 40px !important; border: 1px solid var(--line) !important; border-radius: 10px !important; background: var(--panel) !important; color: var(--ink) !important; box-shadow: none !important; font-size: 12px !important; font-weight: 500 !important; padding: 0 14px !important; }
+.companion-studio .seal, .companion-studio .setup-guide-entry { position: relative !important; min-height: 40px !important; height: 40px !important; border: 1px solid var(--line) !important; border-radius: 8px !important; background: var(--panel) !important; color: var(--ink) !important; box-shadow: none !important; font-size: 12px !important; font-weight: 500 !important; padding: 0 14px !important; }
 .companion-studio .seal { width: 40px !important; padding: 0 !important; transform: none !important; }
 .companion-studio .seal-mark { font-size: 22px !important; }
 .companion-studio .seal small { display: none; }
@@ -5373,13 +5373,13 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 .companion-studio .annotations { position: fixed !important; inset: 0 auto 0 0 !important; width: 226px !important; height: 100dvh !important; display: flex !important; flex-direction: column !important; align-items: stretch !important; gap: 4px !important; padding: 28px 18px 22px !important; border: 0 !important; border-right: 1px solid var(--line-soft) !important; background: var(--studio-sidebar) !important; border-radius: 0 !important; overflow-y: auto !important; overflow-x: hidden !important; z-index: 30 !important; box-shadow: none !important; backdrop-filter: none !important; scrollbar-width: thin; }
 .companion-studio .annot-axis, .companion-studio .annotations::before, .companion-studio .annotations::after { display: none !important; }
 .studio-brand { display: flex; align-items: center; gap: 10px; padding: 1px 6px 28px; flex-shrink: 0; }
-.studio-brand-mark { width: 36px; height: 36px; background: var(--accent); color: #fff; border-radius: 12px; font-size: 33px; line-height: 36px; text-align: center; }
-.studio-brand b { display: block; font-size: 15px; letter-spacing: -.3px; font-weight: 600; }
-.studio-brand small { display: block; font-size: 7px; letter-spacing: 1.6px; color: var(--muted); margin-top: 3px; }
-.companion-studio .studio-find { display: flex; justify-content: space-between; align-items: center; gap: 6px; padding: 10px 11px !important; width: 100%; background: color-mix(in srgb, var(--panel) 62%, transparent) !important; color: var(--muted) !important; border: 1px solid var(--line) !important; border-radius: 9px !important; font-size: 11px !important; font-weight: 400 !important; margin-bottom: 12px; }
+.studio-brand-mark { width: 36px; height: 36px; background: var(--accent); color: #fff; border-radius: 8px; font-size: 33px; line-height: 36px; text-align: center; }
+.studio-brand b { display: block; font-size: 15px; letter-spacing: 0; font-weight: 600; }
+.studio-brand small { display: block; font-size: 7px; letter-spacing: 0; color: var(--muted); margin-top: 3px; }
+.companion-studio .studio-find { display: flex; justify-content: space-between; align-items: center; gap: 6px; padding: 10px 11px !important; width: 100%; background: color-mix(in srgb, var(--panel) 62%, transparent) !important; color: var(--muted) !important; border: 1px solid var(--line) !important; border-radius: 8px !important; font-size: 11px !important; font-weight: 400 !important; margin-bottom: 12px; }
 .studio-find kbd { font: inherit; font-size: 9px; opacity: .75; }
-.studio-nav-label { padding: 17px 14px 7px; font-size: 10px; letter-spacing: 1.4px; color: var(--muted); }
-.companion-studio .annotations .tab { display: flex !important; flex-direction: row !important; align-items: center !important; gap: 14px !important; width: 100% !important; min-width: 0 !important; min-height: 40px !important; padding: 10px 15px !important; margin: 0 !important; border: 0 !important; border-radius: 9px !important; background: transparent !important; color: var(--muted) !important; box-shadow: none !important; font-size: 13px !important; font-weight: 450 !important; transform: none !important; flex-shrink: 0; }
+.studio-nav-label { padding: 17px 14px 7px; font-size: 10px; letter-spacing: 0; color: var(--muted); }
+.companion-studio .annotations .tab { display: flex !important; flex-direction: row !important; align-items: center !important; gap: 14px !important; width: 100% !important; min-width: 0 !important; min-height: 40px !important; padding: 10px 15px !important; margin: 0 !important; border: 0 !important; border-radius: 8px !important; background: transparent !important; color: var(--muted) !important; box-shadow: none !important; font-size: 13px !important; font-weight: 450 !important; transform: none !important; flex-shrink: 0; }
 .companion-studio .annotations .tab i { display: inline-grid; place-items: center; width: 19px; font-size: 19px !important; font-style: normal; font-family: system-ui, sans-serif; font-weight: 400 !important; color: inherit !important; line-height: 1; }
 .companion-studio .annotations .tab span { font-size: inherit !important; font-weight: inherit !important; }
 .companion-studio .annotations .tab:hover { background: var(--accent-soft) !important; color: var(--accent-strong) !important; }
@@ -5388,38 +5388,38 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 .companion-studio .annotations .tab[hidden] { display: none !important; }
 .studio-nav-foot { margin-top: auto; padding: 28px 12px 0; font-size: 10px; color: var(--muted); }
 .studio-nav-foot > span { color: var(--accent); margin-right: 5px; }
-.studio-nav-foot small { display: block; margin-top: 8px; font-size: 7px; letter-spacing: 1.6px; opacity: .7; }
+.studio-nav-foot small { display: block; margin-top: 8px; font-size: 7px; letter-spacing: 0; opacity: .7; }
 /* Home: invitation, four compact signals, then two calm columns. */
 .companion-studio .section-head { gap: 18px !important; margin: 0 0 24px !important; padding: 0 0 20px !important; border-bottom: 1px solid var(--line-soft) !important; background: transparent !important; }
-.companion-studio .section-head h2 { font-size: 23px !important; font-weight: 600 !important; letter-spacing: -.5px; }
+.companion-studio .section-head h2 { font-size: 23px !important; font-weight: 600 !important; letter-spacing: 0; }
 .companion-studio .section-head h2::before, .companion-studio .section-head h2::after { content: none !important; }
 .companion-studio .section-desc { color: var(--muted) !important; font-size: 12px !important; line-height: 1.8 !important; margin-top: 7px !important; font-weight: 400 !important; }
 .companion-studio .dashboard-overview-head { border: 0 !important; padding: 0 !important; margin-bottom: 24px !important; }
 .companion-studio #exportSnapshotBtn { color: var(--muted) !important; background: transparent !important; border: 1px solid var(--line) !important; box-shadow: none !important; font-size: 11px !important; padding: 9px 14px !important; border-radius: 8px !important; }
-.studio-welcome { position: relative; isolation: isolate; display: flex; align-items: center; min-height: 280px; padding: 34px 38px; border: 1px solid color-mix(in srgb, var(--line) 55%, transparent); border-radius: 19px; background: var(--studio-hero); overflow: hidden; }
+.studio-welcome { position: relative; isolation: isolate; display: flex; align-items: center; min-height: 280px; padding: 34px 38px; border: 1px solid color-mix(in srgb, var(--line) 55%, transparent); border-radius: 8px; background: var(--studio-hero); overflow: hidden; }
 .studio-welcome-copy { position: relative; z-index: 1; }
-.studio-kicker { display: flex; align-items: center; gap: 8px; color: var(--accent); font-size: 8px; letter-spacing: 2px; font-weight: 600; }
+.studio-kicker { display: flex; align-items: center; gap: 8px; color: var(--accent); font-size: 8px; letter-spacing: 0; font-weight: 600; }
 .studio-kicker > span { width: 5px; height: 5px; border-radius: 50%; background: var(--accent); }
-.companion-studio .studio-welcome h2 { margin: 18px 0 12px !important; font-size: clamp(25px, 2.4vw, 37px) !important; font-weight: 500 !important; line-height: 1.5 !important; letter-spacing: 1px; color: var(--accent-strong); }
+.companion-studio .studio-welcome h2 { margin: 18px 0 12px !important; font-size: 28px !important; font-weight: 500 !important; line-height: 1.5 !important; letter-spacing: 0; color: var(--accent-strong); }
 .studio-welcome p { font-size: 12px; color: var(--muted); }
 .studio-welcome-actions { display: flex; align-items: center; flex-wrap: wrap; gap: 19px; margin-top: 25px; }
-.companion-studio .studio-primary { background: var(--accent) !important; color: #fff !important; border: 0 !important; border-radius: 9px !important; padding: 11px 17px !important; font-size: 12px !important; font-weight: 500 !important; box-shadow: none !important; }
+.companion-studio .studio-primary { background: var(--accent) !important; color: #fff !important; border: 0 !important; border-radius: 8px !important; padding: 11px 17px !important; font-size: 12px !important; font-weight: 500 !important; box-shadow: none !important; }
 .studio-primary > span { margin-left: 13px; }
 .companion-studio .studio-text-button { border: 0 !important; background: none !important; color: var(--accent-strong) !important; font-size: 11px !important; font-weight: 400 !important; padding: 8px 0 !important; box-shadow: none !important; }
 .studio-text-button > span { margin-left: 6px; }
 .studio-art { position: absolute; right: 20px; bottom: 15px; width: 41%; max-width: 370px; z-index: -1; }
-.studio-art-caption { position: absolute; bottom: 17px; right: 55px; font-size: 7px; color: var(--accent); letter-spacing: 2px; opacity: .65; }
+.studio-art-caption { position: absolute; bottom: 17px; right: 55px; font-size: 7px; color: var(--accent); letter-spacing: 0; opacity: .65; }
 .studio-metrics-label { display: flex; justify-content: space-between; align-items: center; margin: 28px 2px 12px; font-size: 12px; font-weight: 500; }
 .studio-metrics-label small { font-size: 10px; color: var(--muted); font-weight: 400; }
 .companion-studio #stats { display: grid !important; grid-template-columns: repeat(4, minmax(0, 1fr)) !important; gap: 12px !important; margin: 0 0 28px !important; }
-.companion-studio .stat { border: 1px solid var(--line-soft) !important; border-radius: 12px !important; padding: 20px 17px !important; background: var(--panel) !important; box-shadow: none !important; }
+.companion-studio .stat { border: 1px solid var(--line-soft) !important; border-radius: 8px !important; padding: 20px 17px !important; background: var(--panel) !important; box-shadow: none !important; }
 .companion-studio .stat::before, .companion-studio .stat::after { content: none !important; }
-.companion-studio .stat b { font-size: clamp(14px, 1.5vw, 21px) !important; font-weight: 550 !important; letter-spacing: -.5px; margin: 5px 0 8px !important; line-height: 1.4; }
+.companion-studio .stat b { font-size: 18px !important; font-weight: 550 !important; letter-spacing: 0; margin: 5px 0 8px !important; line-height: 1.4; }
 .companion-studio .stat span { display: block; color: var(--muted) !important; font-size: 10px !important; line-height: 1.6; }
 .companion-studio .stat:hover { border-color: var(--accent) !important; background: var(--surface) !important; }
 .companion-studio .dashboard-life-desk { display: grid !important; grid-template-columns: minmax(0, 1fr) minmax(0, 1.13fr) !important; gap: 20px !important; align-items: start !important; margin: 0 !important; }
 .companion-studio .dashboard-life-column { display: grid !important; grid-template-columns: minmax(0,1fr) !important; gap: 20px !important; min-width: 0; }
-.companion-studio .life-desk-card { position: relative; border: 1px solid var(--line-soft) !important; border-radius: 15px !important; padding: 23px !important; background: var(--panel) !important; box-shadow: none !important; overflow: hidden; }
+.companion-studio .life-desk-card { position: relative; border: 1px solid var(--line-soft) !important; border-radius: 8px !important; padding: 23px !important; background: var(--panel) !important; box-shadow: none !important; overflow: hidden; }
 .companion-studio .life-desk-card::before, .companion-studio .life-desk-card::after { content: none !important; }
 .companion-studio .life-desk-card-head { display: flex; justify-content: space-between; gap: 12px !important; align-items: center; margin-bottom: 22px !important; padding: 0 !important; border: 0 !important; }
 .companion-studio .life-desk-card-head h3 { font-size: 16px !important; font-weight: 550 !important; color: var(--ink) !important; }
@@ -5434,21 +5434,21 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 .companion-studio .life-desk-link { padding: 5px 9px !important; border: 1px solid var(--line-soft) !important; color: var(--accent) !important; background: var(--surface) !important; border-radius: 7px !important; font-size: 10px !important; font-weight: 450 !important; box-shadow: none !important; }
 .companion-studio .life-timeline-preview { min-height: 230px !important; max-height: none !important; padding: 0 !important; overflow: visible !important; }
 .companion-studio .life-timeline-row { background: transparent !important; border: 0 !important; border-bottom: 1px solid var(--line-soft) !important; border-radius: 0 !important; padding: 16px 4px !important; margin: 0 !important; box-shadow: none !important; }
-.companion-studio .life-timeline-row.is-current { background: var(--surface) !important; border-radius: 10px !important; padding: 16px 12px !important; border: 1px solid var(--line-soft) !important; }
+.companion-studio .life-timeline-row.is-current { background: var(--surface) !important; border-radius: 8px !important; padding: 16px 12px !important; border: 1px solid var(--line-soft) !important; }
 .companion-studio .life-timeline-content b { font-size: 13px !important; font-weight: 500 !important; }
 .companion-studio .life-timeline-content p { font-size: 11px !important; line-height: 1.8 !important; }
-.companion-studio .life-current-activity { border: 0 !important; background: var(--surface) !important; border-radius: 10px !important; padding: 16px !important; }
+.companion-studio .life-current-activity { border: 0 !important; background: var(--surface) !important; border-radius: 8px !important; padding: 16px !important; }
 .companion-studio .life-current-activity b { font-size: 15px !important; font-weight: 500 !important; }
 .companion-studio .life-state-grid { gap: 14px !important; }
 .companion-studio .life-state-grid > div { border: 0 !important; background: transparent !important; padding: 6px 0 !important; }
 .companion-studio .life-state-grid b { font-size: 12px !important; font-weight: 500 !important; }
 .companion-studio .life-energy-track { height: 4px !important; margin: 20px 0 !important; background: var(--accent-soft) !important; }
 .companion-studio .life-energy-track i { background: var(--accent) !important; }
-.companion-studio .life-empty { display: grid; place-content: center; text-align: center; min-height: 150px; border: 0 !important; border-radius: 10px !important; background: var(--surface) !important; color: var(--muted) !important; font-size: 12px !important; }
+.companion-studio .life-empty { display: grid; place-content: center; text-align: center; min-height: 150px; border: 0 !important; border-radius: 8px !important; background: var(--surface) !important; color: var(--muted) !important; font-size: 12px !important; }
 .companion-studio .dashboard-secondary { margin-top: 30px !important; display: grid; gap: 12px !important; }
 .studio-section-label { font-size: 14px; margin: 0 2px 3px; }
 .studio-section-label small { font-size: 11px; color: var(--muted); margin-left: 12px; }
-.companion-studio .dashboard-disclosure { border: 1px solid var(--line-soft) !important; border-radius: 12px !important; background: var(--panel) !important; box-shadow: none !important; overflow: hidden; }
+.companion-studio .dashboard-disclosure { border: 1px solid var(--line-soft) !important; border-radius: 8px !important; background: var(--panel) !important; box-shadow: none !important; overflow: hidden; }
 .companion-studio .dashboard-disclosure > summary { padding: 20px 23px !important; background: transparent !important; cursor: pointer; }
 .companion-studio .dashboard-disclosure > summary b { font-size: 13px !important; font-weight: 500 !important; }
 .companion-studio .dashboard-disclosure > summary small { font-size: 11px !important; color: var(--muted); font-weight: 400 !important; }
@@ -5458,35 +5458,35 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 .companion-studio .dashboard-companion-terminal { border: 0 !important; box-shadow: none !important; background: transparent !important; margin: 0 !important; padding: 24px !important; }
 .companion-studio .dashboard-companion-terminal h2 { font-size: 18px !important; }
 /* Shared visual system. Component-specific grids and behavior are untouched. */
-.companion-studio :is(.module-card,.dashboard-strategy-card,.dashboard-chart-card,.dashboard-insight-card,.dashboard-activity-card,.qzone-card,.config-persona-selector,.config-persona-top-row > article,.persona-import-panel,.world-knowledge-brief,.proactive-summary,.prompts-catalog,.prompts-editor,.memory-view-card,.feature-card,.config-overview-card,.learning-card) { border-color: var(--line-soft) !important; border-radius: 14px !important; background: var(--panel) !important; box-shadow: none !important; }
+.companion-studio :is(.module-card,.dashboard-strategy-card,.dashboard-chart-card,.dashboard-insight-card,.dashboard-activity-card,.qzone-card,.config-persona-selector,.config-persona-top-row > article,.persona-import-panel,.world-knowledge-brief,.proactive-summary,.prompts-catalog,.prompts-editor,.memory-view-card,.feature-card,.config-overview-card,.learning-card) { border-color: var(--line-soft) !important; border-radius: 8px !important; background: var(--panel) !important; box-shadow: none !important; }
 .companion-studio :is(.module-card,.feature-card,.dashboard-strategy-card,.dashboard-chart-card,.dashboard-insight-card,.dashboard-activity-card)::before,
 .companion-studio :is(.module-card,.feature-card,.dashboard-strategy-card,.dashboard-chart-card,.dashboard-insight-card,.dashboard-activity-card)::after { content: none !important; }
 .companion-studio .module-card { padding: 24px !important; margin-bottom: 20px; }
 .companion-studio :is(.module-card-head,.persona-card-head) { margin-bottom: 20px !important; }
 .companion-studio :is(.module-card-head,.persona-card-head) :is(h2,h3) { font-weight: 550 !important; font-size: 18px !important; }
 .companion-studio :is(.module-card-head,.persona-card-head) :is(p,.section-desc) { font-size: 12px !important; font-weight: 400 !important; line-height: 1.8 !important; }
-.companion-studio :is(input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="color"]),select,textarea) { border-radius: 9px !important; border-color: var(--line) !important; background-color: var(--panel); color: var(--ink); box-shadow: none; font-size: 13px; }
+.companion-studio :is(input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="color"]),select,textarea) { border-radius: 8px !important; border-color: var(--line) !important; background-color: var(--panel); color: var(--ink); box-shadow: none; font-size: 13px; }
 .companion-studio :is(input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="color"]),select) { min-height: 40px; }
 .companion-studio textarea { padding: 13px !important; line-height: 1.8 !important; }
 .companion-studio :is(input,select,textarea):focus { outline: 2px solid color-mix(in srgb,var(--accent) 40%,transparent) !important; outline-offset: 2px; }
 .companion-studio :is(button,[role="button"],a,summary,input,select,textarea):focus-visible { outline: 2px solid var(--accent) !important; outline-offset: 3px !important; }
-.companion-studio button { font-family: inherit; border-radius: 9px; transition: background .15s ease, border-color .15s ease; }
+.companion-studio button { font-family: inherit; border-radius: 8px; transition: background .15s ease, border-color .15s ease; }
 .companion-studio button:disabled { opacity: .5; cursor: not-allowed; }
-.companion-studio :is(.primary-button,.module-form button[type="submit"],#saveFeaturesBtn) { background: var(--accent) !important; color: #fff !important; border: 1px solid var(--accent) !important; box-shadow: none !important; border-radius: 9px !important; }
-.companion-studio :is(.secondary-button,.ghost-button) { background: var(--panel) !important; color: var(--accent-strong) !important; border-color: var(--line) !important; border-radius: 9px !important; box-shadow: none !important; }
+.companion-studio :is(.primary-button,.module-form button[type="submit"],#saveFeaturesBtn) { background: var(--accent) !important; color: #fff !important; border: 1px solid var(--accent) !important; box-shadow: none !important; border-radius: 8px !important; }
+.companion-studio :is(.secondary-button,.ghost-button) { background: var(--panel) !important; color: var(--accent-strong) !important; border-color: var(--line) !important; border-radius: 8px !important; box-shadow: none !important; }
 .companion-studio :is(.module-badge,.world-save-state,.prompts-custom-badge) { border-color: var(--line-soft) !important; background: var(--accent-soft) !important; color: var(--accent-strong) !important; border-radius: 6px !important; font-weight: 500 !important; }
 .companion-studio :is(th,td) { padding: 14px 16px; border-color: var(--line-soft) !important; }
 .companion-studio th { background: var(--surface) !important; color: var(--muted); font-weight: 500; }
-.companion-studio .feature-save-actions { border: 1px solid var(--line) !important; border-radius: 14px !important; background: var(--panel) !important; box-shadow: 0 8px 35px #293d3320 !important; }
+.companion-studio .feature-save-actions { border: 1px solid var(--line) !important; border-radius: 8px !important; background: var(--panel) !important; box-shadow: 0 8px 35px #293d3320 !important; }
 /* Search dialog: navigates by clicking the existing tab, preserving dirty guards. */
-.studio-command { width: min(540px, calc(100vw - 32px)); max-height: 80dvh; padding: 24px; margin: 12vh auto auto; border: 1px solid var(--line); border-radius: 20px; background: var(--panel); color: var(--ink); box-shadow: 0 25px 90px #14291a30; }
+.studio-command { width: min(540px, calc(100vw - 32px)); max-height: 80dvh; padding: 24px; margin: 12vh auto auto; border: 1px solid var(--line); border-radius: 8px; background: var(--panel); color: var(--ink); box-shadow: 0 25px 90px #14291a30; }
 .studio-command::backdrop { background: #20362655; backdrop-filter: blur(5px); }
 .studio-command-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 18px; }
 .studio-command-head h2 { font-size: 19px; font-weight: 550; }
 .studio-command-head button { width: 32px; height: 32px; border: 0; background: var(--surface); color: var(--muted); font-size: 22px; }
 #studioCommandInput { width: 100%; padding: 12px 14px; }
 .studio-command-results { display: grid; gap: 4px; margin-top: 16px; max-height: 42dvh; overflow-y: auto; }
-.companion-studio .studio-command-result { display: flex; gap: 12px; align-items: center; width: 100%; padding: 12px; background: transparent; color: var(--ink); border: 0; border-radius: 9px; text-align: left; }
+.companion-studio .studio-command-result { display: flex; gap: 12px; align-items: center; width: 100%; padding: 12px; background: transparent; color: var(--ink); border: 0; border-radius: 8px; text-align: left; }
 .studio-command-result > span { color: var(--accent); font-size: 20px; }
 .studio-command-result b { font-size: 13px; font-weight: 500; }
 .studio-command-result small { display: block; font-size: 10px; color: var(--muted); margin-top: 2px; }
@@ -5513,7 +5513,7 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
   .companion-studio .shell { padding-left: 196px !important; padding-right: 22px !important; }
   .companion-studio .annotations { width: 174px !important; padding: 22px 10px !important; }
   .studio-find kbd { display: none; }
-  .studio-brand small { font-size: 6px; letter-spacing: 1px; }
+  .studio-brand small { font-size: 6px; letter-spacing: 0; }
   .companion-studio .folio-heading { gap: 5px; }
   .companion-studio .folio-persona-context { text-align: left; max-width: none; }
   .studio-welcome h2 { font-size: 27px !important; }
@@ -5547,7 +5547,7 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
   .studio-welcome p { font-size: 11px; max-width: 220px; }
   .studio-welcome-actions { gap: 10px 18px; margin-top: 22px; }
   .studio-art { width: 180px; bottom: 30px; right: -56px; opacity: .23; }
-  .studio-kicker { font-size: 7px; letter-spacing: 1.4px; }
+  .studio-kicker { font-size: 7px; letter-spacing: 0; }
   .companion-studio #stats { gap: 10px !important; margin-bottom: 20px !important; }
   .companion-studio .stat { padding: 15px !important; }
   .companion-studio .stat b { font-size: 16px !important; }
@@ -5563,7 +5563,7 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 @media (prefers-reduced-motion: reduce) {
   .companion-studio *, .companion-studio *::before, .companion-studio *::after { scroll-behavior: auto !important; animation-duration: .01ms !important; transition-duration: .01ms !important; }
 }
-.companion-studio .life-desk-empty { display: grid; place-content: center; min-height: 210px; text-align: center; border: 0 !important; border-radius: 10px !important; background: var(--surface) !important; color: var(--muted) !important; font-size: 12px !important; }
+.companion-studio .life-desk-empty { display: grid; place-content: center; min-height: 210px; text-align: center; border: 0 !important; border-radius: 8px !important; background: var(--surface) !important; color: var(--muted) !important; font-size: 12px !important; }
 .companion-studio #dashboardTimelinePreview .life-desk-empty::before { content: '◷'; font-size: 30px; color: var(--accent); opacity: .45; margin-bottom: 12px; }
 .companion-studio #dashboardTimelinePreview .life-desk-empty::after { content: '日程同步后，会在这里留下足迹'; font-size: 10px; margin-top: 7px; opacity: .8; }
 /* Balance the home grid: current state becomes a compact, full-width strip. */
@@ -5599,7 +5599,7 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 }
 /* Configuration and model editors share the same quiet surfaces. */
 .companion-studio :is(.config-fold-panel,.config-persona-stats-panel,.proactive-mode-card,.provider-config-mode-card,.provider-toolbar,.provider-card,.persona-card) {
-  background: var(--panel) !important; border: 1px solid var(--line-soft) !important; border-radius: 14px !important; box-shadow: none !important;
+  background: var(--panel) !important; border: 1px solid var(--line-soft) !important; border-radius: 8px !important; box-shadow: none !important;
 }
 .companion-studio :is(.config-fold-panel,.proactive-mode-card,.provider-card,.persona-card)::before,
 .companion-studio :is(.config-fold-panel,.proactive-mode-card,.provider-card,.persona-card)::after { content: none !important; }
@@ -5615,10 +5615,10 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 .companion-studio .provider-tree-title { font-size: 17px !important; font-weight: 550 !important; }
 .companion-studio .provider-tree-body { gap: 14px !important; }
 .companion-studio .provider-tree-preview { font-size: 12px !important; line-height: 1.8 !important; }
-.companion-studio .provider-current { padding: 13px !important; border: 0 !important; background: var(--surface) !important; border-radius: 9px !important; }
+.companion-studio .provider-current { padding: 13px !important; border: 0 !important; background: var(--surface) !important; border-radius: 8px !important; }
 .companion-studio .provider-current b { font-weight: 500 !important; font-size: 12px !important; }
 .companion-studio :is(.provider-config-mode-card,.provider-toolbar) { padding: 20px !important; margin-bottom: 20px !important; }
-.companion-studio :is(.provider-toolbar-actions,.provider-row) button { padding: 10px 15px !important; border: 1px solid var(--line) !important; background: var(--panel) !important; color: var(--accent-strong) !important; border-radius: 9px !important; font-size: 12px !important; font-weight: 500 !important; box-shadow: none !important; }
+.companion-studio :is(.provider-toolbar-actions,.provider-row) button { padding: 10px 15px !important; border: 1px solid var(--line) !important; background: var(--panel) !important; color: var(--accent-strong) !important; border-radius: 8px !important; font-size: 12px !important; font-weight: 500 !important; box-shadow: none !important; }
 .companion-studio #saveProvidersBtn { background: var(--accent) !important; color: white !important; border-color: var(--accent) !important; }
 .companion-studio .provider-guide { margin-top: 12px !important; padding: 14px !important; background: var(--surface) !important; border: 0 !important; border-radius: 8px !important; line-height: 1.8 !important; }
 .studio-provider-guide { border-top: 1px solid var(--line-soft); padding-top: 12px; }
@@ -5662,7 +5662,7 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 .companion-studio .provider-row { flex-wrap: wrap; }
 .companion-studio .provider-row .hint { font-size: 10px; overflow-wrap: anywhere; }
 .companion-studio .studio-welcome { min-height: 220px; }
-.companion-studio .studio-welcome h2 { font-size: clamp(24px,2.1vw,32px) !important; }
+.companion-studio .studio-welcome h2 { font-size: 28px !important; }
 /* Diagnostics: compact summary, readable full-width rows, one page scrollbar. */
 .companion-studio #panel-troubleshooting { --diag-ink: var(--ink); --diag-signal: var(--accent); }
 .companion-studio .troubleshooting-page { display: grid !important; gap: 22px !important; }
@@ -5670,29 +5670,29 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 .companion-studio .diagnostic-kicker { font: inherit; font-size: 11px !important; font-weight: 400 !important; color: var(--muted) !important; }
 .companion-studio .diagnostic-masthead h2 { font-size: 25px !important; font-weight: 600 !important; line-height: 1.5 !important; margin: 5px 0 8px !important; }
 .companion-studio .diagnostic-masthead p { font-size: 13px !important; }
-.companion-studio #refreshTroubleshootingBtn { border: 1px solid var(--accent) !important; background: var(--accent) !important; color: white !important; padding: 9px 17px !important; border-radius: 9px !important; box-shadow: none !important; }
+.companion-studio #refreshTroubleshootingBtn { border: 1px solid var(--accent) !important; background: var(--accent) !important; color: white !important; padding: 9px 17px !important; border-radius: 8px !important; box-shadow: none !important; }
 .companion-studio .diagnostic-live-dot { font-size: 11px; }
 .companion-studio .diagnostic-live-dot i { background: var(--muted); box-shadow: none; width: 5px; height: 5px; }
-.companion-studio .diagnostic-problem-picker { grid-template-columns: 1fr !important; padding: 20px !important; gap: 16px !important; border: 1px solid var(--line-soft) !important; background: var(--panel) !important; border-radius: 13px !important; box-shadow: none !important; }
+.companion-studio .diagnostic-problem-picker { grid-template-columns: 1fr !important; padding: 20px !important; gap: 16px !important; border: 1px solid var(--line-soft) !important; background: var(--panel) !important; border-radius: 8px !important; box-shadow: none !important; }
 .companion-studio .diagnostic-problem-picker > div:first-child { display: flex; flex-wrap: wrap; gap: 6px 12px; align-items: baseline; }
 .companion-studio .diagnostic-problem-picker > div:first-child > span { color: var(--muted); font-size: 10px; font-weight: 400; }
 .companion-studio .diagnostic-problem-picker h3 { font-size: 16px !important; font-weight: 550 !important; }
 .companion-studio .diagnostic-problem-picker p { font-size: 12px !important; }
 .companion-studio .diagnostic-category-list { display: grid !important; grid-template-columns: repeat(auto-fit,minmax(135px,1fr)) !important; gap: 8px !important; }
-.companion-studio .diagnostic-category { min-height: 84px !important; border: 1px solid var(--line-soft) !important; background: var(--surface) !important; border-radius: 9px !important; padding: 12px !important; box-shadow: none !important; transform: none !important; align-content: start; }
+.companion-studio .diagnostic-category { min-height: 84px !important; border: 1px solid var(--line-soft) !important; background: var(--surface) !important; border-radius: 8px !important; padding: 12px !important; box-shadow: none !important; transform: none !important; align-content: start; }
 .companion-studio .diagnostic-category b { font-size: 13px !important; font-weight: 550 !important; }
 .companion-studio .diagnostic-category span { font-size: 11px !important; line-height: 1.6 !important; font-weight: 400 !important; }
 .companion-studio .diagnostic-category.is-active { background: var(--accent-soft) !important; border-color: var(--accent) !important; }
 .companion-studio .troubleshooting-summary { display: grid !important; grid-template-columns: minmax(210px,2fr) repeat(4,minmax(0,1fr)) !important; gap: 10px !important; align-items: stretch !important; }
-.companion-studio .troubleshooting-head-card { border: 1px solid var(--line-soft) !important; background: var(--panel) !important; padding: 17px !important; border-radius: 11px !important; box-shadow: none !important; flex-wrap: wrap; gap: 10px; }
+.companion-studio .troubleshooting-head-card { border: 1px solid var(--line-soft) !important; background: var(--panel) !important; padding: 17px !important; border-radius: 8px !important; box-shadow: none !important; flex-wrap: wrap; gap: 10px; }
 .companion-studio .troubleshooting-head-card b { font-size: 18px !important; font-weight: 550 !important; line-height: 1.5 !important; }
 .companion-studio .troubleshooting-head-card small { font-size: 11px !important; }
 .companion-studio .troubleshooting-head-card > div > span { font-size: 10px !important; }
-.companion-studio .troubleshooting-count { min-height: 95px !important; padding: 15px 8px !important; border: 1px solid var(--line-soft) !important; border-radius: 11px !important; background: var(--panel) !important; box-shadow: none !important; }
+.companion-studio .troubleshooting-count { min-height: 95px !important; padding: 15px 8px !important; border: 1px solid var(--line-soft) !important; border-radius: 8px !important; background: var(--panel) !important; box-shadow: none !important; }
 .companion-studio .troubleshooting-count b { font-size: 25px !important; font-weight: 550 !important; line-height: 1.4 !important; }
 .companion-studio .troubleshooting-count span { font-size: 12px !important; font-weight: 400 !important; }
 .companion-studio .troubleshooting-count.is-active { border-color: var(--accent) !important; background: var(--surface) !important; }
-.companion-studio .studio-reason-details { display: block !important; grid-column: 1 / -1; padding: 0 !important; background: var(--panel) !important; border: 1px solid var(--line-soft) !important; border-radius: 10px !important; box-shadow: none !important; }
+.companion-studio .studio-reason-details { display: block !important; grid-column: 1 / -1; padding: 0 !important; background: var(--panel) !important; border: 1px solid var(--line-soft) !important; border-radius: 8px !important; box-shadow: none !important; }
 .companion-studio .studio-reason-details > summary { display: flex; align-items: center; gap: 12px; padding: 14px 18px; cursor: pointer; list-style: none; }
 .companion-studio .studio-reason-details > summary::after { content: '+'; margin-left: auto; font-size: 18px; color: var(--accent); }
 .companion-studio .studio-reason-details[open] > summary::after { content: '−'; }
@@ -5702,11 +5702,11 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 .companion-studio .studio-reason-body button { text-align: left; padding: 14px; border-color: var(--line-soft); }
 .companion-studio .studio-reason-body button b { display: block; margin-bottom: 6px; font-size: 13px; }
 .companion-studio .studio-reason-body button span { font-size: 12px; color: var(--muted); font-weight: 400; }
-.companion-studio :is(.diagnostic-priority-zone,.diagnostic-live-lane,.diagnostic-event-lane,.diagnostic-runtime-card,.diagnostic-evidence-drawer) { border: 1px solid var(--line-soft) !important; border-radius: 13px !important; box-shadow: none !important; background: var(--panel) !important; padding: 22px !important; }
+.companion-studio :is(.diagnostic-priority-zone,.diagnostic-live-lane,.diagnostic-event-lane,.diagnostic-runtime-card,.diagnostic-evidence-drawer) { border: 1px solid var(--line-soft) !important; border-radius: 8px !important; box-shadow: none !important; background: var(--panel) !important; padding: 22px !important; }
 .companion-studio .diagnostic-zone-head { align-items: center !important; flex-wrap: wrap; gap: 14px !important; margin: 0 0 20px !important; }
 .companion-studio .diagnostic-zone-head h3 { font-size: 18px !important; font-weight: 550 !important; margin-top: 3px !important; }
 .companion-studio .diagnostic-zone-head > div > span { font-size: 10px !important; font-weight: 400 !important; color: var(--muted); }
-.companion-studio .diagnostic-filter { border: 1px solid var(--line-soft) !important; padding: 3px !important; border-radius: 9px !important; background: var(--surface) !important; gap: 2px !important; }
+.companion-studio .diagnostic-filter { border: 1px solid var(--line-soft) !important; padding: 3px !important; border-radius: 8px !important; background: var(--surface) !important; gap: 2px !important; }
 .companion-studio .diagnostic-filter button { border: 0 !important; background: transparent; border-radius: 6px !important; padding: 6px 12px !important; min-height: 32px !important; font-size: 12px !important; font-weight: 400 !important; }
 .companion-studio .diagnostic-filter button.is-active { background: var(--accent) !important; color: white !important; }
 .companion-studio #troubleshootingChecks { display: grid !important; grid-template-columns: minmax(0,1fr) !important; gap: 0 !important; max-height: none !important; height: auto !important; overflow: visible !important; padding: 0 !important; align-items: start !important; }
@@ -5722,7 +5722,7 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 .companion-studio .diagnostic-warning-suppress { background: transparent !important; color: var(--warn) !important; }
 .companion-studio .diagnostic-main-grid { grid-template-columns: minmax(0,1fr) !important; gap: 20px !important; }
 .companion-studio .diagnostic-events { max-height: none !important; overflow: visible !important; padding: 0 !important; }
-.companion-studio .troubleshooting-event { background: var(--surface) !important; border-color: var(--line-soft) !important; padding: 18px !important; box-shadow: none !important; border-radius: 9px !important; }
+.companion-studio .troubleshooting-event { background: var(--surface) !important; border-color: var(--line-soft) !important; padding: 18px !important; box-shadow: none !important; border-radius: 8px !important; }
 .companion-studio .diagnostic-runtime-stack { gap: 14px !important; }
 .companion-studio .diagnostic-runtime-card { background: var(--surface) !important; padding: 17px !important; }
 .companion-studio .diagnostic-runtime-card h3 { font-weight: 550 !important; }
@@ -5757,16 +5757,16 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 /* Subpage controls use one consistent treatment, including lazy-rendered content. */
 .companion-studio :is(.models-page-nav,.models-page-heading,.provider-group-head) { background: transparent !important; box-shadow: none !important; }
 .companion-studio :is(.models-page-heading,.provider-group-head) h2 { font-size: 23px; font-weight: 550; }
-.companion-studio :is(.models-subnav,.provider-config-mode,.provider-mode-switch) { border: 1px solid var(--line-soft) !important; background: var(--surface) !important; border-radius: 9px !important; padding: 4px !important; gap: 3px !important; box-shadow: none !important; }
+.companion-studio :is(.models-subnav,.provider-config-mode,.provider-mode-switch) { border: 1px solid var(--line-soft) !important; background: var(--surface) !important; border-radius: 8px !important; padding: 4px !important; gap: 3px !important; box-shadow: none !important; }
 .companion-studio :is(.models-subnav,.provider-config-mode,.provider-mode-switch) button { appearance: none; border: 0 !important; border-radius: 6px !important; background: transparent !important; color: var(--muted) !important; padding: 9px 13px !important; font-size: 12px !important; font-weight: 500 !important; box-shadow: none !important; }
 .companion-studio :is(.models-subnav,.provider-config-mode,.provider-mode-switch) button.active { background: var(--accent) !important; color: white !important; }
 .companion-studio .models-subnav button::before { content: none !important; }
-.companion-studio .studio-routing-help { margin: 16px 0; border: 1px solid var(--line-soft); border-radius: 10px; background: var(--panel); }
+.companion-studio .studio-routing-help { margin: 16px 0; border: 1px solid var(--line-soft); border-radius: 8px; background: var(--panel); }
 .companion-studio .studio-routing-help > summary { padding: 15px 18px; font-size: 12px; cursor: pointer; color: var(--accent-strong); }
 .companion-studio .studio-routing-help small { font-size: 11px; color: var(--muted); margin-left: 10px; }
 .companion-studio .studio-routing-help .provider-flow { padding: 18px; margin: 0; border: 0; box-shadow: none; }
 .companion-studio .studio-save-explainer { margin: -6px 0 22px; color: var(--muted); font-size: 11px; line-height: 1.8; }
-.companion-studio :is(.empty,.empty.small) { padding: 24px 18px; background: var(--surface); border: 1px solid var(--line-soft); border-radius: 10px; color: var(--muted); font-size: 12px; font-weight: 400; box-shadow: none; }
+.companion-studio :is(.empty,.empty.small) { padding: 24px 18px; background: var(--surface); border: 1px solid var(--line-soft); border-radius: 8px; color: var(--muted); font-size: 12px; font-weight: 400; box-shadow: none; }
 .companion-studio :is(.config-section-nav,.world-outline) { background: var(--surface) !important; box-shadow: none !important; }
 .companion-studio .config-fold-kicker { background: none !important; color: var(--muted) !important; font-weight: 400 !important; font-size: 10px !important; padding: 0 !important; }
 .companion-studio .config-fold-preview > span { border: 0 !important; background: var(--surface) !important; padding: 4px 7px; font-size: 10px; font-weight: 400 !important; }
@@ -5783,7 +5783,7 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 .companion-studio .studio-check-original > summary { font-size: 11px; color: var(--muted); cursor: pointer; }
 .companion-studio .studio-check-original p { background: var(--surface); border-left: 2px solid var(--line); padding: 10px 14px; font-size: 12px !important; }
 .companion-studio .troubleshooting-chain-tests { align-items: start !important; gap: 14px !important; }
-.companion-studio .troubleshooting-chain-test { display: flex !important; flex-direction: column !important; align-items: stretch !important; gap: 14px !important; border: 1px solid var(--line-soft) !important; border-radius: 10px !important; padding: 18px !important; background: var(--surface) !important; box-shadow: none !important; height: auto !important; }
+.companion-studio .troubleshooting-chain-test { display: flex !important; flex-direction: column !important; align-items: stretch !important; gap: 14px !important; border: 1px solid var(--line-soft) !important; border-radius: 8px !important; padding: 18px !important; background: var(--surface) !important; box-shadow: none !important; height: auto !important; }
 .companion-studio .troubleshooting-chain-test b { font-size: 14px !important; font-weight: 550 !important; }
 .companion-studio .troubleshooting-chain-test p { font-size: 12px !important; line-height: 1.8 !important; }
 .companion-studio .troubleshooting-chain-test-actions { display: flex !important; justify-content: flex-start; flex-wrap: wrap; gap: 8px; }
@@ -5987,7 +5987,7 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 .companion-studio .prompts-task-item code { white-space: normal !important; overflow: visible !important; text-overflow: clip !important; overflow-wrap: anywhere; line-height: 1.7; font-size: 10px; }
 .companion-studio .prompts-editor-content { display: block !important; width: 100%; min-width: 0; min-height: 0 !important; }
 .companion-studio .prompts-editor-content[hidden] { display: none !important; }
-.companion-studio .prompts-editor-head { flex-wrap: wrap; padding: 0 0 18px; gap: 10px; }
+.companion-studio .prompts-editor-head { flex-direction: row !important; flex-wrap: wrap; padding: 0 0 18px; gap: 10px; }
 .companion-studio .prompts-editor-head > div { flex: 1 1 240px; min-width: 0; }
 .companion-studio .prompts-editor-head :is(h3,p) { overflow-wrap: anywhere; white-space: normal; }
 .companion-studio .prompts-editor-head h3 { font-size: 19px; font-weight: 550; line-height: 1.6; }
@@ -6007,4 +6007,17 @@ body.companion-studio::before, body.companion-studio::after { content: none !imp
 @supports(container-type:inline-size) {
  @container promptpage (min-width:901px) { .companion-studio .prompts-workspace { grid-template-columns: minmax(230px,280px) minmax(0,1fr) !important; } .companion-studio .prompts-catalog { border-right: 1px solid var(--line) !important; border-bottom: 0 !important; padding: 0 18px 0 0; } }
  @container promptpage (max-width:900px) { .companion-studio .prompts-workspace { grid-template-columns: minmax(0,1fr) !important; } .companion-studio .prompts-catalog { border-right: 0 !important; border-bottom: 1px solid var(--line) !important; padding: 0 0 20px; } .companion-studio .prompts-task-list { max-height: 320px !important; } }
+}
+
+.companion-studio #providerSummary { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0 24px; }
+.companion-studio .provider-summary-card { min-width: 0; border: 0; border-bottom: 1px solid var(--line); border-radius: 0; padding: 12px 0; background: transparent; box-shadow: none; }
+.companion-studio .provider-summary-card b { font-size: 16px; overflow-wrap: anywhere; }
+@media (max-width: 680px) {
+  .companion-studio .annotations { max-width: none !important; }
+  .companion-studio .studio-find { position: sticky; left: 0; z-index: 1; display: inline-flex !important; flex: 0 0 40px; width: 40px !important; height: 40px; justify-content: center; padding: 0 !important; margin: 0; background: var(--studio-sidebar) !important; }
+  .companion-studio .studio-find .studio-find-label { display: none; }
+  .companion-studio #promptsEditor { scroll-margin-top: 80px; }
+}
+@media (max-width: 700px) {
+  .companion-studio .prompts-scope-note { flex-basis: auto; }
 }

--- a/pages/陪伴面板/index.html
+++ b/pages/陪伴面板/index.html
@@ -163,7 +163,7 @@
   </style>
   <link rel="stylesheet" href="./css/header-tools.css?v=20260713-font-options" />
   <link rel="stylesheet" href="./css/qzone-mobile.css?v=20260711-qzone-image-preview" />
-  <link rel="stylesheet" href="./css/polish.css?v=20260810-responsive-containment-v1&amp;world=20260811-responsive-v2&amp;config=multi-persona-summary-v2&amp;mobile=20260829-overflow-v1" />
+  <link rel="stylesheet" href="./css/polish.css?v=20260810-responsive-containment-v1&amp;world=20260811-responsive-v2&amp;config=multi-persona-summary-v2&amp;mobile=20260829-overflow-v1&amp;studio=20260912-v4" />
   <script>
     (function () {
       try {
@@ -208,7 +208,8 @@
     })();
   </script>
 </head>
-<body>
+<body class="companion-studio">
+  <a class="studio-skip" href="#panel-dashboard">跳到主要内容</a>
   <section class="asset-load-fallback" role="status" aria-live="polite">
     <div class="asset-load-fallback__content">
       <div class="asset-load-fallback__state" aria-hidden="true"></div>
@@ -226,8 +227,8 @@
       <div class="folio-meta">
         <div class="folio-heading">
           <div>
-            <div class="folio-eyebrow"><b>●</b> PRIVATE COMPANION</div>
-            <h1 class="folio-title">陪伴面板</h1>
+            <div class="folio-eyebrow">你的专属陪伴空间</div>
+            <h1 class="folio-title">陪伴面板 <span class="studio-header-slash">/</span> <span id="studioPageTitle">总览</span></h1>
           </div>
           <div class="folio-persona-context">
             <label id="pagePersonaSelector" class="page-persona-selector" for="pagePersonaSelect" hidden>
@@ -237,7 +238,7 @@
             <p id="subtitle">读取运行态中...</p>
           </div>
         </div>
-        <div class="folio-stats" id="stats"></div>
+
       </div>
 
       <div class="folio-plate" aria-label="今日穿搭">
@@ -255,35 +256,64 @@
 
     <section class="layout">
       <nav class="annotations" aria-label="视图">
+        <div class="studio-brand"><span class="studio-brand-mark" aria-hidden="true">✳</span><div><b>伴 · Companion</b><small>PRIVATE COMPANION</small></div></div>
+        <button type="button" class="studio-find" id="studioFindBtn"><span>⌕ &nbsp; 查找功能</span><kbd>⌘ K</kbd></button>
         <div class="annot-axis" aria-hidden="true"></div>
-        <button class="tab is-active" data-tab="dashboard"><i>01</i><span>总览</span></button>
-        <button class="tab" data-tab="roleplay"><i>02</i><span>世界知识</span></button>
-        <button class="tab" data-tab="private"><i>03</i><span>用户</span></button>
-        <button class="tab" data-tab="group"><i>04</i><span>群聊</span></button>
-        <button class="tab" data-tab="learning"><i>05</i><span>学习</span></button>
-        <button class="tab" data-tab="memory"><i>06</i><span>观察</span></button>
-        <button class="tab" data-tab="proactive"><i>07</i><span>主动</span></button>
-        <button class="tab" data-tab="creative" hidden><i>08</i><span>创作</span></button>
-        <button class="tab" data-tab="image" hidden><i>09</i><span>生图</span></button>
-        <button class="tab" data-tab="tokens"><i>10</i><span>Token</span></button>
-        <button class="tab" data-tab="troubleshooting"><i>11</i><span>排障</span></button>
-        <button class="tab" data-tab="config"><i>12</i><span>配置</span></button>
-        <button class="tab" data-tab="models"><i>13</i><span>模型</span></button>
-        <button class="tab" data-tab="experimental"><i>14</i><span>实验</span></button>
-        <button class="tab" data-tab="prompts"><i>15</i><span>提示词</span></button>
-        <button class="tab" data-tab="reality" hidden><i>16</i><span>现实触及</span></button>
+        <div class="studio-nav-label">日常陪伴</div>
+        <button class="tab is-active" data-tab="dashboard"><i>◫</i><span>总览</span></button>
+        <button class="tab" data-tab="roleplay"><i>◎</i><span>角色与背景</span></button>
+        <button class="tab" data-tab="private"><i>♧</i><span>陪伴对象</span></button>
+        <button class="tab" data-tab="group"><i>♧</i><span>群聊</span></button>
+        <div class="studio-nav-label">理解与成长</div>
+        <button class="tab" data-tab="learning"><i>✧</i><span>学习</span></button>
+        <button class="tab" data-tab="memory"><i>◷</i><span>日程与记忆</span></button>
+        <button class="tab" data-tab="proactive"><i>↗</i><span>主动消息</span></button>
+        <button class="tab" data-tab="creative" hidden><i>✎</i><span>创作</span></button>
+        <button class="tab" data-tab="image" hidden><i>▧</i><span>生图</span></button>
+        <div class="studio-nav-label">管理与调校</div>
+        <button class="tab" data-tab="tokens"><i>◴</i><span>用量统计</span></button>
+        <button class="tab" data-tab="troubleshooting"><i>⊙</i><span>检查与修复</span></button>
+        <button class="tab" data-tab="config"><i>⚙</i><span>功能设置</span></button>
+        <button class="tab" data-tab="models"><i>◇</i><span>模型服务</span></button>
+        <button class="tab" data-tab="experimental"><i>⚗</i><span>实验</span></button>
+        <button class="tab" data-tab="prompts"><i>≡</i><span>提示词</span></button>
+        <button class="tab" data-tab="reality" hidden><i>⌁</i><span>现实触及</span></button>
+        <div class="studio-nav-foot"><span>✧</span> 让陪伴，回归日常。<small>POWERED BY ASTRBOT</small></div>
       </nav>
 
       <section class="panel dashboard-overview is-active" id="panel-dashboard">
         <div class="section-head dashboard-overview-head">
           <div>
             <h2>今日概览</h2>
-            <p class="section-desc">日程、状态、主动与记忆集中在这里；配置和诊断按需展开。</p>
+            <p class="section-desc">今天的点滴，都在这里。</p>
           </div>
           <div class="actions compact">
             <button id="exportSnapshotBtn" type="button">导出快照</button>
           </div>
         </div>
+
+        <section class="studio-welcome" aria-labelledby="studioWelcomeTitle">
+          <div class="studio-welcome-copy"><span class="studio-kicker"><span></span> OUR EVERYDAY, TOGETHER</span>
+            <h2 id="studioWelcomeTitle">今天，TA 过得怎么样？</h2>
+            <p>看看当前状态和日程；要调整行为，去左侧设置。</p>
+            <div class="studio-welcome-actions"><button type="button" data-jump-tab="memory" class="studio-primary">看看 TA 的一天 <span>↗</span></button><button type="button" data-setup-guide-open class="studio-text-button">初次见面？开始配置 <span>→</span></button></div>
+          </div>
+          <svg class="studio-art" viewBox="0 0 400 280" fill="none" aria-hidden="true">
+            <circle cx="224" cy="135" r="108" fill="#e0e7d9"/><circle cx="224" cy="135" r="84" stroke="#c8d3c1" stroke-dasharray="3 7"/>
+            <ellipse cx="218" cy="240" rx="142" ry="14" fill="#d2ddce" opacity=".55"/>
+            <path d="M117 212c-32-29-40-66-29-102 34 7 59 39 53 80" fill="#809b7d"/><path d="M124 213c-4-43 10-75 44-92 17 35 3 67-44 92Z" fill="#a5b99c"/><path d="M122 218 99 139m24 70 32-65" stroke="#526f57" stroke-width="2"/>
+            <path d="M98 202h58l-8 34h-42z" fill="#ede7d9"/><path d="M98 203h58" stroke="#d7d0bd" stroke-width="4"/>
+            <rect x="182" y="185" width="113" height="48" rx="12" fill="#567761"/><rect x="189" y="179" width="110" height="44" rx="10" fill="#f8f5ea"/><path d="M202 190h77m-77 8h77m-77 8h62" stroke="#d9d9c8" stroke-width="2"/>
+            <rect x="170" y="163" width="118" height="21" rx="6" fill="#a7b693"/><path d="M182 173h91" stroke="#eff1de" stroke-width="2"/>
+            <path d="M206 102h57v39c0 20-57 20-57 0z" fill="#fdfbf3"/><ellipse cx="234.5" cy="103" rx="28.5" ry="8" fill="#dad4bc"/><ellipse cx="234.5" cy="104" rx="23" ry="5" fill="#aa8963"/><path d="M264 111h8c23 0 18 30-8 25" stroke="#fdfbf3" stroke-width="9"/>
+            <path d="M225 83c-12-12 13-18 2-32m17 34c-12-12 13-18 2-32" stroke="#fffdf5" stroke-width="3" stroke-linecap="round"/>
+            <path d="m309 64 4 10 11 3-11 4-4 11-3-11-11-4 11-3z" fill="#82946d"/><circle cx="162" cy="65" r="5" fill="#c2a577"/>
+            <path d="m325 172 3 7 7 3-7 2-3 8-2-8-8-2 8-3z" fill="#bda779"/>
+          </svg>
+          <span class="studio-art-caption">A LITTLE CLOSER, EVERY DAY</span>
+        </section>
+        <div class="studio-metrics-label"><span>运行概况</span><small>点击指标，查看详情 ↗</small></div>
+        <div class="folio-stats" id="stats" aria-label="运行概况"></div>
         <section class="dashboard-life-desk" aria-label="今日生活工作台">
           <aside class="dashboard-life-column dashboard-life-column-left">
             <article class="life-desk-card life-desk-today">
@@ -314,7 +344,11 @@
             </article>
           </section>
 
-          <aside class="dashboard-life-column dashboard-life-column-right">
+
+        </section>
+        <section class="dashboard-secondary" aria-label="更多运行信息">
+          <div class="studio-section-label">更多信息 <small>需要时展开查看。</small></div>
+          <details class="dashboard-disclosure studio-memory-disclosure"><summary><span><b>动态、记忆与运行能力</b><small>近期动向、记忆概况与能力状态</small></span></summary>          <aside class="dashboard-life-column dashboard-life-column-right">
             <article class="life-desk-card life-desk-memory">
               <div class="life-desk-card-head">
                 <div><span class="life-desk-dot"></span><h3>动态与记忆</h3></div>
@@ -336,9 +370,7 @@
               </div>
               <div id="dashboardCapabilitySummary" class="life-capability-list"></div>
             </article>
-          </aside>
-        </section>
-        <section class="dashboard-secondary" aria-label="更多运行信息">
+          </aside></details>
           <details class="dashboard-disclosure">
             <summary>
               <span><b>互动与主动</b><small>私聊、群聊和长线主动策略</small></span>
@@ -387,7 +419,7 @@
             </div>
           </details>
         </section>
-        <section class="dashboard-companion-terminal" aria-labelledby="dashboardCompanionTerminalTitle">
+        <details class="dashboard-disclosure studio-terminal-disclosure"><summary><span><b>扩展连接与诊断</b><small>陪伴系插件发现状态、检查与终端入口</small></span></summary>        <section class="dashboard-companion-terminal" aria-labelledby="dashboardCompanionTerminalTitle">
           <header class="dashboard-companion-terminal-head">
             <div>
               <span class="dashboard-kicker">连接检查</span>
@@ -402,14 +434,14 @@
           </header>
           <div id="dashboardCompanionTerminalSummary" class="dashboard-companion-terminal-summary" aria-live="polite"></div>
           <div id="dashboardCompanionTerminalList" class="dashboard-companion-terminal-list"></div>
-        </section>
+        </section></details>
       </section>
 
       <section class="panel" id="panel-roleplay">
         <div class="section-head">
           <div>
             <h2>世界知识</h2>
-            <span class="muted">整理角色和世界背景，作为陪伴行为的稳定参考。</span>
+            <span class="muted">告诉 TA 自己是谁、生活在哪里，以及与你的关系。</span>
           </div>
           <div class="world-page-actions">
             <span class="world-save-state" id="worldSaveState">已同步</span>
@@ -482,7 +514,7 @@
           </aside>
           <div class="module-card-head">
             <div>
-              <h2>世界知识工作台</h2>
+              <h2>角色与背景资料</h2>
               <span class="section-desc">把角色资料、世界观和用户关系整理成插件可引用的背景材料；不会覆盖 AstrBot 主人格。</span>
             </div>
             <span class="module-badge">知识</span>
@@ -1235,12 +1267,22 @@ QQ空间 = 公开札记
 
       <section class="panel" id="panel-proactive">
         <div class="section-head">
-          <h2>今日主动候选</h2>
-          <span class="muted">统一候选池、去重、配额与调度结果</span>
+          <h2>主动消息记录</h2>
+          <span class="muted">先看待发送和已发送消息；需要追查原因时，再展开统计与执行记录。</span>
         </div>
         <div id="proactiveSummary" class="proactive-summary"></div>
         <div class="proactive-layout">
-          <article>
+          <article class="wide proactive-records-card">
+            <h2>消息列表</h2>
+            <div id="proactiveCandidateFilters" class="proactive-filters"></div>
+            <div id="proactiveCandidateList" class="proactive-candidates"></div>
+          </article>
+          <details class="studio-proactive-disclosure"><summary>执行记录 <small>查看任务安排、发送过程与结果</small></summary>          <article class="wide">
+            <h2>主动任务记录</h2>
+            <div id="proactiveTaskList" class="proactive-tasks"></div>
+          </article>
+</details>
+          <details class="studio-proactive-disclosure"><summary>来源与状态分布 <small>按来源和处理状态查看统计图</small></summary><div class="studio-chart-layout">          <article>
             <h2>来源分布</h2>
             <div id="proactiveSourceChart" class="chart-box"></div>
           </article>
@@ -1248,15 +1290,7 @@ QQ空间 = 公开札记
             <h2>状态分布</h2>
             <div id="proactiveStatusChart" class="chart-box"></div>
           </article>
-          <article class="wide">
-            <h2>主动任务记录</h2>
-            <div id="proactiveTaskList" class="proactive-tasks"></div>
-          </article>
-          <article class="wide proactive-records-card">
-            <h2>候选记录</h2>
-            <div id="proactiveCandidateFilters" class="proactive-filters"></div>
-            <div id="proactiveCandidateList" class="proactive-candidates"></div>
-          </article>
+</div></details>
         </div>
       </section>
 
@@ -1471,21 +1505,21 @@ QQ空间 = 公开札记
         <div class="subpage troubleshooting-page">
           <header class="diagnostic-masthead">
             <div>
-              <span class="diagnostic-kicker">SYSTEM / SIGNAL / EVIDENCE</span>
-              <h2>排障指挥台</h2>
-              <p>先选择遇到的问题，再按对应链路查看检查、证据与测试结果。</p>
+              <span class="diagnostic-kicker">遇到问题，从这里查起</span>
+              <h2>检查与修复</h2>
+              <p>先选问题类型，再查看原因。检查不会自动修改你的配置。</p>
             </div>
             <div class="diagnostic-masthead-actions">
-              <button id="refreshTroubleshootingBtn" type="button">执行检查</button>
-              <span class="diagnostic-live-dot"><i></i> 运行态快照</span>
+              <button id="refreshTroubleshootingBtn" type="button">重新检查</button>
+              <span class="diagnostic-live-dot"><i></i> 最近一次检查结果</span>
             </div>
           </header>
 
           <section class="diagnostic-problem-picker" aria-labelledby="troubleshootingProblemTitle">
             <div>
-              <span>从问题开始</span>
-              <h3 id="troubleshootingProblemTitle">你遇到了什么问题？</h3>
-              <p>选择后只保留相关的检查、事件、链路测试与排查说明。</p>
+              <span>选择范围</span>
+              <h3 id="troubleshootingProblemTitle">哪里不正常？</h3>
+              <p>选一类，就只看这一类的检查结果。</p>
             </div>
             <div id="troubleshootingCategories" class="diagnostic-category-list" role="tablist" aria-label="问题类型"></div>
           </section>
@@ -1495,8 +1529,8 @@ QQ空间 = 公开札记
           <section class="diagnostic-priority-zone">
             <div class="diagnostic-zone-head">
               <div>
-                <span>优先队列</span>
-                <h3 id="troubleshootingChecksTitle">需要处理的信号</h3>
+                <span>逐项检查</span>
+                <h3 id="troubleshootingChecksTitle">检查结果</h3>
               </div>
               <div class="troubleshooting-filter diagnostic-filter" role="group" aria-label="问题筛选">
                 <button type="button" data-troubleshooting-filter="all" class="is-active">全部</button>
@@ -1518,12 +1552,13 @@ QQ空间 = 公开札记
           <div class="diagnostic-main-grid">
             <section class="diagnostic-live-lane">
               <div class="diagnostic-zone-head compact">
-                <div><span>实时验证</span><h3 id="troubleshootingChainTitle">链路与运行状态</h3></div>
+                <div><span>需要时再测试</span><h3 id="troubleshootingChainTitle">连接测试</h3></div>
               </div>
               <div id="troubleshootingChainTests" class="troubleshooting-chain-tests"></div>
+              <details class="studio-runtime-details"><summary>数据库、用户隔离与消息合并 <small>展开查看底层运行状态</small></summary>
               <div id="troubleshootingRuntimeStack" class="diagnostic-runtime-stack">
                 <article class="diagnostic-runtime-card">
-                  <div class="diagnostic-card-head"><h3>统一身份与隔离</h3><span>REQ-041</span></div>
+                  <div class="diagnostic-card-head"><h3>用户身份与数据隔离</h3><span>REQ-041</span></div>
                   <div id="troubleshootingReq041" class="troubleshooting-sqlite"></div>
                 </article>
                 <article class="diagnostic-runtime-card">
@@ -1531,29 +1566,29 @@ QQ空间 = 公开札记
                   <div id="troubleshootingSqlite" class="troubleshooting-sqlite"></div>
                 </article>
                 <article class="diagnostic-runtime-card">
-                  <div class="diagnostic-card-head"><h3>消息收口追踪</h3><span>防抖</span></div>
+                  <div class="diagnostic-card-head"><h3>消息合并记录</h3><span>防抖</span></div>
                   <div id="troubleshootingDebounceTrace" class="troubleshooting-debounce-trace"></div>
                 </article>
-              </div>
+              </div></details>
             </section>
 
             <aside class="diagnostic-event-lane">
               <div class="diagnostic-zone-head compact">
-                <div><span>事件时间线</span><h3 id="troubleshootingEventsTitle">最近问题</h3></div>
+                <div><span>按时间查看</span><h3 id="troubleshootingEventsTitle">最近记录</h3></div>
               </div>
               <div id="troubleshootingEvents" class="troubleshooting-events diagnostic-events"></div>
             </aside>
           </div>
 
           <details class="diagnostic-evidence-drawer">
-            <summary><span>证据与深度排查</span><small>提示词注入、常见问题和运行诊断</small></summary>
+            <summary><span>日志与详细说明</span><small>检查正常但仍有问题？展开查看原始记录</small></summary>
             <div class="diagnostic-evidence-body">
               <article class="troubleshooting-injection-panel">
-                <div><h2>最近注入内容</h2><span class="muted">用于排查污染、错时、TTS 规则和上下文串线</span></div>
+                <div><h2>最近加入对话的上下文</h2><span class="muted">检查是否加进了错误的人物资料、时间信息或语音规则。</span></div>
                 <div id="troubleshootingPromptInjections" class="troubleshooting-prompt-injections"></div>
               </article>
               <article class="troubleshooting-diagnostics-panel">
-                <div><h2>运行诊断</h2><span class="muted">从配置、目标用户、群聊开关和运行态中整理出的诊断项</span></div>
+                <div><h2>运行诊断</h2><span class="muted">查看当前配置、陪伴对象、群聊开关是否符合运行条件。</span></div>
                 <div id="diagnosticPanel" class="diagnostic-list"></div>
               </article>
               <article class="troubleshooting-faq-panel">
@@ -1617,8 +1652,8 @@ QQ空间 = 公开札记
         <header class="config-page-intro">
           <div>
             <span class="config-page-kicker">配置中心</span>
-            <h2>配置工作台</h2>
-            <p>基础维护、运行节奏与功能生命周期集中管理。</p>
+            <h2>插件设置</h2>
+            <p>管理陪伴对象、模型服务和功能开关。改完后记得保存。</p>
           </div>
           <nav class="config-section-nav" aria-label="配置区域">
             <button type="button" data-config-section-target="config-common-settings">通用设置</button>
@@ -1630,7 +1665,7 @@ QQ空间 = 公开札记
           <details class="config-fold-panel config-common-settings" id="config-common-settings">
             <summary class="config-fold-summary">
               <div class="config-fold-heading">
-                <span class="config-fold-kicker">配置工作台</span>
+                <span class="config-fold-kicker">插件设置</span>
                 <h2>通用设置</h2>
                 <p>多人格拓扑、AstrBot 路由状态、群聊范围、数据维护与页面外观。</p>
                 <span class="config-fold-preview" aria-label="包含的配置范围">
@@ -1886,7 +1921,7 @@ QQ空间 = 公开札记
                 </div>
                 <span id="configPersonaStatsSource" class="muted">统计随人格选择更新</span>
               </header>
-              <div class="folio-stats config-stats" id="configStats"></div>
+              <details class="studio-config-stats"><summary>查看当前人格的运行统计</summary><div class="folio-stats config-stats" id="configStats"></div></details>
             </section>
           </section>
 
@@ -1970,6 +2005,7 @@ QQ空间 = 公开札记
                 </label>
                 <button id="enableSafeFeaturesBtn" type="button">启用基础安全项</button>
               </div>
+              <details class="studio-filter-options"><summary>按分类、阶段或状态筛选</summary>
               <section class="feature-filter-row" aria-labelledby="featureDomainLabel">
                 <div class="feature-filter-label">
                   <b id="featureDomainLabel">功能领域</b>
@@ -1990,8 +2026,9 @@ QQ空间 = 公开札记
                   <small>快速核对</small>
                 </div>
                 <div id="featureStatusFilters" class="feature-filter-options" role="group" aria-label="当前状态"></div>
-              </section>
+              </section></details>
             </div>
+            <p class="studio-feature-instructions">点击分组展开。右侧开关控制启停，点击功能名称调整参数；更改后请保存。</p>
             <div class="feature-switch-board" id="featureFlags"></div>
           </article>
           </section>
@@ -2057,7 +2094,7 @@ QQ空间 = 公开札记
         <div class="section-head models-page-head">
           <div class="models-page-heading">
             <h2>模型配置</h2>
-            <span class="muted">任务分流、语音合成与生图后端</span>
+            <span class="muted">设置文字、语音和图片任务使用的模型服务。</span>
           </div>
           <nav class="models-subnav" aria-label="模型配置分类" role="tablist">
             <button id="modelsProvidersTab" type="button" class="active" data-index="01" data-models-section="providers" role="tab" aria-controls="modelsProviderPane" aria-selected="true">任务模型</button>
@@ -2070,13 +2107,13 @@ QQ空间 = 公开札记
           <div id="llmStreamingCard"></div>
           <div id="deepseekPeakCard"></div>
           <div id="modelReplacementCard"></div>
-          <div id="providerFlow" class="provider-flow"></div>
+          <details class="studio-routing-help"><summary>查看模型调用关系 <small>不确定某个任务会用哪个模型？在这里查看。</small></summary><div id="providerFlow" class="provider-flow"></div></details>
           <div class="provider-config-mode-card">
             <div>
-              <b>模型配置模式</b>
+              <b>选择配置方式</b>
               <span id="providerConfigModeHint">插件功能通常会携带较多动态上下文，Token 缓存命中率可能较低，请结合调用频率和预算合理规划模型。</span>
             </div>
-            <div class="provider-config-mode" aria-label="模型配置模式">
+            <div class="provider-config-mode" aria-label="选择配置方式">
               <button type="button" data-provider-config-mode="quick" class="active">快速配置</button>
               <button type="button" data-provider-config-mode="precision">精准配置</button>
             </div>
@@ -2093,9 +2130,10 @@ QQ空间 = 公开札记
             </div>
             <div class="provider-toolbar-actions">
               <button id="testAllProvidersBtn" type="button">测试全部模型</button>
-              <button id="saveProvidersBtn" type="button">保存并覆盖两套模型配置</button>
+              <button id="saveProvidersBtn" type="button" title="保存当前填写的模型设置，同时覆盖快速配置和精准配置">保存两套配置</button>
             </div>
           </div>
+          <p class="studio-save-explainer">保存会同时覆盖快速配置和精准配置；测试只检查连接，不会保存修改。</p>
           <form id="providerForm" class="provider-groups"></form>
         </div>
         <div id="modelsTtsPane" class="tts-model-pane" data-models-pane="tts" role="tabpanel" aria-labelledby="modelsTtsTab" hidden>
@@ -2204,7 +2242,7 @@ QQ空间 = 公开札记
         <div class="section-head prompts-page-head">
           <div>
             <h2>任务提示词</h2>
-            <p class="section-desc">统一管理插件内部任务模型的附加指令，包括工具结果转述、日程、复核、群聊、视觉等任务。</p>
+            <p class="section-desc">为日程、群聊、识图等任务补充要求。这里不会修改主聊天人格。</p>
           </div>
           <div class="prompts-scope-note" role="note">
             <b>作用范围</b>
@@ -2225,7 +2263,8 @@ QQ空间 = 公开札记
               </div>
             </div>
             <nav id="promptsGroupNav" class="prompts-group-nav" aria-label="任务分组"></nav>
-            <div id="promptsTaskList" class="prompts-task-list" role="list" aria-label="任务提示词"></div>
+            <p class="prompts-directory-hint" id="promptsDirectoryHint">任务较多时可在目录内滚动，或用上方搜索定位。选择任务后，在编辑区查看完整内容。</p>
+            <div id="promptsTaskList" class="prompts-task-list" role="list" aria-label="任务提示词" aria-describedby="promptsDirectoryHint" tabindex="0"></div>
           </aside>
 
           <section id="promptsEditor" class="prompts-editor" aria-labelledby="promptsEditorTitle">
@@ -2286,6 +2325,12 @@ QQ空间 = 公开札记
     <button id="saveFeaturesBtn" type="button">保存功能开关</button>
   </div>
 
+  <dialog id="studioCommand" class="studio-command" aria-labelledby="studioCommandTitle">
+    <div class="studio-command-head"><h2 id="studioCommandTitle">你想做什么？</h2><button type="button" id="studioCommandClose" aria-label="关闭功能搜索">×</button></div>
+    <input id="studioCommandInput" type="search" placeholder="搜索功能，例如：日程、模型、提示词…" aria-label="搜索功能" autocomplete="off" />
+    <div id="studioCommandResults" class="studio-command-results"></div>
+    <p class="studio-command-help">↑ ↓ 选择 · Enter 打开 · Esc 关闭</p>
+  </dialog>
   <div id="setupGuideOverlayRoot"></div>
 
   <div id="bookshelfCoverPreview" class="bookshelf-cover-preview" hidden aria-hidden="true">
@@ -2318,6 +2363,6 @@ QQ空间 = 公开札记
   <!-- Loaded on demand by app.js through AstrBot's relative dynamic-import rewriting:
        ./js/panels/provider-tree.js?v=20260804-reading-archive-capability-v1&amp;manual=provider-input-v2&amp;layout=v2&amp;vision-state=v1
        ./js/panels/qzone-panel.js?v=20260810-qzone-classic-loader-v1 -->
-  <script src="./app.js?v=20260809-proactive-tts-external-ability-photo-fixed-v1&amp;build=20260810-reference-upload-v2&amp;page=lazy-classic-loader-v1&amp;scope=photo-scope-quota-v1&amp;touch=reality-redesign-rt2-v4&amp;memory-source=memory-companion-v2&amp;user-create=profile-v1&amp;relationship-role-photo=pr125-v1&amp;camera-runtime-scope=v1&amp;config=multi-persona-summary-v2&amp;troubleshooting=persona-routing-lifecycle-v1&amp;content-visibility=v1&amp;migration-notice=v4&amp;component-order=v1&amp;layout=model-routing-v2&amp;persona-style-batch-recovery=v1&amp;preset-save=v1&amp;directory-nav=v2&amp;mihome=external-runtime-v2&amp;terminal=plugin-check-v1&amp;diagnostic-layout=v2&amp;prompts=task-editor-v2&amp;release=6.4.4f&amp;vision-state=v1"></script>
+  <script src="./app.js?v=20260809-proactive-tts-external-ability-photo-fixed-v1&amp;build=20260810-reference-upload-v2&amp;page=lazy-classic-loader-v1&amp;scope=photo-scope-quota-v1&amp;touch=reality-redesign-rt2-v4&amp;memory-source=memory-companion-v2&amp;user-create=profile-v1&amp;relationship-role-photo=pr125-v1&amp;camera-runtime-scope=v1&amp;config=multi-persona-summary-v2&amp;troubleshooting=persona-routing-lifecycle-v1&amp;content-visibility=v1&amp;migration-notice=v4&amp;component-order=v1&amp;layout=model-routing-v2&amp;persona-style-batch-recovery=v1&amp;preset-save=v1&amp;directory-nav=v2&amp;mihome=external-runtime-v2&amp;terminal=plugin-check-v1&amp;diagnostic-layout=v2&amp;prompts=task-editor-v2&amp;release=6.4.4f&amp;vision-state=v1&amp;studio=20260912-v4"></script>
 </body>
 </html>

--- a/pages/陪伴面板/index.html
+++ b/pages/陪伴面板/index.html
@@ -257,7 +257,7 @@
     <section class="layout">
       <nav class="annotations" aria-label="视图">
         <div class="studio-brand"><span class="studio-brand-mark" aria-hidden="true">✳</span><div><b>伴 · Companion</b><small>PRIVATE COMPANION</small></div></div>
-        <button type="button" class="studio-find" id="studioFindBtn"><span>⌕ &nbsp; 查找功能</span><kbd>⌘ K</kbd></button>
+        <button type="button" class="studio-find" id="studioFindBtn" aria-label="查找功能" title="查找功能"><span aria-hidden="true">⌕</span><span class="studio-find-label">查找功能</span></button>
         <div class="annot-axis" aria-hidden="true"></div>
         <div class="studio-nav-label">日常陪伴</div>
         <button class="tab is-active" data-tab="dashboard"><i>◫</i><span>总览</span></button>
@@ -292,27 +292,7 @@
           </div>
         </div>
 
-        <section class="studio-welcome" aria-labelledby="studioWelcomeTitle">
-          <div class="studio-welcome-copy"><span class="studio-kicker"><span></span> OUR EVERYDAY, TOGETHER</span>
-            <h2 id="studioWelcomeTitle">今天，TA 过得怎么样？</h2>
-            <p>看看当前状态和日程；要调整行为，去左侧设置。</p>
-            <div class="studio-welcome-actions"><button type="button" data-jump-tab="memory" class="studio-primary">看看 TA 的一天 <span>↗</span></button><button type="button" data-setup-guide-open class="studio-text-button">初次见面？开始配置 <span>→</span></button></div>
-          </div>
-          <svg class="studio-art" viewBox="0 0 400 280" fill="none" aria-hidden="true">
-            <circle cx="224" cy="135" r="108" fill="#e0e7d9"/><circle cx="224" cy="135" r="84" stroke="#c8d3c1" stroke-dasharray="3 7"/>
-            <ellipse cx="218" cy="240" rx="142" ry="14" fill="#d2ddce" opacity=".55"/>
-            <path d="M117 212c-32-29-40-66-29-102 34 7 59 39 53 80" fill="#809b7d"/><path d="M124 213c-4-43 10-75 44-92 17 35 3 67-44 92Z" fill="#a5b99c"/><path d="M122 218 99 139m24 70 32-65" stroke="#526f57" stroke-width="2"/>
-            <path d="M98 202h58l-8 34h-42z" fill="#ede7d9"/><path d="M98 203h58" stroke="#d7d0bd" stroke-width="4"/>
-            <rect x="182" y="185" width="113" height="48" rx="12" fill="#567761"/><rect x="189" y="179" width="110" height="44" rx="10" fill="#f8f5ea"/><path d="M202 190h77m-77 8h77m-77 8h62" stroke="#d9d9c8" stroke-width="2"/>
-            <rect x="170" y="163" width="118" height="21" rx="6" fill="#a7b693"/><path d="M182 173h91" stroke="#eff1de" stroke-width="2"/>
-            <path d="M206 102h57v39c0 20-57 20-57 0z" fill="#fdfbf3"/><ellipse cx="234.5" cy="103" rx="28.5" ry="8" fill="#dad4bc"/><ellipse cx="234.5" cy="104" rx="23" ry="5" fill="#aa8963"/><path d="M264 111h8c23 0 18 30-8 25" stroke="#fdfbf3" stroke-width="9"/>
-            <path d="M225 83c-12-12 13-18 2-32m17 34c-12-12 13-18 2-32" stroke="#fffdf5" stroke-width="3" stroke-linecap="round"/>
-            <path d="m309 64 4 10 11 3-11 4-4 11-3-11-11-4 11-3z" fill="#82946d"/><circle cx="162" cy="65" r="5" fill="#c2a577"/>
-            <path d="m325 172 3 7 7 3-7 2-3 8-2-8-8-2 8-3z" fill="#bda779"/>
-          </svg>
-          <span class="studio-art-caption">A LITTLE CLOSER, EVERY DAY</span>
-        </section>
-        <div class="studio-metrics-label"><span>运行概况</span><small>点击指标，查看详情 ↗</small></div>
+        <div class="studio-metrics-label"><span>运行概况</span><button type="button" data-jump-tab="memory" class="studio-text-button">日程与记忆 <span aria-hidden="true">↗</span></button></div>
         <div class="folio-stats" id="stats" aria-label="运行概况"></div>
         <section class="dashboard-life-desk" aria-label="今日生活工作台">
           <aside class="dashboard-life-column dashboard-life-column-left">

--- a/pages/陪伴面板/js/panels/provider-tree.js
+++ b/pages/陪伴面板/js/panels/provider-tree.js
@@ -126,6 +126,7 @@ window.PrivateCompanionProviderTree = (() => {
     const preference = providerPreferenceMeta[guide.preference || ""];
     const impact = providerPassiveImpactMeta[guide.passiveImpact || ""];
     return `
+      <details class="studio-provider-guide"><summary>模型用途与选择建议</summary>
       <span class="provider-guide">
         <span><b>用途</b>${escapeHtml(guide.purpose)}</span>
         <span><b>适合</b>${escapeHtml(guide.fit)}</span>
@@ -134,6 +135,7 @@ window.PrivateCompanionProviderTree = (() => {
         ${guide.note ? `<span><b>注意</b>${escapeHtml(guide.note)}</span>` : ""}
         <span><b>回退</b>${escapeHtml(guide.fallback)}</span>
       </span>
+      </details>
     `;
   }
 

--- a/tests/test_feature_config_ui_ownership.py
+++ b/tests/test_feature_config_ui_ownership.py
@@ -398,7 +398,7 @@ class FeatureConfigUiOwnershipTests(unittest.TestCase):
             'enable_livingmemory_integration: "enable_external_memory_integration"',
             self.script,
         )
-        self.assertIn('<small>${escapeHtml(featurePublicKey(key))}</small>', self.script)
+        self.assertIn('<code>${escapeHtml(featurePublicKey(key))}</code>', self.script)
         self.assertIn('data-feature-key="${escapeHtml(key)}"', self.script)
 
     def test_personal_goal_feature_and_settings_are_saveable(self) -> None:

--- a/tests/test_panel_navigation_guard.py
+++ b/tests/test_panel_navigation_guard.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from html.parser import HTMLParser
+from pathlib import Path
+import shutil
+import subprocess
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class PanelNavigationTests(unittest.TestCase):
+    def test_uninstalled_extensions_and_legacy_routes_preserve_active_panel(self):
+        node = shutil.which("node")
+        if not node:
+            self.skipTest("Node.js is unavailable")
+        source = (ROOT / "pages/companion-panel/app.js").read_text(encoding="utf-8")
+        start = source.index("function switchTab(")
+        end = source.index("\nfunction ", start + 1)
+        script = """
+const assert = require('node:assert/strict');
+const state = {activeTab: 'dashboard'};
+const notices = [];
+const photoReferenceManagerBusy = () => false;
+const contentCompanionInstalled = () => false;
+const realityCompanionInstalled = () => false;
+const imageCompanionInstalled = () => false;
+const showToast = (...args) => notices.push(args);
+const hasUnsavedChanges = () => { throw new Error('guard must precede state or DOM mutations'); };
+""" + source[start:end] + """
+for (const tab of ['creative', 'reality', 'image', 'bookshelf', 'qzone']) {
+  switchTab(tab);
+  assert.equal(state.activeTab, 'dashboard');
+}
+assert.equal(notices.length, 5);
+"""
+        result = subprocess.run([node, "-e", script], text=True, encoding="utf-8", capture_output=True)
+        self.assertEqual(0, result.returncode, result.stderr)
+
+    def test_mirrored_assets_and_unique_dom_ids(self):
+        primary = ROOT / "pages/companion-panel"
+        mirror = ROOT / "pages/陪伴面板"
+        for name in ("app.js", "index.html", "css/polish.css", "js/panels/provider-tree.js"):
+            self.assertEqual((primary / name).read_bytes(), (mirror / name).read_bytes())
+
+        class IdParser(HTMLParser):
+            ids = []
+
+            def handle_starttag(self, tag, attrs):
+                self.ids.extend(value for key, value in attrs if key == "id")
+
+        parser = IdParser()
+        parser.feed((primary / "index.html").read_text(encoding="utf-8"))
+        self.assertEqual(len(parser.ids), len(set(parser.ids)))


### PR DESCRIPTION
陪伴面板在未安装创作或现实触及扩展时，原先可以跳入隐藏面板并出现白屏。此改动统一禁用未安装扩展的入口，并在路由切换前检查安装状态，覆盖书架和空间的旧入口。

面板改为目录导航和折叠分组，首页优先展示运行数据。提示词页按实际容器宽度切换布局，长文本完整保留并可滚动；修复窄屏纵向布局中 flex-basis 产生大块空白的问题。搜索支持桌面快捷键和移动端按钮，关闭后恢复焦点；模型摘要、文字对比度和窄屏间距同步调整。

保留原有 DOM ID、表单和后端契约。英文目录与中文镜像对应文件逐字节一致。

验证：43 项相关测试通过；JavaScript 语法和 git diff --check 通过；使用模拟 API 的 Playwright 在 390、820、1440、2560 像素宽度检查扩展守卫、旧路由、搜索键盘操作、长提示词滚动及窄屏定位，无页面级横向溢出和 JavaScript 错误。未连接真实模型服务。
