### PR TITLE
fix: 修复每日穿搭预览关闭按钮被图片遮挡的层级问题

### DIFF
--- a/pages/companion-panel/app.css
+++ b/pages/companion-panel/app.css
@@ -4725,6 +4725,9 @@ input[type="search"] {
   position: absolute;
   top: 10px;
   right: 10px;
+  /* 预览图始终带 inline transform（scale(1) 也算），会成为后绘制的层叠上下文，
+     不抬高层级时关闭按钮会被图片盖住、点击落到图片上。 */
+  z-index: 2;
   width: 36px;
   height: 36px;
   border-radius: 999px;
@@ -4765,6 +4768,9 @@ input[type="search"] {
 }
 
 .daily-outfit-preview__meta {
+  /* 放大预览时说明文字可能与图片重叠；同样需要压过带 transform 的预览图。 */
+  position: relative;
+  z-index: 1;
   color: var(--muted);
   font-size: 12px;
   line-height: 1.6;

--- a/pages/companion-panel/index.html
+++ b/pages/companion-panel/index.html
@@ -96,7 +96,7 @@
       to { opacity: 1; transform: scaleX(1); transform-origin: left; }
     }
   </style>
-  <link rel="stylesheet" href="./app.css?v=20260809-external-ability-controls-v3&amp;build=20260810-reference-upload-v1&amp;touch=reality-redesign-rt2-v4&amp;migration-notice=v2&amp;component-order=v1&amp;layout=model-routing-v2&amp;directory-nav=v2&amp;terminal=plugin-check-v1&amp;diagnostic-layout=v2&amp;prompts=task-editor-v1&amp;release=6.4.4f" />
+  <link rel="stylesheet" href="./app.css?v=20260809-external-ability-controls-v3&amp;build=20260810-reference-upload-v1&amp;touch=reality-redesign-rt2-v4&amp;migration-notice=v2&amp;component-order=v1&amp;layout=model-routing-v2&amp;directory-nav=v2&amp;terminal=plugin-check-v1&amp;diagnostic-layout=v2&amp;prompts=task-editor-v1&amp;release=6.4.4f&amp;outfit-preview-layering=v1" />
   <!-- Keep the structured roleplay form readable while a WebUI asset is being refreshed. -->
   <style id="roleplay-layout-fallback">
     .roleplay-form,

--- a/pages/陪伴面板/app.css
+++ b/pages/陪伴面板/app.css
@@ -4725,6 +4725,9 @@ input[type="search"] {
   position: absolute;
   top: 10px;
   right: 10px;
+  /* 预览图始终带 inline transform（scale(1) 也算），会成为后绘制的层叠上下文，
+     不抬高层级时关闭按钮会被图片盖住、点击落到图片上。 */
+  z-index: 2;
   width: 36px;
   height: 36px;
   border-radius: 999px;
@@ -4765,6 +4768,9 @@ input[type="search"] {
 }
 
 .daily-outfit-preview__meta {
+  /* 放大预览时说明文字可能与图片重叠；同样需要压过带 transform 的预览图。 */
+  position: relative;
+  z-index: 1;
   color: var(--muted);
   font-size: 12px;
   line-height: 1.6;

--- a/pages/陪伴面板/index.html
+++ b/pages/陪伴面板/index.html
@@ -96,7 +96,7 @@
       to { opacity: 1; transform: scaleX(1); transform-origin: left; }
     }
   </style>
-  <link rel="stylesheet" href="./app.css?v=20260809-external-ability-controls-v3&amp;build=20260810-reference-upload-v1&amp;touch=reality-redesign-rt2-v4&amp;migration-notice=v2&amp;component-order=v1&amp;layout=model-routing-v2&amp;directory-nav=v2&amp;terminal=plugin-check-v1&amp;diagnostic-layout=v2&amp;prompts=task-editor-v1&amp;release=6.4.4f" />
+  <link rel="stylesheet" href="./app.css?v=20260809-external-ability-controls-v3&amp;build=20260810-reference-upload-v1&amp;touch=reality-redesign-rt2-v4&amp;migration-notice=v2&amp;component-order=v1&amp;layout=model-routing-v2&amp;directory-nav=v2&amp;terminal=plugin-check-v1&amp;diagnostic-layout=v2&amp;prompts=task-editor-v1&amp;release=6.4.4f&amp;outfit-preview-layering=v1" />
   <!-- Keep the structured roleplay form readable while a WebUI asset is being refreshed. -->
   <style id="roleplay-layout-fallback">
     .roleplay-form,


### PR DESCRIPTION
## 修复了什么

**故障现象**：在陪伴面板主页点击"每日穿搭"照片打开大图预览后，右上角的关闭按钮（×）被预览图盖住，只露出边缘一小条；点击按钮区域实际命中的是图片，预览无法通过 × 关闭。滚轮放大图片后，底部的说明文字（日期、后端、生成时间）也会被图片盖住。

**影响范围**：陪伴面板主页"每日穿搭"预览层（`#dailyOutfitPreview`），以及复用同一预览层的 QQ 空间图片预览（`js/panels/qzone-panel.js` 调用 `openImagePreview`）。纯前端 CSS 层级问题，不影响后端接口与数据。

**实际根因**：预览图元素始终带有 inline `transform`（`setPreviewScale` 即使在 scale(1) 时也会写入 `style.transform`），而任何非 `none` 的 transform 都会创建层叠上下文；该元素在 DOM 中又位于绝对定位的关闭按钮之后。两者 z-index 均为 auto，浏览器按 DOM 顺序绘制，图片因此始终压在按钮和说明文字之上。

## 怎么修复

- `.daily-outfit-preview__close` 增加 `z-index: 2`，保证关闭按钮始终位于预览图之上、可点击。
- `.daily-outfit-preview__meta` 改为 `position: relative; z-index: 1`，放大预览时说明文字不再被图片盖住。
- `index.html` 中 `app.css` 的链接参数追加 `outfit-preview-layering=v1`，避免已打开过的面板继续使用旧缓存样式。
- 同步修改 `pages/companion-panel/` 与 `pages/陪伴面板/` 两份镜像，全部文件保持逐字节一致。

**边界行为与兼容语义**：仅调整层叠层级，不改动预览的打开/关闭逻辑、Esc 关闭、点击遮罩关闭、滚轮缩放范围（1–3 倍）与 body 滚动锁等行为；不修改 JS 与后端代码。

## 已经验证了什么

- 在本地 AstrBot 4.27.3 测试实例（127.0.0.1:6185）中实际复现并验证：修复前 `elementFromPoint` 在按钮中心命中的是预览图、点击 × 无效、截图可见按钮被图片遮挡；修复后 scale(1) 与 scale(3) 放大状态下，按钮与说明文字的中心点均命自身元素，点击 × 可正常关闭。
- 回归验证 Esc 关闭、点击遮罩关闭、打开时 `body` 滚动锁加锁与关闭后解锁均正常。
- `git diff --check` 无空白错误；`pages/companion-panel/` 与 `pages/陪伴面板/` 两份镜像全部文件 SHA-256 一致。
- 使用 AstrBot 自带 Python 环境执行 `pytest -q`：`test_bookshelf_browser_history_ui.py`、`test_learning_page_ui.py`、`test_page_loading_responsive.py`、`test_c6_capability_matrix.py`、`test_overview_resilience.py`、`test_photo_reference_library_page.py` 共 76 项全部通过（既有断言 `app.css?v=...` 前缀的用例不受追加缓存参数影响）。
- 未执行全量测试套件；本次改动仅涉及两条 CSS 规则与一个 HTML 缓存参数，未运行覆盖全部页面的浏览器端自动化回归。
